### PR TITLE
feat: add dynamic client registration endpoint

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -33,6 +33,9 @@ export function registerClient(metadata: Record<string, unknown>): RegisteredCli
   if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
     throw new Error('redirect_uris is required and must be a non-empty array');
   }
+  if (!redirectUris.every((uri) => typeof uri === 'string' && uri.length > 0)) {
+    throw new Error('redirect_uris must contain only non-empty strings');
+  }
 
   const client: RegisteredClient = {
     client_id: randomUUID(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,6 +58,10 @@ app.post('/register', async (c) => {
     return c.json(jsonError('Invalid JSON body', 400), 400);
   }
 
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return c.json(jsonError('Request body must be a JSON object', 400), 400);
+  }
+
   try {
     const client = registerClient(body as Record<string, unknown>);
     return c.json(client, 201);

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -39,6 +39,7 @@ vi.mock('../src/tools.ts', () => ({
 }));
 
 import { app } from '../src/server.ts';
+import { _resetClientsForTesting } from '../src/auth.ts';
 
 describe('GET /api/health', () => {
   beforeEach(() => {
@@ -389,6 +390,10 @@ describe('GET /.well-known/oauth-protected-resource', () => {
 // ─── POST /register ──────────────────────────────────────────────────────────
 
 describe('POST /register', () => {
+  beforeEach(() => {
+    _resetClientsForTesting();
+  });
+
   it('registers a client and returns client_id', async () => {
     const res = await app.request('http://localhost:3000/register', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- `POST /register` — accepts client metadata, returns registered client with unique client_id
- Creates `src/auth.ts` with store abstraction (`getClient`, `registerClient`)
- In-memory client store for now; designed for easy migration to Postgres
- Validates redirect_uris (required, non-empty array)
- Returns 400 for invalid JSON or missing fields

## Test plan
- [x] 4 new tests (registration, missing redirect_uris, invalid JSON, unique IDs)
- [x] All 210 tests pass (shuffled)
- [x] Typecheck + lint clean

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth 2.1 client registration: accepts client metadata, validates redirect URIs, issues unique client identifiers and records issuance timestamps, and returns registration details with 201 status.

* **Tests**
  * New tests cover successful registrations, error responses for malformed bodies and missing redirect URIs, and uniqueness of generated client identifiers across registrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->