### PR TITLE
docs: add development guide and update project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,14 @@ To get the IDs needed for `item-edit`, use:
 Set status to "In Progress" at the **start** of work (before creating a branch),
 not when opening the PR.
 
+## Development
+
+For server setup, API endpoints, MCP client configuration, and project
+structure, see [docs/development.md](docs/development.md).
+
+For architecture context and design rationale, see
+[docs/architecture-plan.md](docs/architecture-plan.md).
+
 ## Development Standards
 
 ### Testing Requirements

--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ npm run extract
 
 ## Usage
 
+### API server
+
+Start the server to expose REST endpoints and MCP tools:
+
+```bash
+npm run serve
+# Squire server listening on port 3000
+```
+
+The server initializes the vector index and embedder on startup, then
+serves:
+
+- **REST API** — `GET /api/health`, `/api/search/rules`, `/api/search/cards`,
+  `/api/card-types`, `/api/cards`, `/api/cards/:type/:id`, `POST /api/ask`
+- **MCP endpoint** — `POST/GET/DELETE /mcp` (Streamable HTTP transport)
+
+Set `PORT` env var to change the listen port (default 3000).
+
 ### CLI
 
 ```bash
@@ -61,9 +79,12 @@ npm run query "What are the stats of an elite Flame Demon at level 3?"
 npm run query "How many small items can I bring into a scenario?"
 ```
 
-### Discord bot
+### MCP (Claude Desktop, Claude Code, etc.)
 
-Squire can run as a Discord bot, answering rules questions from any user in the channel. See `CLAUDE.md` for configuration details.
+Squire exposes its knowledge tools via the
+[Model Context Protocol](https://modelcontextprotocol.io). Any MCP client can
+connect and use the tools. See [docs/development.md](docs/development.md) for
+local setup instructions.
 
 ## Evaluation
 

--- a/docs/architecture-plan.md
+++ b/docs/architecture-plan.md
@@ -209,11 +209,31 @@ Implemented using `@modelcontextprotocol/sdk` auth handlers. PKCE required
 for all interactive clients. Dynamic Client Registration supported so clients
 auto-register without manual setup.
 
-## Implementation
+## Implementation Status
 
 Work is tracked in the [Squire Service Architecture][project] GitHub project.
 
 [project]: https://github.com/orgs/maz-org/projects/1
+
+### Completed
+
+- **Atomic Tool Layer** — `searchRules`, `searchCards`, `listCardTypes`,
+  `listCards`, `getCard` in `src/tools.ts`. Service layer with `initialize`,
+  `isReady`, `ask` in `src/service.ts`. CLI wrapper in `src/query.ts`.
+- **HTTP/REST API** — Hono server in `src/server.ts` with health check, search
+  endpoints, card discovery/lookup, and `/api/ask` convenience endpoint.
+  Structured JSON errors via global `onError` and `notFound` handlers.
+- **MCP Server** — 5 atomic tools registered as MCP tools in `src/mcp.ts`.
+  Streamable HTTP transport mounted at `/mcp` (stateless, no auth).
+  In-process transport via `createInProcessClient()` for the web UI.
+  Verified with Claude Desktop via `mcp-remote` bridge.
+
+### In Progress / Planned
+
+- **Auth Module** (#55–#59) — OAuth 2.1 for external MCP/REST clients
+- **Web UI** (#60–#65) — Hono JSX + HTMX conversation agent
+- **CLI Client** (#66–#69) — `squire` command-line tool
+- **Campaign State** (#70–#72) — persistent campaign context
 
 ## Key Decisions
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,149 @@
+# Development Guide
+
+## Prerequisites
+
+- Node.js 24+ (see `.nvmrc`)
+- Frosthaven data indexed: `npm run index` and `npm run extract`
+- `.env` file with `ANTHROPIC_API_KEY`
+
+## Running the dev server
+
+```bash
+npm run serve
+```
+
+The server starts on port 3000 (override with `PORT` env var). It
+initializes the vector index, verifies extracted card data, and warms
+the embedder before accepting requests.
+
+Health check:
+
+```bash
+curl http://localhost:3000/api/health
+# {"ready":true,"index_size":2147}
+```
+
+Stop the server with Ctrl-C or `kill $(lsof -ti :3000)`.
+
+## REST API endpoints
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET | `/api/health` | Readiness check with index size |
+| GET | `/api/search/rules?q=&topK=` | Vector search over rulebook passages |
+| GET | `/api/search/cards?q=&topK=` | Keyword search over extracted card data |
+| GET | `/api/card-types` | List card types with record counts |
+| GET | `/api/cards?type=&filter=` | List cards of a type (filter is JSON) |
+| GET | `/api/cards/:type/:id` | Look up a single card |
+| POST | `/api/ask` | Bundled RAG pipeline (`{ question }` → `{ answer }`) |
+
+All errors return `{ error, status }` as JSON.
+
+`topK` defaults to 6, must be 1–100. The `filter` parameter is a
+URL-encoded JSON object with AND-logic field matching.
+
+## MCP server
+
+Squire exposes 5 atomic tools via MCP at `/mcp`:
+
+| Tool | Description |
+| ---- | ----------- |
+| `search_rules` | Vector search over rulebook passages |
+| `search_cards` | Keyword search over extracted card data |
+| `list_card_types` | List available card categories with counts |
+| `list_cards` | List cards of a type with optional field filter |
+| `get_card` | Look up a single card by type and identifier |
+
+The MCP endpoint uses Streamable HTTP transport in stateless mode (no
+auth). OAuth will be added in the Auth Module epic.
+
+### Connecting Claude Desktop (development)
+
+Claude Desktop doesn't natively support Streamable HTTP MCP servers
+yet — it requires a stdio bridge. Use
+[mcp-remote](https://www.npmjs.com/package/mcp-remote):
+
+1. Start the dev server: `npm run serve`
+
+2. Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+   ```json
+   {
+     "mcpServers": {
+       "squire": {
+         "command": "npx",
+         "args": ["-y", "mcp-remote", "http://localhost:3000/mcp"]
+       }
+     }
+   }
+   ```
+
+   If Claude Desktop uses an older Node version (< 20), specify the
+   full path to a Node 24+ `npx` in the `command` field, and set
+   `env.PATH` to include that Node's bin directory.
+
+3. Restart Claude Desktop. The tools appear in the chat input area.
+
+Once the Auth Module is implemented, Squire can be added as a proper
+Connector in Claude Desktop via the `+` button in Settings > Connectors
+(no config file needed).
+
+### Connecting Claude Code (development)
+
+Add to your Claude Code MCP settings
+(`~/.claude/settings.json` or project `.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "squire": {
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}
+```
+
+Claude Code supports Streamable HTTP natively — no bridge needed.
+
+### In-process client (for web UI)
+
+The web UI conversation agent connects via in-process MCP transport
+with no HTTP round-trip:
+
+```typescript
+import { createInProcessClient } from './mcp.ts';
+
+const client = await createInProcessClient();
+const { tools } = await client.listTools();
+const result = await client.callTool({ name: 'search_rules', arguments: { query: 'loot' } });
+await client.close(); // also closes the server side
+```
+
+## Testing
+
+```bash
+npm test              # Run all tests (shuffled order)
+npm run test:watch    # Watch mode
+npm run typecheck     # TypeScript type checking
+npm run lint          # ESLint
+npm run format:check  # Prettier check
+```
+
+Tests use randomized execution order (`sequence.shuffle` in vitest
+config) to catch order-dependent tests. The full suite runs as a
+pre-commit hook along with typecheck and lint.
+
+## Project structure
+
+```text
+src/
+  tools.ts          # Atomic data access primitives (search, list, get)
+  service.ts        # Service initialization + bundled RAG convenience path
+  server.ts         # Hono HTTP server (REST + MCP transport)
+  mcp.ts            # MCP tool registration + in-process client factory
+  query.ts          # Thin CLI wrapper over service.ts
+  embedder.ts       # Local embedding via all-MiniLM-L6-v2
+  vector-store.ts   # Flat-file vector store with cosine similarity
+  extracted-data.ts # Card data loading, search, and formatting
+  schemas.ts        # Zod schemas for all 7 card types
+```


### PR DESCRIPTION
## Summary
- Create `docs/development.md` — comprehensive dev guide covering:
  - Server setup and health checks
  - REST API endpoint reference (all 7 endpoints)
  - MCP server tools reference (all 5 tools)
  - Claude Desktop configuration (with mcp-remote bridge + Node version gotcha)
  - Claude Code configuration (native Streamable HTTP)
  - In-process client usage for web UI
  - Testing commands and project structure
- Update `README.md` with API server and MCP usage sections
- Update `docs/architecture-plan.md` with implementation status (completed/planned)
- Add doc pointers to `CLAUDE.md` (no duplication, just references)

## Test plan
- [x] Documentation-only change (+ markdown lint clean)
- [x] All 203 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated usage instructions with API server setup via `npm run serve`
  * Added configuration guide for server port via `PORT` environment variable
  * Documented REST API endpoints and Model Context Protocol (MCP) support for Claude Desktop and Claude Code integration
  * Added references to development and architecture documentation for contributors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->