### PR TITLE
feat: add token endpoint

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,7 +3,7 @@
  * Client registration, token issuance, and bearer auth middleware.
  */
 
-import { randomUUID } from 'node:crypto';
+import { randomUUID, createHash } from 'node:crypto';
 
 // ─── Client store ────────────────────────────────────────────────────────────
 
@@ -104,8 +104,78 @@ export function consumeAuthorizationCode(code: string): AuthorizationCode | unde
   return authCode;
 }
 
+// ─── Token issuance ──────────────────────────────────────────────────────────
+
+const ACCESS_TOKEN_EXPIRY = 3600; // 1 hour in seconds
+
+interface AccessToken {
+  token: string;
+  clientId: string;
+  createdAt: number;
+  expiresIn: number;
+}
+
+const tokens = new Map<string, AccessToken>();
+
+/**
+ * Verify PKCE code_verifier against the stored code_challenge.
+ * S256: BASE64URL(SHA256(code_verifier)) === code_challenge
+ */
+function verifyPkce(codeVerifier: string, codeChallenge: string): boolean {
+  const hash = createHash('sha256').update(codeVerifier).digest('base64url');
+  return hash === codeChallenge;
+}
+
+/**
+ * Exchange an authorization code for an access token.
+ * Validates PKCE code_verifier, consumes the code (one-time use).
+ */
+export function exchangeAuthorizationCode(
+  code: string,
+  clientId: string,
+  codeVerifier: string,
+  redirectUri: string,
+): { access_token: string; token_type: string; expires_in: number } {
+  const authCode = consumeAuthorizationCode(code);
+  if (!authCode) throw new Error('Invalid or expired authorization code');
+  if (authCode.clientId !== clientId) throw new Error('client_id mismatch');
+  if (authCode.redirectUri !== redirectUri) throw new Error('redirect_uri mismatch');
+  if (!verifyPkce(codeVerifier, authCode.codeChallenge)) {
+    throw new Error('Invalid code_verifier');
+  }
+
+  const accessToken: AccessToken = {
+    token: randomUUID(),
+    clientId,
+    createdAt: Date.now(),
+    expiresIn: ACCESS_TOKEN_EXPIRY,
+  };
+  tokens.set(accessToken.token, accessToken);
+
+  return {
+    access_token: accessToken.token,
+    token_type: 'bearer',
+    expires_in: accessToken.expiresIn,
+  };
+}
+
+/**
+ * Verify an access token. Returns the token record if valid.
+ */
+export function verifyAccessToken(token: string): AccessToken | undefined {
+  const record = tokens.get(token);
+  if (!record) return undefined;
+  const elapsed = (Date.now() - record.createdAt) / 1000;
+  if (elapsed > record.expiresIn) {
+    tokens.delete(token);
+    return undefined;
+  }
+  return record;
+}
+
 /** @internal Reset all stores for testing. */
 export function _resetClientsForTesting(): void {
   clients.clear();
   authCodes.clear();
+  tokens.clear();
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import { searchRules, searchCards, listCardTypes, listCards, getCard } from './t
 import type { CardType } from './schemas.ts';
 import { createMcpServer } from './mcp.ts';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
-import { registerClient, createAuthorizationCode } from './auth.ts';
+import { registerClient, createAuthorizationCode, exchangeAuthorizationCode } from './auth.ts';
 
 export const app = new Hono();
 
@@ -98,6 +98,46 @@ app.get('/authorize', (c) => {
     const message = err instanceof Error ? err.message : 'Authorization failed';
     return c.json(jsonError(message, 400), 400);
   }
+});
+
+// ─── Token endpoint ──────────────────────────────────────────────────────────
+
+app.post('/token', async (c) => {
+  const contentType = c.req.header('content-type') || '';
+  let params: URLSearchParams;
+
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    const body = await c.req.text();
+    params = new URLSearchParams(body);
+  } else if (contentType.includes('application/json')) {
+    const body = (await c.req.json()) as Record<string, string>;
+    params = new URLSearchParams(body);
+  } else {
+    return c.json(jsonError('Unsupported content type', 400), 400);
+  }
+
+  const grantType = params.get('grant_type');
+
+  if (grantType === 'authorization_code') {
+    const code = params.get('code');
+    const clientId = params.get('client_id');
+    const codeVerifier = params.get('code_verifier');
+    const redirectUri = params.get('redirect_uri');
+
+    if (!code || !clientId || !codeVerifier || !redirectUri) {
+      return c.json(jsonError('Missing required parameters', 400), 400);
+    }
+
+    try {
+      const tokenResponse = exchangeAuthorizationCode(code, clientId, codeVerifier, redirectUri);
+      return c.json(tokenResponse);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Token exchange failed';
+      return c.json(jsonError(message, 400), 400);
+    }
+  }
+
+  return c.json(jsonError(`Unsupported grant_type: ${grantType}`, 400), 400);
 });
 
 // ─── MCP transport ───────────────────────────────────────────────────────────

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -532,3 +532,113 @@ describe('GET /authorize', () => {
     expect(res.status).toBe(400);
   });
 });
+
+// ─── POST /token ─────────────────────────────────────────────────────────────
+
+describe('POST /token', () => {
+  beforeEach(() => {
+    _resetClientsForTesting();
+  });
+
+  // PKCE: code_verifier → SHA256 → base64url = code_challenge
+  // Known pair from RFC 7636 Appendix B
+  const CODE_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+  const CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+  async function getAuthCode(): Promise<{ clientId: string; code: string }> {
+    const regRes = await app.request('http://localhost:3000/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        redirect_uris: ['http://localhost:8080/callback'],
+        client_name: 'Test',
+        token_endpoint_auth_method: 'none',
+      }),
+    });
+    const { client_id: clientId } = (await regRes.json()) as { client_id: string };
+
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: 'http://localhost:8080/callback',
+      response_type: 'code',
+      code_challenge: CODE_CHALLENGE,
+      code_challenge_method: 'S256',
+    });
+    const authRes = await app.request(`http://localhost:3000/authorize?${params}`, {
+      redirect: 'manual',
+    });
+    const location = authRes.headers.get('location')!;
+    const code = new URL(location).searchParams.get('code')!;
+    return { clientId, code };
+  }
+
+  it('exchanges auth code for access token', async () => {
+    const { clientId, code } = await getAuthCode();
+    const res = await app.request('http://localhost:3000/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        client_id: clientId,
+        code_verifier: CODE_VERIFIER,
+        redirect_uri: 'http://localhost:8080/callback',
+      }).toString(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('access_token');
+    expect(body).toHaveProperty('token_type', 'bearer');
+    expect(body).toHaveProperty('expires_in');
+  });
+
+  it('rejects invalid code_verifier', async () => {
+    const { clientId, code } = await getAuthCode();
+    const res = await app.request('http://localhost:3000/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        client_id: clientId,
+        code_verifier: 'wrong-verifier',
+        redirect_uri: 'http://localhost:8080/callback',
+      }).toString(),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects reused auth code', async () => {
+    const { clientId, code } = await getAuthCode();
+    const tokenBody = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      client_id: clientId,
+      code_verifier: CODE_VERIFIER,
+      redirect_uri: 'http://localhost:8080/callback',
+    }).toString();
+
+    const res1 = await app.request('http://localhost:3000/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: tokenBody,
+    });
+    expect(res1.status).toBe(200);
+
+    const res2 = await app.request('http://localhost:3000/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: tokenBody,
+    });
+    expect(res2.status).toBe(400);
+  });
+
+  it('rejects unknown grant_type', async () => {
+    const res = await app.request('http://localhost:3000/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ grant_type: 'password' }).toString(),
+    });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /token` with `grant_type=authorization_code` exchanges auth codes for access tokens
- Full PKCE S256 validation (SHA256 of code_verifier must match stored code_challenge)
- Auth codes are consumed on first use (one-time, prevents replay)
- Access tokens have 1-hour expiry
- Supports `application/x-www-form-urlencoded` and `application/json` content types
- In-memory token store (Postgres migration with Storage epic)

## Test plan
- [x] 4 new tests (successful exchange, invalid verifier, reused code, unknown grant_type)
- [x] All 218 tests pass (shuffled)
- [x] Typecheck + lint clean

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced OAuth token exchange endpoint for authorization code grant flow
  * Added secure access token generation with automatic expiration verification
  * Integrated PKCE validation to strengthen security during token exchange
  * Implemented access token lifecycle management with expired token cleanup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->