### PR TITLE
fix: load dotenv in server.ts for API key access

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@
  * Hono-based API with health check and service initialization.
  */
 
+import 'dotenv/config';
 import { Hono } from 'hono';
 import { isReady, initialize, ask } from './service.ts';
 import { loadIndex } from './vector-store.ts';


### PR DESCRIPTION
## Summary
server.ts didn't import `dotenv/config`, so `ANTHROPIC_API_KEY` wasn't loaded from `.env` when running `npm run serve`. The `/api/ask` endpoint returned 500.

Found during interactive testing of the full OAuth flow.

## Test plan
- [x] All 224 tests pass
- [x] Verified manually: full OAuth flow → `/api/ask` returns correct answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced environment variable initialization to improve configuration management at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->