### PR TITLE
feat: add search endpoints

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -22,12 +22,19 @@ app.get('/api/health', (c) => {
 
 // ─── Search endpoints ────────────────────────────────────────────────────────
 
+function parseTopK(raw: string | undefined): number {
+  if (!raw) return 6;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 100) return 6;
+  return n;
+}
+
 app.get('/api/search/rules', async (c) => {
   const q = c.req.query('q');
   if (!q) return c.json({ error: 'Missing required query parameter: q' }, 400);
 
-  const topK = parseInt(c.req.query('topK') || '6', 10);
-  const results = await searchRules(q, Number.isNaN(topK) ? 6 : topK);
+  const topK = parseTopK(c.req.query('topK'));
+  const results = await searchRules(q, topK);
   return c.json({ results });
 });
 
@@ -35,8 +42,8 @@ app.get('/api/search/cards', (c) => {
   const q = c.req.query('q');
   if (!q) return c.json({ error: 'Missing required query parameter: q' }, 400);
 
-  const topK = parseInt(c.req.query('topK') || '6', 10);
-  const results = searchCards(q, Number.isNaN(topK) ? 6 : topK);
+  const topK = parseTopK(c.req.query('topK'));
+  const results = searchCards(q, topK);
   return c.json({ results });
 });
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -99,6 +99,11 @@ describe('GET /api/search/rules', () => {
     const res = await app.request('/api/search/rules?q=');
     expect(res.status).toBe(400);
   });
+
+  it('defaults topK when given invalid value', async () => {
+    await app.request('/api/search/rules?q=loot&topK=abc');
+    expect(mockSearchRules).toHaveBeenCalledWith('loot', 6);
+  });
 });
 
 // ─── GET /api/search/cards ───────────────────────────────────────────────────
@@ -134,6 +139,16 @@ describe('GET /api/search/cards', () => {
   it('returns 400 when q is missing', async () => {
     const res = await app.request('/api/search/cards');
     expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when q is empty', async () => {
+    const res = await app.request('/api/search/cards?q=');
+    expect(res.status).toBe(400);
+  });
+
+  it('defaults topK when given invalid value', async () => {
+    await app.request('/api/search/cards?q=algox&topK=abc');
+    expect(mockSearchCards).toHaveBeenCalledWith('algox', 6);
   });
 });
 


### PR DESCRIPTION
## Summary
- `GET /api/search/rules?q=&topK=` — calls `searchRules()`, returns structured JSON results
- `GET /api/search/cards?q=&topK=` — calls `searchCards()`, returns structured JSON results
- Returns 400 when `q` is missing or empty
- `topK` defaults to 6, validated against NaN

## Test plan
- [x] 9 new tests covering both endpoints (results, parameter passing, defaults, validation)
- [x] All 168 tests pass (shuffled)
- [x] Typecheck clean
- [x] Lint clean

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/api/search/rules` and `/api/search/cards` endpoints for searching rules and cards.
  * Both require a `q` query parameter and accept an optional `topK` (defaults to 6; clamped to 1–100).
  * Endpoints return JSON `{ results }` or a 400 error when `q` is missing/empty.

* **Tests**
  * Added comprehensive tests covering success responses, `topK` parsing/defaults, delegation, and 400 handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->