### PR TITLE
feat: add persisted web conversation backend

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,13 @@
+#!/usr/bin/env sh
+set -e
+
 if [ -s "$HOME/.nvm/nvm.sh" ]; then
   . "$HOME/.nvm/nvm.sh"
   nvm use >/dev/null 2>&1 || true
+fi
+
+hook_path=$(git config --get core.hooksPath 2>/dev/null || true)
+if [ "$hook_path" != ".husky" ]; then
+  echo "WARNING: Git hooks are not installed for this worktree."
+  echo "Run 'npm install' or 'npm run hooks:install' to restore local checks."
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,10 @@
-. "$HOME/.nvm/nvm.sh"
-nvm use >/dev/null 2>&1
+#!/usr/bin/env sh
+set -e
+
+if [ -s "$HOME/.nvm/nvm.sh" ]; then
+  . "$HOME/.nvm/nvm.sh"
+  nvm use >/dev/null 2>&1 || true
+fi
 
 staged_files=$(git diff --cached --name-only)
 if printf '%s\n' "$staged_files" | grep -Eq '^(CLAUDE\.md|AGENTS\.md|docs/agent/agent-baseline\.md|docs/agent/learnings\.md|docs/DEVELOPMENT\.md|\.mcp\.json|scripts/check-agent-parity\.ts|scripts/export-gstack-learnings\.ts)$'
@@ -7,6 +12,6 @@ then
   npm run agent:check
 fi
 
-npx tsc --noEmit
+npm run typecheck
 npx lint-staged
 npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,6 @@
+#!/usr/bin/env sh
+set -e
+
 if [ -s "$HOME/.nvm/nvm.sh" ]; then
   . "$HOME/.nvm/nvm.sh"
   nvm use >/dev/null 2>&1 || true
@@ -16,3 +19,5 @@ if [ "$branch" != "main" ] && [ -n "$branch" ]; then
     exit 1
   fi
 fi
+
+npm run check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,14 @@
 # Squire Project
 
-Start with the shared baseline:
+## Required first read
+
+Before doing any repo work, read the shared baseline:
 
 - [docs/agent/agent-baseline.md](docs/agent/agent-baseline.md)
+
+Do not start task-specific workflows, including `/ship`, `/review`, code
+changes, or repo investigation, until you have read that baseline and then
+loaded any task-specific docs it routes to.
 
 This file only records Codex-specific adapter details.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,14 @@
 # Squire Project
 
-Start with the shared baseline:
+## Required first read
+
+Before doing any repo work, read the shared baseline:
 
 - [docs/agent/agent-baseline.md](docs/agent/agent-baseline.md)
+
+Do not start task-specific workflows, including `/ship`, `/review`, code
+changes, or repo investigation, until you have read that baseline and then
+loaded any task-specific docs it routes to.
 
 This file only records Claude-specific adapter details.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ npm install
 # Add your API keys
 cp .env.example .env
 # Edit .env: ANTHROPIC_API_KEY (required), Google OAuth keys + SESSION_SECRET
-# (required for web UI login). See docs/DEVELOPMENT.md for the full list.
+# (required for web UI login). `GOOGLE_REDIRECT_URI` can stay on
+# `http://localhost:3000/auth/google/callback`; linked worktrees reuse the
+# current localhost origin at runtime, but every localhost callback port you use
+# still has to be pre-registered in Google Cloud Console. See
+# docs/DEVELOPMENT.md for the full list.
 
 # Start the local Postgres + pgvector database
 docker compose up -d
@@ -88,7 +92,9 @@ serves:
   `@tailwindcss/node` on first request and caches the result — no build
   step required on a fresh clone. Prod uses content-hashed URLs
   (`/app.<hash>.css`) with immutable caching. See
-  [ADR 0011](docs/adr/0011-on-demand-asset-pipeline.md))
+  [ADR 0011](docs/adr/0011-on-demand-asset-pipeline.md)). Authenticated chat
+  runs on `/chat` and `/chat/:conversationId`, with persisted per-user
+  conversations in Postgres.
 - **REST API** — `GET /api/health`, `/api/search/rules`, `/api/search/cards`,
   `/api/card-types`, `/api/cards`, `/api/cards/:type/:id`, `POST /api/ask`
 - **MCP endpoint** — `POST/GET/DELETE /mcp` (Streamable HTTP transport)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Squire Architecture
 
-**Version:** 1.0.2
+**Version:** 1.0.3
 **Date:** 2026-04-07
-**Last Refreshed:** 2026-04-08
+**Last Refreshed:** 2026-04-10
 **Owner:** Architect
 **Companion doc:** [SPEC.md](SPEC.md) — product / PM concerns (what / why / who / when)
 
@@ -54,7 +54,11 @@ Per-feature operations are _invocations_, not new tools. "Show me all level-4 ch
 
 Squire's web channel separates **conversation** from **knowledge**:
 
-- **Conversation agent** — thin session manager. Owns chat history, context compaction (summarizing older messages to keep the window bounded), streaming via Server-Sent Events, and presentation (Hono JSX rendering, citations, tool call visibility). One per client session.
+- **Conversation agent** — thin session manager. Owns persisted chat history,
+  failure persistence, ownership checks, streaming via Server-Sent Events, and
+  presentation (Hono JSX rendering, citations, tool call visibility). Real
+  context compaction and summarization remain future work (SQR-12). One per
+  client session.
 - **Knowledge agent** — the actual agent loop. Owns retrieval strategy (which atomic tools to call, in what order), reference resolution (turning "what items work with it?" into "Blinkblade items" via conversation history), campaign context loading (per Phase 4+), and answer generation. Stateless per request. Shared by all clients.
 
 The conversation agent does **not** call atomic tools directly. It delegates all domain reasoning to the knowledge agent via in-process function calls (or `/api/ask` HTTP calls when used for testing or by other channels). This keeps the conversation agent focused on session and UX concerns, and lets the knowledge agent's retrieval strategy evolve independently of the UI.
@@ -252,7 +256,7 @@ _Historical note: an earlier version of Squire used the worldhaven repository pl
 | Vector embeddings              | Postgres + pgvector (docker-compose)                           | Postgres + pgvector      |
 | Extracted card data            | Postgres `card_*` tables (seeded from `data/extracted/*.json`) | Postgres `card_*` tables |
 | OAuth tokens / clients         | N/A (Phase 1)                                                  | Postgres                 |
-| Conversation history           | In-memory per session                                          | Postgres                 |
+| Conversation history           | Postgres `conversations` + `messages`                          | Postgres                 |
 
 pgvector handles vector similarity search in the same database — no separate vector service at this scale. Source PDFs (~164MB) are inputs to indexing, not deployed artifacts; they live in `data/pdfs/` for local development and are excluded from the production image.
 
@@ -290,9 +294,14 @@ _Phase 5 (with the recommendation engine). See [SPEC.md](SPEC.md). Curated URL l
 
 ### User Conversations
 
-- Stored in Postgres (after Phase 3 multi-user platform), scoped to user
-- Bounded context window via summarization of older messages
-- Used as context for future turns
+- Stored in Postgres today via `conversations` and `messages`, scoped to user
+- Addressable on the web channel as `/chat/:conversationId`
+- Web writes persist the user turn first, then either the assistant answer or a
+  generic persisted failure turn
+- Failure turns are excluded from future history passed back into the knowledge
+  agent
+- History forwarded into `ask()` is capped to the most recent 20 non-error
+  messages. Real compaction and summarization remain deferred to SQR-12
 
 ---
 
@@ -301,7 +310,9 @@ _Phase 5 (with the recommendation engine). See [SPEC.md](SPEC.md). Curated URL l
 ### Core agent loop
 
 1. **Input:** User message (text)
-2. **Context gathering:** Load conversation history (with bounded summarization), identify caller identity from session, load campaign context if available
+2. **Context gathering:** Load recent conversation history (currently the most
+   recent 20 non-error messages), identify caller identity from session, load
+   campaign context if available
 3. **Tool use:** Claude calls atomic tools to retrieve relevant rules, cards, items, monsters, or scenarios
 4. **Reasoning:** Claude synthesizes a response from tool results
 5. **Response:** Stream back to the channel (web UI via SSE, MCP via protocol response)
@@ -483,9 +494,11 @@ An earlier design considered using **internal MCP** as the transport between the
 
 **Web UI conversation agent:**
 
-- Calls the knowledge agent's in-process entry point with question, conversation history, campaign ID
+- Calls the knowledge agent's in-process entry point with question, recent
+  stored conversation history, campaign ID
 - Does **not** call MCP tools directly — delegates domain reasoning to the knowledge agent
-- Owns session management: chat history, context compaction, streaming, presentation
+- Owns session management: persisted chat history, ownership checks, failure
+  persistence, and presentation. Context compaction remains future work
 
 **External MCP clients:**
 
@@ -625,7 +638,11 @@ For developer setup, running the server, working on import scripts locally, and 
 
 7. **Prompt injection.** The knowledge agent assembles context from multiple sources (rulebook, card data, conversation history, campaign state) and sends it to Claude. Every input path is a prompt injection surface. See [SECURITY.md](SECURITY.md) for the full threat model and mitigations.
 
-8. **OAuth implementation surface.** Custom auth is a real trust boundary. Use MCP SDK auth handlers, exact-match redirect URI validation, rate limit client registration, short-lived tokens with refresh rotation, encrypt at rest. See [SECURITY.md](SECURITY.md).
+8. **OAuth implementation surface.** Custom auth is a real trust boundary. Use
+   MCP SDK auth handlers, exact-match redirect URI validation, rate limit
+   client registration, hash bearer secrets at rest, and keep the long-lived
+   token policy under review as the threat model changes. See
+   [SECURITY.md](SECURITY.md).
 
 9. **Campaign data isolation (Phase 4).** Multiplayer campaigns require strict horizontal privilege separation — User A must not see User B's personal quest or battle goals, even via LLM-mediated leaks. The data isolation design must come **before** building the campaign data model, not after. See [SECURITY.md](SECURITY.md).
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -201,6 +201,12 @@ Generate `SESSION_SECRET` with:
 openssl rand -base64 48
 ```
 
+Keep `GOOGLE_REDIRECT_URI` on the main-checkout callback unless you want to
+move your primary local login flow. Linked worktrees now build the callback URL
+from their current localhost origin at runtime, but Google still requires exact
+redirect-URI matches, so every localhost callback port you use for browser QA
+must be pre-registered in the OAuth client in Google Cloud Console.
+
 ### Data files
 
 Extracted card data (`data/extracted/`) is committed to the repo as

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -338,15 +338,31 @@ debugging a single failure without waiting for the full suite.
 
 ## Pre-commit hooks
 
+Git hooks are installed automatically when you run `npm install`. Squire pins
+`core.hooksPath` to the checked-in `.husky` directory so linked worktrees use
+their own repo-local hooks instead of depending on generated Husky shims from a
+different checkout. If hook setup ever drifts in a worktree, repair it with
+`npm run hooks:install`.
+
 The pre-commit hook runs automatically on every commit:
 
-1. `tsc --noEmit` — type checking
+1. `npm run typecheck` — type checking
 2. `lint-staged` — ESLint + Prettier on staged `.ts`/`.js` files, stylelint +
    Prettier on staged `.css` files, Prettier on staged `.json`/`.yml`/`.yaml`
    files, markdownlint on staged `.md` files
 3. `npm test` — full test suite
 
 If any step fails, the commit is blocked. Fix the issue and try again.
+
+The pre-push hook runs `npm run check`, which is the local equivalent of the
+main CI gate:
+
+- `npm run typecheck`
+- `npm run lint`
+- `npm run lint:css`
+- `npm run lint:md`
+- `npm run format:check`
+- `npm test`
 
 ## Submitting changes
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,7 +36,18 @@ Generate `SESSION_SECRET` with:
 openssl rand -base64 48
 ```
 
-For local dev without Google OAuth, the app still starts and serves the homepage. Auth routes still need a valid `SESSION_SECRET`, and Google-backed login still needs working OAuth credentials. Run `npm run seed:dev` to create a test user for authenticated code paths without doing the Google round-trip.
+`GOOGLE_REDIRECT_URI` is still the configured fallback callback. In local
+development, `/auth/google/start` and `/auth/google/callback` reuse the current
+`localhost` origin so linked worktrees can log in on their own ports. Google
+still requires exact redirect-URI matches, so add every localhost callback port
+you use, such as `http://localhost:4450/auth/google/callback`, to the OAuth
+client in Google Cloud Console.
+
+For local dev without Google OAuth, the app still starts and serves the
+homepage. Auth routes still need a valid `SESSION_SECRET`, and Google-backed
+login still needs working OAuth credentials. Run `npm run seed:dev` to create a
+test user for authenticated code paths without doing the Google round-trip, but
+note that the browser sign-in UI still follows the real Google OAuth flow.
 
 Extracted card data (`data/extracted/*.json`) is committed to the repo.
 The rulebook vector index lives in Postgres (pgvector) and is populated by

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -301,6 +301,16 @@ npm run agent:check
 This is meant to package parity fixes into the same branch and PR as the
 primary change, instead of discovering drift later in CI or a follow-up pass.
 
+Git hooks are installed by `npm install` via the `prepare` script. Squire now
+pins `core.hooksPath` to the checked-in `.husky` directory instead of Husky's
+generated `._` shim path, so linked worktrees do not depend on generated hook
+files from another checkout. If a fresh worktree warns that hooks are missing,
+repair them with:
+
+```bash
+npm run hooks:install
+```
+
 `npm run agent:export-learnings` is **not** automated in git hooks. It reads
 machine-local `~/.gstack/projects/maz-org-squire/learnings.jsonl`, generates
 `docs/agent/learnings.md`, and should be run deliberately when the local
@@ -342,23 +352,25 @@ npm run test:watch    # Watch mode
 npm run typecheck     # TypeScript type checking
 npm run lint          # ESLint
 npm run lint:css      # stylelint (CSS, Tailwind v4 aware — SQR-70)
+npm run lint:md       # markdownlint
 npm run format:check  # Prettier check
+npm run check         # local CI gate: typecheck + lint + format + tests
 # No CSS build step — `/app.css` is compiled in-process on request
 # via @tailwindcss/node. SQR-71 / ADR 0011 replaced the former
 # `npm run build:css` pipeline.
 ```
 
 Tests use randomized execution order (`sequence.shuffle` in vitest
-config) to catch order-dependent tests. The full suite runs as a
-pre-commit hook along with typecheck and lint.
+config) to catch order-dependent tests. The pre-commit hook runs typecheck,
+lint-staged, and the full test suite. The pre-push hook runs `npm run check`,
+which is the canonical local gate before CI.
 
 **Prettier covers everything CI checks.** CI runs `prettier --check src/ test/`
 which walks those directories and formats _every_ file type Prettier knows
 (`.ts`, `.js`, `.json`, `.yml`, `.md`, etc.). `lint-staged` in `package.json`
-must stay in sync — if CI formats a file type, the pre-commit hook must too,
-otherwise drift slips through locally and fails in CI. When adding a new file
-type under `src/` or `test/`, add it to both `lint-staged` and leave
-`format:check` alone (it already globs everything).
+must stay in sync with CI, and `npm run check` is the single local entry point
+for that contract. When adding a new file type under `src/` or `test/`, add it
+to `lint-staged` and leave `format:check` alone (it already globs everything).
 
 ## Data management
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -30,6 +30,9 @@ to Claude. Every input path is a prompt injection surface.
 
 - Clearly delimit user input vs system context in prompts (XML tags,
   not just prose boundaries)
+- Persist generic assistant-visible failure turns instead of raw error
+  text, and exclude those error turns from future history passed back
+  into the model
 - Never include the system prompt or tool schemas in LLM output
 - Input length limits on questions and history
 - Anomaly detection via Langfuse traces (e.g., responses that contain
@@ -70,6 +73,9 @@ planned as a custom implementation inside the Hono server.
   and error formatting) cannot justify. The valuable part of "use the SDK"
   is the provider contract, which we wrap directly. Tracking issue: SQR-69.
 - Exact-match redirect URI validation, no wildcards
+- For the web channel, local dev may derive the Google callback from the
+  current `localhost` origin, but only for `localhost` / `127.0.0.1`;
+  non-local hosts still use the configured redirect URI
 - Rate limit client registration (e.g., 10/hour per IP) — tracked in the
   Production Readiness project (SQR-52) alongside other rate-limit configuration
 - **Long-lived access tokens (30-day default)** stored as SHA-256 hashes at rest.
@@ -206,6 +212,8 @@ HTML/JS and are rendered unsanitized, prompt injection becomes XSS.
 - If rendering markdown, use a sanitizing renderer that strips HTML
   tags
 - HttpOnly, Secure, SameSite=Lax cookies
+- User-owned conversation lookups return indistinguishable `404`s, so a
+  guessed conversation ID does not disclose whether the resource exists
 
 ### 8. Supply Chain / Data Pipeline
 

--- a/docs/agent/shipping.md
+++ b/docs/agent/shipping.md
@@ -32,6 +32,10 @@ Example: `feat(auth): add user login endpoint`
 
 For the actual ship workflow, invoke the gstack **`/ship`** skill rather than running the steps by hand. In Squire, interpret `/ship` as: detect and merge the base branch, run tests, review the diff, commit, push, and open the PR. Do **not** bump version numbers or edit `CHANGELOG.md` for ordinary feature-branch PRs unless the user explicitly asks for a release/version cut. Open PRs as published PRs, not drafts, unless the user explicitly asks for a draft PR.
 
+Before pushing, run `npm run check` (or ensure `/ship` does). This is the
+canonical local gate and must stay aligned with CI's formatting, lint, and test
+expectations.
+
 The rules in this file still apply — `/ship` doesn't override them, it executes them:
 
 - Branch must follow the naming convention above (Linear's `gitBranchName` already does).

--- a/docs/plans/sqr-7-eng-plan.md
+++ b/docs/plans/sqr-7-eng-plan.md
@@ -1,0 +1,274 @@
+# Engineering Plan: SQR-7 Conversation Backend
+
+## Context
+
+SQR-7 adds the persisted web conversation backend for Squire's authenticated web
+channel.
+
+This ticket does **not** add a second reasoning engine. The only reasoning path
+remains:
+
+- [src/service.ts](/Users/bcm/.codex/worktrees/e628/squire/src/service.ts) `ask()`
+- [src/agent.ts](/Users/bcm/.codex/worktrees/e628/squire/src/agent.ts) `runAgentLoop()`
+
+SQR-7 adds a thin conversation orchestration layer around that path:
+
+- persisted conversations and messages in Postgres
+- ownership checks for URL-addressable conversations
+- explicit failure persistence
+- a cookie-authenticated web route under `/chat/*`
+
+Relevant existing code:
+
+- [src/server.ts](/Users/bcm/.codex/worktrees/e628/squire/src/server.ts)
+- [src/auth/session-middleware.ts](/Users/bcm/.codex/worktrees/e628/squire/src/auth/session-middleware.ts)
+- [src/db/repositories/session-repository.ts](/Users/bcm/.codex/worktrees/e628/squire/src/db/repositories/session-repository.ts)
+- [src/db/repositories/user-repository.ts](/Users/bcm/.codex/worktrees/e628/squire/src/db/repositories/user-repository.ts)
+- [docs/ARCHITECTURE.md](/Users/bcm/.codex/worktrees/e628/squire/docs/ARCHITECTURE.md)
+- [docs/SECURITY.md](/Users/bcm/.codex/worktrees/e628/squire/docs/SECURITY.md)
+
+## Scope
+
+### In scope
+
+- New persisted `conversations` and `messages` tables
+- Narrow `conversation-service` orchestration module
+- Repository layer for conversation persistence
+- Cookie-authenticated `/chat/*` web route(s)
+- URL-backed conversation identity via `/chat/:conversationId`
+- Explicit assistant failure turns
+- Phase 1 recent-history cap aligned with the agent's existing 20-message cap
+- Integration and boundary tests listed below
+
+### Out of scope
+
+- SSE-rich streaming protocol, tool indicators, citations: SQR-8
+- Context compaction and summarization: SQR-12
+- `tool_calls` on conversation messages: SQR-8
+- Browser-level E2E chat flows: deferred follow-up work
+- Broader reliability policy: [SQR-86](https://linear.app/maz-org/issue/SQR-86/define-phase-1-reliability-policy-for-web-chat-failures-and-retries)
+- Broader observability plan: [SQR-87](https://linear.app/maz-org/issue/SQR-87/define-phase-1-observability-plan-for-app-failures-and-llm-traces)
+
+## Naming
+
+Reserve `session` for auth/web session concepts.
+
+Name the new persisted chat resource:
+
+- `conversation`
+- `conversationId`
+- `conversations`
+
+Rationale: avoids collision with the existing auth `Session` domain object and
+avoids ambiguity around "thread".
+
+## Architecture
+
+### Shape
+
+- Keep exactly one reasoning engine, the existing `ask()` path.
+- Add one narrow `conversation-service` module.
+- Add one or two repositories:
+  - `conversation-repository`
+  - `message-repository`
+- Do not split the workflow into micro-files per verb.
+
+### Route and auth boundary
+
+- Do **not** reuse `/api/ask` for the web channel.
+- Web chat uses cookie auth and CSRF under `/chat/*`.
+- `/api/ask` remains bearer-only and channel-neutral.
+
+### Conversation identity and ownership
+
+- Conversations are URL-addressable via `/chat/:conversationId`.
+- Every conversation read/write must scope by both `conversation_id` and
+  `user_id`.
+- Missing and non-owned conversations return indistinguishable `404`.
+
+### First-message creation and idempotency
+
+- First message creation accepts a client-generated idempotency key.
+- Server guarantees one create result per `(user, idempotency_key)` pair.
+- UI must prevent double-submit while the first-send request is in flight.
+
+### Write order and failure behavior
+
+- Persist user turn first.
+- Call `ask()` in-process using stored history.
+- On success, persist assistant text turn.
+- On failure, persist a generic assistant-visible failure turn:
+  - `"I hit an error and couldn't answer that. Please try again."`
+- Exclude failure turns from future history sent back into `ask()`.
+
+### Retry policy
+
+- Retry transparently once for clear network or transient transport failures.
+- Do **not** retry LLM server-side failures automatically.
+- If the retry still fails, persist the generic failure turn and let the user
+  retry explicitly.
+
+### `ask()` contract
+
+- Keep `ask()` returning plain text in SQR-7.
+- If SQR-8 needs richer output, widen the interface there.
+- Do not add speculative structured return types in this ticket.
+
+## Data Model
+
+### Tables
+
+- `conversations`
+  - `id`
+  - `user_id`
+  - `created_at`
+  - `last_message_at`
+- `messages`
+  - `id`
+  - `conversation_id`
+  - `role` (`user` | `assistant`)
+  - `content`
+  - `created_at`
+  - optional status/type fields only if needed to distinguish failure turns
+
+### Constraints and indexes
+
+- New Drizzle migration file for `conversations` and `messages`
+- `conversations.user_id` foreign key to `users.id`
+- `messages.conversation_id` foreign key to `conversations.id`
+- Composite index on `(conversation_id, created_at)` for ordered history reads
+- User-scoped conversation listing/resume index, e.g. `(user_id, last_message_at)`
+- First-message idempotency uniqueness must be scoped to user
+
+### Explicitly deferred
+
+- No `tool_calls` field in SQR-7
+
+## Request Flow
+
+```text
+Authenticated browser
+  |
+  | GET /chat/:conversationId
+  v
+Cookie session middleware -> load auth session
+  |
+  v
+conversation-service -> load owned conversation by (conversation_id, user_id)
+  |
+  +-- not found / not owned -> 404
+  |
+  +-- found -> load recent messages ordered by created_at
+  v
+render chat page
+
+Authenticated browser
+  |
+  | POST /chat/:conversationId/messages
+  | CSRF token via existing web UI meta-tag/header pattern
+  v
+Cookie session middleware + CSRF middleware
+  |
+  v
+conversation-service
+  |
+  +-- persist user turn
+  +-- load recent message history (max 20)
+  +-- call ask(question, { history, userId })
+  |     |
+  |     +-- transient transport failure -> retry once
+  |     +-- LLM/server failure -> no auto retry
+  |
+  +-- success -> persist assistant turn
+  +-- failure -> persist generic assistant failure turn
+  v
+return updated conversation response
+```
+
+## CSRF
+
+- Authenticated chat pages render the CSRF token in HTML.
+- Every `/chat/*` POST sends it using the same header/meta-tag pattern already
+  used by the authenticated web UI.
+- Do not create a separate chat-specific CSRF token transport.
+
+## History Window
+
+- In SQR-7, cap loaded persisted history to the same 20-message limit already
+  enforced by [src/agent.ts](/Users/bcm/.codex/worktrees/e628/squire/src/agent.ts).
+- This is a Phase 1 guardrail only.
+- SQR-12 replaces this with real compaction/summarization.
+
+## Files
+
+### New
+
+- `src/chat/conversation-service.ts`
+- `src/db/repositories/conversation-repository.ts`
+- `src/db/repositories/message-repository.ts`
+- Drizzle migration for `conversations` and `messages`
+- conversation backend tests
+
+### Modified
+
+- `src/db/schema/core.ts` or another appropriate schema file under `src/db/schema/`
+- `src/db/repositories/types.ts` if shared domain types belong there
+- `src/server.ts`
+- relevant test helpers if truncate/reset coverage must expand
+- [docs/ARCHITECTURE.md](/Users/bcm/.codex/worktrees/e628/squire/docs/ARCHITECTURE.md) post-merge if any load-bearing pattern should graduate out of `docs/plans`
+
+## Testing
+
+This ticket should stay at unit + integration level. Full browser E2E remains
+deferred.
+
+### Required tests
+
+1. Adversarial integration test proving user A cannot access user B's
+   `/chat/:conversationId`
+2. Integration test proving:
+   - user turn is persisted first
+   - `ask()` failure persists a generic assistant failure turn
+3. Integration test proving:
+   - first message creates a stable conversation
+   - reload resumes ordered history
+4. Boundary test proving conversation orchestration forwards stored history to
+   `ask()` untouched
+5. Tests covering the aligned 20-message history cap
+6. Tests covering the first-send idempotency key and duplicate-submit protection
+
+### QA artifact
+
+Primary QA input already written to:
+
+- [bcm-bcm-sqr-7-conversation-agent-backend-eng-review-test-plan-20260410-100636.md](/Users/bcm/.gstack/projects/maz-org-squire/bcm-bcm-sqr-7-conversation-agent-backend-eng-review-test-plan-20260410-100636.md)
+
+## Production Risks and Follow-ups
+
+### Already tracked
+
+- Per-user rate limit and cost budget: [SQR-60](https://linear.app/maz-org/issue/SQR-60/per-user-rate-limit-daily-cost-budget-circuit-breaker)
+- Reliability policy: [SQR-86](https://linear.app/maz-org/issue/SQR-86/define-phase-1-reliability-policy-for-web-chat-failures-and-retries)
+- Observability plan: [SQR-87](https://linear.app/maz-org/issue/SQR-87/define-phase-1-observability-plan-for-app-failures-and-llm-traces)
+
+### Minimum expectations for SQR-7
+
+- failures are visible in logs/traces well enough to debug locally
+- conversation id and user id can be correlated during debugging
+- generic assistant failure turns do not leak internal error text
+
+## Implementation Order
+
+1. Add schema + migration
+2. Add repositories
+3. Add `conversation-service`
+4. Add `/chat/*` route wiring with cookie auth + CSRF
+5. Add tests
+6. Verify history-cap, retry, and failure-turn behavior
+
+## Review Outcome
+
+- Scope reduced and clarified during eng review
+- Outside voice used Claude CLI, not Codex, for actual independence
+- Durable checkpoint:
+  - [20260410-103406-bcm-sqr-7-conversation-agent-backend-plan-eng-review-sqr7.md](/Users/bcm/.gstack/projects/maz-org-squire/checkpoints/20260410-103406-bcm-sqr-7-conversation-agent-backend-plan-eng-review-sqr7.md)

--- a/docs/plans/sqr-7-eng-plan.md
+++ b/docs/plans/sqr-7-eng-plan.md
@@ -8,8 +8,8 @@ channel.
 This ticket does **not** add a second reasoning engine. The only reasoning path
 remains:
 
-- [src/service.ts](/Users/bcm/.codex/worktrees/e628/squire/src/service.ts) `ask()`
-- [src/agent.ts](/Users/bcm/.codex/worktrees/e628/squire/src/agent.ts) `runAgentLoop()`
+- [src/service.ts](../../src/service.ts) `ask()`
+- [src/agent.ts](../../src/agent.ts) `runAgentLoop()`
 
 SQR-7 adds a thin conversation orchestration layer around that path:
 
@@ -20,12 +20,12 @@ SQR-7 adds a thin conversation orchestration layer around that path:
 
 Relevant existing code:
 
-- [src/server.ts](/Users/bcm/.codex/worktrees/e628/squire/src/server.ts)
-- [src/auth/session-middleware.ts](/Users/bcm/.codex/worktrees/e628/squire/src/auth/session-middleware.ts)
-- [src/db/repositories/session-repository.ts](/Users/bcm/.codex/worktrees/e628/squire/src/db/repositories/session-repository.ts)
-- [src/db/repositories/user-repository.ts](/Users/bcm/.codex/worktrees/e628/squire/src/db/repositories/user-repository.ts)
-- [docs/ARCHITECTURE.md](/Users/bcm/.codex/worktrees/e628/squire/docs/ARCHITECTURE.md)
-- [docs/SECURITY.md](/Users/bcm/.codex/worktrees/e628/squire/docs/SECURITY.md)
+- [src/server.ts](../../src/server.ts)
+- [src/auth/session-middleware.ts](../../src/auth/session-middleware.ts)
+- [src/db/repositories/session-repository.ts](../../src/db/repositories/session-repository.ts)
+- [src/db/repositories/user-repository.ts](../../src/db/repositories/user-repository.ts)
+- [docs/ARCHITECTURE.md](../ARCHITECTURE.md)
+- [docs/SECURITY.md](../SECURITY.md)
 
 ## Scope
 
@@ -195,7 +195,7 @@ return updated conversation response
 ## History Window
 
 - In SQR-7, cap loaded persisted history to the same 20-message limit already
-  enforced by [src/agent.ts](/Users/bcm/.codex/worktrees/e628/squire/src/agent.ts).
+  enforced by [src/agent.ts](../../src/agent.ts).
 - This is a Phase 1 guardrail only.
 - SQR-12 replaces this with real compaction/summarization.
 
@@ -215,7 +215,8 @@ return updated conversation response
 - `src/db/repositories/types.ts` if shared domain types belong there
 - `src/server.ts`
 - relevant test helpers if truncate/reset coverage must expand
-- [docs/ARCHITECTURE.md](/Users/bcm/.codex/worktrees/e628/squire/docs/ARCHITECTURE.md) post-merge if any load-bearing pattern should graduate out of `docs/plans`
+- [docs/ARCHITECTURE.md](../ARCHITECTURE.md) post-merge if any load-bearing
+  pattern should graduate out of `docs/plans`
 
 ## Testing
 
@@ -239,9 +240,7 @@ deferred.
 
 ### QA artifact
 
-Primary QA input already written to:
-
-- [bcm-bcm-sqr-7-conversation-agent-backend-eng-review-test-plan-20260410-100636.md](/Users/bcm/.gstack/projects/maz-org-squire/bcm-bcm-sqr-7-conversation-agent-backend-eng-review-test-plan-20260410-100636.md)
+Primary QA input exists in the local gstack project artifacts for this branch.
 
 ## Production Risks and Follow-ups
 
@@ -269,6 +268,6 @@ Primary QA input already written to:
 ## Review Outcome
 
 - Scope reduced and clarified during eng review
-- Outside voice used Claude CLI, not Codex, for actual independence
-- Durable checkpoint:
-  - [20260410-103406-bcm-sqr-7-conversation-agent-backend-plan-eng-review-sqr7.md](/Users/bcm/.gstack/projects/maz-org-squire/checkpoints/20260410-103406-bcm-sqr-7-conversation-agent-backend-plan-eng-review-sqr7.md)
+- Outside voice used a local CLI review pass for actual independence
+- Durable checkpoint exists in the local gstack checkpoint artifacts for this
+  branch

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "scripts": {
+    "check": "npm run typecheck && npm run lint && npm run lint:css && npm run lint:md && npm run format:check && npm test",
     "index": "node src/index-docs.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "node scripts/db-migrate.ts",
@@ -28,7 +29,8 @@
     "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules' '#data' '#.beads'",
     "format": "prettier --write src/ test/",
     "format:check": "prettier --check src/ test/",
-    "prepare": "husky && npm run agent:install-launchagent"
+    "hooks:install": "node scripts/setup-git-hooks.ts",
+    "prepare": "npm run hooks:install && npm run agent:install-launchagent"
   },
   "lint-staged": {
     "*.{ts,js}": [

--- a/scripts/setup-git-hooks.ts
+++ b/scripts/setup-git-hooks.ts
@@ -6,16 +6,23 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..');
 const hookDir = path.join(repoRoot, '.husky');
+const gitMetadataPath = path.join(repoRoot, '.git');
 const hookFiles = ['post-checkout', 'pre-commit', 'pre-push'];
 
-if (!existsSync(hookDir)) {
-  throw new Error(`Missing hook directory: ${hookDir}`);
+if (!existsSync(gitMetadataPath) || !existsSync(hookDir)) {
+  console.warn(`Skipping git hook setup outside a full git worktree: ${repoRoot}`);
+  process.exit(0);
 }
 
-execFileSync('git', ['config', 'core.hooksPath', '.husky'], {
-  cwd: repoRoot,
-  stdio: 'inherit',
-});
+try {
+  execFileSync('git', ['config', 'core.hooksPath', '.husky'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+} catch {
+  console.warn(`Skipping git hook setup because git is unavailable: ${repoRoot}`);
+  process.exit(0);
+}
 
 for (const hookFile of hookFiles) {
   const fullPath = path.join(hookDir, hookFile);

--- a/scripts/setup-git-hooks.ts
+++ b/scripts/setup-git-hooks.ts
@@ -1,0 +1,27 @@
+import { chmodSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const hookDir = path.join(repoRoot, '.husky');
+const hookFiles = ['post-checkout', 'pre-commit', 'pre-push'];
+
+if (!existsSync(hookDir)) {
+  throw new Error(`Missing hook directory: ${hookDir}`);
+}
+
+execFileSync('git', ['config', 'core.hooksPath', '.husky'], {
+  cwd: repoRoot,
+  stdio: 'inherit',
+});
+
+for (const hookFile of hookFiles) {
+  const fullPath = path.join(hookDir, hookFile);
+  if (!existsSync(fullPath)) {
+    throw new Error(`Missing hook file: ${fullPath}`);
+  }
+
+  chmodSync(fullPath, 0o755);
+}

--- a/src/auth/google.ts
+++ b/src/auth/google.ts
@@ -22,14 +22,30 @@ import * as SessionRepository from '../db/repositories/session-repository.ts';
 
 // ─── Configuration ──────────────────────────────────────────────────────────
 
-function getGoogleConfig() {
+function getGoogleConfig(redirectUriOverride?: string) {
   const clientId = process.env.GOOGLE_CLIENT_ID;
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
   const redirectUri = process.env.GOOGLE_REDIRECT_URI;
-  if (!clientId || !clientSecret || !redirectUri) {
+  if (!clientId || !clientSecret || (!redirectUri && !redirectUriOverride)) {
     throw new Error('Missing GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, or GOOGLE_REDIRECT_URI');
   }
-  return { clientId, clientSecret, redirectUri };
+  return { clientId, clientSecret, redirectUri: redirectUriOverride ?? redirectUri! };
+}
+
+export function resolveGoogleRedirectUri(requestUrl?: string): string {
+  const { redirectUri } = getGoogleConfig();
+
+  if (!requestUrl || process.env.NODE_ENV === 'production') {
+    return redirectUri;
+  }
+
+  const request = new URL(requestUrl);
+  const isLocalHost = request.hostname === 'localhost' || request.hostname === '127.0.0.1';
+  if (!isLocalHost) {
+    return redirectUri;
+  }
+
+  return `${request.origin}/auth/google/callback`;
 }
 
 // SESSION_LIFETIME_MS lives in session-repository.ts; getSessionSecret() in session-middleware.ts
@@ -92,8 +108,12 @@ export function computeCodeChallenge(verifier: string): string {
  * Build the Google consent URL with PKCE and state parameters.
  * Returns the URL to redirect to and the state + verifier to store in a cookie.
  */
-export function buildGoogleAuthUrl(state: string, codeChallenge: string): string {
-  const { clientId, redirectUri } = getGoogleConfig();
+export function buildGoogleAuthUrl(
+  state: string,
+  codeChallenge: string,
+  redirectUriOverride?: string,
+): string {
+  const { clientId, redirectUri } = getGoogleConfig(redirectUriOverride);
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
@@ -117,8 +137,9 @@ export function buildGoogleAuthUrl(state: string, codeChallenge: string): string
 export async function exchangeGoogleCode(
   code: string,
   codeVerifier: string,
+  redirectUriOverride?: string,
 ): Promise<{ id_token: string }> {
-  const { clientId, clientSecret, redirectUri } = getGoogleConfig();
+  const { clientId, clientSecret, redirectUri } = getGoogleConfig(redirectUriOverride);
   const client = new OAuth2Client(clientId, clientSecret, redirectUri);
   const { tokens } = await client.getToken({
     code,
@@ -152,6 +173,7 @@ export async function handleGoogleCallback(
   cookieVerifier: string | undefined,
   ipAddress?: string,
   userAgent?: string,
+  redirectUriOverride?: string,
 ): Promise<HandleCallbackResult> {
   // 1. Verify state matches
   if (!cookieState || !cookieVerifier || state !== cookieState) {
@@ -162,7 +184,7 @@ export async function handleGoogleCallback(
   // 2. Exchange code for tokens
   let idToken: string;
   try {
-    const tokens = await exchangeGoogleCode(code, cookieVerifier);
+    const tokens = await exchangeGoogleCode(code, cookieVerifier, redirectUriOverride);
     idToken = tokens.id_token;
   } catch (err) {
     console.warn('[auth:google] token exchange failed:', (err as Error).message);

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -1,0 +1,163 @@
+import { ask, type HistoryMessage } from '../service.ts';
+import { getDb } from '../db.ts';
+import * as ConversationRepository from '../db/repositories/conversation-repository.ts';
+import * as MessageRepository from '../db/repositories/message-repository.ts';
+import type { Conversation, ConversationMessage } from '../db/repositories/types.ts';
+
+const HISTORY_LIMIT = 20;
+
+export const GENERIC_FAILURE_MESSAGE =
+  "I hit an error and couldn't answer that. Please try again.";
+
+function isRetryableTransportError(err: unknown): boolean {
+  const error = err as { code?: string; cause?: { code?: string }; name?: string; message?: string };
+  const code = error.code ?? error.cause?.code;
+  if (code && ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'EAI_AGAIN', 'ECONNREFUSED'].includes(code)) {
+    return true;
+  }
+
+  return error.name === 'AbortError' || /network|socket|timed out/i.test(error.message ?? '');
+}
+
+function toHistory(messages: ConversationMessage[]): HistoryMessage[] {
+  return messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+  }));
+}
+
+async function generateAssistantReply(question: string, history: HistoryMessage[], userId: string) {
+  try {
+    return await ask(question, {
+      history,
+      userId,
+    });
+  } catch (err) {
+    if (!isRetryableTransportError(err)) {
+      throw err;
+    }
+
+    return ask(question, {
+      history,
+      userId,
+    });
+  }
+}
+
+async function persistAssistantOutcome(input: {
+  conversationId: string;
+  question: string;
+  userId: string;
+  currentUserMessageId: string;
+}): Promise<void> {
+  const priorMessages = await MessageRepository.listByConversationId(input.conversationId, {
+    includeErrors: false,
+    limit: HISTORY_LIMIT + 1,
+  });
+  const history = toHistory(priorMessages.filter((message) => message.id !== input.currentUserMessageId));
+
+  try {
+    const answer = await generateAssistantReply(input.question, history, input.userId);
+    await getDb('server').db.transaction(async (tx) => {
+      const assistantMessage = await MessageRepository.create(tx, {
+        conversationId: input.conversationId,
+        role: 'assistant',
+        content: answer,
+      });
+      await ConversationRepository.touchLastMessageAt(tx, input.conversationId, assistantMessage.createdAt);
+    });
+  } catch (err) {
+    console.error('[conversation] ask failed:', err instanceof Error ? err.message : err);
+    await getDb('server').db.transaction(async (tx) => {
+      const failureMessage = await MessageRepository.create(tx, {
+        conversationId: input.conversationId,
+        role: 'assistant',
+        content: GENERIC_FAILURE_MESSAGE,
+        isError: true,
+      });
+      await ConversationRepository.touchLastMessageAt(tx, input.conversationId, failureMessage.createdAt);
+    });
+  }
+}
+
+export async function startConversation(input: {
+  userId: string;
+  question: string;
+  idempotencyKey: string;
+}): Promise<Conversation> {
+  const result = await getDb('server').db.transaction(async (tx) => {
+    const existingOrCreated = await ConversationRepository.getOrCreateByIdempotencyKey(tx, {
+      userId: input.userId,
+      creationIdempotencyKey: input.idempotencyKey,
+    });
+
+    if (!existingOrCreated.created) {
+      return { conversation: existingOrCreated.conversation, currentUserMessageId: null, created: false };
+    }
+
+    const userMessage = await MessageRepository.create(tx, {
+      conversationId: existingOrCreated.conversation.id,
+      role: 'user',
+      content: input.question,
+    });
+    await ConversationRepository.touchLastMessageAt(tx, existingOrCreated.conversation.id, userMessage.createdAt);
+    return {
+      conversation: existingOrCreated.conversation,
+      currentUserMessageId: userMessage.id,
+      created: true,
+    };
+  });
+
+  if (result.created && result.currentUserMessageId) {
+    await persistAssistantOutcome({
+      conversationId: result.conversation.id,
+      question: input.question,
+      userId: input.userId,
+      currentUserMessageId: result.currentUserMessageId,
+    });
+  }
+
+  return result.conversation;
+}
+
+export async function appendMessage(input: {
+  conversationId: string;
+  userId: string;
+  question: string;
+}): Promise<Conversation | null> {
+  const conversation = await ConversationRepository.findOwnedById(input.userId, input.conversationId);
+  if (!conversation) return null;
+
+  const result = await getDb('server').db.transaction(async (tx) => {
+    const userMessage = await MessageRepository.create(tx, {
+      conversationId: input.conversationId,
+      role: 'user',
+      content: input.question,
+    });
+    await ConversationRepository.touchLastMessageAt(tx, input.conversationId, userMessage.createdAt);
+    return userMessage;
+  });
+
+  await persistAssistantOutcome({
+    conversationId: input.conversationId,
+    question: input.question,
+    userId: input.userId,
+    currentUserMessageId: result.id,
+  });
+
+  return conversation;
+}
+
+export async function loadConversation(input: {
+  conversationId: string;
+  userId: string;
+}): Promise<{ conversation: Conversation; messages: ConversationMessage[] } | null> {
+  const conversation = await ConversationRepository.findOwnedById(input.userId, input.conversationId);
+  if (!conversation) return null;
+
+  const messages = await MessageRepository.listByConversationId(conversation.id, {
+    includeErrors: true,
+  });
+
+  return { conversation, messages };
+}

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -5,6 +5,7 @@ import * as MessageRepository from '../db/repositories/message-repository.ts';
 import type { Conversation, ConversationMessage } from '../db/repositories/types.ts';
 
 const HISTORY_LIMIT = 20;
+const RETRY_DELAY_MS = 200;
 
 export const GENERIC_FAILURE_MESSAGE = "I hit an error and couldn't answer that. Please try again.";
 
@@ -44,6 +45,7 @@ async function generateAssistantReply(question: string, history: HistoryMessage[
       throw err;
     }
 
+    await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
     return ask(question, {
       history,
       userId,
@@ -174,11 +176,11 @@ export async function appendMessage(input: {
   userId: string;
   question: string;
 }): Promise<Conversation | null> {
-  const conversation = await ConversationRepository.findOwnedById(
+  const existingConversation = await ConversationRepository.findOwnedById(
     input.userId,
     input.conversationId,
   );
-  if (!conversation) return null;
+  if (!existingConversation) return null;
 
   const result = await getDb('server').db.transaction(async (tx) => {
     const userMessage = await MessageRepository.create(tx, {
@@ -201,7 +203,7 @@ export async function appendMessage(input: {
     currentUserMessageId: result.id,
   });
 
-  return conversation;
+  return ConversationRepository.findOwnedById(input.userId, input.conversationId);
 }
 
 export async function loadConversation(input: {

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -6,13 +6,20 @@ import type { Conversation, ConversationMessage } from '../db/repositories/types
 
 const HISTORY_LIMIT = 20;
 
-export const GENERIC_FAILURE_MESSAGE =
-  "I hit an error and couldn't answer that. Please try again.";
+export const GENERIC_FAILURE_MESSAGE = "I hit an error and couldn't answer that. Please try again.";
 
 function isRetryableTransportError(err: unknown): boolean {
-  const error = err as { code?: string; cause?: { code?: string }; name?: string; message?: string };
+  const error = err as {
+    code?: string;
+    cause?: { code?: string };
+    name?: string;
+    message?: string;
+  };
   const code = error.code ?? error.cause?.code;
-  if (code && ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'EAI_AGAIN', 'ECONNREFUSED'].includes(code)) {
+  if (
+    code &&
+    ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'EAI_AGAIN', 'ECONNREFUSED'].includes(code)
+  ) {
     return true;
   }
 
@@ -54,7 +61,9 @@ async function persistAssistantOutcome(input: {
     includeErrors: false,
     limit: HISTORY_LIMIT + 1,
   });
-  const history = toHistory(priorMessages.filter((message) => message.id !== input.currentUserMessageId));
+  const history = toHistory(
+    priorMessages.filter((message) => message.id !== input.currentUserMessageId),
+  );
 
   try {
     const answer = await generateAssistantReply(input.question, history, input.userId);
@@ -65,7 +74,11 @@ async function persistAssistantOutcome(input: {
         content: answer,
         responseToMessageId: input.currentUserMessageId,
       });
-      await ConversationRepository.touchLastMessageAt(tx, input.conversationId, assistantMessage.createdAt);
+      await ConversationRepository.touchLastMessageAt(
+        tx,
+        input.conversationId,
+        assistantMessage.createdAt,
+      );
     });
   } catch (err) {
     console.error('[conversation] ask failed:', err instanceof Error ? err.message : err);
@@ -77,17 +90,25 @@ async function persistAssistantOutcome(input: {
         isError: true,
         responseToMessageId: input.currentUserMessageId,
       });
-      await ConversationRepository.touchLastMessageAt(tx, input.conversationId, failureMessage.createdAt);
+      await ConversationRepository.touchLastMessageAt(
+        tx,
+        input.conversationId,
+        failureMessage.createdAt,
+      );
     });
   }
 }
 
-async function findRepairableInitialUserMessage(conversationId: string): Promise<ConversationMessage | null> {
+async function findRepairableInitialUserMessage(
+  conversationId: string,
+): Promise<ConversationMessage | null> {
   const storedMessages = await MessageRepository.listByConversationId(conversationId, {
     includeErrors: true,
   });
 
-  return storedMessages.length === 1 && storedMessages[0]?.role === 'user' ? storedMessages[0] : null;
+  return storedMessages.length === 1 && storedMessages[0]?.role === 'user'
+    ? storedMessages[0]
+    : null;
 }
 
 export async function startConversation(input: {
@@ -102,7 +123,11 @@ export async function startConversation(input: {
     });
 
     if (!existingOrCreated.created) {
-      return { conversation: existingOrCreated.conversation, currentUserMessageId: null, created: false };
+      return {
+        conversation: existingOrCreated.conversation,
+        currentUserMessageId: null,
+        created: false,
+      };
     }
 
     const userMessage = await MessageRepository.create(tx, {
@@ -110,7 +135,11 @@ export async function startConversation(input: {
       role: 'user',
       content: input.question,
     });
-    await ConversationRepository.touchLastMessageAt(tx, existingOrCreated.conversation.id, userMessage.createdAt);
+    await ConversationRepository.touchLastMessageAt(
+      tx,
+      existingOrCreated.conversation.id,
+      userMessage.createdAt,
+    );
     return {
       conversation: existingOrCreated.conversation,
       currentUserMessageId: userMessage.id,
@@ -145,7 +174,10 @@ export async function appendMessage(input: {
   userId: string;
   question: string;
 }): Promise<Conversation | null> {
-  const conversation = await ConversationRepository.findOwnedById(input.userId, input.conversationId);
+  const conversation = await ConversationRepository.findOwnedById(
+    input.userId,
+    input.conversationId,
+  );
   if (!conversation) return null;
 
   const result = await getDb('server').db.transaction(async (tx) => {
@@ -154,7 +186,11 @@ export async function appendMessage(input: {
       role: 'user',
       content: input.question,
     });
-    await ConversationRepository.touchLastMessageAt(tx, input.conversationId, userMessage.createdAt);
+    await ConversationRepository.touchLastMessageAt(
+      tx,
+      input.conversationId,
+      userMessage.createdAt,
+    );
     return userMessage;
   });
 
@@ -172,7 +208,10 @@ export async function loadConversation(input: {
   conversationId: string;
   userId: string;
 }): Promise<{ conversation: Conversation; messages: ConversationMessage[] } | null> {
-  const conversation = await ConversationRepository.findOwnedById(input.userId, input.conversationId);
+  const conversation = await ConversationRepository.findOwnedById(
+    input.userId,
+    input.conversationId,
+  );
   if (!conversation) return null;
 
   const messages = await MessageRepository.listByConversationId(conversation.id, {

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -10,13 +10,18 @@ const RETRY_DELAY_MS = 200;
 export const GENERIC_FAILURE_MESSAGE = "I hit an error and couldn't answer that. Please try again.";
 
 function isRetryableTransportError(err: unknown): boolean {
-  const error = err as {
+  if (typeof err !== 'object' || err === null) {
+    return false;
+  }
+
+  const errObj = err as {
     code?: string;
     cause?: { code?: string };
     name?: string;
     message?: string;
   };
-  const code = error.code ?? error.cause?.code;
+  const code = errObj.code ?? errObj.cause?.code;
+  const message = errObj.message ?? '';
   if (
     code &&
     ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'EAI_AGAIN', 'ECONNREFUSED'].includes(code)
@@ -24,7 +29,7 @@ function isRetryableTransportError(err: unknown): boolean {
     return true;
   }
 
-  return error.name === 'AbortError' || /network|socket|timed out/i.test(error.message ?? '');
+  return errObj.name === 'AbortError' || /network|socket|timed out/i.test(message);
 }
 
 function toHistory(messages: ConversationMessage[]): HistoryMessage[] {
@@ -168,7 +173,10 @@ export async function startConversation(input: {
     }
   }
 
-  return result.conversation;
+  return (
+    (await ConversationRepository.findOwnedById(input.userId, result.conversation.id)) ??
+    result.conversation
+  );
 }
 
 export async function appendMessage(input: {

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -59,25 +59,35 @@ async function persistAssistantOutcome(input: {
   try {
     const answer = await generateAssistantReply(input.question, history, input.userId);
     await getDb('server').db.transaction(async (tx) => {
-      const assistantMessage = await MessageRepository.create(tx, {
+      const assistantMessage = await MessageRepository.createResponse(tx, {
         conversationId: input.conversationId,
         role: 'assistant',
         content: answer,
+        responseToMessageId: input.currentUserMessageId,
       });
       await ConversationRepository.touchLastMessageAt(tx, input.conversationId, assistantMessage.createdAt);
     });
   } catch (err) {
     console.error('[conversation] ask failed:', err instanceof Error ? err.message : err);
     await getDb('server').db.transaction(async (tx) => {
-      const failureMessage = await MessageRepository.create(tx, {
+      const failureMessage = await MessageRepository.createResponse(tx, {
         conversationId: input.conversationId,
         role: 'assistant',
         content: GENERIC_FAILURE_MESSAGE,
         isError: true,
+        responseToMessageId: input.currentUserMessageId,
       });
       await ConversationRepository.touchLastMessageAt(tx, input.conversationId, failureMessage.createdAt);
     });
   }
+}
+
+async function findRepairableInitialUserMessage(conversationId: string): Promise<ConversationMessage | null> {
+  const storedMessages = await MessageRepository.listByConversationId(conversationId, {
+    includeErrors: true,
+  });
+
+  return storedMessages.length === 1 && storedMessages[0]?.role === 'user' ? storedMessages[0] : null;
 }
 
 export async function startConversation(input: {
@@ -115,6 +125,16 @@ export async function startConversation(input: {
       userId: input.userId,
       currentUserMessageId: result.currentUserMessageId,
     });
+  } else {
+    const repairableMessage = await findRepairableInitialUserMessage(result.conversation.id);
+    if (repairableMessage) {
+      await persistAssistantOutcome({
+        conversationId: result.conversation.id,
+        question: repairableMessage.content,
+        userId: input.userId,
+        currentUserMessageId: repairableMessage.id,
+      });
+    }
   }
 
   return result.conversation;

--- a/src/db/migrations/0006_conversations_messages.sql
+++ b/src/db/migrations/0006_conversations_messages.sql
@@ -1,0 +1,25 @@
+CREATE TABLE conversations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  creation_idempotency_key TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_message_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX conversations_user_creation_idempotency_idx
+  ON conversations (user_id, creation_idempotency_key);
+
+CREATE INDEX conversations_user_last_message_idx
+  ON conversations (user_id, last_message_at);
+
+CREATE TABLE messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
+  content TEXT NOT NULL,
+  is_error BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX messages_conversation_created_at_idx
+  ON messages (conversation_id, created_at);

--- a/src/db/migrations/0007_message_response_dedup.sql
+++ b/src/db/migrations/0007_message_response_dedup.sql
@@ -1,0 +1,5 @@
+ALTER TABLE messages
+  ADD COLUMN response_to_message_id UUID REFERENCES messages(id) ON DELETE CASCADE;
+
+CREATE UNIQUE INDEX messages_response_to_message_id_idx
+  ON messages (response_to_message_id);

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776297600000,
       "tag": "0005_sessions_last_seen_at",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1776384000000,
+      "tag": "0006_conversations_messages",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776384000000,
       "tag": "0006_conversations_messages",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1776466800000,
+      "tag": "0007_message_response_dedup",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/repositories/conversation-repository.ts
+++ b/src/db/repositories/conversation-repository.ts
@@ -1,0 +1,92 @@
+import { and, eq } from 'drizzle-orm';
+
+import { getDb } from '../../db.ts';
+import type { DbOrTx } from '../../auth/audit.ts';
+import { conversations } from '../schema/conversations.ts';
+import type { Conversation, CreateConversationInput } from './types.ts';
+
+type ConversationRow = typeof conversations.$inferSelect;
+
+function toDomain(row: ConversationRow): Conversation {
+  return {
+    id: row.id,
+    userId: row.userId,
+    creationIdempotencyKey: row.creationIdempotencyKey,
+    createdAt: row.createdAt,
+    lastMessageAt: row.lastMessageAt,
+  };
+}
+
+export async function findOwnedById(userId: string, conversationId: string): Promise<Conversation | null> {
+  const { db } = getDb('server');
+  const rows = await db
+    .select()
+    .from(conversations)
+    .where(and(eq(conversations.id, conversationId), eq(conversations.userId, userId)))
+    .limit(1);
+  return rows[0] ? toDomain(rows[0]) : null;
+}
+
+export async function create(handle: DbOrTx, input: CreateConversationInput): Promise<Conversation> {
+  const [row] = await handle
+    .insert(conversations)
+    .values({
+      userId: input.userId,
+      creationIdempotencyKey: input.creationIdempotencyKey ?? null,
+    })
+    .returning();
+  return toDomain(row);
+}
+
+export async function getOrCreateByIdempotencyKey(
+  handle: DbOrTx,
+  input: CreateConversationInput,
+): Promise<{ conversation: Conversation; created: boolean }> {
+  const key = input.creationIdempotencyKey ?? null;
+  if (!key) {
+    return { conversation: await create(handle, input), created: true };
+  }
+
+  const inserted = await handle
+    .insert(conversations)
+    .values({
+      userId: input.userId,
+      creationIdempotencyKey: key,
+    })
+    .onConflictDoNothing({
+      target: [conversations.userId, conversations.creationIdempotencyKey],
+    })
+    .returning();
+
+  if (inserted[0]) {
+    return { conversation: toDomain(inserted[0]), created: true };
+  }
+
+  const existing = await handle
+    .select()
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.userId, input.userId),
+        eq(conversations.creationIdempotencyKey, key),
+      ),
+    )
+    .limit(1);
+
+  if (!existing[0]) {
+    throw new Error('Failed to load conversation for idempotency key');
+  }
+
+  return { conversation: toDomain(existing[0]), created: false };
+}
+
+export async function touchLastMessageAt(
+  handle: DbOrTx,
+  conversationId: string,
+  timestamp: Date,
+): Promise<void> {
+  await handle
+    .update(conversations)
+    .set({ lastMessageAt: timestamp })
+    .where(eq(conversations.id, conversationId));
+}

--- a/src/db/repositories/conversation-repository.ts
+++ b/src/db/repositories/conversation-repository.ts
@@ -17,7 +17,10 @@ function toDomain(row: ConversationRow): Conversation {
   };
 }
 
-export async function findOwnedById(userId: string, conversationId: string): Promise<Conversation | null> {
+export async function findOwnedById(
+  userId: string,
+  conversationId: string,
+): Promise<Conversation | null> {
   const { db } = getDb('server');
   const rows = await db
     .select()
@@ -27,7 +30,10 @@ export async function findOwnedById(userId: string, conversationId: string): Pro
   return rows[0] ? toDomain(rows[0]) : null;
 }
 
-export async function create(handle: DbOrTx, input: CreateConversationInput): Promise<Conversation> {
+export async function create(
+  handle: DbOrTx,
+  input: CreateConversationInput,
+): Promise<Conversation> {
   const [row] = await handle
     .insert(conversations)
     .values({
@@ -66,10 +72,7 @@ export async function getOrCreateByIdempotencyKey(
     .select()
     .from(conversations)
     .where(
-      and(
-        eq(conversations.userId, input.userId),
-        eq(conversations.creationIdempotencyKey, key),
-      ),
+      and(eq(conversations.userId, input.userId), eq(conversations.creationIdempotencyKey, key)),
     )
     .limit(1);
 

--- a/src/db/repositories/message-repository.ts
+++ b/src/db/repositories/message-repository.ts
@@ -14,6 +14,7 @@ function toDomain(row: MessageRow): ConversationMessage {
     role: row.role as 'user' | 'assistant',
     content: row.content,
     isError: row.isError,
+    responseToMessageId: row.responseToMessageId,
     createdAt: row.createdAt,
   };
 }
@@ -29,9 +30,45 @@ export async function create(
       role: input.role,
       content: input.content,
       isError: input.isError ?? false,
+      responseToMessageId: input.responseToMessageId ?? null,
     })
     .returning();
   return toDomain(row);
+}
+
+export async function createResponse(
+  handle: DbOrTx,
+  input: CreateConversationMessageInput & { responseToMessageId: string },
+): Promise<ConversationMessage> {
+  const inserted = await handle
+    .insert(messages)
+    .values({
+      conversationId: input.conversationId,
+      role: input.role,
+      content: input.content,
+      isError: input.isError ?? false,
+      responseToMessageId: input.responseToMessageId,
+    })
+    .onConflictDoNothing({
+      target: messages.responseToMessageId,
+    })
+    .returning();
+
+  if (inserted[0]) {
+    return toDomain(inserted[0]);
+  }
+
+  const existing = await handle
+    .select()
+    .from(messages)
+    .where(eq(messages.responseToMessageId, input.responseToMessageId))
+    .limit(1);
+
+  if (!existing[0]) {
+    throw new Error('Failed to load existing response message');
+  }
+
+  return toDomain(existing[0]);
 }
 
 export async function listByConversationId(

--- a/src/db/repositories/message-repository.ts
+++ b/src/db/repositories/message-repository.ts
@@ -1,0 +1,55 @@
+import { and, desc, eq } from 'drizzle-orm';
+
+import { getDb } from '../../db.ts';
+import type { DbOrTx } from '../../auth/audit.ts';
+import { messages } from '../schema/conversations.ts';
+import type { ConversationMessage, CreateConversationMessageInput } from './types.ts';
+
+type MessageRow = typeof messages.$inferSelect;
+
+function toDomain(row: MessageRow): ConversationMessage {
+  return {
+    id: row.id,
+    conversationId: row.conversationId,
+    role: row.role as 'user' | 'assistant',
+    content: row.content,
+    isError: row.isError,
+    createdAt: row.createdAt,
+  };
+}
+
+export async function create(
+  handle: DbOrTx,
+  input: CreateConversationMessageInput,
+): Promise<ConversationMessage> {
+  const [row] = await handle
+    .insert(messages)
+    .values({
+      conversationId: input.conversationId,
+      role: input.role,
+      content: input.content,
+      isError: input.isError ?? false,
+    })
+    .returning();
+  return toDomain(row);
+}
+
+export async function listByConversationId(
+  conversationId: string,
+  options?: { includeErrors?: boolean; limit?: number },
+): Promise<ConversationMessage[]> {
+  const { db } = getDb('server');
+  const includeErrors = options?.includeErrors ?? true;
+  const where = includeErrors
+    ? eq(messages.conversationId, conversationId)
+    : and(eq(messages.conversationId, conversationId), eq(messages.isError, false));
+
+  const query = db
+    .select()
+    .from(messages)
+    .where(where!)
+    .orderBy(desc(messages.createdAt), desc(messages.id));
+
+  const rows = options?.limit ? await query.limit(options.limit) : await query;
+  return rows.reverse().map(toDomain);
+}

--- a/src/db/repositories/types.ts
+++ b/src/db/repositories/types.ts
@@ -67,6 +67,7 @@ export interface ConversationMessage {
   role: 'user' | 'assistant';
   content: string;
   isError: boolean;
+  responseToMessageId: string | null;
   createdAt: Date;
 }
 
@@ -75,4 +76,5 @@ export interface CreateConversationMessageInput {
   role: 'user' | 'assistant';
   content: string;
   isError?: boolean;
+  responseToMessageId?: string | null;
 }

--- a/src/db/repositories/types.ts
+++ b/src/db/repositories/types.ts
@@ -45,3 +45,34 @@ export interface CreateSessionInput {
   ipAddress?: string | null;
   userAgent?: string | null;
 }
+
+// ─── Conversation ───────────────────────────────────────────────────────────
+
+export interface Conversation {
+  id: string;
+  userId: string;
+  creationIdempotencyKey: string | null;
+  createdAt: Date;
+  lastMessageAt: Date;
+}
+
+export interface CreateConversationInput {
+  userId: string;
+  creationIdempotencyKey?: string | null;
+}
+
+export interface ConversationMessage {
+  id: string;
+  conversationId: string;
+  role: 'user' | 'assistant';
+  content: string;
+  isError: boolean;
+  createdAt: Date;
+}
+
+export interface CreateConversationMessageInput {
+  conversationId: string;
+  role: 'user' | 'assistant';
+  content: string;
+  isError?: boolean;
+}

--- a/src/db/schema/conversations.ts
+++ b/src/db/schema/conversations.ts
@@ -42,12 +42,9 @@ export const messages = pgTable(
     role: text('role').notNull(),
     content: text('content').notNull(),
     isError: boolean('is_error').notNull().default(false),
-    responseToMessageId: uuid('response_to_message_id').references(
-      (): AnyPgColumn => messages.id,
-      {
-        onDelete: 'cascade',
-      },
-    ),
+    responseToMessageId: uuid('response_to_message_id').references((): AnyPgColumn => messages.id, {
+      onDelete: 'cascade',
+    }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [

--- a/src/db/schema/conversations.ts
+++ b/src/db/schema/conversations.ts
@@ -1,0 +1,59 @@
+import { relations } from 'drizzle-orm';
+import {
+  boolean,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core';
+
+import { users } from './core.ts';
+
+export const conversations = pgTable(
+  'conversations',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    creationIdempotencyKey: text('creation_idempotency_key'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    lastMessageAt: timestamp('last_message_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('conversations_user_last_message_idx').on(t.userId, t.lastMessageAt),
+    uniqueIndex('conversations_user_creation_idempotency_idx').on(
+      t.userId,
+      t.creationIdempotencyKey,
+    ),
+  ],
+);
+
+export const messages = pgTable(
+  'messages',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    conversationId: uuid('conversation_id')
+      .notNull()
+      .references(() => conversations.id, { onDelete: 'cascade' }),
+    role: text('role').notNull(),
+    content: text('content').notNull(),
+    isError: boolean('is_error').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index('messages_conversation_created_at_idx').on(t.conversationId, t.createdAt)],
+);
+
+export const conversationsRelations = relations(conversations, ({ one, many }) => ({
+  user: one(users, { fields: [conversations.userId], references: [users.id] }),
+  messages: many(messages),
+}));
+
+export const messagesRelations = relations(messages, ({ one }) => ({
+  conversation: one(conversations, {
+    fields: [messages.conversationId],
+    references: [conversations.id],
+  }),
+}));

--- a/src/db/schema/conversations.ts
+++ b/src/db/schema/conversations.ts
@@ -1,5 +1,6 @@
 import { relations } from 'drizzle-orm';
 import {
+  type AnyPgColumn,
   boolean,
   index,
   pgTable,
@@ -41,9 +42,18 @@ export const messages = pgTable(
     role: text('role').notNull(),
     content: text('content').notNull(),
     isError: boolean('is_error').notNull().default(false),
+    responseToMessageId: uuid('response_to_message_id').references(
+      (): AnyPgColumn => messages.id,
+      {
+        onDelete: 'cascade',
+      },
+    ),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
-  (t) => [index('messages_conversation_created_at_idx').on(t.conversationId, t.createdAt)],
+  (t) => [
+    index('messages_conversation_created_at_idx').on(t.conversationId, t.createdAt),
+    uniqueIndex('messages_response_to_message_id_idx').on(t.responseToMessageId),
+  ],
 );
 
 export const conversationsRelations = relations(conversations, ({ one, many }) => ({

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -10,3 +10,4 @@
 export * from './core.ts';
 export * from './auth.ts';
 export * from './cards.ts';
+export * from './conversations.ts';

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ import {
   buildGoogleAuthUrl,
   handleGoogleCallback,
   GoogleAuthError,
+  resolveGoogleRedirectUri,
 } from './auth/google.ts';
 import { getSessionSecret } from './auth/session-middleware.ts';
 import * as SessionRepository from './db/repositories/session-repository.ts';
@@ -373,7 +374,7 @@ app.get('/auth/google/start', async (c) => {
     maxAge: 300, // 5 minutes
   });
 
-  const url = buildGoogleAuthUrl(state, codeChallenge);
+  const url = buildGoogleAuthUrl(state, codeChallenge, resolveGoogleRedirectUri(c.req.url));
   return c.redirect(url);
 });
 
@@ -419,6 +420,7 @@ app.get('/auth/google/callback', async (c) => {
       cookieVerifier,
       c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
       c.req.header('user-agent'),
+      resolveGoogleRedirectUri(c.req.url),
     );
 
     await setSessionCookie(c, result.sessionId);

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,11 +49,17 @@ import { createCsrfToken, requireCsrf } from './auth/csrf.ts';
 import { setSignedCookie, getSignedCookie, deleteCookie } from 'hono/cookie';
 import {
   layoutShell,
+  renderConversationPage,
   renderHomePage,
   renderLoginPage,
   renderNotInvitedPage,
 } from './web-ui/layout.ts';
 import { getAppCss, getSquireJs } from './web-ui/assets.ts';
+import {
+  appendMessage,
+  loadConversation,
+  startConversation,
+} from './chat/conversation-service.ts';
 
 export const app = new Hono();
 
@@ -464,6 +470,79 @@ app.use('/chat/*', requirePageSession());
 app.use('/chat', requirePageSession());
 app.use('/chat/*', requireCsrf());
 app.use('/chat', requireCsrf());
+
+function badChatRequest(c: Context, message: string) {
+  return c.json(jsonError(message, 400), 400);
+}
+
+async function readQuestionForm(c: Context): Promise<{ question: string; idempotencyKey?: string }> {
+  const form = await c.req.formData();
+  const questionValue = form.get('question');
+  const idempotencyValue = form.get('idempotencyKey');
+
+  return {
+    question: typeof questionValue === 'string' ? questionValue.trim() : '',
+    idempotencyKey:
+      typeof idempotencyValue === 'string' && idempotencyValue.trim().length > 0
+        ? idempotencyValue.trim()
+        : undefined,
+  };
+}
+
+app.get('/chat/:conversationId', async (c) => {
+  const session = c.get('session')!;
+  const loaded = await loadConversation({
+    conversationId: c.req.param('conversationId'),
+    userId: session.userId,
+  });
+  if (!loaded) return c.notFound();
+
+  c.header('Cache-Control', 'no-store');
+  c.header('Vary', 'Cookie');
+  return c.html(
+    await renderConversationPage({
+      session,
+      csrfToken: createCsrfToken(session.id),
+      conversationId: loaded.conversation.id,
+      messages: loaded.messages,
+    }),
+  );
+});
+
+app.post('/chat', async (c) => {
+  const session = c.get('session')!;
+  const { question, idempotencyKey } = await readQuestionForm(c);
+
+  if (!question) return badChatRequest(c, 'Question is required');
+  if (!idempotencyKey) return badChatRequest(c, 'Idempotency key is required');
+
+  const conversation = await startConversation({
+    userId: session.userId,
+    question,
+    idempotencyKey,
+  });
+
+  c.header('Cache-Control', 'no-store');
+  c.header('Vary', 'Cookie');
+  return c.redirect(`/chat/${conversation.id}`, 302);
+});
+
+app.post('/chat/:conversationId/messages', async (c) => {
+  const session = c.get('session')!;
+  const { question } = await readQuestionForm(c);
+  if (!question) return badChatRequest(c, 'Question is required');
+
+  const conversation = await appendMessage({
+    conversationId: c.req.param('conversationId'),
+    userId: session.userId,
+    question,
+  });
+  if (!conversation) return c.notFound();
+
+  c.header('Cache-Control', 'no-store');
+  c.header('Vary', 'Cookie');
+  return c.redirect(`/chat/${conversation.id}`, 302);
+});
 
 // ─── Bearer auth middleware ──────────────────────────────────────────────────
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,11 +56,7 @@ import {
   renderNotInvitedPage,
 } from './web-ui/layout.ts';
 import { getAppCss, getSquireJs } from './web-ui/assets.ts';
-import {
-  appendMessage,
-  loadConversation,
-  startConversation,
-} from './chat/conversation-service.ts';
+import { appendMessage, loadConversation, startConversation } from './chat/conversation-service.ts';
 
 export const app = new Hono();
 
@@ -477,7 +473,9 @@ function badChatRequest(c: Context, message: string) {
   return c.json(jsonError(message, 400), 400);
 }
 
-async function readQuestionForm(c: Context): Promise<{ question: string; idempotencyKey?: string }> {
+async function readQuestionForm(
+  c: Context,
+): Promise<{ question: string; idempotencyKey?: string }> {
   const form = await c.req.formData();
   const questionValue = form.get('question');
   const idempotencyValue = form.get('idempotencyKey');

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -22,7 +22,7 @@ import type { HtmlEscapedString } from 'hono/utils/html';
 import { getAppCssUrl, getSquireJsUrl } from './assets.ts';
 import { CSRF_FORM_FIELD_NAME, CSRF_HEADER_NAME, CSRF_META_NAME } from './csrf.ts';
 import { FONT_PRECONNECTS, GOOGLE_FONTS_HREF } from './fonts.ts';
-import type { Session } from '../db/repositories/types.ts';
+import type { ConversationMessage, Session } from '../db/repositories/types.ts';
 
 export interface LayoutShellOptions {
   /**
@@ -55,6 +55,8 @@ export interface LayoutShellOptions {
    * document head and inherited by HTMX requests via `hx-headers`.
    */
   csrfToken?: string;
+  chatFormAction?: string;
+  chatFormHiddenFields?: Array<{ name: string; value: string }>;
 }
 
 interface DocumentOptions {
@@ -127,6 +129,8 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
   // Session present = logged in = full chrome. Absent = brand only.
   const authenticated = options.session !== undefined;
   const csrfToken = options.csrfToken;
+  const chatFormAction = options.chatFormAction ?? '/chat';
+  const chatFormHiddenFields = options.chatFormHiddenFields ?? [];
 
   // SAFETY: `errorBanner.message` is interpolated via hono/html's tagged
   // template, which auto-escapes — safe to receive raw `Error.message`
@@ -235,16 +239,11 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
                   <span class="squire-chip">Element infusion</span>
                   <span class="squire-chip">Negative scenario effects</span>
                 </nav>
-                <!--
-              SQR-65 ships the structural form only. The action target points
-              at /api/ask, which is the eventual endpoint, but the API requires
-              Bearer auth and a JSON body — a raw HTML form POST will 401
-              today. SQR-6 wires real submission (HTMX + SSE streaming + the
-              recent-questions chip row), at which point this form gets
-              hx-post, hx-swap, and friends layered on. Do not try to make
-              the form work before SQR-6 lands — it is a layout slot.
-            -->
-                <form class="squire-input-dock" method="post" action="/api/ask">
+                <form class="squire-input-dock" method="post" action="${chatFormAction}">
+                  ${chatFormHiddenFields.map(
+                    (field) =>
+                      html`<input type="hidden" name="${field.name}" value="${field.value}" />`,
+                  )}
                   <input
                     id="squire-input"
                     name="question"
@@ -366,5 +365,47 @@ export async function renderHomePage(
   session?: Session,
   csrfToken?: string,
 ): Promise<HtmlEscapedString> {
-  return layoutShell({ session, csrfToken });
+  return layoutShell({
+    session,
+    csrfToken,
+    chatFormAction: '/chat',
+    chatFormHiddenFields: [{ name: 'idempotencyKey', value: '' }],
+  });
+}
+
+export async function renderConversationPage(options: {
+  session: Session;
+  csrfToken: string;
+  conversationId: string;
+  messages: ConversationMessage[];
+}): Promise<HtmlEscapedString> {
+  const transcript =
+    options.messages.length === 0
+      ? html`<section class="squire-empty" aria-label="Conversation">
+          <h1 class="squire-question">Conversation is empty.</h1>
+        </section>`
+      : html`<section
+          class="squire-transcript"
+          aria-label="Conversation transcript"
+          data-conversation-id="${options.conversationId}"
+        >
+          ${options.messages.map((message) =>
+            message.role === 'user'
+              ? html`<article class="squire-turn squire-question">
+                  <p>${message.content}</p>
+                </article>`
+              : html`<article
+                  class="squire-turn squire-answer${message.isError ? ' squire-answer--error' : ''}"
+                >
+                  <p>${message.content}</p>
+                </article>`,
+          )}
+        </section>`;
+
+  return layoutShell({
+    session: options.session,
+    csrfToken: options.csrfToken,
+    mainContent: transcript as HtmlEscapedString,
+    chatFormAction: `/chat/${options.conversationId}/messages`,
+  });
 }

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -130,7 +130,10 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
   const authenticated = options.session !== undefined;
   const csrfToken = options.csrfToken;
   const chatFormAction = options.chatFormAction ?? '/chat';
-  const chatFormHiddenFields = options.chatFormHiddenFields ?? [];
+  const chatFormHiddenFields = [
+    ...(csrfToken ? [{ name: CSRF_FORM_FIELD_NAME, value: csrfToken }] : []),
+    ...(options.chatFormHiddenFields ?? []),
+  ];
 
   // SAFETY: `errorBanner.message` is interpolated via hono/html's tagged
   // template, which auto-escapes — safe to receive raw `Error.message`

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -26,7 +26,6 @@ document.addEventListener('submit', function (e) {
 
   var questionInput = form.querySelector('input[name="question"]');
   var submitButton = form.querySelector('button[type="submit"]');
-  var action = form.getAttribute('action') || '';
   var idempotencyInput = form.querySelector('input[name="idempotencyKey"]');
 
   if (idempotencyInput && !idempotencyInput.value) {
@@ -40,7 +39,7 @@ document.addEventListener('submit', function (e) {
   form.dataset.submitting = 'true';
   if (questionInput) questionInput.setAttribute('readonly', 'true');
   if (submitButton) submitButton.setAttribute('disabled', 'true');
-  if (action === '/chat' && submitButton) {
+  if (submitButton) {
     submitButton.textContent = '...';
   }
 });

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -19,3 +19,28 @@ document.addEventListener('click', function (e) {
     cite.classList.toggle('is-active');
   }
 });
+
+document.addEventListener('submit', function (e) {
+  var form = e.target;
+  if (!form || !form.matches || !form.matches('.squire-input-dock')) return;
+
+  var questionInput = form.querySelector('input[name="question"]');
+  var submitButton = form.querySelector('button[type="submit"]');
+  var action = form.getAttribute('action') || '';
+  var idempotencyInput = form.querySelector('input[name="idempotencyKey"]');
+
+  if (idempotencyInput && !idempotencyInput.value) {
+    if (window.crypto && window.crypto.randomUUID) {
+      idempotencyInput.value = window.crypto.randomUUID();
+    } else {
+      idempotencyInput.value = String(Date.now()) + '-' + Math.random().toString(16).slice(2);
+    }
+  }
+
+  form.dataset.submitting = 'true';
+  if (questionInput) questionInput.setAttribute('readonly', 'true');
+  if (submitButton) submitButton.setAttribute('disabled', 'true');
+  if (action === '/chat' && submitButton) {
+    submitButton.textContent = '...';
+  }
+});

--- a/test/auth-google.test.ts
+++ b/test/auth-google.test.ts
@@ -190,6 +190,30 @@ describe('Google OAuth callback', () => {
     expect(sessionRows[0].expiresAt.getTime()).toBeGreaterThan(Date.now());
     expect(sessionRows[0].lastSeenAt).not.toBeNull();
   });
+
+  it('1b. uses the request host for localhost worktree OAuth start URLs', async () => {
+    const res = await app.request('http://localhost:4450/auth/google/start', {
+      redirect: 'manual',
+    });
+
+    expect(res.status).toBe(302);
+    const redirectUrl = new URL(res.headers.get('location')!);
+    expect(redirectUrl.searchParams.get('redirect_uri')).toBe(
+      'http://localhost:4450/auth/google/callback',
+    );
+  });
+
+  it('1c. keeps the configured callback for non-local hosts', async () => {
+    const res = await app.request('http://example.com/auth/google/start', {
+      redirect: 'manual',
+    });
+
+    expect(res.status).toBe(302);
+    const redirectUrl = new URL(res.headers.get('location')!);
+    expect(redirectUrl.searchParams.get('redirect_uri')).toBe(
+      'http://localhost:3000/auth/google/callback',
+    );
+  });
 });
 
 describe('/auth/me', () => {

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -1,0 +1,336 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { generateSignedCookie } from 'hono/cookie';
+
+import { resetTestDb, setupTestDb, teardownTestDb } from './helpers/db.ts';
+
+const { mockAsk } = vi.hoisted(() => ({
+  mockAsk: vi.fn(),
+}));
+
+vi.mock('../src/service.ts', () => ({
+  initialize: vi.fn(),
+  isReady: vi.fn(() => true),
+  ask: mockAsk,
+}));
+
+vi.mock('../src/tools.ts', () => ({
+  searchRules: vi.fn(),
+  searchCards: vi.fn(),
+  listCardTypes: vi.fn(),
+  listCards: vi.fn(),
+  getCard: vi.fn(),
+}));
+
+process.env.SESSION_SECRET = 'test-session-secret-must-be-at-least-32-characters-long';
+
+import { app } from '../src/server.ts';
+import { shutdownServerPool, getDb } from '../src/db.ts';
+import { createCsrfToken } from '../src/auth/csrf.ts';
+import { SESSION_COOKIE_NAME, getSessionSecret } from '../src/auth/session-middleware.ts';
+import * as SessionRepository from '../src/db/repositories/session-repository.ts';
+import { SESSION_LIFETIME_MS } from '../src/db/repositories/session-repository.ts';
+import { users } from '../src/db/schema/core.ts';
+import { conversations, messages } from '../src/db/schema/conversations.ts';
+
+interface AuthContext {
+  cookie: string;
+  sessionId: string;
+  userId: string;
+}
+
+async function createAuthContext(overrides?: {
+  email?: string;
+  googleSub?: string;
+  name?: string | null;
+}): Promise<AuthContext> {
+  const { db } = getDb('server');
+  const email = overrides?.email ?? 'alice@example.com';
+  const googleSub = overrides?.googleSub ?? 'google-sub-alice';
+  const name = overrides?.name ?? 'Alice';
+
+  const [user] = await db
+    .insert(users)
+    .values({
+      email,
+      googleSub,
+      name,
+    })
+    .returning();
+
+  const { sessionId } = await SessionRepository.create(db, { userId: user.id });
+  const signedCookie = await generateSignedCookie(
+    SESSION_COOKIE_NAME,
+    sessionId,
+    getSessionSecret(),
+    {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+      maxAge: SESSION_LIFETIME_MS / 1000,
+    },
+  );
+
+  return {
+    cookie: signedCookie.split(';')[0],
+    sessionId,
+    userId: user.id,
+  };
+}
+
+async function requestWithAuth(
+  auth: AuthContext,
+  url: string,
+  init?: RequestInit & { csrf?: boolean },
+): Promise<Response> {
+  const headers = new Headers(init?.headers);
+  headers.set('Cookie', auth.cookie);
+  if (init?.csrf) {
+    headers.set('x-csrf-token', createCsrfToken(auth.sessionId));
+  }
+
+  return app.request(url, {
+    ...init,
+    headers,
+  });
+}
+
+function formBody(data: Record<string, string>): string {
+  return new URLSearchParams(data).toString();
+}
+
+function requireLocation(response: Response): string {
+  const location = response.headers.get('location');
+  expect(location).toBeTruthy();
+  return location!;
+}
+
+beforeAll(async () => {
+  await setupTestDb();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  vi.clearAllMocks();
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+  await shutdownServerPool();
+});
+
+describe('conversation web backend', () => {
+  it('creates a conversation on first message and reload restores ordered history', async () => {
+    mockAsk.mockResolvedValueOnce('Loot tokens in your hex are picked up.');
+    const auth = await createAuthContext();
+
+    const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'How does looting work?',
+        idempotencyKey: 'idem-1',
+      }),
+      redirect: 'manual',
+    });
+
+    expect(createRes.status).toBe(302);
+    const location = requireLocation(createRes);
+    expect(location).toMatch(/^\/chat\/[0-9a-f-]+$/);
+
+    const pageRes = await requestWithAuth(auth, `http://localhost:3000${location}`);
+    expect(pageRes.status).toBe(200);
+
+    const page = await pageRes.text();
+    expect(page).toContain('How does looting work?');
+    expect(page).toContain('Loot tokens in your hex are picked up.');
+
+    const { db } = getDb('server');
+    const messages = await db.execute(sql`
+      select role, content
+      from messages
+      order by created_at asc, id asc
+    `);
+    expect(messages.rows).toEqual([
+      { role: 'user', content: 'How does looting work?' },
+      { role: 'assistant', content: 'Loot tokens in your hex are picked up.' },
+    ]);
+  });
+
+  it("returns 404 when one user requests another user's conversation URL", async () => {
+    mockAsk.mockResolvedValueOnce('First answer.');
+    const owner = await createAuthContext();
+    const intruder = await createAuthContext({
+      email: 'mallory@example.com',
+      googleSub: 'google-sub-mallory',
+      name: 'Mallory',
+    });
+
+    const createRes = await requestWithAuth(owner, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'Owner-only question',
+        idempotencyKey: 'idem-owner',
+      }),
+      redirect: 'manual',
+    });
+
+    const location = requireLocation(createRes);
+    const intruderRes = await requestWithAuth(intruder, `http://localhost:3000${location}`);
+    expect(intruderRes.status).toBe(404);
+  });
+
+  it('persists the user turn and a generic assistant failure turn when ask fails', async () => {
+    mockAsk.mockRejectedValueOnce(new Error('upstream exploded'));
+    const auth = await createAuthContext();
+
+    const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'Will this fail?',
+        idempotencyKey: 'idem-failure',
+      }),
+      redirect: 'manual',
+    });
+
+    expect(createRes.status).toBe(302);
+    const location = requireLocation(createRes);
+
+    const pageRes = await requestWithAuth(auth, `http://localhost:3000${location}`);
+    const page = await pageRes.text();
+    expect(page).toContain('Will this fail?');
+    expect(page).toContain('I hit an error and couldn&#39;t answer that. Please try again.');
+
+    const { db } = getDb('server');
+    const messages = await db.execute(sql`
+      select role, content
+      from messages
+      order by created_at asc, id asc
+    `);
+    expect(messages.rows).toEqual([
+      { role: 'user', content: 'Will this fail?' },
+      {
+        role: 'assistant',
+        content: "I hit an error and couldn't answer that. Please try again.",
+      },
+    ]);
+  });
+
+  it('forwards prior stored history unchanged on follow-up messages', async () => {
+    mockAsk
+      .mockResolvedValueOnce('First answer.')
+      .mockResolvedValueOnce('Second answer.');
+    const auth = await createAuthContext();
+
+    const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'First question',
+        idempotencyKey: 'idem-history',
+      }),
+      redirect: 'manual',
+    });
+    const location = requireLocation(createRes);
+
+    const followUpRes = await requestWithAuth(auth, `http://localhost:3000${location}/messages`, {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'Second question',
+      }),
+      redirect: 'manual',
+    });
+
+    expect(followUpRes.status).toBe(302);
+    expect(mockAsk).toHaveBeenNthCalledWith(2, 'Second question', {
+      history: [
+        { role: 'user', content: 'First question' },
+        { role: 'assistant', content: 'First answer.' },
+      ],
+      userId: auth.userId,
+    });
+  });
+
+  it('reuses the same conversation for repeated first-send idempotency keys', async () => {
+    mockAsk.mockResolvedValue('One answer only.');
+    const auth = await createAuthContext();
+
+    const firstRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'Start one conversation',
+        idempotencyKey: 'idem-repeat',
+      }),
+      redirect: 'manual',
+    });
+    const secondRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'Start one conversation',
+        idempotencyKey: 'idem-repeat',
+      }),
+      redirect: 'manual',
+    });
+
+    expect(requireLocation(firstRes)).toBe(requireLocation(secondRes));
+    expect(mockAsk).toHaveBeenCalledTimes(1);
+
+    const { db } = getDb('server');
+    const conversationCount = await db.execute(sql`select count(*)::int as count from conversations`);
+    const messageCount = await db.execute(sql`select count(*)::int as count from messages`);
+    expect(conversationCount.rows[0].count).toBe(1);
+    expect(messageCount.rows[0].count).toBe(2);
+  });
+
+  it('caps forwarded history to the most recent 20 non-error messages', async () => {
+    mockAsk.mockResolvedValueOnce('Capped answer.');
+    const auth = await createAuthContext();
+    const { db } = getDb('server');
+
+    const [conversation] = await db
+      .insert(conversations)
+      .values({
+        userId: auth.userId,
+      })
+      .returning();
+
+    const baseTime = new Date('2026-04-10T10:00:00.000Z').getTime();
+    const seededMessages = Array.from({ length: 24 }, (_, index) => ({
+      conversationId: conversation.id,
+      role: index % 2 === 0 ? ('user' as const) : ('assistant' as const),
+      content: `Seed message ${index + 1}`,
+      isError: false,
+      createdAt: new Date(baseTime + index * 1000),
+    }));
+    await db.insert(messages).values(seededMessages);
+
+    const res = await requestWithAuth(auth, `http://localhost:3000/chat/${conversation.id}/messages`, {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({ question: 'Newest question' }),
+      redirect: 'manual',
+    });
+
+    expect(res.status).toBe(302);
+    expect(mockAsk).toHaveBeenCalledWith('Newest question', {
+      history: Array.from({ length: 20 }, (_, index) => ({
+        role: (index + 5) % 2 === 1 ? 'user' : 'assistant',
+        content: `Seed message ${index + 5}`,
+      })),
+      userId: auth.userId,
+    });
+  });
+});

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -294,6 +294,65 @@ describe('conversation web backend', () => {
     expect(messageCount.rows[0].count).toBe(2);
   });
 
+  it('repairs an interrupted first send on same-key retry without duplicating assistant turns', async () => {
+    let resolveFirstAsk!: (value: string) => void;
+    const firstAsk = new Promise<string>((resolve) => {
+      resolveFirstAsk = resolve;
+    });
+
+    mockAsk.mockImplementationOnce(() => firstAsk).mockResolvedValueOnce('Recovered answer.');
+    const auth = await createAuthContext();
+
+    const firstResPromise = requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'Start one conversation',
+        idempotencyKey: 'idem-repair',
+      }),
+      redirect: 'manual',
+    });
+
+    const { db } = getDb('server');
+    await vi.waitFor(async () => {
+      const count = await db.execute(sql`select count(*)::int as count from messages`);
+      expect(count.rows[0].count).toBe(1);
+    });
+
+    const retryRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'Start one conversation',
+        idempotencyKey: 'idem-repair',
+      }),
+      redirect: 'manual',
+    });
+
+    expect(retryRes.status).toBe(302);
+    const location = requireLocation(retryRes);
+
+    const pageRes = await requestWithAuth(auth, `http://localhost:3000${location}`);
+    const page = await pageRes.text();
+    expect(page).toContain('Recovered answer.');
+
+    resolveFirstAsk('Late original answer.');
+    await firstResPromise;
+
+    const storedMessages = await db.execute(sql`
+      select role, content
+      from messages
+      order by created_at asc, id asc
+    `);
+    expect(storedMessages.rows).toEqual([
+      { role: 'user', content: 'Start one conversation' },
+      { role: 'assistant', content: 'Recovered answer.' },
+    ]);
+    expect(mockAsk).toHaveBeenCalledTimes(2);
+  });
+
   it('caps forwarded history to the most recent 20 non-error messages', async () => {
     mockAsk.mockResolvedValueOnce('Capped answer.');
     const auth = await createAuthContext();

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -222,9 +222,7 @@ describe('conversation web backend', () => {
   });
 
   it('forwards prior stored history unchanged on follow-up messages', async () => {
-    mockAsk
-      .mockResolvedValueOnce('First answer.')
-      .mockResolvedValueOnce('Second answer.');
+    mockAsk.mockResolvedValueOnce('First answer.').mockResolvedValueOnce('Second answer.');
     const auth = await createAuthContext();
 
     const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
@@ -288,7 +286,9 @@ describe('conversation web backend', () => {
     expect(mockAsk).toHaveBeenCalledTimes(1);
 
     const { db } = getDb('server');
-    const conversationCount = await db.execute(sql`select count(*)::int as count from conversations`);
+    const conversationCount = await db.execute(
+      sql`select count(*)::int as count from conversations`,
+    );
     const messageCount = await db.execute(sql`select count(*)::int as count from messages`);
     expect(conversationCount.rows[0].count).toBe(1);
     expect(messageCount.rows[0].count).toBe(2);
@@ -375,13 +375,17 @@ describe('conversation web backend', () => {
     }));
     await db.insert(messages).values(seededMessages);
 
-    const res = await requestWithAuth(auth, `http://localhost:3000/chat/${conversation.id}/messages`, {
-      method: 'POST',
-      csrf: true,
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      body: formBody({ question: 'Newest question' }),
-      redirect: 'manual',
-    });
+    const res = await requestWithAuth(
+      auth,
+      `http://localhost:3000/chat/${conversation.id}/messages`,
+      {
+        method: 'POST',
+        csrf: true,
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: formBody({ question: 'Newest question' }),
+        redirect: 'manual',
+      },
+    );
 
     expect(res.status).toBe(302);
     expect(mockAsk).toHaveBeenCalledWith('Newest question', {

--- a/test/helpers/db.ts
+++ b/test/helpers/db.ts
@@ -47,8 +47,8 @@ export async function setupTestDb(): Promise<ReturnType<typeof drizzle<typeof sc
 export async function resetTestDb(): Promise<void> {
   if (!db) throw new Error('resetTestDb called before setupTestDb');
   await db.execute(sql`
-    TRUNCATE embeddings, oauth_audit_log, oauth_tokens, oauth_authorization_codes,
-             oauth_clients, sessions, users
+    TRUNCATE messages, conversations, embeddings, oauth_audit_log, oauth_tokens,
+             oauth_authorization_codes, oauth_clients, sessions, users
              RESTART IDENTITY CASCADE
   `);
 }

--- a/test/web-ui-csrf.regression-1.test.ts
+++ b/test/web-ui-csrf.regression-1.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderConversationPage, renderHomePage } from '../src/web-ui/layout.ts';
+import { CSRF_FORM_FIELD_NAME } from '../src/web-ui/csrf.ts';
+import type { Session } from '../src/db/repositories/types.ts';
+
+const testSession: Session = {
+  id: 'test-session-id',
+  userId: 'test-user-id',
+  expiresAt: new Date(Date.now() + 86400000),
+  createdAt: new Date(),
+  ipAddress: null,
+  userAgent: null,
+  lastSeenAt: new Date(),
+  user: {
+    id: 'test-user-id',
+    googleSub: 'test-google-sub',
+    email: 'test@example.com',
+    name: 'Test User',
+    createdAt: new Date(),
+  },
+};
+
+describe('authenticated chat form CSRF regression', () => {
+  it('renders a hidden CSRF field on the first-message form', async () => {
+    // Regression: ISSUE-001 — authenticated home page chat submit fails CSRF
+    // Found by /qa on 2026-04-10
+    // Report: .gstack/qa-reports/qa-report-localhost-2026-04-10.md
+    const body = String(await renderHomePage(testSession, 'test-csrf-token'));
+
+    expect(body).toMatch(
+      new RegExp(
+        `<form[^>]*class="squire-input-dock"[^>]*action="/chat"[\\s\\S]*<input[^>]*name="${CSRF_FORM_FIELD_NAME}"[^>]*value="test-csrf-token"`,
+      ),
+    );
+  });
+
+  it('renders a hidden CSRF field on the follow-up form', async () => {
+    // Regression: ISSUE-001 — authenticated follow-up chat submit fails CSRF
+    // Found by /qa on 2026-04-10
+    // Report: .gstack/qa-reports/qa-report-localhost-2026-04-10.md
+    const body = String(
+      await renderConversationPage({
+        session: testSession,
+        csrfToken: 'test-csrf-token',
+        conversationId: 'conversation-123',
+        messages: [],
+      }),
+    );
+
+    expect(body).toMatch(
+      new RegExp(
+        `<form[^>]*class="squire-input-dock"[^>]*action="/chat/conversation-123/messages"[\\s\\S]*<input[^>]*name="${CSRF_FORM_FIELD_NAME}"[^>]*value="test-csrf-token"`,
+      ),
+    );
+  });
+});

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -234,6 +234,8 @@ describe('SQR-71 dev asset pipeline — bare paths', () => {
     const body = await res.text();
     expect(body).toContain('squire-answer');
     expect(body).toContain('is-active');
+    expect(body).toContain("submitButton.textContent = '...'");
+    expect(body).not.toContain("action === '/chat'");
   });
 
   it('404s the hashed CSS route in dev (it is prod-only)', async () => {

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -184,7 +184,8 @@ describe('GET / — companion-first layout shell (SQR-65)', () => {
     expect(body).toMatch(/<a href="#squire-input"[^>]*sr-only-focusable/);
     expect(body).toMatch(/<input[^>]*id="squire-input"/);
     expect(body).not.toMatch(/<form[^>]*id="squire-input"/);
-    expect(body).toMatch(/<form[^>]*class="squire-input-dock"[^>]*action="\/api\/ask"/);
+    expect(body).toMatch(/<form[^>]*class="squire-input-dock"[^>]*action="\/chat"/);
+    expect(body).toMatch(/<input[^>]*type="hidden"[^>]*name="idempotencyKey"[^>]*value=""/);
   });
 
   it('renders the CSRF token in both meta and inherited hx-headers for authenticated pages', async () => {


### PR DESCRIPTION
## Summary
- add persisted web conversation and message storage for authenticated `/chat` flows
- wire cookie-authenticated chat routes with CSRF protection, ownership checks, idempotent first-send handling, and persisted failure turns
- harden local QA flows with localhost-aware Google OAuth redirects, follow-up submit loading state, and explicit agent bootstrap guidance in `AGENTS.md`

## Verification
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" npm test -- test/auth-google.test.ts test/web-ui-layout.test.ts test/conversation.test.ts`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" npm run typecheck`
- manual QA on worktree server at `http://localhost:4450` for login, first-send, follow-up, refresh persistence, logout redirect, and direct conversation URL access

## Notes
- follow-up reliability gap for interrupted same-key first sends is tracked separately in `SQR-88`
- no version bump or changelog edit in this PR per repo shipping rules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent per-user chat with addressable conversations (/chat/:id), stored message history, generic failure turns, idempotent first-message handling, and client-side idempotency support.

* **UX**
  * Chat form now posts to /chat endpoints; conversation pages render ordered transcripts and include CSRF-hidden fields.

* **Documentation**
  * Added mandatory baseline read, new conversation backend plan, updated architecture, security, contributing, and README guidance.

* **Tests**
  * End-to-end conversation, CSRF regression, and OAuth redirect tests added.

* **Chores**
  * Git hook setup and new project check script; OAuth redirect URI handling improved for local dev.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Documentation
- `README.md`: clarified localhost OAuth callback setup for linked worktrees and documented that authenticated chat now lives on `/chat` with persisted per-user conversations.
- `CLAUDE.md`: made the agent baseline a required first read before repo work or skill execution.
- `docs/ARCHITECTURE.md`: refreshed the conversation model to describe persisted `conversations` and `messages`, the 20-message non-error history cap, current ownership and failure persistence behavior, and the current long-lived bearer-token policy wording.
- `docs/CONTRIBUTING.md`: added the local Google OAuth callback-port registration note for browser QA on linked worktrees.
- `docs/DEVELOPMENT.md`: documented localhost-origin callback reuse for worktree ports and the need to pre-register each callback port in Google Cloud Console.
- `docs/SECURITY.md`: synced the threat model with persisted failure turns, localhost-only dynamic callback derivation, and indistinguishable `404`s for non-owned conversations.

