### PR TITLE
feat: add getCard() lookup tool

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -103,6 +103,44 @@ export function listCards(
   });
 }
 
+// ─── ID field mapping ────────────────────────────────────────────────────────
+
+/** The natural identifier field for each card type. */
+const ID_FIELDS: Record<CardType, string> = {
+  'monster-stats': 'name',
+  'monster-abilities': 'cardName',
+  'character-abilities': 'cardName',
+  items: 'number',
+  events: 'number',
+  'battle-goals': 'name',
+  buildings: 'buildingNumber',
+};
+
+/**
+ * Look up a single card by type and identifier.
+ * Uses the natural ID field for each card type (e.g., name for monsters, number for items).
+ * Case-insensitive for string identifiers.
+ */
+export function getCard(type: CardType, id: string): Record<string, unknown> | null {
+  const field = ID_FIELDS[type];
+  const records = load(type);
+  const idLower = id.toLowerCase();
+
+  const match = records.find((record) => {
+    const value = record[field];
+    if (typeof value === 'string') return value.toLowerCase() === idLower;
+    return value === id;
+  });
+
+  if (!match) return null;
+
+  const data: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(match)) {
+    if (!key.startsWith('_')) data[key] = value;
+  }
+  return data;
+}
+
 /**
  * Re-score a record for the structured result.
  * Uses the same keyword overlap logic as extracted-data.ts.

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -73,7 +73,7 @@ vi.mock('../src/embedder.ts', () => ({
   embed: vi.fn().mockResolvedValue(Array(384).fill(0.05)),
 }));
 
-import { searchRules, searchCards, listCardTypes, listCards } from '../src/tools.ts';
+import { searchRules, searchCards, listCardTypes, listCards, getCard } from '../src/tools.ts';
 import type { RuleResult, CardResult, CardTypeInfo } from '../src/tools.ts';
 
 // ─── searchRules ─────────────────────────────────────────────────────────────
@@ -275,5 +275,45 @@ describe('listCards', () => {
       expect(card).not.toHaveProperty('_error');
       expect(card).not.toHaveProperty('_parseError');
     }
+  });
+});
+
+// ─── getCard ─────────────────────────────────────────────────────────────────
+
+describe('getCard', () => {
+  it('looks up a monster by name', () => {
+    const card = getCard('monster-stats', 'Algox Archer');
+    expect(card).not.toBeNull();
+    expect(card!.name).toBe('Algox Archer');
+  });
+
+  it('looks up an item by number', () => {
+    const card = getCard('items', '001');
+    expect(card).not.toBeNull();
+    expect(card!.name).toBe('Boots of Speed');
+  });
+
+  it('returns null for non-existent card', () => {
+    const card = getCard('monster-stats', 'Nonexistent Monster');
+    expect(card).toBeNull();
+  });
+
+  it('returns null for empty type', () => {
+    const card = getCard('events', '999');
+    expect(card).toBeNull();
+  });
+
+  it('does not include internal fields in result', () => {
+    const card = getCard('monster-stats', 'Algox Archer');
+    expect(card).not.toBeNull();
+    expect(card).not.toHaveProperty('_type');
+    expect(card).not.toHaveProperty('_error');
+    expect(card).not.toHaveProperty('_parseError');
+  });
+
+  it('is case-insensitive for name lookups', () => {
+    const card = getCard('monster-stats', 'algox archer');
+    expect(card).not.toBeNull();
+    expect(card!.name).toBe('Algox Archer');
   });
 });


### PR DESCRIPTION
## Summary
- Add `getCard(type, id)` to `src/tools.ts` — direct lookup of a single card by type and natural identifier
- Each card type uses its natural ID field: `name` for monsters/battle goals, `number` for items/events, `cardName` for abilities, `buildingNumber` for buildings
- Case-insensitive matching for string identifiers
- Returns `null` when no match found

## Test plan
- [x] 6 new tests covering lookup, missing cards, empty types, internal field stripping, case insensitivity
- [x] All 144 tests pass
- [x] Typecheck clean
- [x] Lint clean

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added card lookup functionality to retrieve specific cards by type and identifier
  * Supports case-insensitive matching for text-based card identifiers
  * Returns clean card data without exposing internal metadata

* **Tests**
  * Added comprehensive test coverage for card lookup behavior across multiple card types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->