### PR TITLE
feat(api): stream /api/ask responses via SSE

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -7,11 +7,12 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { searchRules, searchCards, listCardTypes, listCards, getCard } from './tools.ts';
 import type { CardType } from './schemas.ts';
-import type { AskOptions, HistoryMessage } from './service.ts';
+import type { AskOptions, HistoryMessage, EmitFn } from './service.ts';
 
 type MessageParam = Anthropic.MessageParam;
 type Tool = Anthropic.Tool;
 type ContentBlockParam = Anthropic.ContentBlockParam;
+type Message = Anthropic.Message;
 
 const client = new Anthropic();
 
@@ -156,11 +157,39 @@ export async function executeToolCall(
 }
 
 /**
+ * Call the Claude API, either streaming or non-streaming based on emit.
+ * Returns the final Message in both cases.
+ */
+async function callClaude(messages: MessageParam[], emit?: EmitFn): Promise<Message> {
+  const params = {
+    model: 'claude-sonnet-4-6' as const,
+    max_tokens: 4096,
+    system: AGENT_SYSTEM_PROMPT,
+    tools: AGENT_TOOLS,
+    messages,
+  };
+
+  if (!emit) {
+    return client.messages.create(params);
+  }
+
+  const stream = client.messages.stream(params);
+  stream.on('text', (delta) => {
+    void emit('text', { delta });
+  });
+  return stream.finalMessage();
+}
+
+/**
  * Run the knowledge agent loop. Claude decides which tools to call,
  * iterates until it has enough context, then produces a final answer.
+ *
+ * When `options.emit` is provided, text is streamed as it's generated
+ * and tool activity is emitted as events.
  */
 export async function runAgentLoop(question: string, options?: AskOptions): Promise<string> {
   const history = options?.history;
+  const emit = options?.emit;
   const truncatedHistory = history ? history.slice(-MAX_HISTORY_TURNS) : [];
 
   const messages: MessageParam[] = [
@@ -174,13 +203,7 @@ export async function runAgentLoop(question: string, options?: AskOptions): Prom
   let lastTextContent = '';
 
   for (let i = 0; i < MAX_AGENT_ITERATIONS; i++) {
-    const response = await client.messages.create({
-      model: 'claude-sonnet-4-6',
-      max_tokens: 4096,
-      system: AGENT_SYSTEM_PROMPT,
-      tools: AGENT_TOOLS,
-      messages,
-    });
+    const response = await callClaude(messages, emit);
 
     // Collect all text content from this response
     const texts: string[] = [];
@@ -195,6 +218,7 @@ export async function runAgentLoop(question: string, options?: AskOptions): Prom
 
     // If the model is done (no more tool calls), return the answer
     if (response.stop_reason === 'end_turn' || response.stop_reason === 'stop_sequence') {
+      if (emit) await emit('done', {});
       return lastTextContent;
     }
 
@@ -207,13 +231,15 @@ export async function runAgentLoop(question: string, options?: AskOptions): Prom
 
     // Process tool calls
     if (response.stop_reason === 'tool_use') {
-      // Add the assistant's response (with tool_use blocks) to messages
       messages.push({ role: 'assistant', content: response.content });
 
-      // Execute each tool call and build tool_result blocks
       const toolResults: ContentBlockParam[] = [];
       for (const block of response.content) {
         if (block.type === 'tool_use') {
+          if (emit) {
+            await emit('tool_call', { name: block.name, input: block.input });
+          }
+
           let result: string;
           let isError = false;
           try {
@@ -222,6 +248,11 @@ export async function runAgentLoop(question: string, options?: AskOptions): Prom
             result = `Tool error: ${err instanceof Error ? err.message : String(err)}`;
             isError = true;
           }
+
+          if (emit) {
+            await emit('tool_result', { name: block.name });
+          }
+
           toolResults.push({
             type: 'tool_result',
             tool_use_id: block.id,
@@ -236,9 +267,11 @@ export async function runAgentLoop(question: string, options?: AskOptions): Prom
     }
 
     // Unrecoverable stop reasons (refusal, context window exceeded, etc.)
+    if (emit) await emit('done', {});
     return lastTextContent || 'I was unable to answer this question.';
   }
 
-  // Iteration limit reached — return whatever text we have
+  // Iteration limit reached
+  if (emit) await emit('done', {});
   return lastTextContent || 'I was unable to produce an answer within the allowed number of steps.';
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@
 
 import 'dotenv/config';
 import { Hono } from 'hono';
+import { streamSSE } from 'hono/streaming';
 import { isReady, initialize, ask } from './service.ts';
 import { loadIndex } from './vector-store.ts';
 import { searchRules, searchCards, listCardTypes, listCards, getCard } from './tools.ts';
@@ -307,8 +308,21 @@ app.post('/api/ask', async (c) => {
   }
 
   const { question, ...options } = result.data;
-  const answer = await ask(question, options);
-  return c.json({ answer });
+  return streamSSE(c, async (stream) => {
+    try {
+      await ask(question, {
+        ...options,
+        emit: async (event, data) => {
+          await stream.writeSSE({ event, data: JSON.stringify(data) });
+        },
+      });
+    } catch {
+      await stream.writeSSE({
+        event: 'error',
+        data: JSON.stringify({ message: 'Internal server error' }),
+      });
+    }
+  });
 });
 
 // ─── Server startup ──────────────────────────────────────────────────────────

--- a/src/service.ts
+++ b/src/service.ts
@@ -64,12 +64,16 @@ export interface HistoryMessage {
   content: string;
 }
 
+export type EmitFn = (event: string, data: unknown) => Promise<void>;
+
 export interface AskOptions {
   history?: HistoryMessage[];
   /** Campaign UUID — reserved for future campaign context loading. */
   campaignId?: string;
   /** User UUID — reserved for future player context loading. */
   userId?: string;
+  /** SSE emit callback. When provided, the agent streams text deltas and tool events. */
+  emit?: EmitFn;
 }
 
 /**

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -2,18 +2,25 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
-const { mockMessagesCreate, mockSearchRules, mockSearchCards, mockListCardTypes, mockGetCard } =
-  vi.hoisted(() => ({
-    mockMessagesCreate: vi.fn(),
-    mockSearchRules: vi.fn(),
-    mockSearchCards: vi.fn(),
-    mockListCardTypes: vi.fn(),
-    mockGetCard: vi.fn(),
-  }));
+const {
+  mockMessagesCreate,
+  mockMessagesStream,
+  mockSearchRules,
+  mockSearchCards,
+  mockListCardTypes,
+  mockGetCard,
+} = vi.hoisted(() => ({
+  mockMessagesCreate: vi.fn(),
+  mockMessagesStream: vi.fn(),
+  mockSearchRules: vi.fn(),
+  mockSearchCards: vi.fn(),
+  mockListCardTypes: vi.fn(),
+  mockGetCard: vi.fn(),
+}));
 
 vi.mock('@anthropic-ai/sdk', () => ({
   default: class {
-    messages = { create: mockMessagesCreate };
+    messages = { create: mockMessagesCreate, stream: mockMessagesStream };
   },
 }));
 
@@ -28,6 +35,27 @@ vi.mock('../src/tools.ts', () => ({
 import { runAgentLoop, executeToolCall, AGENT_TOOLS, MAX_AGENT_ITERATIONS } from '../src/agent.ts';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Create a mock MessageStream that emits text deltas and resolves to a final message. */
+function mockStream(finalMessage: Record<string, unknown>, textDeltas: string[] = []) {
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+  return {
+    on(event: string, cb: (...args: unknown[]) => void) {
+      listeners[event] = listeners[event] || [];
+      listeners[event].push(cb);
+      // Fire text deltas immediately after registration
+      if (event === 'text') {
+        for (const delta of textDeltas) {
+          cb(delta, '');
+        }
+      }
+      return this;
+    },
+    async finalMessage() {
+      return finalMessage;
+    },
+  };
+}
 
 /** Create a mock response where Claude returns text immediately (no tool use). */
 function textResponse(text: string) {
@@ -252,5 +280,64 @@ describe('executeToolCall', () => {
   it('returns error for unknown tool', async () => {
     const result = await executeToolCall('unknown_tool', {});
     expect(result).toContain('Unknown tool');
+  });
+});
+
+// ─── streaming ───────────────────────────────────────────────────────────────
+
+describe('runAgentLoop with emit (streaming)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchRules.mockResolvedValue([
+      { text: 'Loot: pick up all loot tokens.', source: 'rulebook.pdf:42', score: 0.9 },
+    ]);
+    mockSearchCards.mockReturnValue([]);
+    mockGetCard.mockReturnValue({ name: 'Boots of Speed', effect: 'Move +1' });
+  });
+
+  it('uses stream() instead of create() when emit is provided', async () => {
+    const msg = textResponse('Streamed answer');
+    mockMessagesStream.mockReturnValue(mockStream(msg, ['Streamed ', 'answer']));
+    const emit = vi.fn().mockResolvedValue(undefined);
+
+    await runAgentLoop('test', { emit });
+    expect(mockMessagesStream).toHaveBeenCalledTimes(1);
+    expect(mockMessagesCreate).not.toHaveBeenCalled();
+  });
+
+  it('emits text deltas', async () => {
+    const msg = textResponse('Hello world');
+    mockMessagesStream.mockReturnValue(mockStream(msg, ['Hello ', 'world']));
+    const emit = vi.fn().mockResolvedValue(undefined);
+
+    await runAgentLoop('test', { emit });
+    expect(emit).toHaveBeenCalledWith('text', { delta: 'Hello ' });
+    expect(emit).toHaveBeenCalledWith('text', { delta: 'world' });
+  });
+
+  it('emits done event at the end', async () => {
+    const msg = textResponse('Done');
+    mockMessagesStream.mockReturnValue(mockStream(msg, ['Done']));
+    const emit = vi.fn().mockResolvedValue(undefined);
+
+    await runAgentLoop('test', { emit });
+    expect(emit).toHaveBeenCalledWith('done', {});
+  });
+
+  it('emits tool_call and tool_result events', async () => {
+    const toolMsg = toolUseResponse('search_rules', { query: 'loot' });
+    const finalMsg = textResponse('Answer');
+    mockMessagesStream
+      .mockReturnValueOnce(mockStream(toolMsg))
+      .mockReturnValueOnce(mockStream(finalMsg, ['Answer']));
+    const emit = vi.fn().mockResolvedValue(undefined);
+
+    await runAgentLoop('test', { emit });
+    expect(emit).toHaveBeenCalledWith('tool_call', {
+      name: 'search_rules',
+      input: { query: 'loot' },
+    });
+    expect(emit).toHaveBeenCalledWith('tool_result', { name: 'search_rules' });
+    expect(emit).toHaveBeenCalledWith('done', {});
   });
 });

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -311,30 +311,52 @@ describe('GET /api/cards/:type/:id', () => {
 
 // ─── POST /api/ask ───────────────────────────────────────────────────────────
 
+/** Parse SSE events from a response body string. */
+function parseSSE(text: string): Array<{ event?: string; data: string }> {
+  return text
+    .split('\n\n')
+    .filter((block) => block.trim())
+    .map((block) => {
+      const lines = block.split('\n');
+      const event = lines
+        .find((l) => l.startsWith('event:'))
+        ?.slice(6)
+        .trim();
+      const data =
+        lines
+          .find((l) => l.startsWith('data:'))
+          ?.slice(5)
+          .trim() ?? '';
+      return { event, data };
+    });
+}
+
 describe('POST /api/ask', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAsk.mockResolvedValue('Loot tokens are picked up in your hex.');
   });
 
-  it('returns an answer for a valid question', async () => {
+  it('returns SSE content type', async () => {
     const res = await app.request('/api/ask', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...(await auth()) },
       body: JSON.stringify({ question: 'What is the loot action?' }),
     });
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body).toHaveProperty('answer', 'Loot tokens are picked up in your hex.');
+    expect(res.headers.get('content-type')).toContain('text/event-stream');
   });
 
-  it('calls service.ask with the question', async () => {
+  it('calls service.ask with the question and emit callback', async () => {
     await app.request('/api/ask', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...(await auth()) },
       body: JSON.stringify({ question: 'What is the loot action?' }),
     });
-    expect(mockAsk).toHaveBeenCalledWith('What is the loot action?', {});
+    expect(mockAsk).toHaveBeenCalledWith(
+      'What is the loot action?',
+      expect.objectContaining({ emit: expect.any(Function) }),
+    );
   });
 
   it('returns 400 when question is missing', async () => {
@@ -374,16 +396,7 @@ describe('POST /api/ask', () => {
       headers: { 'Content-Type': 'application/json', ...(await auth()) },
       body: JSON.stringify({ question: 'What about traps?', history }),
     });
-    expect(mockAsk).toHaveBeenCalledWith('What about traps?', { history });
-  });
-
-  it('works without history (backward compatible)', async () => {
-    await app.request('/api/ask', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...(await auth()) },
-      body: JSON.stringify({ question: 'What is loot?' }),
-    });
-    expect(mockAsk).toHaveBeenCalledWith('What is loot?', {});
+    expect(mockAsk).toHaveBeenCalledWith('What about traps?', expect.objectContaining({ history }));
   });
 
   it('passes campaignId and userId to ask()', async () => {
@@ -394,7 +407,10 @@ describe('POST /api/ask', () => {
       headers: { 'Content-Type': 'application/json', ...(await auth()) },
       body: JSON.stringify({ question: 'What items do I have?', campaignId, userId }),
     });
-    expect(mockAsk).toHaveBeenCalledWith('What items do I have?', { campaignId, userId });
+    expect(mockAsk).toHaveBeenCalledWith(
+      'What items do I have?',
+      expect.objectContaining({ campaignId, userId }),
+    );
   });
 
   it('returns 400 for non-UUID campaignId', async () => {
@@ -448,17 +464,19 @@ describe('POST /api/ask', () => {
     expect(res.status).toBe(400);
   });
 
-  it('returns 500 when ask() throws', async () => {
+  it('emits error event when ask() throws', async () => {
     mockAsk.mockRejectedValue(new Error('Claude API error'));
     const res = await app.request('/api/ask', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...(await auth()) },
       body: JSON.stringify({ question: 'test' }),
     });
-    expect(res.status).toBe(500);
-    const body = await res.json();
-    expect(body).toHaveProperty('error', 'Internal server error');
-    expect(body).toHaveProperty('status', 500);
+    expect(res.status).toBe(200); // SSE streams always return 200
+    const text = await res.text();
+    const events = parseSSE(text);
+    const errorEvent = events.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect(JSON.parse(errorEvent!.data)).toHaveProperty('message', 'Internal server error');
   });
 });
 


### PR DESCRIPTION
## Summary
- Switch `/api/ask` from JSON to Server-Sent Events (SSE) streaming
- Add `emit` callback to `AskOptions` — agent uses `client.messages.stream()` when provided
- SSE events: `text` (delta), `tool_call`, `tool_result`, `done`, `error`
- No new endpoints or function renames — same `/api/ask`, same `ask()`, same `runAgentLoop()`

## Test plan
- [x] Agent tests: streaming text deltas, tool events, done event (4 new tests)
- [x] Server tests: SSE content type, emit callback passed through, error events
- [x] All 250 tests pass
- [x] Lint clean

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/api/ask` endpoint now returns streamed responses via Server-Sent Events, delivering agent text updates and tool execution events in real-time as requests are processed instead of waiting for the complete response to finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->