### PR TITLE
chore(deps): exclude TypeScript 6 from Dependabot until ecosystem catches up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
+        exclude-patterns:
+          - "typescript"
+    ignore:
+      # typescript-eslint doesn't support TS 6 yet; ignore until ecosystem catches up
+      - dependency-name: "typescript"
+        versions: [">=6.0.0"]
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- Exclude `typescript` from the dev-dependencies Dependabot group so it doesn't block other updates
- Ignore `typescript >=6.0.0` until `typescript-eslint` supports it (currently requires `<6.0.0`)
- Unblocks Dependabot from updating `@vitest/coverage-v8` and other dev deps independently

Ref: PR #19 was failing due to this incompatibility.

## Test plan

- [x] All 114 tests pass (no code changes)
- [ ] Verify Dependabot creates separate PRs for non-TypeScript dev deps on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to refine automated dependency update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->