### PR TITLE
feat(data): import personal quest data from GHS

### DIFF
--- a/data/extracted/personal-quests.json
+++ b/data/extracted/personal-quests.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:899328b6b900f5ec06a62ec86236ae4b8971c6137099e18134073e7a1af1f9cc
+size 9491

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -30,6 +30,7 @@ const CARD_TYPES = [
   'events',
   'battle-goals',
   'buildings',
+  'personal-quests',
 ] as const;
 
 export const AGENT_SYSTEM_PROMPT = `You are a knowledgeable Frosthaven rules assistant with access to tools \

--- a/src/extract-card-data.ts
+++ b/src/extract-card-data.ts
@@ -36,7 +36,9 @@ interface CardTypeConfig {
   context: string;
 }
 
-const CARD_TYPES: Record<CardType, CardTypeConfig> = {
+// Card types that have image-based OCR extraction. Not all CardTypes are here —
+// types like personal-quests are imported directly from structured GHS data.
+const CARD_TYPES: Partial<Record<CardType, CardTypeConfig>> = {
   'monster-stats': {
     imageDir: join(IMAGES_BASE, 'monster-stat-cards', 'frosthaven'),
     filter: (f) => f.endsWith('.png'),
@@ -117,7 +119,9 @@ export function extractNumberFromFilename(filename: string, cardType: CardType):
 // ─── Image collection ─────────────────────────────────────────────────────────
 
 export function collectImages(cardType: CardType): string[] {
-  const config = CARD_TYPES[cardType];
+  const maybeConfig = CARD_TYPES[cardType];
+  if (!maybeConfig) return [];
+  const config: CardTypeConfig = maybeConfig;
   const images: string[] = [];
 
   function scanDir(dir: string): void {

--- a/src/extracted-data.ts
+++ b/src/extracted-data.ts
@@ -20,6 +20,7 @@ export const TYPES: CardType[] = [
   'events',
   'battle-goals',
   'buildings',
+  'personal-quests',
 ];
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -114,6 +115,26 @@ function recordToText(record: ExtractedRecord): string {
   if (t === 'battle-goals') {
     const r = record as ExtractedRecord;
     return `Battle Goal: "${r.name}". Condition: ${r.condition}. Checkmarks: ${r.checkmarks}.`;
+  }
+
+  if (t === 'personal-quests') {
+    const r = record as ExtractedRecord;
+    const reqs =
+      (r.requirements as Array<{
+        description: string;
+        target: number | string;
+        options: string[] | null;
+        dependsOn: number[] | null;
+      }>) || [];
+    const reqText = reqs
+      .map((req, i) => {
+        let line = `${i + 1}. ${req.description} (target: ${req.target})`;
+        if (req.options) line += ` [${req.options.join(', ')}]`;
+        if (req.dependsOn) line += ` (requires step ${req.dependsOn.join(', ')})`;
+        return line;
+      })
+      .join('; ');
+    return `Personal Quest #${r.cardId}: "${r.name}". Requirements: ${reqText}. Completion: open envelope ${r.openEnvelope}.`;
   }
 
   if (t === 'buildings') {

--- a/src/import-personal-quests.ts
+++ b/src/import-personal-quests.ts
@@ -1,0 +1,162 @@
+/**
+ * Import personal quest data from Gloomhaven Secretariat (GHS) reference data.
+ *
+ * Run with: npx tsx src/import-personal-quests.ts
+ *
+ * Requires: data/gloomhavensecretariat/ (git submodule)
+ * Output: data/extracted/personal-quests.json
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  GHS_DATA_DIR,
+  resolveLabel,
+  resolveGameTokens,
+  loadLabels,
+  type LabelData,
+} from './ghs-utils.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const GHS_PERSONAL_QUESTS_PATH = join(GHS_DATA_DIR, 'personal-quests.json');
+const OUTPUT_PATH = join(__dirname, '..', 'data', 'extracted', 'personal-quests.json');
+
+// ─── GHS types ──────────────────────────────────────────────────────────────
+
+interface GhsRequirement {
+  name: string;
+  counter: number | string;
+  checkbox?: string[];
+  autotrack?: string;
+  requires?: number[];
+}
+
+interface GhsPersonalQuest {
+  cardId: string;
+  altId: string;
+  spoiler?: boolean;
+  requirements: GhsRequirement[];
+  openEnvelope: string;
+  errata?: string;
+}
+
+// ─── Our extracted format ───────────────────────────────────────────────────
+
+interface ExtractedRequirement {
+  description: string;
+  target: number | string;
+  options: string[] | null;
+  dependsOn: number[] | null;
+}
+
+interface ExtractedPersonalQuest {
+  cardId: string;
+  name: string;
+  requirements: ExtractedRequirement[];
+  openEnvelope: string;
+  _source: string;
+}
+
+// ─── Conversion ─────────────────────────────────────────────────────────────
+
+/**
+ * Resolve %character.X.Y% tokens to human-readable text, using the same
+ * last-segment approach as resolveGameTokens.
+ */
+function resolveCharacterTokens(text: string): string {
+  return text.replace(/%character\.([^%]+)%/g, (_match, path: string) => {
+    const parts = path.split('.');
+    const lastPart = parts[parts.length - 1];
+    return lastPart.charAt(0).toUpperCase() + lastPart.slice(1);
+  });
+}
+
+/**
+ * Resolve a requirement name to human-readable text.
+ * Handles %data.% label references, %game.% tokens, and %character.% tokens.
+ */
+function resolveRequirementName(name: string, labels: LabelData): string {
+  if (name.startsWith('%data.')) {
+    return resolveLabel(name, labels);
+  }
+  // For non-%data. refs, resolve both game and character tokens
+  let result = resolveGameTokens(name);
+  result = resolveCharacterTokens(result);
+  return result;
+}
+
+/**
+ * Look up the quest title from labels. Falls back to "Personal Quest {cardId}"
+ * if the label is missing.
+ */
+function resolveQuestTitle(cardId: string, labels: LabelData): string {
+  const ref = `%data.personalQuest.fh.${cardId}.%`;
+  const resolved = resolveLabel(ref, labels);
+  if (resolved === ref) {
+    return `Personal Quest ${cardId}`;
+  }
+  return resolved;
+}
+
+export function convertPersonalQuest(
+  ghs: GhsPersonalQuest,
+  labels: LabelData,
+): ExtractedPersonalQuest {
+  const requirements: ExtractedRequirement[] = ghs.requirements.map((req) => {
+    const description = resolveRequirementName(req.name, labels);
+
+    const options = req.checkbox ? req.checkbox.map((opt) => resolveGameTokens(opt)) : null;
+
+    return {
+      description,
+      target: req.counter,
+      options,
+      dependsOn: req.requires ?? null,
+    };
+  });
+
+  return {
+    cardId: ghs.cardId,
+    name: resolveQuestTitle(ghs.cardId, labels),
+    requirements,
+    openEnvelope: ghs.openEnvelope,
+    _source: `gloomhavensecretariat:personal-quest/${ghs.cardId}`,
+  };
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+export function importPersonalQuests(): ExtractedPersonalQuest[] {
+  const labels = loadLabels();
+  const quests: GhsPersonalQuest[] = JSON.parse(readFileSync(GHS_PERSONAL_QUESTS_PATH, 'utf-8'));
+
+  const results: ExtractedPersonalQuest[] = [];
+
+  for (const quest of quests) {
+    const converted = convertPersonalQuest(quest, labels);
+
+    // Verify all data/game tokens were resolved
+    const allText = [
+      converted.name,
+      ...converted.requirements.map((r) => r.description),
+      ...converted.requirements.flatMap((r) => r.options ?? []),
+    ];
+    const unresolved = allText.find((t) => /%(?:data|game|character)\./.test(t));
+    if (unresolved) {
+      throw new Error(`Unresolved label/token in personal quest ${quest.cardId}: ${unresolved}`);
+    }
+
+    results.push(converted);
+  }
+
+  return results;
+}
+
+if (process.argv[1]?.endsWith('import-personal-quests.ts')) {
+  const results = importPersonalQuests();
+  mkdirSync(dirname(OUTPUT_PATH), { recursive: true });
+  writeFileSync(OUTPUT_PATH, JSON.stringify(results, null, 2), 'utf-8');
+  console.log(`Wrote ${results.length} records to ${OUTPUT_PATH}`);
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -18,6 +18,7 @@ const CARD_TYPES = [
   'events',
   'battle-goals',
   'buildings',
+  'personal-quests',
 ] as const;
 
 export function createMcpServer(): McpServer {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -136,6 +136,28 @@ export const BuildingSchema = z.object({
   notes: nullableStr.describe('Any other relevant text, or null'),
 });
 
+const PersonalQuestRequirementSchema = z.object({
+  description: z.string().describe('Human-readable requirement text'),
+  target: z
+    .union([z.number().int(), z.string()])
+    .describe('Counter target (number) or formula string (e.g. "80+20xP")'),
+  options: z
+    .array(z.string())
+    .nullable()
+    .describe('Checkbox options (e.g. herb names), or null if not applicable'),
+  dependsOn: z
+    .array(z.number().int())
+    .nullable()
+    .describe('1-based indices of prerequisite requirements, or null'),
+});
+
+export const PersonalQuestSchema = z.object({
+  cardId: z.string().describe('Personal quest card ID'),
+  name: z.string().describe('Quest title'),
+  requirements: z.array(PersonalQuestRequirementSchema).describe('Completion requirements'),
+  openEnvelope: z.string().describe('Envelope/section references to open on completion'),
+});
+
 export const SCHEMAS = {
   'monster-stats': MonsterStatSchema,
   'monster-abilities': MonsterAbilitySchema,
@@ -144,6 +166,7 @@ export const SCHEMAS = {
   events: EventSchema,
   'battle-goals': BattleGoalSchema,
   buildings: BuildingSchema,
+  'personal-quests': PersonalQuestSchema,
 } as const;
 
 export type CardType = keyof typeof SCHEMAS;
@@ -156,6 +179,7 @@ export type Item = z.infer<typeof ItemSchema>;
 export type Event = z.infer<typeof EventSchema>;
 export type BattleGoal = z.infer<typeof BattleGoalSchema>;
 export type Building = z.infer<typeof BuildingSchema>;
+export type PersonalQuest = z.infer<typeof PersonalQuestSchema>;
 export type CardData =
   | MonsterStat
   | MonsterAbility
@@ -163,4 +187,5 @@ export type CardData =
   | Item
   | Event
   | BattleGoal
-  | Building;
+  | Building
+  | PersonalQuest;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -114,6 +114,7 @@ const ID_FIELDS: Record<CardType, string> = {
   events: 'number',
   'battle-goals': 'name',
   buildings: 'buildingNumber',
+  'personal-quests': 'cardId',
 };
 
 /**

--- a/test/import-personal-quests.test.ts
+++ b/test/import-personal-quests.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { convertPersonalQuest } from '../src/import-personal-quests.ts';
+import type { LabelData } from '../src/ghs-utils.ts';
+
+const labels: LabelData = {
+  personalQuest: {
+    fh: {
+      '100': {
+        '': 'Test Quest Title',
+        '1': 'Things collected',
+        '2': 'Follow "Some Place" %game.scenarioNumber:42% to a conclusion',
+      },
+      '200': {
+        '': 'Checkbox Quest',
+        '1': 'Different herbs looted',
+      },
+      '300': {
+        '': 'Multi Requirement',
+        '1': 'First thing done',
+        '2': 'Second thing done',
+        '3': 'Third thing done',
+      },
+    },
+  },
+};
+
+describe('convertPersonalQuest', () => {
+  it('converts a simple single-requirement quest', () => {
+    const ghs = {
+      cardId: '100',
+      altId: '01',
+      requirements: [{ name: '%data.personalQuest.fh.100.1%', counter: 5 }],
+      openEnvelope: '24:42',
+    };
+
+    const result = convertPersonalQuest(ghs, labels);
+
+    expect(result).toEqual({
+      cardId: '100',
+      name: 'Test Quest Title',
+      requirements: [
+        {
+          description: 'Things collected',
+          target: 5,
+          options: null,
+          dependsOn: null,
+        },
+      ],
+      openEnvelope: '24:42',
+      _source: 'gloomhavensecretariat:personal-quest/100',
+    });
+  });
+
+  it('resolves game tokens in requirement text', () => {
+    const ghs = {
+      cardId: '100',
+      altId: '02',
+      requirements: [
+        { name: '%data.personalQuest.fh.100.1%', counter: 8 },
+        {
+          name: '%data.personalQuest.fh.100.2%',
+          counter: 1,
+          requires: [1],
+        },
+      ],
+      openEnvelope: '24:42',
+    };
+
+    const result = convertPersonalQuest(ghs, labels);
+
+    expect(result.requirements[1].description).toBe(
+      'Follow "Some Place" ScenarioNumber 42 to a conclusion',
+    );
+    expect(result.requirements[1].dependsOn).toEqual([1]);
+  });
+
+  it('converts checkbox options with game tokens', () => {
+    const ghs = {
+      cardId: '200',
+      altId: '03',
+      requirements: [
+        {
+          name: '%data.personalQuest.fh.200.1%',
+          counter: 3,
+          checkbox: ['%game.resource.arrowvine%', '%game.resource.axenut%'],
+        },
+      ],
+      openEnvelope: '37:74',
+    };
+
+    const result = convertPersonalQuest(ghs, labels);
+
+    expect(result.requirements[0].options).toEqual(['Arrowvine', 'Axenut']);
+  });
+
+  it('handles multiple requirements with dependencies', () => {
+    const ghs = {
+      cardId: '300',
+      altId: '04',
+      requirements: [
+        { name: '%data.personalQuest.fh.300.1%', counter: 5 },
+        { name: '%data.personalQuest.fh.300.2%', counter: 3, requires: [1] },
+        { name: '%data.personalQuest.fh.300.3%', counter: 1, requires: [1, 2] },
+      ],
+      openEnvelope: '90:83',
+    };
+
+    const result = convertPersonalQuest(ghs, labels);
+
+    expect(result.requirements).toHaveLength(3);
+    expect(result.requirements[0].dependsOn).toBeNull();
+    expect(result.requirements[1].dependsOn).toEqual([1]);
+    expect(result.requirements[2].dependsOn).toEqual([1, 2]);
+  });
+
+  it('handles non-%data. name references as fallback text', () => {
+    const ghs = {
+      cardId: '400',
+      altId: '05',
+      requirements: [{ name: '%character.progress.gold%', counter: '80+20xP' }],
+      openEnvelope: '37:74',
+    };
+
+    const result = convertPersonalQuest(ghs, labels);
+
+    // Falls back to resolving game tokens on the name itself
+    expect(result.requirements[0].description).toBe('Gold');
+    expect(result.requirements[0].target).toBe('80+20xP');
+    // Quest title comes from labels — not found here, so falls back to cardId
+    expect(result.name).toBe('Personal Quest 400');
+  });
+
+  it('handles formula counter strings', () => {
+    const ghs = {
+      cardId: '100',
+      altId: '06',
+      requirements: [{ name: '%data.personalQuest.fh.100.1%', counter: '80+20xP' }],
+      openEnvelope: '24:42',
+    };
+
+    const result = convertPersonalQuest(ghs, labels);
+
+    expect(result.requirements[0].target).toBe('80+20xP');
+  });
+
+  it('preserves errata field when present', () => {
+    const ghs = {
+      cardId: '100',
+      altId: '01',
+      requirements: [{ name: '%data.personalQuest.fh.100.1%', counter: 5 }],
+      openEnvelope: '24:42',
+      errata: 'env24',
+    };
+
+    // errata is not in our extracted schema — just ensure it doesn't break
+    const result = convertPersonalQuest(ghs, labels);
+    expect(result.cardId).toBe('100');
+  });
+
+  it('sets options to null when no checkbox present', () => {
+    const ghs = {
+      cardId: '100',
+      altId: '01',
+      requirements: [{ name: '%data.personalQuest.fh.100.1%', counter: 5 }],
+      openEnvelope: '24:42',
+    };
+
+    const result = convertPersonalQuest(ghs, labels);
+    expect(result.requirements[0].options).toBeNull();
+  });
+});

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -218,9 +218,9 @@ describe('listCardTypes', () => {
     expect(events!.count).toBe(0);
   });
 
-  it('returns all 7 card types', () => {
+  it('returns all 8 card types', () => {
     const types = listCardTypes();
-    expect(types.length).toBe(7);
+    expect(types.length).toBe(8);
     const typeNames = types.map((t) => t.type);
     expect(typeNames).toContain('monster-stats');
     expect(typeNames).toContain('monster-abilities');
@@ -229,6 +229,7 @@ describe('listCardTypes', () => {
     expect(typeNames).toContain('events');
     expect(typeNames).toContain('battle-goals');
     expect(typeNames).toContain('buildings');
+    expect(typeNames).toContain('personal-quests');
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #130

- Define `PersonalQuestSchema` with requirements (counter targets, checkbox options, dependency chains)
- Add `import-personal-quests.ts` that resolves GHS label templates and game/character tokens
- Register `personal-quests` as a new card type in extracted-data, MCP server, agent, and tools
- Extract 23 personal quest records to `data/extracted/personal-quests.json`
- Add unit tests covering conversion, token resolution, checkboxes, dependencies, and fallback handling

## Test plan

- [x] 8 unit tests for `convertPersonalQuest` covering all edge cases
- [x] Full test suite passes (322 tests)
- [x] TypeScript compiles cleanly
- [x] ESLint passes on all changed files
- [x] Import script produces 23 valid records with no unresolved tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added personal quests as a new card type available for listing and querying throughout the system
  * Personal quest requirements now include descriptions, completion targets, optional selections, and prerequisite dependency tracking
  * System now supports importing and processing personal quest data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->