### PR TITLE
feat(api): accept conversation history in /api/ask

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { isReady, initialize, ask } from './service.ts';
 import { loadIndex } from './vector-store.ts';
 import { searchRules, searchCards, listCardTypes, listCards, getCard } from './tools.ts';
 import type { CardType } from './schemas.ts';
+import { z } from 'zod';
 import { createMcpServer } from './mcp.ts';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import {
@@ -277,6 +278,19 @@ app.get('/api/cards', (c) => {
 
 // ─── Ask endpoint ────────────────────────────────────────────────────────────
 
+const AskRequestSchema = z.object({
+  question: z.string().min(1),
+  history: z
+    .array(
+      z.object({
+        role: z.enum(['user', 'assistant']),
+        content: z.string(),
+      }),
+    )
+    .max(20)
+    .optional(),
+});
+
 app.post('/api/ask', async (c) => {
   let body: unknown;
   try {
@@ -285,10 +299,13 @@ app.post('/api/ask', async (c) => {
     return c.json(jsonError('Invalid JSON body', 400), 400);
   }
 
-  const { question } = body as { question?: string };
-  if (!question) return c.json(jsonError('Missing required field: question', 400), 400);
+  const result = AskRequestSchema.safeParse(body);
+  if (!result.success) {
+    return c.json(jsonError('Invalid request: ' + result.error.issues[0].message, 400), 400);
+  }
 
-  const answer = await ask(question);
+  const { question, history } = result.data;
+  const answer = await ask(question, history);
   return c.json({ answer });
 });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -67,12 +67,23 @@ export function isReady(): boolean {
   return ready;
 }
 
+/** Maximum number of history messages to include in the LLM call. */
+const MAX_HISTORY_TURNS = 20;
+
+export interface HistoryMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
 /**
  * Answer a Frosthaven rules question using the bundled RAG pipeline.
  * This is the "graduated optimization" convenience path — it composes
  * the atomic tools (searchRules, searchCards) with an LLM call.
+ *
+ * @param history - Optional conversation history for multi-turn context.
+ *   Truncated to the last {@link MAX_HISTORY_TURNS} messages.
  */
-export async function ask(question: string): Promise<string> {
+export async function ask(question: string, history?: HistoryMessage[]): Promise<string> {
   if (!ready) {
     throw new Error('Service not initialized. Call initialize() first.');
   }
@@ -93,12 +104,19 @@ export async function ask(question: string): Promise<string> {
 
   const userMessage = `## Rulebook Excerpts\n\n${rulebookContext}${cardContext}\n\n---\n\nQuestion: ${question}`;
 
-  // Step 3: LLM generation
+  // Step 3: Build messages array with optional history
+  const truncatedHistory = history ? history.slice(-MAX_HISTORY_TURNS) : [];
+  const messages = [
+    ...truncatedHistory.map((m) => ({ role: m.role, content: m.content })),
+    { role: 'user' as const, content: userMessage },
+  ];
+
+  // Step 4: LLM generation
   const response = await client.messages.create({
     model: 'claude-opus-4-6',
     max_tokens: 1024,
     system: SYSTEM_PROMPT,
-    messages: [{ role: 'user', content: userMessage }],
+    messages,
   });
 
   return response.content.find((b) => b.type === 'text')?.text ?? '';

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -334,7 +334,7 @@ describe('POST /api/ask', () => {
       headers: { 'Content-Type': 'application/json', ...(await auth()) },
       body: JSON.stringify({ question: 'What is the loot action?' }),
     });
-    expect(mockAsk).toHaveBeenCalledWith('What is the loot action?');
+    expect(mockAsk).toHaveBeenCalledWith('What is the loot action?', undefined);
   });
 
   it('returns 400 when question is missing', async () => {
@@ -360,6 +360,61 @@ describe('POST /api/ask', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...(await auth()) },
       body: 'not json',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('passes history to ask()', async () => {
+    const history = [
+      { role: 'user', content: 'What is loot?' },
+      { role: 'assistant', content: 'Loot tokens are picked up.' },
+    ];
+    await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'What about traps?', history }),
+    });
+    expect(mockAsk).toHaveBeenCalledWith('What about traps?', history);
+  });
+
+  it('works without history (backward compatible)', async () => {
+    await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'What is loot?' }),
+    });
+    expect(mockAsk).toHaveBeenCalledWith('What is loot?', undefined);
+  });
+
+  it('returns 400 for invalid history role', async () => {
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({
+        question: 'test',
+        history: [{ role: 'system', content: 'hi' }],
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when history is not an array', async () => {
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'test', history: 'not-array' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when history item missing content', async () => {
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({
+        question: 'test',
+        history: [{ role: 'user' }],
+      }),
     });
     expect(res.status).toBe(400);
   });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -156,6 +156,46 @@ describe('ask', () => {
     expect(userMessage).toContain('Boots of Speed');
   });
 
+  it('passes history messages before the context message', async () => {
+    await initialize();
+    const history = [
+      { role: 'user' as const, content: 'What is loot?' },
+      { role: 'assistant' as const, content: 'Loot tokens are picked up in your hex.' },
+    ];
+    await ask('What about traps?', history);
+    const messages = mockMessagesCreate.mock.calls[0][0].messages;
+    expect(messages).toHaveLength(3);
+    expect(messages[0]).toEqual({ role: 'user', content: 'What is loot?' });
+    expect(messages[1]).toEqual({
+      role: 'assistant',
+      content: 'Loot tokens are picked up in your hex.',
+    });
+    expect(messages[2].role).toBe('user');
+    expect(messages[2].content).toContain('What about traps?');
+  });
+
+  it('sends only the context message when history is omitted', async () => {
+    await initialize();
+    await ask('What is the loot action?');
+    const messages = mockMessagesCreate.mock.calls[0][0].messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe('user');
+  });
+
+  it('truncates history to the last 20 messages', async () => {
+    await initialize();
+    const history = Array.from({ length: 30 }, (_, i) => ({
+      role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+      content: `message ${i}`,
+    }));
+    await ask('Final question', history);
+    const messages = mockMessagesCreate.mock.calls[0][0].messages;
+    // 20 history + 1 context = 21
+    expect(messages).toHaveLength(21);
+    // Should keep the last 20 (indices 10-29)
+    expect(messages[0].content).toBe('message 10');
+  });
+
   it('throws if not initialized', async () => {
     // Use a fresh module import to get uninitialized state
     vi.resetModules();


### PR DESCRIPTION
## Summary
- Add optional `history` array parameter to `/api/ask` for multi-turn conversation context
- Knowledge agent prepends history before the RAG-assembled context message in the Claude API call
- Zod schema validates request body (role must be `user` | `assistant`, history capped at 20 messages)
- Fully backward compatible — omitting history works as before

## Test plan
- [x] Unit tests for `ask()` with history, without history, and with >20 messages (truncation)
- [x] Endpoint tests for valid history, invalid roles, non-array history, missing fields
- [x] All 232 existing tests pass
- [x] Lint clean

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation history support: The API endpoint now accepts and maintains conversation history, enabling multi-turn context-aware interactions. Up to 20 prior messages are preserved per request to maintain conversation continuity.

* **Improvements**
  * Stricter request validation with informative error messages to help developers identify and fix payload issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->