### PR TITLE
feat: add /api/ask convenience endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -98,8 +98,13 @@ app.post('/api/ask', async (c) => {
   const { question } = body as { question?: string };
   if (!question) return c.json({ error: 'Missing required field: question' }, 400);
 
-  const answer = await ask(question);
-  return c.json({ answer });
+  try {
+    const answer = await ask(question);
+    return c.json({ answer });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Internal server error';
+    return c.json({ error: message }, 500);
+  }
 });
 
 // ─── Server startup ──────────────────────────────────────────────────────────

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -300,6 +300,18 @@ describe('POST /api/ask', () => {
     });
     expect(res.status).toBe(400);
   });
+
+  it('returns 500 when ask() throws', async () => {
+    mockAsk.mockRejectedValue(new Error('Claude API error'));
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question: 'test' }),
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toHaveProperty('error', 'Claude API error');
+  });
 });
 
 // ─── unknown routes ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `POST /api/ask` with `{ question }` returns `{ answer }` via `service.ask()`
- Validates JSON body and required `question` field
- Returns 400 for missing/empty question or invalid JSON

## Test plan
- [x] 5 new tests (success, delegation, missing question, empty question, invalid JSON)
- [x] All 183 tests pass (shuffled)
- [x] Typecheck clean
- [x] Lint clean

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint that accepts questions and returns answers with request validation for JSON format and non-empty questions.
* **Tests**
  * Added comprehensive endpoint tests covering successful responses, validation errors (missing/empty question, invalid JSON), and error handling when answer generation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->