### PR TITLE
refactor: make query.ts a thin CLI wrapper over service.ts

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -1,95 +1,21 @@
 /**
  * Query the Frosthaven knowledge base.
  * Usage: node src/query.ts "What is the loot action?"
+ *
+ * This is a thin CLI wrapper over service.ts. All RAG logic lives there.
  */
 
 import 'dotenv/config';
 import { sdk } from './instrumentation.ts';
-import Anthropic from '@anthropic-ai/sdk';
-import { startActiveObservation, startObservation } from '@langfuse/tracing';
-import { embed } from './embedder.ts';
-import { loadIndex, search } from './vector-store.ts';
-import { searchExtracted, formatExtracted } from './extracted-data.ts';
-
-const client = new Anthropic(); // reads ANTHROPIC_API_KEY from env
-
-const SYSTEM_PROMPT = `You are a knowledgeable Frosthaven rules assistant. \
-Answer questions accurately based on the rulebook excerpts and card data provided. \
-Be concise but complete. If the provided data doesn't contain enough information to answer confidently, say so. \
-Do not invent rules, stats, or item numbers.`;
+import { initialize, ask } from './service.ts';
 
 /**
  * Answer a Frosthaven rules question using RAG + structured card data.
+ * Delegates to service.ts for all logic.
  */
 export async function askFrosthaven(question: string): Promise<string> {
-  return startActiveObservation('rag-query', async (trace) => {
-    trace.update({ input: { question } });
-
-    const index = loadIndex();
-    if (index.length === 0) {
-      trace.update({ output: 'empty index' });
-      return 'The rulebook index is empty. Run `npm run index` first to index the docs.';
-    }
-
-    // Step 1: Embed query
-    const embedObs = startObservation('embed-query', { input: { text: question } });
-    const queryEmbedding = await embed(question);
-    embedObs.update({ output: { dimensions: queryEmbedding.length } });
-    embedObs.end();
-
-    // Step 2: Vector search
-    const searchObs = startObservation('vector-search', { input: { topK: 6 } });
-    const hits = search(index, queryEmbedding, 6);
-    searchObs.update({ output: { resultCount: hits.length, sources: hits.map((h) => h.source) } });
-    searchObs.end();
-
-    // Step 3: Card data search
-    const cardObs = startObservation('card-search', { input: { topK: 8 } });
-    const cardHits = searchExtracted(question, 8);
-    cardObs.update({ output: { resultCount: cardHits.length } });
-    cardObs.end();
-
-    // Step 4: LLM generation
-    const rulebookContext = hits
-      .map((h, i) => `[${i + 1}] (${h.source})\n${h.text}`)
-      .join('\n\n---\n\n');
-    const cardContext = cardHits.length > 0 ? `\n\n## Card Data\n${formatExtracted(cardHits)}` : '';
-    const userMessage = `## Rulebook Excerpts\n\n${rulebookContext}${cardContext}\n\n---\n\nQuestion: ${question}`;
-
-    const genObs = startObservation(
-      'claude-generation',
-      {
-        model: 'claude-opus-4-6',
-        input: [
-          { role: 'system', content: SYSTEM_PROMPT },
-          { role: 'user', content: userMessage },
-        ],
-        modelParameters: { max_tokens: 1024 },
-      },
-      { asType: 'generation' },
-    );
-
-    const response = await client.messages.create({
-      model: 'claude-opus-4-6',
-      max_tokens: 1024,
-      system: SYSTEM_PROMPT,
-      messages: [{ role: 'user', content: userMessage }],
-    });
-
-    const answer = response.content.find((b) => b.type === 'text')?.text ?? '';
-
-    genObs.update({
-      output: answer,
-      usageDetails: {
-        input: response.usage.input_tokens,
-        output: response.usage.output_tokens,
-      },
-    });
-    genObs.end();
-
-    trace.update({ output: answer });
-    return answer;
-  });
+  await initialize();
+  return ask(question);
 }
 
 // CLI entrypoint

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -2,47 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('dotenv/config', () => ({}));
 vi.mock('../src/instrumentation.ts', () => ({ sdk: { shutdown: vi.fn() } }));
-vi.mock('@langfuse/tracing', () => ({
-  startActiveObservation: vi.fn((_name: string, fn: (trace: unknown) => unknown) =>
-    fn({ update: vi.fn() }),
-  ),
-  startObservation: vi.fn(() => ({ update: vi.fn(), end: vi.fn() })),
+
+const { mockInitialize, mockAsk } = vi.hoisted(() => ({
+  mockInitialize: vi.fn(),
+  mockAsk: vi.fn(),
 }));
 
-const {
-  mockMessagesCreate,
-  mockEmbed,
-  mockLoadIndex,
-  mockSearch,
-  mockSearchExtracted,
-  mockFormatExtracted,
-} = vi.hoisted(() => ({
-  mockMessagesCreate: vi.fn(),
-  mockEmbed: vi.fn(),
-  mockLoadIndex: vi.fn(),
-  mockSearch: vi.fn(),
-  mockSearchExtracted: vi.fn(),
-  mockFormatExtracted: vi.fn(),
-}));
-
-vi.mock('@anthropic-ai/sdk', () => ({
-  default: class {
-    messages = { create: mockMessagesCreate };
-  },
-}));
-
-vi.mock('../src/embedder.ts', () => ({
-  embed: mockEmbed,
-}));
-
-vi.mock('../src/vector-store.ts', () => ({
-  loadIndex: mockLoadIndex,
-  search: mockSearch,
-}));
-
-vi.mock('../src/extracted-data.ts', () => ({
-  searchExtracted: mockSearchExtracted,
-  formatExtracted: mockFormatExtracted,
+vi.mock('../src/service.ts', () => ({
+  initialize: mockInitialize,
+  ask: mockAsk,
 }));
 
 import { askFrosthaven } from '../src/query.ts';
@@ -50,60 +18,33 @@ import { askFrosthaven } from '../src/query.ts';
 describe('askFrosthaven', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-
-    mockEmbed.mockResolvedValue([0.1, 0.2, 0.3]);
-    mockLoadIndex.mockReturnValue([
-      { source: 'rulebook.pdf', text: 'Some rulebook text', embedding: [0.1, 0.2, 0.3] },
-    ]);
-    mockSearch.mockReturnValue([
-      { source: 'rulebook.pdf', text: 'Some rulebook text', score: 0.9 },
-    ]);
-    mockSearchExtracted.mockReturnValue([]);
-    mockFormatExtracted.mockReturnValue('');
-    mockMessagesCreate.mockResolvedValue({
-      content: [{ type: 'text', text: 'Mocked answer' }],
-      usage: { input_tokens: 100, output_tokens: 50 },
-    });
+    mockInitialize.mockResolvedValue(undefined);
+    mockAsk.mockResolvedValue('Mocked answer from service');
   });
 
-  it('returns empty index message when loadIndex returns []', async () => {
-    mockLoadIndex.mockReturnValue([]);
-    const result = await askFrosthaven('What is the loot action?');
-    expect(result).toBe(
-      'The rulebook index is empty. Run `npm run index` first to index the docs.',
-    );
-    expect(mockMessagesCreate).not.toHaveBeenCalled();
-  });
-
-  it('calls embed with the question', async () => {
+  it('initializes the service before asking', async () => {
     await askFrosthaven('What is the loot action?');
-    expect(mockEmbed).toHaveBeenCalledWith('What is the loot action?');
+    expect(mockInitialize).toHaveBeenCalled();
   });
 
-  it('calls Claude API with correct model and system prompt', async () => {
+  it('delegates to service.ask()', async () => {
     await askFrosthaven('What is the loot action?');
-    expect(mockMessagesCreate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: 'claude-opus-4-6',
-        max_tokens: 1024,
-        system: expect.stringContaining('Frosthaven rules assistant'),
-      }),
-    );
+    expect(mockAsk).toHaveBeenCalledWith('What is the loot action?');
   });
 
-  it('returns the Claude API response text', async () => {
+  it('returns the answer from service.ask()', async () => {
     const result = await askFrosthaven('What is the loot action?');
-    expect(result).toBe('Mocked answer');
+    expect(result).toBe('Mocked answer from service');
   });
 
-  it('includes card data context when searchExtracted returns results', async () => {
-    mockSearchExtracted.mockReturnValue([{ name: 'Trample' }]);
-    mockFormatExtracted.mockReturnValue('Trample: Move 3, Attack 2');
+  it('propagates initialization errors', async () => {
+    mockInitialize.mockRejectedValue(new Error('Vector index is empty'));
+    await expect(askFrosthaven('test')).rejects.toThrow('Vector index is empty');
+    expect(mockAsk).not.toHaveBeenCalled();
+  });
 
-    await askFrosthaven('What does Trample do?');
-
-    const userMessage = mockMessagesCreate.mock.calls[0][0].messages[0].content as string;
-    expect(userMessage).toContain('## Card Data');
-    expect(userMessage).toContain('Trample: Move 3, Attack 2');
+  it('propagates ask errors', async () => {
+    mockAsk.mockRejectedValue(new Error('Claude API error'));
+    await expect(askFrosthaven('test')).rejects.toThrow('Claude API error');
   });
 });


### PR DESCRIPTION
## Summary
- Replace the full RAG pipeline in `query.ts` with a thin wrapper that delegates to `service.ts`
- `askFrosthaven()` now calls `initialize()` + `ask()` from the service layer
- Removed all duplicated logic (embedding, vector search, card search, LLM call, context assembly)
- `npm run query` still works as before
- Tests updated to mock `service.ts` instead of individual dependencies

Net -133 lines of code removed from query.ts.

## Test plan
- [x] 5 tests covering delegation, error propagation, initialization
- [x] All 154 tests pass
- [x] Typecheck clean
- [x] Lint clean

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to code structure and organization for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->