### PR TITLE
feat(api): add campaignId and userId params to /api/ask

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -289,6 +289,8 @@ const AskRequestSchema = z.object({
     )
     .max(20)
     .optional(),
+  campaignId: z.string().uuid().optional(),
+  userId: z.string().uuid().optional(),
 });
 
 app.post('/api/ask', async (c) => {
@@ -304,8 +306,8 @@ app.post('/api/ask', async (c) => {
     return c.json(jsonError('Invalid request: ' + result.error.issues[0].message, 400), 400);
   }
 
-  const { question, history } = result.data;
-  const answer = await ask(question, history);
+  const { question, ...options } = result.data;
+  const answer = await ask(question, options);
   return c.json({ answer });
 });
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -75,15 +75,26 @@ export interface HistoryMessage {
   content: string;
 }
 
+export interface AskOptions {
+  history?: HistoryMessage[];
+  /** Campaign UUID — reserved for future campaign context loading. */
+  campaignId?: string;
+  /** User UUID — reserved for future player context loading. */
+  userId?: string;
+}
+
 /**
  * Answer a Frosthaven rules question using the bundled RAG pipeline.
  * This is the "graduated optimization" convenience path — it composes
  * the atomic tools (searchRules, searchCards) with an LLM call.
  *
- * @param history - Optional conversation history for multi-turn context.
+ * @param options.history - Optional conversation history for multi-turn context.
  *   Truncated to the last {@link MAX_HISTORY_TURNS} messages.
+ * @param options.campaignId - Optional campaign UUID. Reserved for future use —
+ *   campaign context loading depends on #94 (data isolation design).
+ * @param options.userId - Optional user UUID. Reserved for future use.
  */
-export async function ask(question: string, history?: HistoryMessage[]): Promise<string> {
+export async function ask(question: string, options?: AskOptions): Promise<string> {
   if (!ready) {
     throw new Error('Service not initialized. Call initialize() first.');
   }
@@ -105,6 +116,7 @@ export async function ask(question: string, history?: HistoryMessage[]): Promise
   const userMessage = `## Rulebook Excerpts\n\n${rulebookContext}${cardContext}\n\n---\n\nQuestion: ${question}`;
 
   // Step 3: Build messages array with optional history
+  const history = options?.history;
   const truncatedHistory = history ? history.slice(-MAX_HISTORY_TURNS) : [];
   const messages = [
     ...truncatedHistory.map((m) => ({ role: m.role, content: m.content })),

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -334,7 +334,7 @@ describe('POST /api/ask', () => {
       headers: { 'Content-Type': 'application/json', ...(await auth()) },
       body: JSON.stringify({ question: 'What is the loot action?' }),
     });
-    expect(mockAsk).toHaveBeenCalledWith('What is the loot action?', undefined);
+    expect(mockAsk).toHaveBeenCalledWith('What is the loot action?', {});
   });
 
   it('returns 400 when question is missing', async () => {
@@ -374,7 +374,7 @@ describe('POST /api/ask', () => {
       headers: { 'Content-Type': 'application/json', ...(await auth()) },
       body: JSON.stringify({ question: 'What about traps?', history }),
     });
-    expect(mockAsk).toHaveBeenCalledWith('What about traps?', history);
+    expect(mockAsk).toHaveBeenCalledWith('What about traps?', { history });
   });
 
   it('works without history (backward compatible)', async () => {
@@ -383,7 +383,36 @@ describe('POST /api/ask', () => {
       headers: { 'Content-Type': 'application/json', ...(await auth()) },
       body: JSON.stringify({ question: 'What is loot?' }),
     });
-    expect(mockAsk).toHaveBeenCalledWith('What is loot?', undefined);
+    expect(mockAsk).toHaveBeenCalledWith('What is loot?', {});
+  });
+
+  it('passes campaignId and userId to ask()', async () => {
+    const campaignId = '550e8400-e29b-41d4-a716-446655440000';
+    const userId = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+    await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'What items do I have?', campaignId, userId }),
+    });
+    expect(mockAsk).toHaveBeenCalledWith('What items do I have?', { campaignId, userId });
+  });
+
+  it('returns 400 for non-UUID campaignId', async () => {
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'test', campaignId: 'not-a-uuid' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for non-UUID userId', async () => {
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'test', userId: 'not-a-uuid' }),
+    });
+    expect(res.status).toBe(400);
   });
 
   it('returns 400 for invalid history role', async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -162,7 +162,7 @@ describe('ask', () => {
       { role: 'user' as const, content: 'What is loot?' },
       { role: 'assistant' as const, content: 'Loot tokens are picked up in your hex.' },
     ];
-    await ask('What about traps?', history);
+    await ask('What about traps?', { history });
     const messages = mockMessagesCreate.mock.calls[0][0].messages;
     expect(messages).toHaveLength(3);
     expect(messages[0]).toEqual({ role: 'user', content: 'What is loot?' });
@@ -188,12 +188,31 @@ describe('ask', () => {
       role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
       content: `message ${i}`,
     }));
-    await ask('Final question', history);
+    await ask('Final question', { history });
     const messages = mockMessagesCreate.mock.calls[0][0].messages;
     // 20 history + 1 context = 21
     expect(messages).toHaveLength(21);
     // Should keep the last 20 (indices 10-29)
     expect(messages[0].content).toBe('message 10');
+  });
+
+  it('accepts options object with history', async () => {
+    await initialize();
+    const history = [{ role: 'user' as const, content: 'What is loot?' }];
+    await ask('Follow-up', { history });
+    const messages = mockMessagesCreate.mock.calls[0][0].messages;
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toEqual({ role: 'user', content: 'What is loot?' });
+  });
+
+  it('accepts campaignId and userId in options', async () => {
+    await initialize();
+    await ask('What items do I have?', {
+      campaignId: '550e8400-e29b-41d4-a716-446655440000',
+      userId: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+    });
+    // Should still produce a valid answer (campaign context not loaded yet)
+    expect(mockMessagesCreate).toHaveBeenCalled();
   });
 
   it('throws if not initialized', async () => {


### PR DESCRIPTION
## Summary
- Add optional `campaignId` (UUID) and `userId` (UUID) parameters to `/api/ask`
- Refactor `ask()` from positional args to an `AskOptions` object for cleaner extensibility
- Zod validates UUID format; non-UUID values return 400
- Actual campaign data loading is deferred — depends on #94 (data isolation design) and #70-72 (campaign state)
- Backward compatible — omitting both fields works as before

## Test plan
- [x] Service tests: options object with history, campaignId, userId
- [x] Endpoint tests: passthrough, UUID validation (400 for non-UUID), backward compat
- [x] All 237 tests pass
- [x] Lint clean

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/api/ask` endpoint now accepts two new optional parameters: `campaignId` and `userId`. These fields are reserved for future use and do not affect current API behavior. All existing requests remain fully compatible.

* **Tests**
  * Expanded test coverage to validate new parameters and ensure backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->