### PR TITLE
fix(ci): use GitHub App token for Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,6 +2,8 @@ name: Auto-merge Dependabot PRs
 
 on: pull_request_target
 
+permissions: {}
+
 jobs:
   dependabot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace GITHUB_TOKEN with squire-auto-merge GitHub App token
- Org-level settings block GITHUB_TOKEN from approving PRs
- App token has pull_requests:write and contents:write permissions

## Test plan
- [ ] Merge this, then re-run the dependabot workflow on PR #7 to verify approval works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow authentication to use app-based credentials with reduced top-level permissions, and migrated automated Dependabot/merge operations to the new token. This improves security for automated merges and metadata fetches while keeping existing automation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->