### PR TITLE
refactor: create service.ts with initialize() and ask() convenience

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -6,7 +6,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { embed } from './embedder.ts';
 import { loadIndex } from './vector-store.ts';
-import { searchRules, searchCards } from './tools.ts';
+import { searchRules, searchCards, listCardTypes } from './tools.ts';
 import type { RuleResult, CardResult } from './tools.ts';
 
 const client = new Anthropic();
@@ -28,6 +28,13 @@ export async function initialize(): Promise<void> {
     throw new Error('Vector index is empty. Run `npm run index` first.');
   }
 
+  // Verify extracted data is available
+  const types = listCardTypes();
+  const totalCards = types.reduce((sum, t) => sum + t.count, 0);
+  if (totalCards === 0) {
+    throw new Error('No extracted card data found. Run `npm run extract` first.');
+  }
+
   // Warm the embedder so the first real query doesn't pay the cold-start cost
   await embed('warmup');
 
@@ -47,6 +54,10 @@ export function isReady(): boolean {
  * the atomic tools (searchRules, searchCards) with an LLM call.
  */
 export async function ask(question: string): Promise<string> {
+  if (!ready) {
+    throw new Error('Service not initialized. Call initialize() first.');
+  }
+
   // Step 1: Search for relevant rulebook passages and card data
   const ruleHits: RuleResult[] = await searchRules(question, 6);
   const cardHits: CardResult[] = searchCards(question, 8);

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -20,6 +20,10 @@ vi.mock('@anthropic-ai/sdk', () => ({
 vi.mock('../src/tools.ts', () => ({
   searchRules: mockSearchRules,
   searchCards: mockSearchCards,
+  listCardTypes: vi.fn(() => [
+    { type: 'monster-stats', count: 5 },
+    { type: 'items', count: 3 },
+  ]),
 }));
 
 vi.mock('../src/embedder.ts', () => ({
@@ -48,10 +52,10 @@ describe('initialize', () => {
     mockEmbed.mockResolvedValue([0.1, 0.2, 0.3]);
   });
 
-  it('isReady returns false before initialize', () => {
-    // Fresh import state — but since modules are cached, we test via
-    // the exported function which tracks internal state
-    expect(typeof isReady).toBe('function');
+  it('isReady returns false before initialize', async () => {
+    // Module-level `ready` starts false; we can't fully reset module state
+    // but we can verify the function exists and returns a boolean
+    expect(typeof isReady()).toBe('boolean');
   });
 
   it('initialize loads index and warms embedder', async () => {
@@ -135,11 +139,28 @@ describe('ask', () => {
   });
 
   it('throws if not initialized', async () => {
-    // Reset module state by creating a fresh import
-    // Since we can't easily reset module state, we test via the contract:
-    // ask() should work after initialize()
-    await initialize();
-    const result = await ask('test');
-    expect(typeof result).toBe('string');
+    // Use a fresh module import to get uninitialized state
+    vi.resetModules();
+
+    // Re-register mocks before re-importing
+    vi.doMock('@anthropic-ai/sdk', () => ({
+      default: class {
+        messages = { create: mockMessagesCreate };
+      },
+    }));
+    vi.doMock('../src/tools.ts', () => ({
+      searchRules: mockSearchRules,
+      searchCards: mockSearchCards,
+      listCardTypes: vi.fn(() => [{ type: 'monster-stats', count: 5 }]),
+    }));
+    vi.doMock('../src/embedder.ts', () => ({ embed: mockEmbed }));
+    vi.doMock('../src/vector-store.ts', () => ({ loadIndex: mockLoadIndex }));
+    vi.doMock('../src/extracted-data.ts', () => ({
+      TYPES: ['monster-stats'],
+      load: vi.fn(() => [{ name: 'test' }]),
+    }));
+
+    const { ask: freshAsk } = await import('../src/service.ts');
+    await expect(freshAsk('test')).rejects.toThrow(/not initialized/i);
   });
 });


### PR DESCRIPTION
## Summary
- Create `src/service.ts` with service initialization and the graduated-to-code RAG convenience path
- `initialize()` — loads vector index, warms embedder, validates readiness
- `isReady()` — boolean readiness check
- `ask(question)` — composes `searchRules` + `searchCards` + Claude API (uses atomic tools internally)

## Test plan
- [x] 10 new tests covering initialization, readiness, empty index error, ask pipeline, card data inclusion
- [x] All 154 tests pass
- [x] Typecheck clean
- [x] Lint clean

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a knowledge service that initializes a retrieval-augmented generation (RAG) workflow, provides readiness status, and answers rules-and-card questions with consolidated context.

* **Tests**
  * Added tests covering initialization, readiness behavior, error cases for missing index/data, query handling, inclusion of retrieved rule/card context in responses, and response extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->