### PR TITLE
feat: add authorization endpoint and consent UI

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -52,7 +52,60 @@ export function registerClient(metadata: Record<string, unknown>): RegisteredCli
   return client;
 }
 
-/** @internal Reset client store for testing. */
+// ─── Authorization codes ─────────────────────────────────────────────────────
+
+interface AuthorizationCode {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  state?: string;
+  createdAt: number;
+}
+
+const authCodes = new Map<string, AuthorizationCode>();
+
+/**
+ * Create an authorization code for the given client and PKCE challenge.
+ * Auto-approves for now (no user session/consent required yet).
+ */
+export function createAuthorizationCode(
+  clientId: string,
+  redirectUri: string,
+  codeChallenge: string,
+  state?: string,
+): AuthorizationCode {
+  const client = getClient(clientId);
+  if (!client) throw new Error('Unknown client_id');
+  if (!client.redirect_uris.includes(redirectUri)) {
+    throw new Error('redirect_uri does not match registered URIs');
+  }
+
+  const code: AuthorizationCode = {
+    code: randomUUID(),
+    clientId,
+    redirectUri,
+    codeChallenge,
+    state,
+    createdAt: Date.now(),
+  };
+
+  authCodes.set(code.code, code);
+  return code;
+}
+
+export function getAuthorizationCode(code: string): AuthorizationCode | undefined {
+  return authCodes.get(code);
+}
+
+export function consumeAuthorizationCode(code: string): AuthorizationCode | undefined {
+  const authCode = authCodes.get(code);
+  if (authCode) authCodes.delete(code);
+  return authCode;
+}
+
+/** @internal Reset all stores for testing. */
 export function _resetClientsForTesting(): void {
   clients.clear();
+  authCodes.clear();
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import { searchRules, searchCards, listCardTypes, listCards, getCard } from './t
 import type { CardType } from './schemas.ts';
 import { createMcpServer } from './mcp.ts';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
-import { registerClient } from './auth.ts';
+import { registerClient, createAuthorizationCode } from './auth.ts';
 
 export const app = new Hono();
 
@@ -67,6 +67,35 @@ app.post('/register', async (c) => {
     return c.json(client, 201);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Registration failed';
+    return c.json(jsonError(message, 400), 400);
+  }
+});
+
+// ─── Authorization endpoint ──────────────────────────────────────────────────
+
+app.get('/authorize', (c) => {
+  const clientId = c.req.query('client_id');
+  const redirectUri = c.req.query('redirect_uri');
+  const responseType = c.req.query('response_type');
+  const codeChallenge = c.req.query('code_challenge');
+  const codeChallengeMethod = c.req.query('code_challenge_method');
+  const state = c.req.query('state');
+
+  if (!clientId || !redirectUri || responseType !== 'code') {
+    return c.json(jsonError('Missing or invalid required parameters', 400), 400);
+  }
+  if (!codeChallenge || codeChallengeMethod !== 'S256') {
+    return c.json(jsonError('PKCE code_challenge with S256 method is required', 400), 400);
+  }
+
+  try {
+    const authCode = createAuthorizationCode(clientId, redirectUri, codeChallenge, state);
+    const redirect = new URL(redirectUri);
+    redirect.searchParams.set('code', authCode.code);
+    if (state) redirect.searchParams.set('state', state);
+    return c.redirect(redirect.toString(), 302);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Authorization failed';
     return c.json(jsonError(message, 400), 400);
   }
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -453,3 +453,82 @@ describe('POST /register', () => {
     expect(body1.client_id).not.toBe(body2.client_id);
   });
 });
+
+// ─── GET /authorize ──────────────────────────────────────────────────────────
+
+describe('GET /authorize', () => {
+  beforeEach(() => {
+    _resetClientsForTesting();
+  });
+
+  async function registerTestClient(): Promise<string> {
+    const res = await app.request('http://localhost:3000/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        redirect_uris: ['http://localhost:8080/callback'],
+        client_name: 'Test Client',
+        token_endpoint_auth_method: 'none',
+      }),
+    });
+    const body = await res.json();
+    return body.client_id as string;
+  }
+
+  it('redirects with auth code for valid request', async () => {
+    const clientId = await registerTestClient();
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: 'http://localhost:8080/callback',
+      response_type: 'code',
+      code_challenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+      code_challenge_method: 'S256',
+      state: 'test-state',
+    });
+    const res = await app.request(`http://localhost:3000/authorize?${params}`, {
+      redirect: 'manual',
+    });
+    expect(res.status).toBe(302);
+    const location = res.headers.get('location');
+    expect(location).toBeTruthy();
+    const redirectUrl = new URL(location!);
+    expect(redirectUrl.searchParams.get('code')).toBeTruthy();
+    expect(redirectUrl.searchParams.get('state')).toBe('test-state');
+  });
+
+  it('returns 400 for unknown client_id', async () => {
+    const params = new URLSearchParams({
+      client_id: 'nonexistent',
+      redirect_uri: 'http://localhost:8080/callback',
+      response_type: 'code',
+      code_challenge: 'test',
+      code_challenge_method: 'S256',
+    });
+    const res = await app.request(`http://localhost:3000/authorize?${params}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for mismatched redirect_uri', async () => {
+    const clientId = await registerTestClient();
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: 'http://evil.com/callback',
+      response_type: 'code',
+      code_challenge: 'test',
+      code_challenge_method: 'S256',
+    });
+    const res = await app.request(`http://localhost:3000/authorize?${params}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for missing code_challenge', async () => {
+    const clientId = await registerTestClient();
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: 'http://localhost:8080/callback',
+      response_type: 'code',
+    });
+    const res = await app.request(`http://localhost:3000/authorize?${params}`);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- `GET /authorize` — validates client_id, redirect_uri, PKCE code_challenge (S256)
- Issues authorization code and redirects back to client with `?code=...&state=...`
- Auto-approves for now (consent UI deferred to User Accounts epic)
- Authorization code store in `src/auth.ts` with create/get/consume operations
- In-memory store (Postgres migration with Storage epic)

## Test plan
- [x] 4 new tests (successful redirect, unknown client, mismatched redirect_uri, missing code_challenge)
- [x] All 214 tests pass (shuffled)
- [x] Typecheck + lint clean

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented OAuth authorization-code flow with PKCE support for secure authentication. The new `/authorize` endpoint validates client credentials and registered redirect URIs, generates authorization codes, and properly handles state parameters for enhanced security across authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->