### PR TITLE
fix: decouple server boot from bootstrap readiness

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -378,8 +378,12 @@ main CI gate:
 
    ```bash
    git push -u origin feat/my-change
-   gh pr create
+   gh pr create --title "SQR-XX: <exact Linear issue title>"
    ```
+
+   Replace `SQR-XX` and the title with the exact Linear issue id and issue
+   title. Do not use the branch slug as the PR title. This is how Linear
+   automatically links the PR back to the issue.
 
 4. Wait for CI and [CodeRabbit](https://coderabbit.ai) review.
 
@@ -388,6 +392,8 @@ main CI gate:
 ### PR guidelines
 
 - Keep PRs small and focused — one logical change per PR.
+- PR titles must be `SQR-XX: <exact Linear issue title>` so Linear links the PR
+  to the issue automatically.
 - Use [Conventional Commits](https://www.conventionalcommits.org/) for commit
   messages (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, `ci:`).
 - All CI checks must pass before merging.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -378,12 +378,12 @@ main CI gate:
 
    ```bash
    git push -u origin feat/my-change
-   gh pr create --title "SQR-XX: <exact Linear issue title>"
+   gh pr create
    ```
 
-   Replace `SQR-XX` and the title with the exact Linear issue id and issue
-   title. Do not use the branch slug as the PR title. This is how Linear
-   automatically links the PR back to the issue.
+   Before submitting, edit the PR body so it includes a `Fixes SQR-XX` or
+   `Closes SQR-XX` line for the Linear issue you are shipping. That is how
+   Linear links the PR back to the issue.
 
 4. Wait for CI and [CodeRabbit](https://coderabbit.ai) review.
 
@@ -392,8 +392,8 @@ main CI gate:
 ### PR guidelines
 
 - Keep PRs small and focused — one logical change per PR.
-- PR titles must be `SQR-XX: <exact Linear issue title>` so Linear links the PR
-  to the issue automatically.
+- PR bodies must include `Fixes SQR-XX` or `Closes SQR-XX` so Linear links the
+  PR to the issue automatically.
 - Use [Conventional Commits](https://www.conventionalcommits.org/) for commit
   messages (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, `ci:`).
 - All CI checks must pass before merging.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -177,6 +177,31 @@ are logged server-side rather than returned from public endpoints.
 `topK` defaults to 6, must be 1–100. The `filter` parameter is a
 URL-encoded JSON object with AND-logic field matching.
 
+### Bootstrap design guardrails
+
+Startup and readiness are modeled as an explicit lifecycle in
+[`src/service.ts`](../src/service.ts), not as route-local booleans. If you are
+adding a new endpoint or capability:
+
+- keep `/api/health` snapshot-only; do not add live DB probes or warmup waits
+  to the health path
+- map the endpoint to a capability based on the dependencies it actually uses
+  on the request path, not just on nearby data being present
+- preserve request validation order: malformed requests should still return
+  their normal `400` responses before bootstrap gating when validation is
+  independent of readiness
+- add lifecycle tests for any new partial-availability claim
+
+Examples:
+
+- rule search depends on both the embeddings table and the embedder, because it
+  calls `embed(query)` on every request
+- card lookup depends on seeded card tables, but not on embedder warmup
+- ask depends on successful warmup as well as bootstrap data
+
+For the full state-machine rationale and endpoint policy table, see
+[docs/plans/sqr-84-startup-lifecycle-state-machine.md](plans/sqr-84-startup-lifecycle-state-machine.md).
+
 ## MCP server
 
 Squire exposes 5 atomic tools via MCP at `/mcp`:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -134,9 +134,10 @@ The server chooses a checkout-local port in two steps:
 Override with `PORT` if you want a specific port. On startup, the server logs
 the final port it selected. It binds the port immediately, then warms the
 retrieval stack in the background. If embeddings or card data are missing,
-startup no longer crashes; `/api/health` reports the missing bootstrap step(s)
-and query endpoints return `503` JSON errors until `npm run index` and/or
-`npm run seed:cards` has been run.
+startup no longer crashes; `/api/health` returns a coarse lifecycle snapshot
+immediately and query endpoints return `503` JSON errors until `npm run index`
+and/or `npm run seed:cards` has been run. Detailed bootstrap and dependency
+reasons are logged server-side.
 
 To discover the current worktree's runtime settings, use startup logs or ask
 the app directly by checking:
@@ -162,7 +163,7 @@ Stop the server with Ctrl-C or `kill $(lsof -ti :<port>)`.
 
 | Method | Path                         | Description                                                |
 | ------ | ---------------------------- | ---------------------------------------------------------- |
-| GET    | `/api/health`                | Readiness check with bootstrap details and index/card size |
+| GET    | `/api/health`                | Snapshot-only readiness check (`lifecycle`, `ready`, `warming_up`) |
 | GET    | `/api/search/rules?q=&topK=` | Vector search over rulebook passages                       |
 | GET    | `/api/search/cards?q=&topK=` | Postgres FTS over the `card_*` tables, ranked by `ts_rank` |
 | GET    | `/api/card-types`            | List card types with record counts                         |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -149,7 +149,7 @@ Example health check for the main checkout:
 
 ```bash
 curl http://localhost:3000/api/health
-# {"lifecycle":"ready","ready":true,"bootstrap_ready":true,"warming_up":false,"index_size":2147,"card_count":1234,"missing_bootstrap_steps":[],"errors":[]}
+# {"lifecycle":"ready","ready":true,"warming_up":false}
 ```
 
 For linked worktrees, replace `3000` with that worktree's logged port. Do not
@@ -170,10 +170,8 @@ Stop the server with Ctrl-C or `kill $(lsof -ti :<port>)`.
 | GET    | `/api/cards/:type/:id`       | Look up a single card                                      |
 | POST   | `/api/ask`                   | Bundled RAG pipeline (`{ question }` → `{ answer }`)       |
 
-All errors return `{ error, status }` as JSON. Bootstrap-related `503`
-responses also include `missing_bootstrap_steps` so local dev and QA can see
-whether the checkout still needs `npm run index`, `npm run seed:cards`, or
-both, plus `lifecycle` and `capability_reason` for typed denial state.
+All errors return `{ error, status }` as JSON. Bootstrap and dependency details
+are logged server-side rather than returned from public endpoints.
 
 `topK` defaults to 6, must be 1–100. The `filter` parameter is a
 URL-encoded JSON object with AND-logic field matching.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -161,15 +161,15 @@ Stop the server with Ctrl-C or `kill $(lsof -ti :<port>)`.
 
 ## REST API endpoints
 
-| Method | Path                         | Description                                                |
-| ------ | ---------------------------- | ---------------------------------------------------------- |
+| Method | Path                         | Description                                                        |
+| ------ | ---------------------------- | ------------------------------------------------------------------ |
 | GET    | `/api/health`                | Snapshot-only readiness check (`lifecycle`, `ready`, `warming_up`) |
-| GET    | `/api/search/rules?q=&topK=` | Vector search over rulebook passages                       |
-| GET    | `/api/search/cards?q=&topK=` | Postgres FTS over the `card_*` tables, ranked by `ts_rank` |
-| GET    | `/api/card-types`            | List card types with record counts                         |
-| GET    | `/api/cards?type=&filter=`   | List cards of a type (filter is JSON)                      |
-| GET    | `/api/cards/:type/:id`       | Look up a single card                                      |
-| POST   | `/api/ask`                   | Bundled RAG pipeline (`{ question }` → `{ answer }`)       |
+| GET    | `/api/search/rules?q=&topK=` | Vector search over rulebook passages                               |
+| GET    | `/api/search/cards?q=&topK=` | Postgres FTS over the `card_*` tables, ranked by `ts_rank`         |
+| GET    | `/api/card-types`            | List card types with record counts                                 |
+| GET    | `/api/cards?type=&filter=`   | List cards of a type (filter is JSON)                              |
+| GET    | `/api/cards/:type/:id`       | Look up a single card                                              |
+| POST   | `/api/ask`                   | Bundled RAG pipeline (`{ question }` → `{ answer }`)               |
 
 All errors return `{ error, status }` as JSON. Bootstrap and dependency details
 are logged server-side rather than returned from public endpoints.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -149,7 +149,7 @@ Example health check for the main checkout:
 
 ```bash
 curl http://localhost:3000/api/health
-# {"ready":true,"bootstrap_ready":true,"warming_up":false,"index_size":2147,"card_count":1234,"missing_bootstrap_steps":[],"errors":[]}
+# {"lifecycle":"ready","ready":true,"bootstrap_ready":true,"warming_up":false,"index_size":2147,"card_count":1234,"missing_bootstrap_steps":[],"errors":[]}
 ```
 
 For linked worktrees, replace `3000` with that worktree's logged port. Do not
@@ -173,7 +173,7 @@ Stop the server with Ctrl-C or `kill $(lsof -ti :<port>)`.
 All errors return `{ error, status }` as JSON. Bootstrap-related `503`
 responses also include `missing_bootstrap_steps` so local dev and QA can see
 whether the checkout still needs `npm run index`, `npm run seed:cards`, or
-both.
+both, plus `lifecycle` and `capability_reason` for typed denial state.
 
 `topK` defaults to 6, must be 1–100. The `filter` parameter is a
 URL-encoded JSON object with AND-logic field matching.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -132,8 +132,11 @@ The server chooses a checkout-local port in two steps:
   the first available port in the managed `4000-5999` range
 
 Override with `PORT` if you want a specific port. On startup, the server logs
-the final port it selected. It initializes the vector index, verifies
-extracted card data, and warms the embedder before accepting requests.
+the final port it selected. It binds the port immediately, then warms the
+retrieval stack in the background. If embeddings or card data are missing,
+startup no longer crashes; `/api/health` reports the missing bootstrap step(s)
+and query endpoints return `503` JSON errors until `npm run index` and/or
+`npm run seed:cards` has been run.
 
 To discover the current worktree's runtime settings, use startup logs or ask
 the app directly by checking:
@@ -146,7 +149,7 @@ Example health check for the main checkout:
 
 ```bash
 curl http://localhost:3000/api/health
-# {"ready":true,"index_size":2147}
+# {"ready":true,"bootstrap_ready":true,"warming_up":false,"index_size":2147,"card_count":1234,"missing_bootstrap_steps":[],"errors":[]}
 ```
 
 For linked worktrees, replace `3000` with that worktree's logged port. Do not
@@ -159,7 +162,7 @@ Stop the server with Ctrl-C or `kill $(lsof -ti :<port>)`.
 
 | Method | Path                         | Description                                                |
 | ------ | ---------------------------- | ---------------------------------------------------------- |
-| GET    | `/api/health`                | Readiness check with index size                            |
+| GET    | `/api/health`                | Readiness check with bootstrap details and index/card size |
 | GET    | `/api/search/rules?q=&topK=` | Vector search over rulebook passages                       |
 | GET    | `/api/search/cards?q=&topK=` | Postgres FTS over the `card_*` tables, ranked by `ts_rank` |
 | GET    | `/api/card-types`            | List card types with record counts                         |
@@ -167,7 +170,10 @@ Stop the server with Ctrl-C or `kill $(lsof -ti :<port>)`.
 | GET    | `/api/cards/:type/:id`       | Look up a single card                                      |
 | POST   | `/api/ask`                   | Bundled RAG pipeline (`{ question }` → `{ answer }`)       |
 
-All errors return `{ error, status }` as JSON.
+All errors return `{ error, status }` as JSON. Bootstrap-related `503`
+responses also include `missing_bootstrap_steps` so local dev and QA can see
+whether the checkout still needs `npm run index`, `npm run seed:cards`, or
+both.
 
 `topK` defaults to 6, must be 1–100. The `filter` parameter is a
 URL-encoded JSON object with AND-logic field matching.

--- a/docs/agent/issue-workflow.md
+++ b/docs/agent/issue-workflow.md
@@ -44,6 +44,23 @@ branch), not when opening the PR.
 GitHub Issues is only used for repo-level concerns (Dependabot, security
 advisories) — not for work tracking.
 
+## Pull requests: mirror the Linear issue id and title
+
+When you open the PR for a Linear issue, the PR title must be:
+
+```text
+SQR-XX: <exact Linear issue title>
+```
+
+Example:
+
+```text
+SQR-8: Streaming chat protocol: text deltas, tool indicators, citations
+```
+
+Use the issue id and exact title from Linear, not the git branch slug. This is
+required so Linear auto-links the PR attachment back to the issue.
+
 ## Dependencies: capture in BOTH Linear Relations AND description text
 
 When a ticket depends on other work, record the dependency in **both** places:

--- a/docs/agent/issue-workflow.md
+++ b/docs/agent/issue-workflow.md
@@ -44,22 +44,22 @@ branch), not when opening the PR.
 GitHub Issues is only used for repo-level concerns (Dependabot, security
 advisories) — not for work tracking.
 
-## Pull requests: mirror the Linear issue id and title
+## Pull requests: explicitly close the Linear issue in the PR body
 
-When you open the PR for a Linear issue, the PR title must be:
+When you open the PR for a Linear issue, include a closing line in the PR body:
 
 ```text
-SQR-XX: <exact Linear issue title>
+Fixes SQR-XX
 ```
 
 Example:
 
 ```text
-SQR-8: Streaming chat protocol: text deltas, tool indicators, citations
+Fixes SQR-8
 ```
 
-Use the issue id and exact title from Linear, not the git branch slug. This is
-required so Linear auto-links the PR attachment back to the issue.
+`Closes SQR-XX` is also acceptable. The important part is that the PR body
+explicitly references the Linear issue so the PR is linked back to the ticket.
 
 ## Dependencies: capture in BOTH Linear Relations AND description text
 

--- a/docs/agent/shipping.md
+++ b/docs/agent/shipping.md
@@ -6,7 +6,13 @@
    - Always include the Linear issue key in the branch name
    - Use the `gitBranchName` field Linear pre-computes for each issue (format: `bcm/sqr-XX-<short-description>`)
 
-2. **Commit Practices**
+2. **Pull Request Metadata**
+   - PR titles must start with the full Linear issue id and exact issue title: `SQR-XX: <Linear issue title>`
+   - Example: `SQR-8: Streaming chat protocol: text deltas, tool indicators, citations`
+   - Use the exact Linear title so Linear auto-links the PR to the issue
+   - Do not use branch-name slugs or `gh pr create --fill` defaults as the final PR title/body
+
+3. **Commit Practices**
    - Commit logical changes together
    - Write meaningful commit messages using Conventional Commits format
    - Commit frequently
@@ -32,6 +38,8 @@ Example: `feat(auth): add user login endpoint`
 
 For the actual ship workflow, invoke the gstack **`/ship`** skill rather than running the steps by hand. In Squire, interpret `/ship` as: detect and merge the base branch, run tests, review the diff, commit, push, and open the PR. Do **not** bump version numbers or edit `CHANGELOG.md` for ordinary feature-branch PRs unless the user explicitly asks for a release/version cut. Open PRs as published PRs, not drafts, unless the user explicitly asks for a draft PR.
 
+When `/ship` opens the PR, set the PR title explicitly to `SQR-XX: <Linear issue title>` instead of accepting GitHub's branch-derived default. Write a short body that explains the user-visible or architectural change plus the validation you ran; do not use the raw commit list as the PR description.
+
 Before pushing, run `npm run check` (or ensure `/ship` does). This is the
 canonical local gate and must stay aligned with CI's formatting, lint, and test
 expectations.
@@ -39,6 +47,7 @@ expectations.
 The rules in this file still apply — `/ship` doesn't override them, it executes them:
 
 - Branch must follow the naming convention above (Linear's `gitBranchName` already does).
+- PR title must be `SQR-XX: <exact Linear issue title>` so Linear auto-links the PR.
 - Commits must follow Conventional Commits.
 - One logical change per PR.
 - Never force-push, never push to main directly. `/ship` always goes through a PR.

--- a/docs/agent/shipping.md
+++ b/docs/agent/shipping.md
@@ -7,9 +7,8 @@
    - Use the `gitBranchName` field Linear pre-computes for each issue (format: `bcm/sqr-XX-<short-description>`)
 
 2. **Pull Request Metadata**
-   - PR titles must start with the full Linear issue id and exact issue title: `SQR-XX: <Linear issue title>`
-   - Example: `SQR-8: Streaming chat protocol: text deltas, tool indicators, citations`
-   - Use the exact Linear title so Linear auto-links the PR to the issue
+   - PR titles may follow the normal `/ship` format or another sensible summary
+   - The PR body must include an explicit Linear closing line such as `Fixes SQR-84` or `Closes SQR-84`
    - Do not use branch-name slugs or `gh pr create --fill` defaults as the final PR title/body
 
 3. **Commit Practices**
@@ -38,7 +37,7 @@ Example: `feat(auth): add user login endpoint`
 
 For the actual ship workflow, invoke the gstack **`/ship`** skill rather than running the steps by hand. In Squire, interpret `/ship` as: detect and merge the base branch, run tests, review the diff, commit, push, and open the PR. Do **not** bump version numbers or edit `CHANGELOG.md` for ordinary feature-branch PRs unless the user explicitly asks for a release/version cut. Open PRs as published PRs, not drafts, unless the user explicitly asks for a draft PR.
 
-When `/ship` opens the PR, set the PR title explicitly to `SQR-XX: <Linear issue title>` instead of accepting GitHub's branch-derived default. Write a short body that explains the user-visible or architectural change plus the validation you ran; do not use the raw commit list as the PR description.
+When `/ship` opens the PR, keep the title human-readable, but make sure the PR body includes a `Fixes SQR-XX` or `Closes SQR-XX` line so Linear links the PR back to the issue. Write a structured body that explains the shipped change and the validation you ran; do not use the raw commit list as the PR description.
 
 Before pushing, run `npm run check` (or ensure `/ship` does). This is the
 canonical local gate and must stay aligned with CI's formatting, lint, and test
@@ -47,7 +46,7 @@ expectations.
 The rules in this file still apply — `/ship` doesn't override them, it executes them:
 
 - Branch must follow the naming convention above (Linear's `gitBranchName` already does).
-- PR title must be `SQR-XX: <exact Linear issue title>` so Linear auto-links the PR.
+- PR body must include `Fixes SQR-XX` or `Closes SQR-XX` so Linear auto-links the PR.
 - Commits must follow Conventional Commits.
 - One logical change per PR.
 - Never force-push, never push to main directly. `/ship` always goes through a PR.

--- a/docs/plans/sqr-84-startup-lifecycle-state-machine.md
+++ b/docs/plans/sqr-84-startup-lifecycle-state-machine.md
@@ -21,7 +21,7 @@ This is not a one-line bug. It is a lifecycle-modeling problem.
 Model bootstrap explicitly in `src/service.ts` and make that module the single
 owner of startup/readiness state.
 
-```
+```text
 LIFECYCLE
 =========
 starting
@@ -63,7 +63,7 @@ An explicit lifecycle snapshot makes those questions separable and testable.
 
 Routes should consume typed capability state, not parse prose from `errors[]`.
 
-```
+```text
 capabilities:
   rules -> allowed + reason + message
   cards -> allowed + reason + message
@@ -100,7 +100,7 @@ present if the request still touches another subsystem at runtime.
 
 ## Endpoint Policy
 
-```
+```text
 STATE              /api/health   rules   cards   ask
 ----------------------------------------------------
 starting              yes         wait    wait    wait
@@ -138,7 +138,7 @@ service snapshot for route gating and logs, not the public health payload.
 
 The service layer owns state transitions.
 
-```
+```text
 WRITERS
 =======
 - startup bootstrap loop

--- a/docs/plans/sqr-84-startup-lifecycle-state-machine.md
+++ b/docs/plans/sqr-84-startup-lifecycle-state-machine.md
@@ -1,0 +1,180 @@
+# SQR-84 Startup Lifecycle State Machine
+
+## Problem
+
+SQR-84 started as a narrow change: bind the server port before embeddings and
+card seed warmup complete. The first implementation got the basic behavior, but
+the follow-up bugs all pointed at the same root cause: startup state was spread
+across multiple overlapping truths.
+
+Examples:
+
+- the process could be listening while health still behaved like startup was
+  blocking
+- search and card endpoints could succeed while health still reported not ready
+- route gating depended on string-matching error text instead of typed state
+
+This is not a one-line bug. It is a lifecycle-modeling problem.
+
+## Recommendation
+
+Model bootstrap explicitly in `src/service.ts` and make that module the single
+owner of startup/readiness state.
+
+```
+LIFECYCLE
+=========
+boot_blocked
+  Dependencies reachable, but required bootstrap data is missing.
+  Example: embeddings table empty or cards not seeded.
+
+warming_up
+  Dependencies reachable, bootstrap data exists, initialization is in flight.
+
+ready
+  Warmup complete. Full service is available.
+
+dependency_failed
+  A required dependency is unavailable right now.
+  Example: Postgres cannot be reached.
+
+init_failed
+  Dependencies are reachable and bootstrap data exists, but warmup failed.
+  Example: embedder warmup crashes.
+```
+
+## Why This Matters
+
+Health checks and route gating are answering different questions:
+
+1. Is the process listening?
+2. Are dependencies reachable?
+3. Is bootstrap data present?
+4. Has warmup completed?
+
+Trying to answer all four with one `ready` boolean creates ambiguous behavior.
+An explicit lifecycle snapshot makes those questions separable and testable.
+
+## Capability Model
+
+Routes should consume typed capability state, not parse prose from `errors[]`.
+
+```
+capabilities:
+  rules -> allowed + reason + message
+  cards -> allowed + reason + message
+  ask   -> allowed + reason + message
+```
+
+Suggested typed reasons:
+
+- `missing_index`
+- `missing_cards`
+- `dependency_unavailable`
+- `warming_up`
+- `init_failed`
+
+This is the important part. `errors[]` is diagnostics. It should never be
+control flow.
+
+## Endpoint Policy
+
+```
+STATE              /api/health   rules   cards   ask
+----------------------------------------------------
+boot_blocked          yes        maybe   maybe   no
+warming_up            yes        yes*    yes*    no
+ready                 yes        yes     yes     yes
+dependency_failed     yes        no      no      no
+init_failed           yes        no      yes*    no
+```
+
+`yes*` means the capability can be served if its own prerequisites are already
+valid. Example: card endpoints can still work while ask remains blocked.
+
+## Health Rules
+
+`/api/health` should be a pure snapshot read:
+
+- never start warmup
+- never wait on warmup
+- always return immediately
+
+If the state machine is modeled correctly, health can report:
+
+- `lifecycle`
+- `ready`
+- `bootstrap_ready`
+- `warming_up`
+- `missing_bootstrap_steps`
+- typed capability denial reasons
+
+without doing work on the request path.
+
+## Writer / Reader Split
+
+The service layer owns state transitions.
+
+```
+WRITERS
+=======
+- startup bootstrap loop
+- initialize() beginning warmup
+- initialize() success
+- initialize() failure
+- explicit refresh / retry hooks
+
+READERS
+=======
+- /api/health
+- route gating
+- ask()
+```
+
+That split is the whole game. Readers observe. Writers transition.
+
+## Database Reachability
+
+`"I can't reach the database"` is not the same problem as `"you forgot to run
+npm run index"`.
+
+- Missing bootstrap data means the dependency is up, but the required content is
+  absent. State: `boot_blocked`.
+- Unreachable Postgres means the dependency itself is down. State:
+  `dependency_failed`.
+
+Do not hide DB failure inside `errors[]` and keep pretending the service is just
+"not bootstrapped yet". That gives operators the wrong fix.
+
+## Test Matrix
+
+The lifecycle model needs an executable test matrix:
+
+- `boot_blocked`
+- `warming_up`
+- `ready`
+- `dependency_failed`
+- `init_failed`
+
+And these regressions need dedicated coverage:
+
+- `/api/health` returns immediately during `warming_up`
+- `startServer()` binds before warmup completes
+- `startServer()` binds even when bootstrap prerequisites are absent
+- route gating is driven by typed capability reasons, not error-string parsing
+
+## Minimal Implementation Plan
+
+1. Add a typed lifecycle snapshot to `src/service.ts`.
+2. Move bootstrap probing into writer-side refresh logic.
+3. Make `/api/health` read the snapshot only.
+4. Make route gating consume typed capability status.
+5. Keep background bootstrap attempts in the service layer, not in health.
+6. Add lifecycle-matrix tests and startup regressions.
+
+## Not In Scope
+
+- introducing a generic external state-machine library
+- changing user-facing API semantics beyond clearer lifecycle fields/reasons
+- redesigning retrieval or card-search internals
+- production deployment orchestration changes

--- a/docs/plans/sqr-84-startup-lifecycle-state-machine.md
+++ b/docs/plans/sqr-84-startup-lifecycle-state-machine.md
@@ -24,6 +24,10 @@ owner of startup/readiness state.
 ```
 LIFECYCLE
 =========
+starting
+  Process is listening, but the bootstrap loop has not produced the first
+  dependency snapshot yet. Health may report this briefly after bind.
+
 boot_blocked
   Dependencies reachable, but required bootstrap data is missing.
   Example: embeddings table empty or cards not seeded.
@@ -82,21 +86,25 @@ control flow.
 ```
 STATE              /api/health   rules   cards   ask
 ----------------------------------------------------
+starting              yes         wait    wait    wait
 boot_blocked          yes        maybe   maybe   no
 warming_up            yes        yes*    yes*    no
 ready                 yes        yes     yes     yes
-dependency_failed     yes        no      no      no
+dependency_failed     yes        maybe   maybe   no
 init_failed           yes        no      yes*    no
 ```
 
 `yes*` means the capability can be served if its own prerequisites are already
 valid. Example: card endpoints can still work while ask remains blocked.
+`wait` means admission-control paths may await the first live probe, while
+health still returns the cached `starting` snapshot immediately.
 
 ## Health Rules
 
 `/api/health` should be a pure snapshot read:
 
 - never start warmup
+- never perform bootstrap probes
 - never wait on warmup
 - always return immediately
 
@@ -104,12 +112,10 @@ If the state machine is modeled correctly, health can report:
 
 - `lifecycle`
 - `ready`
-- `bootstrap_ready`
 - `warming_up`
-- `missing_bootstrap_steps`
-- typed capability denial reasons
 
-without doing work on the request path.
+without doing work on the request path. Richer capability details stay in the
+service snapshot for route gating and logs, not the public health payload.
 
 ## Writer / Reader Split
 

--- a/docs/plans/sqr-84-startup-lifecycle-state-machine.md
+++ b/docs/plans/sqr-84-startup-lifecycle-state-machine.md
@@ -81,6 +81,23 @@ Suggested typed reasons:
 This is the important part. `errors[]` is diagnostics. It should never be
 control flow.
 
+Capability design rule:
+
+- A capability is allowed only if every dependency exercised on that request
+  path is healthy right now.
+
+Examples:
+
+- `rules` requires retrieval data plus the embedder, because each request calls
+  `embed(query)` before vector search.
+- `cards` depends on card tables, but not on embedder warmup.
+- `ask` depends on both retrieval and card bootstrap, plus successful warmup.
+
+This is the easiest place to make subtle mistakes. If a new route or tool calls
+into a dependency on the request path, that dependency must be reflected in the
+capability decision table. Do not infer capability from "related" data being
+present if the request still touches another subsystem at runtime.
+
 ## Endpoint Policy
 
 ```
@@ -169,6 +186,15 @@ And these regressions need dedicated coverage:
 - `startServer()` binds even when bootstrap prerequisites are absent
 - route gating is driven by typed capability reasons, not error-string parsing
 
+For future feature work:
+
+- when adding a new capability, add at least one test for each lifecycle that
+  should block it
+- add one test proving malformed requests still return their normal `400`
+  validation errors before bootstrap gating
+- add one test for any partial-availability claim, for example "cards still
+  work while ask is blocked"
+
 ## Minimal Implementation Plan
 
 1. Add a typed lifecycle snapshot to `src/service.ts`.
@@ -177,6 +203,23 @@ And these regressions need dedicated coverage:
 4. Make route gating consume typed capability status.
 5. Keep background bootstrap attempts in the service layer, not in health.
 6. Add lifecycle-matrix tests and startup regressions.
+
+## Future Development Checklist
+
+When adding a new capability, endpoint, or dependency:
+
+1. Identify every runtime dependency that endpoint touches on the request path.
+2. Decide which lifecycle states should block it and which should allow it.
+3. Update `ServiceBootstrapStatus.capabilities` in `src/service.ts`.
+4. Update the endpoint policy table in this doc if the public contract changes.
+5. Keep `/api/health` snapshot-only. If you need richer diagnostics, use logs or
+   a separate internal surface instead of adding probes to health.
+6. Add regression tests for:
+   - startup / `starting`
+   - blocked bootstrap
+   - dependency failure
+   - init failure
+   - malformed-request validation order when applicable
 
 ## Not In Scope
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "agent:install-launchagent": "node scripts/install-agent-learnings-launchagent.ts",
     "lint": "eslint src/ test/ scripts/",
     "lint:css": "stylelint 'src/web-ui/**/*.css'",
-    "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules' '#data' '#.beads'",
+    "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules' '#data' '#.beads' '#.gstack'",
     "format": "prettier --write src/ test/",
     "format:check": "prettier --check src/ test/",
     "hooks:install": "node scripts/setup-git-hooks.ts",

--- a/src/server.ts
+++ b/src/server.ts
@@ -639,12 +639,7 @@ app.get('/api/health', async (c) => {
   return c.json({
     lifecycle: status.lifecycle,
     ready: status.ready,
-    bootstrap_ready: status.bootstrapReady,
     warming_up: status.warmingUp,
-    index_size: status.indexSize,
-    card_count: status.cardCount,
-    missing_bootstrap_steps: status.missingBootstrapSteps,
-    errors: status.errors,
   });
 });
 
@@ -668,13 +663,13 @@ async function bootstrapErrorResponse(
 
   if (capability.allowed) return null;
 
+  const message =
+    status.lifecycle === 'warming_up'
+      ? 'Service is warming up. Retry in a moment.'
+      : 'Service unavailable.';
+
   return c.json(
-    {
-      ...jsonError(capability.message ?? 'Service bootstrap incomplete', 503),
-      lifecycle: status.lifecycle,
-      capability_reason: capability.reason,
-      missing_bootstrap_steps: status.missingBootstrapSteps,
-    },
+    jsonError(message, 503),
     503,
   );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,10 +10,9 @@ import 'dotenv/config';
 import './instrumentation.ts';
 import { Hono, type Context } from 'hono';
 import { streamSSE } from 'hono/streaming';
-import { isReady, initialize, ask } from './service.ts';
-import { sql } from 'drizzle-orm';
+import { ask, getBootstrapStatus, initialize, refreshInitializationIfReady } from './service.ts';
 
-import { getDb, getWorktreeRuntime } from './db.ts';
+import { getWorktreeRuntime } from './db.ts';
 import { claimWorktreePort } from './worktree-runtime.ts';
 import { searchRules, searchCards, listCardTypes, listCards, getCard } from './tools.ts';
 import type { CardType } from './schemas.ts';
@@ -631,20 +630,16 @@ app.onError((err, c) => {
 // ─── Health endpoint ─────────────────────────────────────────────────────────
 
 app.get('/api/health', async (c) => {
-  let indexSize = 0;
-  try {
-    const { db } = getDb('server');
-    const result = await db.execute<{ count: string }>(
-      sql`SELECT COUNT(*)::text AS count FROM embeddings`,
-    );
-    indexSize = Number(result.rows[0]?.count ?? 0);
-  } catch {
-    // Health endpoint stays best-effort — if the DB is down, report ready:false
-    // via isReady() and leave index_size at 0 rather than 500ing.
-  }
+  await refreshInitializationIfReady();
+  const status = await getBootstrapStatus();
   return c.json({
-    ready: isReady(),
-    index_size: indexSize,
+    ready: status.ready,
+    bootstrap_ready: status.bootstrapReady,
+    warming_up: status.warmingUp,
+    index_size: status.indexSize,
+    card_count: status.cardCount,
+    missing_bootstrap_steps: status.missingBootstrapSteps,
+    errors: status.errors,
   });
 });
 
@@ -657,9 +652,42 @@ function parseTopK(raw: string | undefined): number {
   return n;
 }
 
+async function bootstrapErrorResponse(
+  c: Context,
+  scope: 'rules' | 'cards' | 'ask',
+): Promise<Response | null> {
+  const status = await getBootstrapStatus();
+  const isReady =
+    scope === 'rules'
+      ? status.ruleQueriesReady
+      : scope === 'cards'
+        ? status.cardQueriesReady
+        : status.askReady;
+
+  if (isReady) return null;
+
+  const message =
+    scope === 'rules'
+      ? status.errors.find((err) => err.includes('npm run index') || err.includes('vector-store'))
+      : scope === 'cards'
+        ? status.errors.find((err) => err.includes('npm run seed:cards') || err.includes('card data'))
+        : status.errors[0];
+
+  return c.json(
+    {
+      ...jsonError(message ?? 'Service bootstrap incomplete', 503),
+      missing_bootstrap_steps: status.missingBootstrapSteps,
+    },
+    503,
+  );
+}
+
 app.get('/api/search/rules', async (c) => {
   const q = c.req.query('q');
   if (!q) return c.json(jsonError('Missing required query parameter: q', 400), 400);
+
+  const bootstrapError = await bootstrapErrorResponse(c, 'rules');
+  if (bootstrapError) return bootstrapError;
 
   const topK = parseTopK(c.req.query('topK'));
   const results = await searchRules(q, topK);
@@ -670,6 +698,9 @@ app.get('/api/search/cards', async (c) => {
   const q = c.req.query('q');
   if (!q) return c.json(jsonError('Missing required query parameter: q', 400), 400);
 
+  const bootstrapError = await bootstrapErrorResponse(c, 'cards');
+  if (bootstrapError) return bootstrapError;
+
   const topK = parseTopK(c.req.query('topK'));
   const results = await searchCards(q, topK);
   return c.json({ results });
@@ -678,11 +709,17 @@ app.get('/api/search/cards', async (c) => {
 // ─── Card discovery and lookup endpoints ─────────────────────────────────────
 
 app.get('/api/card-types', async (c) => {
+  const bootstrapError = await bootstrapErrorResponse(c, 'cards');
+  if (bootstrapError) return bootstrapError;
+
   const types = await listCardTypes();
   return c.json({ types });
 });
 
 app.get('/api/cards/:type/:id', async (c) => {
+  const bootstrapError = await bootstrapErrorResponse(c, 'cards');
+  if (bootstrapError) return bootstrapError;
+
   const type = c.req.param('type') as CardType;
   const id = decodeURIComponent(c.req.param('id'));
   const card = await getCard(type, id);
@@ -693,6 +730,9 @@ app.get('/api/cards/:type/:id', async (c) => {
 app.get('/api/cards', async (c) => {
   const type = c.req.query('type');
   if (!type) return c.json(jsonError('Missing required query parameter: type', 400), 400);
+
+  const bootstrapError = await bootstrapErrorResponse(c, 'cards');
+  if (bootstrapError) return bootstrapError;
 
   const filterRaw = c.req.query('filter');
   let filter: Record<string, unknown> | undefined;
@@ -742,6 +782,9 @@ app.post('/api/ask', async (c) => {
     return c.json(jsonError('Invalid request: ' + result.error.issues[0].message, 400), 400);
   }
 
+  const bootstrapError = await bootstrapErrorResponse(c, 'ask');
+  if (bootstrapError) return bootstrapError;
+
   const { question, ...options } = result.data;
   return streamSSE(c, async (stream) => {
     try {
@@ -763,8 +806,6 @@ app.post('/api/ask', async (c) => {
 // ─── Server startup ──────────────────────────────────────────────────────────
 
 export async function startServer(): Promise<void> {
-  await initialize();
-
   const configuredPort = parseInt(process.env.PORT || '', 10);
   const runtime = getWorktreeRuntime();
   const { createAdaptorServer } = await import('@hono/node-server');
@@ -782,6 +823,9 @@ export async function startServer(): Promise<void> {
         server.once('close', () => {
           void claim.release();
         });
+        void initialize().catch((err: unknown) => {
+          console.warn('Server bootstrap incomplete:', err instanceof Error ? err.message : err);
+        });
         console.log(`Squire server listening on port ${claim.port}`);
         return;
       } catch (error) {
@@ -794,6 +838,9 @@ export async function startServer(): Promise<void> {
 
   const server = createAdaptorServer({ fetch: app.fetch });
   await listen(server, configuredPort);
+  void initialize().catch((err: unknown) => {
+    console.warn('Server bootstrap incomplete:', err instanceof Error ? err.message : err);
+  });
   console.log(`Squire server listening on port ${configuredPort}`);
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,12 @@ import 'dotenv/config';
 import './instrumentation.ts';
 import { Hono, type Context } from 'hono';
 import { streamSSE } from 'hono/streaming';
-import { ask, getBootstrapStatus, initialize, refreshInitializationIfReady } from './service.ts';
+import {
+  ask,
+  getBootstrapStatus,
+  isReady,
+  startBootstrapLifecycle,
+} from './service.ts';
 
 import { getWorktreeRuntime } from './db.ts';
 import { claimWorktreePort } from './worktree-runtime.ts';
@@ -630,9 +635,9 @@ app.onError((err, c) => {
 // ─── Health endpoint ─────────────────────────────────────────────────────────
 
 app.get('/api/health', async (c) => {
-  await refreshInitializationIfReady();
   const status = await getBootstrapStatus();
   return c.json({
+    lifecycle: status.lifecycle,
     ready: status.ready,
     bootstrap_ready: status.bootstrapReady,
     warming_up: status.warmingUp,
@@ -656,26 +661,18 @@ async function bootstrapErrorResponse(
   c: Context,
   scope: 'rules' | 'cards' | 'ask',
 ): Promise<Response | null> {
+  if (isReady()) return null;
+
   const status = await getBootstrapStatus();
-  const isReady =
-    scope === 'rules'
-      ? status.ruleQueriesReady
-      : scope === 'cards'
-        ? status.cardQueriesReady
-        : status.askReady;
+  const capability = status.capabilities[scope];
 
-  if (isReady) return null;
-
-  const message =
-    scope === 'rules'
-      ? status.errors.find((err) => err.includes('npm run index') || err.includes('vector-store'))
-      : scope === 'cards'
-        ? status.errors.find((err) => err.includes('npm run seed:cards') || err.includes('card data'))
-        : status.errors[0];
+  if (capability.allowed) return null;
 
   return c.json(
     {
-      ...jsonError(message ?? 'Service bootstrap incomplete', 503),
+      ...jsonError(capability.message ?? 'Service bootstrap incomplete', 503),
+      lifecycle: status.lifecycle,
+      capability_reason: capability.reason,
       missing_bootstrap_steps: status.missingBootstrapSteps,
     },
     503,
@@ -823,9 +820,7 @@ export async function startServer(): Promise<void> {
         server.once('close', () => {
           void claim.release();
         });
-        void initialize().catch((err: unknown) => {
-          console.warn('Server bootstrap incomplete:', err instanceof Error ? err.message : err);
-        });
+        startBootstrapLifecycle();
         console.log(`Squire server listening on port ${claim.port}`);
         return;
       } catch (error) {
@@ -838,9 +833,7 @@ export async function startServer(): Promise<void> {
 
   const server = createAdaptorServer({ fetch: app.fetch });
   await listen(server, configuredPort);
-  void initialize().catch((err: unknown) => {
-    console.warn('Server bootstrap incomplete:', err instanceof Error ? err.message : err);
-  });
+  startBootstrapLifecycle();
   console.log(`Squire server listening on port ${configuredPort}`);
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,7 @@ import 'dotenv/config';
 // before service.ts transitively loads db.ts, otherwise Postgres spans never
 // reach Langfuse in production. Same pattern as query.ts and eval/run.ts.
 import './instrumentation.ts';
-import { Hono, type Context } from 'hono';
+import { Hono, type Context, type MiddlewareHandler } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import {
   ask,
@@ -674,24 +674,28 @@ async function bootstrapErrorResponse(
   );
 }
 
-app.get('/api/search/rules', async (c) => {
+function requireBootstrapCapability(
+  scope: 'rules' | 'cards' | 'ask',
+): MiddlewareHandler {
+  return async (c, next) => {
+    const bootstrapError = await bootstrapErrorResponse(c, scope);
+    if (bootstrapError) return bootstrapError;
+    await next();
+  };
+}
+
+app.get('/api/search/rules', requireBootstrapCapability('rules'), async (c) => {
   const q = c.req.query('q');
   if (!q) return c.json(jsonError('Missing required query parameter: q', 400), 400);
-
-  const bootstrapError = await bootstrapErrorResponse(c, 'rules');
-  if (bootstrapError) return bootstrapError;
 
   const topK = parseTopK(c.req.query('topK'));
   const results = await searchRules(q, topK);
   return c.json({ results });
 });
 
-app.get('/api/search/cards', async (c) => {
+app.get('/api/search/cards', requireBootstrapCapability('cards'), async (c) => {
   const q = c.req.query('q');
   if (!q) return c.json(jsonError('Missing required query parameter: q', 400), 400);
-
-  const bootstrapError = await bootstrapErrorResponse(c, 'cards');
-  if (bootstrapError) return bootstrapError;
 
   const topK = parseTopK(c.req.query('topK'));
   const results = await searchCards(q, topK);
@@ -700,18 +704,12 @@ app.get('/api/search/cards', async (c) => {
 
 // ─── Card discovery and lookup endpoints ─────────────────────────────────────
 
-app.get('/api/card-types', async (c) => {
-  const bootstrapError = await bootstrapErrorResponse(c, 'cards');
-  if (bootstrapError) return bootstrapError;
-
+app.get('/api/card-types', requireBootstrapCapability('cards'), async (c) => {
   const types = await listCardTypes();
   return c.json({ types });
 });
 
-app.get('/api/cards/:type/:id', async (c) => {
-  const bootstrapError = await bootstrapErrorResponse(c, 'cards');
-  if (bootstrapError) return bootstrapError;
-
+app.get('/api/cards/:type/:id', requireBootstrapCapability('cards'), async (c) => {
   const type = c.req.param('type') as CardType;
   const id = decodeURIComponent(c.req.param('id'));
   const card = await getCard(type, id);
@@ -719,12 +717,9 @@ app.get('/api/cards/:type/:id', async (c) => {
   return c.json({ card });
 });
 
-app.get('/api/cards', async (c) => {
+app.get('/api/cards', requireBootstrapCapability('cards'), async (c) => {
   const type = c.req.query('type');
   if (!type) return c.json(jsonError('Missing required query parameter: type', 400), 400);
-
-  const bootstrapError = await bootstrapErrorResponse(c, 'cards');
-  if (bootstrapError) return bootstrapError;
 
   const filterRaw = c.req.query('filter');
   let filter: Record<string, unknown> | undefined;
@@ -761,7 +756,7 @@ const AskRequestSchema = z.object({
   userId: z.string().uuid().optional(),
 });
 
-app.post('/api/ask', async (c) => {
+app.post('/api/ask', requireBootstrapCapability('ask'), async (c) => {
   let body: unknown;
   try {
     body = await c.req.json();
@@ -773,9 +768,6 @@ app.post('/api/ask', async (c) => {
   if (!result.success) {
     return c.json(jsonError('Invalid request: ' + result.error.issues[0].message, 400), 400);
   }
-
-  const bootstrapError = await bootstrapErrorResponse(c, 'ask');
-  if (bootstrapError) return bootstrapError;
 
   const { question, ...options } = result.data;
   return streamSSE(c, async (stream) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { Hono, type Context, type MiddlewareHandler } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import {
   ask,
+  ensureBootstrapStatus,
   getBootstrapStatus,
   isReady,
   startBootstrapLifecycle,
@@ -635,7 +636,8 @@ app.onError((err, c) => {
 // ─── Health endpoint ─────────────────────────────────────────────────────────
 
 app.get('/api/health', async (c) => {
-  const status = await getBootstrapStatus();
+  // Health is a pure snapshot read. Do not await live bootstrap probes here.
+  const status = getBootstrapStatus();
   return c.json({
     lifecycle: status.lifecycle,
     ready: status.ready,
@@ -658,7 +660,7 @@ async function bootstrapErrorResponse(
 ): Promise<Response | null> {
   if (isReady()) return null;
 
-  const status = await getBootstrapStatus();
+  const status = await ensureBootstrapStatus();
   const capability = status.capabilities[scope];
 
   if (capability.allowed) return null;
@@ -684,18 +686,31 @@ function requireBootstrapCapability(
   };
 }
 
-app.get('/api/search/rules', requireBootstrapCapability('rules'), async (c) => {
+async function ensureBootstrapCapability(
+  c: Context,
+  scope: 'rules' | 'cards' | 'ask',
+): Promise<Response | null> {
+  return bootstrapErrorResponse(c, scope);
+}
+
+app.get('/api/search/rules', async (c) => {
   const q = c.req.query('q');
   if (!q) return c.json(jsonError('Missing required query parameter: q', 400), 400);
+
+  const bootstrapError = await ensureBootstrapCapability(c, 'rules');
+  if (bootstrapError) return bootstrapError;
 
   const topK = parseTopK(c.req.query('topK'));
   const results = await searchRules(q, topK);
   return c.json({ results });
 });
 
-app.get('/api/search/cards', requireBootstrapCapability('cards'), async (c) => {
+app.get('/api/search/cards', async (c) => {
   const q = c.req.query('q');
   if (!q) return c.json(jsonError('Missing required query parameter: q', 400), 400);
+
+  const bootstrapError = await ensureBootstrapCapability(c, 'cards');
+  if (bootstrapError) return bootstrapError;
 
   const topK = parseTopK(c.req.query('topK'));
   const results = await searchCards(q, topK);
@@ -717,7 +732,7 @@ app.get('/api/cards/:type/:id', requireBootstrapCapability('cards'), async (c) =
   return c.json({ card });
 });
 
-app.get('/api/cards', requireBootstrapCapability('cards'), async (c) => {
+app.get('/api/cards', async (c) => {
   const type = c.req.query('type');
   if (!type) return c.json(jsonError('Missing required query parameter: type', 400), 400);
 
@@ -734,6 +749,9 @@ app.get('/api/cards', requireBootstrapCapability('cards'), async (c) => {
       return c.json(jsonError('Invalid filter JSON', 400), 400);
     }
   }
+
+  const bootstrapError = await ensureBootstrapCapability(c, 'cards');
+  if (bootstrapError) return bootstrapError;
 
   const cards = await listCards(type as CardType, filter);
   return c.json({ cards });
@@ -756,7 +774,7 @@ const AskRequestSchema = z.object({
   userId: z.string().uuid().optional(),
 });
 
-app.post('/api/ask', requireBootstrapCapability('ask'), async (c) => {
+app.post('/api/ask', async (c) => {
   let body: unknown;
   try {
     body = await c.req.json();
@@ -768,6 +786,9 @@ app.post('/api/ask', requireBootstrapCapability('ask'), async (c) => {
   if (!result.success) {
     return c.json(jsonError('Invalid request: ' + result.error.issues[0].message, 400), 400);
   }
+
+  const bootstrapError = await ensureBootstrapCapability(c, 'ask');
+  if (bootstrapError) return bootstrapError;
 
   const { question, ...options } = result.data;
   return streamSSE(c, async (stream) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import {
   startBootstrapLifecycle,
 } from './service.ts';
 
-import { getWorktreeRuntime } from './db.ts';
+import { getDb, getWorktreeRuntime } from './db.ts';
 import { claimWorktreePort } from './worktree-runtime.ts';
 import { searchRules, searchCards, listCardTypes, listCards, getCard } from './tools.ts';
 import type { CardType } from './schemas.ts';
@@ -670,15 +670,10 @@ async function bootstrapErrorResponse(
       ? 'Service is warming up. Retry in a moment.'
       : 'Service unavailable.';
 
-  return c.json(
-    jsonError(message, 503),
-    503,
-  );
+  return c.json(jsonError(message, 503), 503);
 }
 
-function requireBootstrapCapability(
-  scope: 'rules' | 'cards' | 'ask',
-): MiddlewareHandler {
+function requireBootstrapCapability(scope: 'rules' | 'cards' | 'ask'): MiddlewareHandler {
   return async (c, next) => {
     const bootstrapError = await bootstrapErrorResponse(c, scope);
     if (bootstrapError) return bootstrapError;

--- a/src/service.ts
+++ b/src/service.ts
@@ -74,6 +74,9 @@ let initPromise: Promise<void> | null = null;
 let initErrorMessage: string | null = null;
 let lifecycle: BootstrapLifecycle = 'boot_blocked';
 let bootstrapPoller: ReturnType<typeof setInterval> | null = null;
+let bootstrapRefreshPromise: Promise<ServiceBootstrapStatus> | null = null;
+let bootstrapStatusReady = false;
+let lastBootstrapLogSignature: string | null = null;
 
 let bootstrapStatus: ServiceBootstrapStatus = {
   lifecycle,
@@ -100,6 +103,9 @@ export function _resetForTesting(): void {
   initPromise = null;
   initErrorMessage = null;
   lifecycle = 'boot_blocked';
+  bootstrapRefreshPromise = null;
+  bootstrapStatusReady = false;
+  lastBootstrapLogSignature = null;
   if (bootstrapPoller) {
     clearInterval(bootstrapPoller);
     bootstrapPoller = null;
@@ -129,7 +135,7 @@ export function _resetForTesting(): void {
  * verify extracted data is available. Safe to call concurrently.
  */
 export async function initialize(): Promise<void> {
-  if (initialized) return;
+  if (initialized && lifecycle === 'ready') return;
   if (initPromise) return initPromise;
 
   const snapshot = await refreshBootstrapState();
@@ -332,16 +338,51 @@ function buildBootstrapStatus(
   };
 }
 
+function logBootstrapTransition(status: ServiceBootstrapStatus): void {
+  const signature = `${status.lifecycle}|${status.errors.join('|')}`;
+  if (signature === lastBootstrapLogSignature) return;
+  lastBootstrapLogSignature = signature;
+
+  if (status.lifecycle === 'ready') {
+    console.log('Squire bootstrap ready.');
+    return;
+  }
+
+  const detail = status.errors[0];
+  if (detail) {
+    console.warn(`Squire bootstrap ${status.lifecycle}: ${detail}`);
+    return;
+  }
+
+  if (status.lifecycle === 'warming_up') {
+    console.log('Squire bootstrap warming up.');
+    return;
+  }
+
+  console.warn(`Squire bootstrap ${status.lifecycle}.`);
+}
+
 export async function refreshBootstrapState(): Promise<ServiceBootstrapStatus> {
+  if (bootstrapRefreshPromise) return bootstrapRefreshPromise;
+
+  bootstrapRefreshPromise = (async () => {
   const [retrieval, cards] = await Promise.all([
     getRetrievalBootstrapStatus(),
     getCardBootstrapStatus(),
   ]);
-  bootstrapStatus = buildBootstrapStatus(retrieval, cards);
-  return bootstrapStatus;
+    bootstrapStatus = buildBootstrapStatus(retrieval, cards);
+    bootstrapStatusReady = true;
+    logBootstrapTransition(bootstrapStatus);
+    return bootstrapStatus;
+  })().finally(() => {
+    bootstrapRefreshPromise = null;
+  });
+
+  return bootstrapRefreshPromise;
 }
 
 export async function getBootstrapStatus(): Promise<ServiceBootstrapStatus> {
+  if (!bootstrapStatusReady) return refreshBootstrapState();
   return bootstrapStatus;
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -6,27 +6,52 @@
 import { embed } from './embedder.ts';
 import {
   EMBEDDINGS_BOOTSTRAP_MESSAGE,
+  type RetrievalBootstrapStatus,
   getRetrievalBootstrapStatus,
   initializeRetrieval,
 } from './vector-store.ts';
 import { listCardTypes } from './tools.ts';
 import { runAgentLoop } from './agent.ts';
 
-let ready = false;
-let initPromise: Promise<void> | null = null;
-
 const CARD_BOOTSTRAP_MESSAGE = 'No card data found in Postgres. Run `npm run seed:cards` first.';
 const CARD_DB_HINT =
   'Is Postgres running? Try `docker compose up -d` and `npm run db:migrate`.';
+const WARMING_UP_MESSAGE = 'Service is warming up. Retry in a moment.';
+const INIT_FAILED_MESSAGE = 'Service warmup failed. Check server logs and retry.';
+const BOOTSTRAP_POLL_MS = 5000;
+
+type MissingBootstrapStep = 'npm run index' | 'npm run seed:cards';
+
+export type BootstrapLifecycle =
+  | 'boot_blocked'
+  | 'warming_up'
+  | 'ready'
+  | 'dependency_failed'
+  | 'init_failed';
+
+export type CapabilityReason =
+  | 'missing_index'
+  | 'missing_cards'
+  | 'dependency_unavailable'
+  | 'warming_up'
+  | 'init_failed';
 
 interface CardBootstrapStatus {
   ready: boolean;
   cardCount: number;
   error?: string;
   missingStep?: 'npm run seed:cards';
+  reason?: 'missing_cards' | 'dependency_unavailable';
+}
+
+export interface CapabilityStatus {
+  allowed: boolean;
+  reason: CapabilityReason | null;
+  message: string | null;
 }
 
 export interface ServiceBootstrapStatus {
+  lifecycle: BootstrapLifecycle;
   ready: boolean;
   bootstrapReady: boolean;
   warmingUp: boolean;
@@ -35,49 +60,132 @@ export interface ServiceBootstrapStatus {
   ruleQueriesReady: boolean;
   cardQueriesReady: boolean;
   askReady: boolean;
-  missingBootstrapSteps: Array<'npm run index' | 'npm run seed:cards'>;
+  missingBootstrapSteps: MissingBootstrapStep[];
   errors: string[];
+  capabilities: {
+    rules: CapabilityStatus;
+    cards: CapabilityStatus;
+    ask: CapabilityStatus;
+  };
 }
+
+let initialized = false;
+let initPromise: Promise<void> | null = null;
+let initErrorMessage: string | null = null;
+let lifecycle: BootstrapLifecycle = 'boot_blocked';
+let bootstrapPoller: ReturnType<typeof setInterval> | null = null;
+
+let bootstrapStatus: ServiceBootstrapStatus = {
+  lifecycle,
+  ready: false,
+  bootstrapReady: false,
+  warmingUp: false,
+  indexSize: 0,
+  cardCount: 0,
+  ruleQueriesReady: false,
+  cardQueriesReady: false,
+  askReady: false,
+  missingBootstrapSteps: [],
+  errors: [],
+  capabilities: {
+    rules: { allowed: false, reason: 'missing_index', message: EMBEDDINGS_BOOTSTRAP_MESSAGE },
+    cards: { allowed: false, reason: 'missing_cards', message: CARD_BOOTSTRAP_MESSAGE },
+    ask: { allowed: false, reason: 'missing_index', message: EMBEDDINGS_BOOTSTRAP_MESSAGE },
+  },
+};
 
 /** @internal Reset service state for testing. */
 export function _resetForTesting(): void {
-  ready = false;
+  initialized = false;
   initPromise = null;
+  initErrorMessage = null;
+  lifecycle = 'boot_blocked';
+  if (bootstrapPoller) {
+    clearInterval(bootstrapPoller);
+    bootstrapPoller = null;
+  }
+  bootstrapStatus = {
+    lifecycle,
+    ready: false,
+    bootstrapReady: false,
+    warmingUp: false,
+    indexSize: 0,
+    cardCount: 0,
+    ruleQueriesReady: false,
+    cardQueriesReady: false,
+    askReady: false,
+    missingBootstrapSteps: [],
+    errors: [],
+    capabilities: {
+      rules: { allowed: false, reason: 'missing_index', message: EMBEDDINGS_BOOTSTRAP_MESSAGE },
+      cards: { allowed: false, reason: 'missing_cards', message: CARD_BOOTSTRAP_MESSAGE },
+      ask: { allowed: false, reason: 'missing_index', message: EMBEDDINGS_BOOTSTRAP_MESSAGE },
+    },
+  };
 }
 
 /**
  * Initialize the service: load the vector index, warm the embedder, and
- * verify extracted data is available. Throws if the index is empty.
- * Safe to call concurrently — only the first call does work.
+ * verify extracted data is available. Safe to call concurrently.
  */
 export async function initialize(): Promise<void> {
-  if (ready) return;
+  if (initialized) return;
   if (initPromise) return initPromise;
 
-  initPromise = doInitialize().catch((err) => {
-    initPromise = null;
-    throw err;
-  });
+  const snapshot = await refreshBootstrapState();
+  if (!snapshot.bootstrapReady) {
+    throw new Error(snapshot.capabilities.ask.message ?? snapshot.errors[0] ?? EMBEDDINGS_BOOTSTRAP_MESSAGE);
+  }
+
+  lifecycle = 'warming_up';
+  bootstrapStatus = buildBootstrapStatus(
+    snapshot.lifecycle === 'dependency_failed'
+      ? {
+          ready: false,
+          indexSize: snapshot.indexSize,
+          error: snapshot.errors[0],
+          reason: 'dependency_unavailable',
+        }
+      : { ready: true, indexSize: snapshot.indexSize },
+    snapshot.lifecycle === 'dependency_failed'
+      ? {
+          ready: false,
+          cardCount: snapshot.cardCount,
+          error: snapshot.errors[0],
+          reason: 'dependency_unavailable',
+        }
+      : { ready: true, cardCount: snapshot.cardCount },
+  );
+
+  initPromise = doInitialize()
+    .then(() => {
+      initialized = true;
+      initErrorMessage = null;
+      lifecycle = 'ready';
+    })
+    .catch((err) => {
+      initialized = false;
+      initErrorMessage = err instanceof Error ? err.message : String(err);
+      lifecycle = 'init_failed';
+      throw err;
+    })
+    .finally(async () => {
+      initPromise = null;
+      await refreshBootstrapState();
+    });
+
   return initPromise;
 }
 
 async function doInitialize(): Promise<void> {
-  const bootstrap = await getBootstrapStatus();
-  if (!bootstrap.bootstrapReady) {
-    throw new Error(bootstrap.errors[0] ?? EMBEDDINGS_BOOTSTRAP_MESSAGE);
-  }
-
-  // Retrieval layer owns vector index + embedder warmup + drift guard.
   await initializeRetrieval(embed);
-
-  ready = true;
 }
 
 /**
  * Whether the service has been initialized and is ready to serve requests.
  */
 export function isReady(): boolean {
-  return ready;
+  return initialized && lifecycle === 'ready';
 }
 
 async function getCardBootstrapStatus(): Promise<CardBootstrapStatus> {
@@ -90,6 +198,7 @@ async function getCardBootstrapStatus(): Promise<CardBootstrapStatus> {
         cardCount: 0,
         error: CARD_BOOTSTRAP_MESSAGE,
         missingStep: 'npm run seed:cards',
+        reason: 'missing_cards',
       };
     }
     return { ready: true, cardCount: totalCards };
@@ -99,16 +208,78 @@ async function getCardBootstrapStatus(): Promise<CardBootstrapStatus> {
       ready: false,
       cardCount: 0,
       error: `card data query failed: ${message}. ${CARD_DB_HINT}`,
+      reason: 'dependency_unavailable',
     };
   }
 }
 
-export async function getBootstrapStatus(): Promise<ServiceBootstrapStatus> {
-  const [retrieval, cards] = await Promise.all([
-    getRetrievalBootstrapStatus(),
-    getCardBootstrapStatus(),
-  ]);
-  const missingBootstrapSteps: Array<'npm run index' | 'npm run seed:cards'> = [];
+function buildCapabilityStatus(
+  kind: BootstrapLifecycle,
+  scope: 'rules' | 'cards' | 'ask',
+  retrieval: RetrievalBootstrapStatus,
+  cards: CardBootstrapStatus,
+): CapabilityStatus {
+  if (kind === 'ready') return { allowed: true, reason: null, message: null };
+
+  if (kind === 'dependency_failed') {
+    const message = retrieval.error ?? cards.error ?? CARD_DB_HINT;
+    return { allowed: false, reason: 'dependency_unavailable', message };
+  }
+
+  if (scope === 'rules') {
+    if (retrieval.ready) return { allowed: true, reason: null, message: null };
+    return {
+      allowed: false,
+      reason: retrieval.reason ?? 'missing_index',
+      message: retrieval.error ?? EMBEDDINGS_BOOTSTRAP_MESSAGE,
+    };
+  }
+
+  if (scope === 'cards') {
+    if (cards.ready) return { allowed: true, reason: null, message: null };
+    return {
+      allowed: false,
+      reason: cards.reason ?? 'missing_cards',
+      message: cards.error ?? CARD_BOOTSTRAP_MESSAGE,
+    };
+  }
+
+  if (kind === 'warming_up') {
+    return { allowed: false, reason: 'warming_up', message: WARMING_UP_MESSAGE };
+  }
+
+  if (kind === 'init_failed') {
+    return {
+      allowed: false,
+      reason: 'init_failed',
+      message: initErrorMessage ?? INIT_FAILED_MESSAGE,
+    };
+  }
+
+  if (!retrieval.ready) {
+    return {
+      allowed: false,
+      reason: retrieval.reason ?? 'missing_index',
+      message: retrieval.error ?? EMBEDDINGS_BOOTSTRAP_MESSAGE,
+    };
+  }
+
+  if (!cards.ready) {
+    return {
+      allowed: false,
+      reason: cards.reason ?? 'missing_cards',
+      message: cards.error ?? CARD_BOOTSTRAP_MESSAGE,
+    };
+  }
+
+  return { allowed: false, reason: 'warming_up', message: WARMING_UP_MESSAGE };
+}
+
+function buildBootstrapStatus(
+  retrieval: RetrievalBootstrapStatus,
+  cards: CardBootstrapStatus,
+): ServiceBootstrapStatus {
+  const missingBootstrapSteps: MissingBootstrapStep[] = [];
   const errors: string[] = [];
 
   if (!retrieval.ready) {
@@ -121,40 +292,86 @@ export async function getBootstrapStatus(): Promise<ServiceBootstrapStatus> {
     if (cards.error) errors.push(cards.error);
   }
 
-  const bootstrapReady = missingBootstrapSteps.length === 0 && errors.length === 0;
+  const dependencyUnavailable =
+    retrieval.reason === 'dependency_unavailable' || cards.reason === 'dependency_unavailable';
+  const bootstrapReady = retrieval.ready && cards.ready;
+
+  if (dependencyUnavailable) {
+    lifecycle = 'dependency_failed';
+  } else if (!bootstrapReady) {
+    lifecycle = 'boot_blocked';
+  } else if (initialized) {
+    lifecycle = 'ready';
+  } else if (initPromise) {
+    lifecycle = 'warming_up';
+  } else if (initErrorMessage) {
+    lifecycle = 'init_failed';
+  } else {
+    lifecycle = 'warming_up';
+  }
+
+  const capabilities = {
+    rules: buildCapabilityStatus(lifecycle, 'rules', retrieval, cards),
+    cards: buildCapabilityStatus(lifecycle, 'cards', retrieval, cards),
+    ask: buildCapabilityStatus(lifecycle, 'ask', retrieval, cards),
+  };
 
   return {
-    ready: ready && bootstrapReady,
+    lifecycle,
+    ready: lifecycle === 'ready',
     bootstrapReady,
-    warmingUp: bootstrapReady && !ready,
+    warmingUp: lifecycle === 'warming_up',
     indexSize: retrieval.indexSize,
     cardCount: cards.cardCount,
-    ruleQueriesReady: retrieval.ready,
-    cardQueriesReady: cards.ready,
-    askReady: retrieval.ready && cards.ready,
+    ruleQueriesReady: capabilities.rules.allowed,
+    cardQueriesReady: capabilities.cards.allowed,
+    askReady: capabilities.ask.allowed,
     missingBootstrapSteps,
     errors,
+    capabilities,
   };
 }
 
+export async function refreshBootstrapState(): Promise<ServiceBootstrapStatus> {
+  const [retrieval, cards] = await Promise.all([
+    getRetrievalBootstrapStatus(),
+    getCardBootstrapStatus(),
+  ]);
+  bootstrapStatus = buildBootstrapStatus(retrieval, cards);
+  return bootstrapStatus;
+}
+
+export async function getBootstrapStatus(): Promise<ServiceBootstrapStatus> {
+  return bootstrapStatus;
+}
+
+export function startBootstrapLifecycle(): void {
+  if (bootstrapPoller) return;
+
+  const tick = async (): Promise<void> => {
+    const status = await refreshBootstrapState();
+    if (status.bootstrapReady && !status.ready && !initPromise) {
+      void initialize().catch(() => {});
+    }
+  };
+
+  void tick();
+  bootstrapPoller = setInterval(() => {
+    void tick();
+  }, BOOTSTRAP_POLL_MS);
+  bootstrapPoller.unref?.();
+}
+
 /**
- * Best-effort recovery hook for health checks. If bootstrap prerequisites now
- * exist but the process has not finished initializing yet, kick initialization
- * once so `/api/health` can converge back to ready without waiting for an
- * `/api/ask` request.
+ * Deprecated compatibility hook for earlier tests and callers. Performs a
+ * non-blocking state refresh and kicks background initialization when
+ * prerequisites are available.
  */
 export async function refreshInitializationIfReady(): Promise<void> {
-  if (ready || initPromise) {
-    if (initPromise) {
-      await initPromise.catch(() => {});
-    }
-    return;
+  const status = await refreshBootstrapState();
+  if (status.bootstrapReady && !status.ready && !initPromise) {
+    void initialize().catch(() => {});
   }
-
-  const status = await getBootstrapStatus();
-  if (!status.bootstrapReady) return;
-
-  await initialize().catch(() => {});
 }
 
 export interface HistoryMessage {
@@ -180,7 +397,6 @@ export interface AskOptions {
  * iterates until it has enough context, then produces a grounded answer.
  */
 export async function ask(question: string, options?: AskOptions): Promise<string> {
-  if (!ready) await initialize();
-
+  if (!isReady()) await initialize();
   return runAgentLoop(question, options);
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,12 +4,40 @@
  */
 
 import { embed } from './embedder.ts';
-import { initializeRetrieval } from './vector-store.ts';
+import {
+  EMBEDDINGS_BOOTSTRAP_MESSAGE,
+  getRetrievalBootstrapStatus,
+  initializeRetrieval,
+} from './vector-store.ts';
 import { listCardTypes } from './tools.ts';
 import { runAgentLoop } from './agent.ts';
 
 let ready = false;
 let initPromise: Promise<void> | null = null;
+
+const CARD_BOOTSTRAP_MESSAGE = 'No card data found in Postgres. Run `npm run seed:cards` first.';
+const CARD_DB_HINT =
+  'Is Postgres running? Try `docker compose up -d` and `npm run db:migrate`.';
+
+interface CardBootstrapStatus {
+  ready: boolean;
+  cardCount: number;
+  error?: string;
+  missingStep?: 'npm run seed:cards';
+}
+
+export interface ServiceBootstrapStatus {
+  ready: boolean;
+  bootstrapReady: boolean;
+  warmingUp: boolean;
+  indexSize: number;
+  cardCount: number;
+  ruleQueriesReady: boolean;
+  cardQueriesReady: boolean;
+  askReady: boolean;
+  missingBootstrapSteps: Array<'npm run index' | 'npm run seed:cards'>;
+  errors: string[];
+}
 
 /** @internal Reset service state for testing. */
 export function _resetForTesting(): void {
@@ -34,15 +62,13 @@ export async function initialize(): Promise<void> {
 }
 
 async function doInitialize(): Promise<void> {
+  const bootstrap = await getBootstrapStatus();
+  if (!bootstrap.bootstrapReady) {
+    throw new Error(bootstrap.errors[0] ?? EMBEDDINGS_BOOTSTRAP_MESSAGE);
+  }
+
   // Retrieval layer owns vector index + embedder warmup + drift guard.
   await initializeRetrieval(embed);
-
-  // Verify extracted data is available.
-  const types = await listCardTypes();
-  const totalCards = types.reduce((sum, t) => sum + t.count, 0);
-  if (totalCards === 0) {
-    throw new Error('No card data found in Postgres. Run `npm run seed:cards` first.');
-  }
 
   ready = true;
 }
@@ -52,6 +78,83 @@ async function doInitialize(): Promise<void> {
  */
 export function isReady(): boolean {
   return ready;
+}
+
+async function getCardBootstrapStatus(): Promise<CardBootstrapStatus> {
+  try {
+    const types = await listCardTypes();
+    const totalCards = types.reduce((sum, t) => sum + t.count, 0);
+    if (totalCards === 0) {
+      return {
+        ready: false,
+        cardCount: 0,
+        error: CARD_BOOTSTRAP_MESSAGE,
+        missingStep: 'npm run seed:cards',
+      };
+    }
+    return { ready: true, cardCount: totalCards };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ready: false,
+      cardCount: 0,
+      error: `card data query failed: ${message}. ${CARD_DB_HINT}`,
+    };
+  }
+}
+
+export async function getBootstrapStatus(): Promise<ServiceBootstrapStatus> {
+  const [retrieval, cards] = await Promise.all([
+    getRetrievalBootstrapStatus(),
+    getCardBootstrapStatus(),
+  ]);
+  const missingBootstrapSteps: Array<'npm run index' | 'npm run seed:cards'> = [];
+  const errors: string[] = [];
+
+  if (!retrieval.ready) {
+    if (retrieval.missingStep) missingBootstrapSteps.push(retrieval.missingStep);
+    if (retrieval.error) errors.push(retrieval.error);
+  }
+
+  if (!cards.ready) {
+    if (cards.missingStep) missingBootstrapSteps.push(cards.missingStep);
+    if (cards.error) errors.push(cards.error);
+  }
+
+  const bootstrapReady = missingBootstrapSteps.length === 0 && errors.length === 0;
+
+  return {
+    ready: ready && bootstrapReady,
+    bootstrapReady,
+    warmingUp: bootstrapReady && !ready,
+    indexSize: retrieval.indexSize,
+    cardCount: cards.cardCount,
+    ruleQueriesReady: retrieval.ready,
+    cardQueriesReady: cards.ready,
+    askReady: retrieval.ready && cards.ready,
+    missingBootstrapSteps,
+    errors,
+  };
+}
+
+/**
+ * Best-effort recovery hook for health checks. If bootstrap prerequisites now
+ * exist but the process has not finished initializing yet, kick initialization
+ * once so `/api/health` can converge back to ready without waiting for an
+ * `/api/ask` request.
+ */
+export async function refreshInitializationIfReady(): Promise<void> {
+  if (ready || initPromise) {
+    if (initPromise) {
+      await initPromise.catch(() => {});
+    }
+    return;
+  }
+
+  const status = await getBootstrapStatus();
+  if (!status.bootstrapReady) return;
+
+  await initialize().catch(() => {});
 }
 
 export interface HistoryMessage {
@@ -77,9 +180,7 @@ export interface AskOptions {
  * iterates until it has enough context, then produces a grounded answer.
  */
 export async function ask(question: string, options?: AskOptions): Promise<string> {
-  if (!ready) {
-    throw new Error('Service not initialized. Call initialize() first.');
-  }
+  if (!ready) await initialize();
 
   return runAgentLoop(question, options);
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -23,6 +23,7 @@ const BOOTSTRAP_POLL_MS = 5000;
 type MissingBootstrapStep = 'npm run index' | 'npm run seed:cards';
 
 export type BootstrapLifecycle =
+  | 'starting'
   | 'boot_blocked'
   | 'warming_up'
   | 'ready'
@@ -72,7 +73,7 @@ export interface ServiceBootstrapStatus {
 let initialized = false;
 let initPromise: Promise<void> | null = null;
 let initErrorMessage: string | null = null;
-let lifecycle: BootstrapLifecycle = 'boot_blocked';
+let lifecycle: BootstrapLifecycle = 'starting';
 let bootstrapPoller: ReturnType<typeof setInterval> | null = null;
 let bootstrapRefreshPromise: Promise<ServiceBootstrapStatus> | null = null;
 let bootstrapStatusReady = false;
@@ -91,9 +92,9 @@ let bootstrapStatus: ServiceBootstrapStatus = {
   missingBootstrapSteps: [],
   errors: [],
   capabilities: {
-    rules: { allowed: false, reason: 'missing_index', message: EMBEDDINGS_BOOTSTRAP_MESSAGE },
-    cards: { allowed: false, reason: 'missing_cards', message: CARD_BOOTSTRAP_MESSAGE },
-    ask: { allowed: false, reason: 'missing_index', message: EMBEDDINGS_BOOTSTRAP_MESSAGE },
+    rules: { allowed: false, reason: 'warming_up', message: WARMING_UP_MESSAGE },
+    cards: { allowed: false, reason: 'warming_up', message: WARMING_UP_MESSAGE },
+    ask: { allowed: false, reason: 'warming_up', message: WARMING_UP_MESSAGE },
   },
 };
 
@@ -102,7 +103,7 @@ export function _resetForTesting(): void {
   initialized = false;
   initPromise = null;
   initErrorMessage = null;
-  lifecycle = 'boot_blocked';
+  lifecycle = 'starting';
   bootstrapRefreshPromise = null;
   bootstrapStatusReady = false;
   lastBootstrapLogSignature = null;
@@ -123,9 +124,9 @@ export function _resetForTesting(): void {
     missingBootstrapSteps: [],
     errors: [],
     capabilities: {
-      rules: { allowed: false, reason: 'missing_index', message: EMBEDDINGS_BOOTSTRAP_MESSAGE },
-      cards: { allowed: false, reason: 'missing_cards', message: CARD_BOOTSTRAP_MESSAGE },
-      ask: { allowed: false, reason: 'missing_index', message: EMBEDDINGS_BOOTSTRAP_MESSAGE },
+      rules: { allowed: false, reason: 'warming_up', message: WARMING_UP_MESSAGE },
+      cards: { allowed: false, reason: 'warming_up', message: WARMING_UP_MESSAGE },
+      ask: { allowed: false, reason: 'warming_up', message: WARMING_UP_MESSAGE },
     },
   };
 }
@@ -143,6 +144,9 @@ export async function initialize(): Promise<void> {
     throw new Error(snapshot.capabilities.ask.message ?? snapshot.errors[0] ?? EMBEDDINGS_BOOTSTRAP_MESSAGE);
   }
 
+  // A retry is a fresh warmup attempt, so clear the stale terminal error
+  // before rebuilding the in-flight snapshot.
+  initErrorMessage = null;
   lifecycle = 'warming_up';
   bootstrapStatus = buildBootstrapStatus(
     snapshot.lifecycle === 'dependency_failed'
@@ -226,11 +230,6 @@ function buildCapabilityStatus(
   cards: CardBootstrapStatus,
 ): CapabilityStatus {
   if (kind === 'ready') return { allowed: true, reason: null, message: null };
-
-  if (kind === 'dependency_failed') {
-    const message = retrieval.error ?? cards.error ?? CARD_DB_HINT;
-    return { allowed: false, reason: 'dependency_unavailable', message };
-  }
 
   if (scope === 'rules') {
     if (retrieval.ready) return { allowed: true, reason: null, message: null };
@@ -366,10 +365,10 @@ export async function refreshBootstrapState(): Promise<ServiceBootstrapStatus> {
   if (bootstrapRefreshPromise) return bootstrapRefreshPromise;
 
   bootstrapRefreshPromise = (async () => {
-  const [retrieval, cards] = await Promise.all([
-    getRetrievalBootstrapStatus(),
-    getCardBootstrapStatus(),
-  ]);
+    const [retrieval, cards] = await Promise.all([
+      getRetrievalBootstrapStatus(),
+      getCardBootstrapStatus(),
+    ]);
     bootstrapStatus = buildBootstrapStatus(retrieval, cards);
     bootstrapStatusReady = true;
     logBootstrapTransition(bootstrapStatus);
@@ -381,7 +380,19 @@ export async function refreshBootstrapState(): Promise<ServiceBootstrapStatus> {
   return bootstrapRefreshPromise;
 }
 
-export async function getBootstrapStatus(): Promise<ServiceBootstrapStatus> {
+/**
+ * Snapshot-only read for health and other observers. This must never trigger
+ * live bootstrap probes or await dependency checks on the request path.
+ */
+export function getBootstrapStatus(): ServiceBootstrapStatus {
+  return bootstrapStatus;
+}
+
+/**
+ * Resolve bootstrap status for admission-control paths. This may perform live
+ * dependency probes until the first real snapshot has been established.
+ */
+export async function ensureBootstrapStatus(): Promise<ServiceBootstrapStatus> {
   if (!bootstrapStatusReady) return refreshBootstrapState();
   return bootstrapStatus;
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -70,6 +70,39 @@ export interface ServiceBootstrapStatus {
   };
 }
 
+/**
+ * Lifecycle contract
+ *
+ * starting
+ *   Process is listening, but no live probe has completed yet.
+ * boot_blocked
+ *   Dependencies are reachable, but required bootstrap data is missing.
+ * warming_up
+ *   Bootstrap prerequisites exist and warmup is currently in flight.
+ * ready
+ *   Warmup completed successfully.
+ * dependency_failed
+ *   A required dependency probe failed.
+ * init_failed
+ *   Warmup itself failed after prerequisites were available.
+ *
+ * Transition sketch
+ *   starting -> boot_blocked | warming_up | dependency_failed
+ *   boot_blocked -> warming_up | dependency_failed
+ *   warming_up -> ready | init_failed | dependency_failed
+ *   ready -> boot_blocked | dependency_failed
+ *   dependency_failed -> boot_blocked | warming_up
+ *   init_failed -> warming_up | dependency_failed | boot_blocked
+ *
+ * Extension rules
+ *   1. Keep health on snapshot reads only. Do not add live probes to
+ *      getBootstrapStatus().
+ *   2. A capability may be allowed only if every dependency it exercises on
+ *      the request path is healthy. Example: rules require embeddings AND the
+ *      embedder, so init_failed must block them.
+ *   3. When adding a capability, update the capability map, endpoint policy,
+ *      and lifecycle tests together.
+ */
 let initialized = false;
 let initPromise: Promise<void> | null = null;
 let initErrorMessage: string | null = null;
@@ -230,6 +263,14 @@ function buildCapabilityStatus(
   cards: CardBootstrapStatus,
 ): CapabilityStatus {
   if (kind === 'ready') return { allowed: true, reason: null, message: null };
+
+  if (kind === 'init_failed' && scope !== 'cards') {
+    return {
+      allowed: false,
+      reason: 'init_failed',
+      message: initErrorMessage ?? INIT_FAILED_MESSAGE,
+    };
+  }
 
   if (scope === 'rules') {
     if (retrieval.ready) return { allowed: true, reason: null, message: null };

--- a/src/service.ts
+++ b/src/service.ts
@@ -14,8 +14,7 @@ import { listCardTypes } from './tools.ts';
 import { runAgentLoop } from './agent.ts';
 
 const CARD_BOOTSTRAP_MESSAGE = 'No card data found in Postgres. Run `npm run seed:cards` first.';
-const CARD_DB_HINT =
-  'Is Postgres running? Try `docker compose up -d` and `npm run db:migrate`.';
+const CARD_DB_HINT = 'Is Postgres running? Try `docker compose up -d` and `npm run db:migrate`.';
 const WARMING_UP_MESSAGE = 'Service is warming up. Retry in a moment.';
 const INIT_FAILED_MESSAGE = 'Service warmup failed. Check server logs and retry.';
 const BOOTSTRAP_POLL_MS = 5000;
@@ -174,7 +173,9 @@ export async function initialize(): Promise<void> {
 
   const snapshot = await refreshBootstrapState();
   if (!snapshot.bootstrapReady) {
-    throw new Error(snapshot.capabilities.ask.message ?? snapshot.errors[0] ?? EMBEDDINGS_BOOTSTRAP_MESSAGE);
+    throw new Error(
+      snapshot.capabilities.ask.message ?? snapshot.errors[0] ?? EMBEDDINGS_BOOTSTRAP_MESSAGE,
+    );
   }
 
   // A retry is a fresh warmup attempt, so clear the stale terminal error

--- a/src/vector-store.ts
+++ b/src/vector-store.ts
@@ -193,6 +193,41 @@ function wrapDbError(err: unknown): Error {
   );
 }
 
+export const EMBEDDINGS_BOOTSTRAP_MESSAGE =
+  'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.';
+
+export interface RetrievalBootstrapStatus {
+  ready: boolean;
+  indexSize: number;
+  error?: string;
+  missingStep?: 'npm run index';
+}
+
+export async function getRetrievalBootstrapStatus(): Promise<RetrievalBootstrapStatus> {
+  try {
+    const { db } = getDb('server');
+    const result = await db.execute<{ count: string }>(
+      sql`SELECT COUNT(*)::text AS count FROM embeddings`,
+    );
+    const count = Number(result.rows[0]?.count ?? 0);
+    if (count === 0) {
+      return {
+        ready: false,
+        indexSize: 0,
+        error: EMBEDDINGS_BOOTSTRAP_MESSAGE,
+        missingStep: 'npm run index',
+      };
+    }
+    return { ready: true, indexSize: count };
+  } catch (err) {
+    return {
+      ready: false,
+      indexSize: 0,
+      error: wrapDbError(err).message,
+    };
+  }
+}
+
 /**
  * Bring the retrieval layer into a ready state: verify the embeddings table
  * is populated, warm the embedder, and run the embedding-version drift guard.
@@ -203,21 +238,9 @@ function wrapDbError(err: unknown): Error {
 export async function initializeRetrieval(
   warmupEmbed: (text: string) => Promise<unknown>,
 ): Promise<void> {
-  try {
-    const { db } = getDb('server');
-    const result = await db.execute<{ count: string }>(
-      sql`SELECT COUNT(*)::text AS count FROM embeddings`,
-    );
-    const count = Number(result.rows[0]?.count ?? 0);
-    if (count === 0) {
-      throw new Error(
-        'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
-      );
-    }
-  } catch (err) {
-    // Surface DB connectivity problems with the same friendly hint as search().
-    if ((err as Error).message?.startsWith('Embeddings table is empty')) throw err;
-    throw wrapDbError(err);
+  const status = await getRetrievalBootstrapStatus();
+  if (!status.ready) {
+    throw new Error(status.error ?? EMBEDDINGS_BOOTSTRAP_MESSAGE);
   }
 
   // Pay the embedder cold-start cost now so the first real query is fast.

--- a/src/vector-store.ts
+++ b/src/vector-store.ts
@@ -201,6 +201,7 @@ export interface RetrievalBootstrapStatus {
   indexSize: number;
   error?: string;
   missingStep?: 'npm run index';
+  reason?: 'missing_index' | 'dependency_unavailable';
 }
 
 export async function getRetrievalBootstrapStatus(): Promise<RetrievalBootstrapStatus> {
@@ -216,6 +217,7 @@ export async function getRetrievalBootstrapStatus(): Promise<RetrievalBootstrapS
         indexSize: 0,
         error: EMBEDDINGS_BOOTSTRAP_MESSAGE,
         missingStep: 'npm run index',
+        reason: 'missing_index',
       };
     }
     return { ready: true, indexSize: count };
@@ -224,6 +226,7 @@ export async function getRetrievalBootstrapStatus(): Promise<RetrievalBootstrapS
       ready: false,
       indexSize: 0,
       error: wrapDbError(err).message,
+      reason: 'dependency_unavailable',
     };
   }
 }

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -142,9 +142,9 @@ describe('GET /api/health', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toHaveProperty('ready', true);
-    expect(body).toHaveProperty('bootstrap_ready', true);
-    expect(body).toHaveProperty('index_size');
-    expect(typeof body.index_size).toBe('number');
+    expect(body).toHaveProperty('lifecycle', 'ready');
+    expect(body).toHaveProperty('warming_up', false);
+    expect(body).not.toHaveProperty('errors');
   });
 
   it('returns ready=false when service is not initialized', async () => {
@@ -166,12 +166,6 @@ describe('GET /api/health', () => {
     const body = await res.json();
     expect(body.ready).toBe(false);
     expect(body.warming_up).toBe(true);
-  });
-
-  it('includes index_size in response', async () => {
-    const res = await app.request('/api/health');
-    const body = await res.json();
-    expect(body.index_size).toBe(3);
   });
 
   it('returns JSON content type', async () => {
@@ -262,8 +256,8 @@ describe('GET /api/search/rules', () => {
     const res = await app.request('/api/search/rules?q=loot', { headers: await auth() });
     expect(res.status).toBe(503);
     const body = await res.json();
-    expect(body.error).toMatch(/npm run index/);
-    expect(body.missing_bootstrap_steps).toEqual(['npm run index']);
+    expect(body.error).toBe('Service unavailable.');
+    expect(body).not.toHaveProperty('missing_bootstrap_steps');
   });
 });
 
@@ -344,7 +338,7 @@ describe('GET /api/search/cards', () => {
     const res = await app.request('/api/search/cards?q=algox', { headers: await auth() });
     expect(res.status).toBe(503);
     const body = await res.json();
-    expect(body.error).toMatch(/npm run seed:cards/);
+    expect(body.error).toBe('Service unavailable.');
   });
 });
 
@@ -618,7 +612,8 @@ describe('POST /api/ask', () => {
     expect(res.status).toBe(503);
     expect(res.headers.get('content-type')).toContain('application/json');
     const body = await res.json();
-    expect(body.missing_bootstrap_steps).toEqual(['npm run index', 'npm run seed:cards']);
+    expect(body.error).toBe('Service unavailable.');
+    expect(body).not.toHaveProperty('missing_bootstrap_steps');
   });
 
   it('emits error event when ask() throws', async () => {

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -15,9 +15,51 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { parseSSE } from './helpers/server-oauth-helpers.ts';
 
+function makeStatus(
+  overrides: Partial<{
+    lifecycle: string;
+    ready: boolean;
+    bootstrapReady: boolean;
+    warmingUp: boolean;
+    indexSize: number;
+    cardCount: number;
+    ruleQueriesReady: boolean;
+    cardQueriesReady: boolean;
+    askReady: boolean;
+    missingBootstrapSteps: string[];
+    errors: string[];
+    capabilities: {
+      rules: { allowed: boolean; reason: string | null; message: string | null };
+      cards: { allowed: boolean; reason: string | null; message: string | null };
+      ask: { allowed: boolean; reason: string | null; message: string | null };
+    };
+  }> = {},
+) {
+  return {
+    lifecycle: 'ready',
+    ready: true,
+    bootstrapReady: true,
+    warmingUp: false,
+    indexSize: 3,
+    cardCount: 15,
+    ruleQueriesReady: true,
+    cardQueriesReady: true,
+    askReady: true,
+    missingBootstrapSteps: [],
+    errors: [],
+    capabilities: {
+      rules: { allowed: true, reason: null, message: null },
+      cards: { allowed: true, reason: null, message: null },
+      ask: { allowed: true, reason: null, message: null },
+    },
+    ...overrides,
+  };
+}
+
 const {
   mockInitialize,
   mockGetBootstrapStatus,
+  mockIsReady,
   mockRefreshInitializationIfReady,
   mockAsk,
   mockSearchRules,
@@ -28,6 +70,7 @@ const {
 } = vi.hoisted(() => ({
   mockInitialize: vi.fn(),
   mockGetBootstrapStatus: vi.fn(),
+  mockIsReady: vi.fn(),
   mockRefreshInitializationIfReady: vi.fn(),
   mockAsk: vi.fn(),
   mockSearchRules: vi.fn(),
@@ -40,6 +83,7 @@ const {
 vi.mock('../src/service.ts', () => ({
   initialize: mockInitialize,
   getBootstrapStatus: mockGetBootstrapStatus,
+  isReady: mockIsReady,
   refreshInitializationIfReady: mockRefreshInitializationIfReady,
   ask: mockAsk,
 }));
@@ -88,19 +132,9 @@ async function auth(): Promise<Record<string, string>> {
 describe('GET /api/health', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsReady.mockReturnValue(true);
     mockRefreshInitializationIfReady.mockResolvedValue(undefined);
-    mockGetBootstrapStatus.mockResolvedValue({
-      ready: true,
-      bootstrapReady: true,
-      warmingUp: false,
-      indexSize: 3,
-      cardCount: 15,
-      ruleQueriesReady: true,
-      cardQueriesReady: true,
-      askReady: true,
-      missingBootstrapSteps: [],
-      errors: [],
-    });
+    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
   });
 
   it('returns 200 with ready status', async () => {
@@ -114,18 +148,19 @@ describe('GET /api/health', () => {
   });
 
   it('returns ready=false when service is not initialized', async () => {
-    mockGetBootstrapStatus.mockResolvedValueOnce({
-      ready: false,
-      bootstrapReady: true,
-      warmingUp: true,
-      indexSize: 3,
-      cardCount: 15,
-      ruleQueriesReady: true,
-      cardQueriesReady: true,
-      askReady: true,
-      missingBootstrapSteps: [],
-      errors: [],
-    });
+    mockGetBootstrapStatus.mockResolvedValueOnce(
+      makeStatus({
+        lifecycle: 'warming_up',
+        ready: false,
+        warmingUp: true,
+        capabilities: {
+          rules: { allowed: true, reason: null, message: null },
+          cards: { allowed: true, reason: null, message: null },
+          ask: { allowed: false, reason: 'warming_up', message: 'Service is warming up. Retry in a moment.' },
+        },
+        askReady: false,
+      }),
+    );
     const res = await app.request('/api/health');
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -144,9 +179,9 @@ describe('GET /api/health', () => {
     expect(res.headers.get('content-type')).toContain('application/json');
   });
 
-  it('asks the service to recover readiness before reporting health', async () => {
+  it('reports lifecycle state without invoking recovery hooks', async () => {
     await app.request('/api/health');
-    expect(mockRefreshInitializationIfReady).toHaveBeenCalled();
+    expect(mockRefreshInitializationIfReady).not.toHaveBeenCalled();
   });
 });
 
@@ -155,18 +190,8 @@ describe('GET /api/health', () => {
 describe('GET /api/search/rules', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetBootstrapStatus.mockResolvedValue({
-      ready: true,
-      bootstrapReady: true,
-      warmingUp: false,
-      indexSize: 3,
-      cardCount: 15,
-      ruleQueriesReady: true,
-      cardQueriesReady: true,
-      askReady: true,
-      missingBootstrapSteps: [],
-      errors: [],
-    });
+    mockIsReady.mockReturnValue(true);
+    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
     mockSearchRules.mockResolvedValue([
       { text: 'Loot: pick up all loot tokens.', source: 'rulebook.pdf:42', score: 0.9 },
     ]);
@@ -208,18 +233,32 @@ describe('GET /api/search/rules', () => {
   });
 
   it('returns 503 with an actionable bootstrap error when embeddings are missing', async () => {
-    mockGetBootstrapStatus.mockResolvedValueOnce({
-      ready: false,
-      bootstrapReady: false,
-      warmingUp: false,
-      indexSize: 0,
-      cardCount: 15,
-      ruleQueriesReady: false,
-      cardQueriesReady: true,
-      askReady: false,
-      missingBootstrapSteps: ['npm run index'],
-      errors: ['Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.'],
-    });
+    mockIsReady.mockReturnValueOnce(false);
+    mockGetBootstrapStatus.mockResolvedValueOnce(
+      makeStatus({
+        lifecycle: 'boot_blocked',
+        ready: false,
+        bootstrapReady: false,
+        indexSize: 0,
+        ruleQueriesReady: false,
+        askReady: false,
+        missingBootstrapSteps: ['npm run index'],
+        errors: ['Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.'],
+        capabilities: {
+          rules: {
+            allowed: false,
+            reason: 'missing_index',
+            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+          },
+          cards: { allowed: true, reason: null, message: null },
+          ask: {
+            allowed: false,
+            reason: 'missing_index',
+            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+          },
+        },
+      }),
+    );
     const res = await app.request('/api/search/rules?q=loot', { headers: await auth() });
     expect(res.status).toBe(503);
     const body = await res.json();
@@ -233,18 +272,8 @@ describe('GET /api/search/rules', () => {
 describe('GET /api/search/cards', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetBootstrapStatus.mockResolvedValue({
-      ready: true,
-      bootstrapReady: true,
-      warmingUp: false,
-      indexSize: 3,
-      cardCount: 15,
-      ruleQueriesReady: true,
-      cardQueriesReady: true,
-      askReady: true,
-      missingBootstrapSteps: [],
-      errors: [],
-    });
+    mockIsReady.mockReturnValue(true);
+    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
     mockSearchCards.mockReturnValue([
       { type: 'monster-stats', data: { name: 'Algox Archer' }, score: 2 },
     ]);
@@ -286,18 +315,32 @@ describe('GET /api/search/cards', () => {
   });
 
   it('returns 503 with an actionable bootstrap error when card data is missing', async () => {
-    mockGetBootstrapStatus.mockResolvedValueOnce({
-      ready: false,
-      bootstrapReady: false,
-      warmingUp: false,
-      indexSize: 3,
-      cardCount: 0,
-      ruleQueriesReady: true,
-      cardQueriesReady: false,
-      askReady: false,
-      missingBootstrapSteps: ['npm run seed:cards'],
-      errors: ['No card data found in Postgres. Run `npm run seed:cards` first.'],
-    });
+    mockIsReady.mockReturnValueOnce(false);
+    mockGetBootstrapStatus.mockResolvedValueOnce(
+      makeStatus({
+        lifecycle: 'boot_blocked',
+        ready: false,
+        bootstrapReady: false,
+        cardCount: 0,
+        cardQueriesReady: false,
+        askReady: false,
+        missingBootstrapSteps: ['npm run seed:cards'],
+        errors: ['No card data found in Postgres. Run `npm run seed:cards` first.'],
+        capabilities: {
+          rules: { allowed: true, reason: null, message: null },
+          cards: {
+            allowed: false,
+            reason: 'missing_cards',
+            message: 'No card data found in Postgres. Run `npm run seed:cards` first.',
+          },
+          ask: {
+            allowed: false,
+            reason: 'missing_cards',
+            message: 'No card data found in Postgres. Run `npm run seed:cards` first.',
+          },
+        },
+      }),
+    );
     const res = await app.request('/api/search/cards?q=algox', { headers: await auth() });
     expect(res.status).toBe(503);
     const body = await res.json();
@@ -310,18 +353,8 @@ describe('GET /api/search/cards', () => {
 describe('GET /api/card-types', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetBootstrapStatus.mockResolvedValue({
-      ready: true,
-      bootstrapReady: true,
-      warmingUp: false,
-      indexSize: 3,
-      cardCount: 15,
-      ruleQueriesReady: true,
-      cardQueriesReady: true,
-      askReady: true,
-      missingBootstrapSteps: [],
-      errors: [],
-    });
+    mockIsReady.mockReturnValue(true);
+    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
     mockListCardTypes.mockReturnValue([
       { type: 'monster-stats', count: 10 },
       { type: 'items', count: 5 },
@@ -343,18 +376,8 @@ describe('GET /api/card-types', () => {
 describe('GET /api/cards', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetBootstrapStatus.mockResolvedValue({
-      ready: true,
-      bootstrapReady: true,
-      warmingUp: false,
-      indexSize: 3,
-      cardCount: 15,
-      ruleQueriesReady: true,
-      cardQueriesReady: true,
-      askReady: true,
-      missingBootstrapSteps: [],
-      errors: [],
-    });
+    mockIsReady.mockReturnValue(true);
+    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
     mockListCards.mockReturnValue([{ name: 'Algox Archer' }]);
   });
 
@@ -390,18 +413,8 @@ describe('GET /api/cards', () => {
 describe('GET /api/cards/:type/:id', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetBootstrapStatus.mockResolvedValue({
-      ready: true,
-      bootstrapReady: true,
-      warmingUp: false,
-      indexSize: 3,
-      cardCount: 15,
-      ruleQueriesReady: true,
-      cardQueriesReady: true,
-      askReady: true,
-      missingBootstrapSteps: [],
-      errors: [],
-    });
+    mockIsReady.mockReturnValue(true);
+    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
     mockGetCard.mockReturnValue({ name: 'Algox Archer', levelRange: '0-3' });
   });
 
@@ -429,18 +442,8 @@ describe('GET /api/cards/:type/:id', () => {
 describe('POST /api/ask', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetBootstrapStatus.mockResolvedValue({
-      ready: true,
-      bootstrapReady: true,
-      warmingUp: false,
-      indexSize: 3,
-      cardCount: 15,
-      ruleQueriesReady: true,
-      cardQueriesReady: true,
-      askReady: true,
-      missingBootstrapSteps: [],
-      errors: [],
-    });
+    mockIsReady.mockReturnValue(true);
+    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
     mockAsk.mockResolvedValue('Loot tokens are picked up in your hex.');
   });
 
@@ -572,21 +575,41 @@ describe('POST /api/ask', () => {
   });
 
   it('returns 503 JSON before opening the stream when bootstrap is incomplete', async () => {
-    mockGetBootstrapStatus.mockResolvedValueOnce({
-      ready: false,
-      bootstrapReady: false,
-      warmingUp: false,
-      indexSize: 0,
-      cardCount: 0,
-      ruleQueriesReady: false,
-      cardQueriesReady: false,
-      askReady: false,
-      missingBootstrapSteps: ['npm run index', 'npm run seed:cards'],
-      errors: [
-        'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
-        'No card data found in Postgres. Run `npm run seed:cards` first.',
-      ],
-    });
+    mockIsReady.mockReturnValueOnce(false);
+    mockGetBootstrapStatus.mockResolvedValueOnce(
+      makeStatus({
+        lifecycle: 'boot_blocked',
+        ready: false,
+        bootstrapReady: false,
+        indexSize: 0,
+        cardCount: 0,
+        ruleQueriesReady: false,
+        cardQueriesReady: false,
+        askReady: false,
+        missingBootstrapSteps: ['npm run index', 'npm run seed:cards'],
+        errors: [
+          'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+          'No card data found in Postgres. Run `npm run seed:cards` first.',
+        ],
+        capabilities: {
+          rules: {
+            allowed: false,
+            reason: 'missing_index',
+            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+          },
+          cards: {
+            allowed: false,
+            reason: 'missing_cards',
+            message: 'No card data found in Postgres. Run `npm run seed:cards` first.',
+          },
+          ask: {
+            allowed: false,
+            reason: 'missing_index',
+            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+          },
+        },
+      }),
+    );
     const res = await app.request('/api/ask', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...(await auth()) },
@@ -611,6 +634,21 @@ describe('POST /api/ask', () => {
     const errorEvent = events.find((e) => e.event === 'error');
     expect(errorEvent).toBeDefined();
     expect(JSON.parse(errorEvent!.data)).toHaveProperty('message', 'Internal server error');
+  });
+});
+
+describe('bootstrapErrorResponse fast path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsReady.mockReturnValue(true);
+    mockSearchRules.mockResolvedValue([
+      { text: 'Loot: pick up all loot tokens.', source: 'rulebook.pdf:42', score: 0.9 },
+    ]);
+  });
+
+  it('skips bootstrap probes for ready search requests', async () => {
+    await app.request('/api/search/rules?q=loot', { headers: await auth() });
+    expect(mockGetBootstrapStatus).not.toHaveBeenCalled();
   });
 });
 

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -17,7 +17,8 @@ import { parseSSE } from './helpers/server-oauth-helpers.ts';
 
 const {
   mockInitialize,
-  mockIsReady,
+  mockGetBootstrapStatus,
+  mockRefreshInitializationIfReady,
   mockAsk,
   mockSearchRules,
   mockSearchCards,
@@ -26,7 +27,8 @@ const {
   mockGetCard,
 } = vi.hoisted(() => ({
   mockInitialize: vi.fn(),
-  mockIsReady: vi.fn(),
+  mockGetBootstrapStatus: vi.fn(),
+  mockRefreshInitializationIfReady: vi.fn(),
   mockAsk: vi.fn(),
   mockSearchRules: vi.fn(),
   mockSearchCards: vi.fn(),
@@ -37,19 +39,12 @@ const {
 
 vi.mock('../src/service.ts', () => ({
   initialize: mockInitialize,
-  isReady: mockIsReady,
+  getBootstrapStatus: mockGetBootstrapStatus,
+  refreshInitializationIfReady: mockRefreshInitializationIfReady,
   ask: mockAsk,
 }));
-
-// /api/health queries Postgres directly (COUNT(*) on embeddings). Mock
-// getDb so these tests stay hermetic — no Postgres needed to run.
 vi.mock('../src/db.ts', () => ({
-  getDb: () => ({
-    db: {
-      execute: vi.fn().mockResolvedValue({ rows: [{ count: '3' }] }),
-    },
-    close: async () => {},
-  }),
+  getWorktreeRuntime: vi.fn(),
   shutdownServerPool: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -93,37 +88,65 @@ async function auth(): Promise<Record<string, string>> {
 describe('GET /api/health', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRefreshInitializationIfReady.mockResolvedValue(undefined);
+    mockGetBootstrapStatus.mockResolvedValue({
+      ready: true,
+      bootstrapReady: true,
+      warmingUp: false,
+      indexSize: 3,
+      cardCount: 15,
+      ruleQueriesReady: true,
+      cardQueriesReady: true,
+      askReady: true,
+      missingBootstrapSteps: [],
+      errors: [],
+    });
   });
 
   it('returns 200 with ready status', async () => {
-    mockIsReady.mockReturnValue(true);
     const res = await app.request('/api/health');
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toHaveProperty('ready', true);
+    expect(body).toHaveProperty('bootstrap_ready', true);
     expect(body).toHaveProperty('index_size');
     expect(typeof body.index_size).toBe('number');
   });
 
   it('returns ready=false when service is not initialized', async () => {
-    mockIsReady.mockReturnValue(false);
+    mockGetBootstrapStatus.mockResolvedValueOnce({
+      ready: false,
+      bootstrapReady: true,
+      warmingUp: true,
+      indexSize: 3,
+      cardCount: 15,
+      ruleQueriesReady: true,
+      cardQueriesReady: true,
+      askReady: true,
+      missingBootstrapSteps: [],
+      errors: [],
+    });
     const res = await app.request('/api/health');
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ready).toBe(false);
+    expect(body.warming_up).toBe(true);
   });
 
   it('includes index_size in response', async () => {
-    mockIsReady.mockReturnValue(true);
     const res = await app.request('/api/health');
     const body = await res.json();
     expect(body.index_size).toBe(3);
   });
 
   it('returns JSON content type', async () => {
-    mockIsReady.mockReturnValue(true);
     const res = await app.request('/api/health');
     expect(res.headers.get('content-type')).toContain('application/json');
+  });
+
+  it('asks the service to recover readiness before reporting health', async () => {
+    await app.request('/api/health');
+    expect(mockRefreshInitializationIfReady).toHaveBeenCalled();
   });
 });
 
@@ -132,6 +155,18 @@ describe('GET /api/health', () => {
 describe('GET /api/search/rules', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetBootstrapStatus.mockResolvedValue({
+      ready: true,
+      bootstrapReady: true,
+      warmingUp: false,
+      indexSize: 3,
+      cardCount: 15,
+      ruleQueriesReady: true,
+      cardQueriesReady: true,
+      askReady: true,
+      missingBootstrapSteps: [],
+      errors: [],
+    });
     mockSearchRules.mockResolvedValue([
       { text: 'Loot: pick up all loot tokens.', source: 'rulebook.pdf:42', score: 0.9 },
     ]);
@@ -171,6 +206,26 @@ describe('GET /api/search/rules', () => {
     await app.request('/api/search/rules?q=loot&topK=abc', { headers: await auth() });
     expect(mockSearchRules).toHaveBeenCalledWith('loot', 6);
   });
+
+  it('returns 503 with an actionable bootstrap error when embeddings are missing', async () => {
+    mockGetBootstrapStatus.mockResolvedValueOnce({
+      ready: false,
+      bootstrapReady: false,
+      warmingUp: false,
+      indexSize: 0,
+      cardCount: 15,
+      ruleQueriesReady: false,
+      cardQueriesReady: true,
+      askReady: false,
+      missingBootstrapSteps: ['npm run index'],
+      errors: ['Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.'],
+    });
+    const res = await app.request('/api/search/rules?q=loot', { headers: await auth() });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toMatch(/npm run index/);
+    expect(body.missing_bootstrap_steps).toEqual(['npm run index']);
+  });
 });
 
 // ─── GET /api/search/cards ───────────────────────────────────────────────────
@@ -178,6 +233,18 @@ describe('GET /api/search/rules', () => {
 describe('GET /api/search/cards', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetBootstrapStatus.mockResolvedValue({
+      ready: true,
+      bootstrapReady: true,
+      warmingUp: false,
+      indexSize: 3,
+      cardCount: 15,
+      ruleQueriesReady: true,
+      cardQueriesReady: true,
+      askReady: true,
+      missingBootstrapSteps: [],
+      errors: [],
+    });
     mockSearchCards.mockReturnValue([
       { type: 'monster-stats', data: { name: 'Algox Archer' }, score: 2 },
     ]);
@@ -217,6 +284,25 @@ describe('GET /api/search/cards', () => {
     await app.request('/api/search/cards?q=algox&topK=abc', { headers: await auth() });
     expect(mockSearchCards).toHaveBeenCalledWith('algox', 6);
   });
+
+  it('returns 503 with an actionable bootstrap error when card data is missing', async () => {
+    mockGetBootstrapStatus.mockResolvedValueOnce({
+      ready: false,
+      bootstrapReady: false,
+      warmingUp: false,
+      indexSize: 3,
+      cardCount: 0,
+      ruleQueriesReady: true,
+      cardQueriesReady: false,
+      askReady: false,
+      missingBootstrapSteps: ['npm run seed:cards'],
+      errors: ['No card data found in Postgres. Run `npm run seed:cards` first.'],
+    });
+    const res = await app.request('/api/search/cards?q=algox', { headers: await auth() });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toMatch(/npm run seed:cards/);
+  });
 });
 
 // ─── GET /api/card-types ─────────────────────────────────────────────────────
@@ -224,6 +310,18 @@ describe('GET /api/search/cards', () => {
 describe('GET /api/card-types', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetBootstrapStatus.mockResolvedValue({
+      ready: true,
+      bootstrapReady: true,
+      warmingUp: false,
+      indexSize: 3,
+      cardCount: 15,
+      ruleQueriesReady: true,
+      cardQueriesReady: true,
+      askReady: true,
+      missingBootstrapSteps: [],
+      errors: [],
+    });
     mockListCardTypes.mockReturnValue([
       { type: 'monster-stats', count: 10 },
       { type: 'items', count: 5 },
@@ -245,6 +343,18 @@ describe('GET /api/card-types', () => {
 describe('GET /api/cards', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetBootstrapStatus.mockResolvedValue({
+      ready: true,
+      bootstrapReady: true,
+      warmingUp: false,
+      indexSize: 3,
+      cardCount: 15,
+      ruleQueriesReady: true,
+      cardQueriesReady: true,
+      askReady: true,
+      missingBootstrapSteps: [],
+      errors: [],
+    });
     mockListCards.mockReturnValue([{ name: 'Algox Archer' }]);
   });
 
@@ -280,6 +390,18 @@ describe('GET /api/cards', () => {
 describe('GET /api/cards/:type/:id', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetBootstrapStatus.mockResolvedValue({
+      ready: true,
+      bootstrapReady: true,
+      warmingUp: false,
+      indexSize: 3,
+      cardCount: 15,
+      ruleQueriesReady: true,
+      cardQueriesReady: true,
+      askReady: true,
+      missingBootstrapSteps: [],
+      errors: [],
+    });
     mockGetCard.mockReturnValue({ name: 'Algox Archer', levelRange: '0-3' });
   });
 
@@ -307,6 +429,18 @@ describe('GET /api/cards/:type/:id', () => {
 describe('POST /api/ask', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetBootstrapStatus.mockResolvedValue({
+      ready: true,
+      bootstrapReady: true,
+      warmingUp: false,
+      indexSize: 3,
+      cardCount: 15,
+      ruleQueriesReady: true,
+      cardQueriesReady: true,
+      askReady: true,
+      missingBootstrapSteps: [],
+      errors: [],
+    });
     mockAsk.mockResolvedValue('Loot tokens are picked up in your hex.');
   });
 
@@ -435,6 +569,33 @@ describe('POST /api/ask', () => {
       }),
     });
     expect(res.status).toBe(400);
+  });
+
+  it('returns 503 JSON before opening the stream when bootstrap is incomplete', async () => {
+    mockGetBootstrapStatus.mockResolvedValueOnce({
+      ready: false,
+      bootstrapReady: false,
+      warmingUp: false,
+      indexSize: 0,
+      cardCount: 0,
+      ruleQueriesReady: false,
+      cardQueriesReady: false,
+      askReady: false,
+      missingBootstrapSteps: ['npm run index', 'npm run seed:cards'],
+      errors: [
+        'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+        'No card data found in Postgres. Run `npm run seed:cards` first.',
+      ],
+    });
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'test' }),
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(body.missing_bootstrap_steps).toEqual(['npm run index', 'npm run seed:cards']);
   });
 
   it('emits error event when ask() throws', async () => {

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -160,7 +160,11 @@ describe('GET /api/health', () => {
         capabilities: {
           rules: { allowed: true, reason: null, message: null },
           cards: { allowed: true, reason: null, message: null },
-          ask: { allowed: false, reason: 'warming_up', message: 'Service is warming up. Retry in a moment.' },
+          ask: {
+            allowed: false,
+            reason: 'warming_up',
+            message: 'Service is warming up. Retry in a moment.',
+          },
         },
         askReady: false,
       }),
@@ -182,9 +186,21 @@ describe('GET /api/health', () => {
         cardQueriesReady: false,
         askReady: false,
         capabilities: {
-          rules: { allowed: false, reason: 'warming_up', message: 'Service is warming up. Retry in a moment.' },
-          cards: { allowed: false, reason: 'warming_up', message: 'Service is warming up. Retry in a moment.' },
-          ask: { allowed: false, reason: 'warming_up', message: 'Service is warming up. Retry in a moment.' },
+          rules: {
+            allowed: false,
+            reason: 'warming_up',
+            message: 'Service is warming up. Retry in a moment.',
+          },
+          cards: {
+            allowed: false,
+            reason: 'warming_up',
+            message: 'Service is warming up. Retry in a moment.',
+          },
+          ask: {
+            allowed: false,
+            reason: 'warming_up',
+            message: 'Service is warming up. Retry in a moment.',
+          },
         },
       }),
     );
@@ -272,18 +288,22 @@ describe('GET /api/search/rules', () => {
         ruleQueriesReady: false,
         askReady: false,
         missingBootstrapSteps: ['npm run index'],
-        errors: ['Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.'],
+        errors: [
+          'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+        ],
         capabilities: {
           rules: {
             allowed: false,
             reason: 'missing_index',
-            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+            message:
+              'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
           },
           cards: { allowed: true, reason: null, message: null },
           ask: {
             allowed: false,
             reason: 'missing_index',
-            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+            message:
+              'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
           },
         },
       }),
@@ -647,7 +667,8 @@ describe('POST /api/ask', () => {
           rules: {
             allowed: false,
             reason: 'missing_index',
-            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+            message:
+              'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
           },
           cards: {
             allowed: false,
@@ -657,7 +678,8 @@ describe('POST /api/ask', () => {
           ask: {
             allowed: false,
             reason: 'missing_index',
-            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+            message:
+              'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
           },
         },
       }),
@@ -725,13 +747,15 @@ describe('bootstrapErrorResponse fast path', () => {
           rules: {
             allowed: false,
             reason: 'missing_index',
-            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+            message:
+              'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
           },
           cards: { allowed: true, reason: null, message: null },
           ask: {
             allowed: false,
             reason: 'missing_index',
-            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+            message:
+              'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
           },
         },
       }),

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -645,6 +645,41 @@ describe('bootstrapErrorResponse fast path', () => {
     await app.request('/api/search/rules?q=loot', { headers: await auth() });
     expect(mockGetBootstrapStatus).not.toHaveBeenCalled();
   });
+
+  it('lets a ready request reach the handler via capability middleware', async () => {
+    await app.request('/api/search/rules?q=loot', { headers: await auth() });
+    expect(mockSearchRules).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks the handler when capability middleware denies the route', async () => {
+    mockIsReady.mockReturnValueOnce(false);
+    mockGetBootstrapStatus.mockResolvedValueOnce(
+      makeStatus({
+        lifecycle: 'boot_blocked',
+        ready: false,
+        bootstrapReady: false,
+        ruleQueriesReady: false,
+        askReady: false,
+        capabilities: {
+          rules: {
+            allowed: false,
+            reason: 'missing_index',
+            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+          },
+          cards: { allowed: true, reason: null, message: null },
+          ask: {
+            allowed: false,
+            reason: 'missing_index',
+            message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+          },
+        },
+      }),
+    );
+
+    const res = await app.request('/api/search/rules?q=loot', { headers: await auth() });
+    expect(res.status).toBe(503);
+    expect(mockSearchRules).not.toHaveBeenCalled();
+  });
 });
 
 // ─── Error handling ──────────────────────────────────────────────────────────

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -58,6 +58,7 @@ function makeStatus(
 
 const {
   mockInitialize,
+  mockEnsureBootstrapStatus,
   mockGetBootstrapStatus,
   mockIsReady,
   mockRefreshInitializationIfReady,
@@ -69,6 +70,7 @@ const {
   mockGetCard,
 } = vi.hoisted(() => ({
   mockInitialize: vi.fn(),
+  mockEnsureBootstrapStatus: vi.fn(),
   mockGetBootstrapStatus: vi.fn(),
   mockIsReady: vi.fn(),
   mockRefreshInitializationIfReady: vi.fn(),
@@ -82,6 +84,7 @@ const {
 
 vi.mock('../src/service.ts', () => ({
   initialize: mockInitialize,
+  ensureBootstrapStatus: mockEnsureBootstrapStatus,
   getBootstrapStatus: mockGetBootstrapStatus,
   isReady: mockIsReady,
   refreshInitializationIfReady: mockRefreshInitializationIfReady,
@@ -134,7 +137,8 @@ describe('GET /api/health', () => {
     vi.clearAllMocks();
     mockIsReady.mockReturnValue(true);
     mockRefreshInitializationIfReady.mockResolvedValue(undefined);
-    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
+    mockGetBootstrapStatus.mockReturnValue(makeStatus());
+    mockEnsureBootstrapStatus.mockResolvedValue(makeStatus());
   });
 
   it('returns 200 with ready status', async () => {
@@ -148,7 +152,7 @@ describe('GET /api/health', () => {
   });
 
   it('returns ready=false when service is not initialized', async () => {
-    mockGetBootstrapStatus.mockResolvedValueOnce(
+    mockGetBootstrapStatus.mockReturnValueOnce(
       makeStatus({
         lifecycle: 'warming_up',
         ready: false,
@@ -168,6 +172,29 @@ describe('GET /api/health', () => {
     expect(body.warming_up).toBe(true);
   });
 
+  it('returns the starting snapshot immediately before probes complete', async () => {
+    mockGetBootstrapStatus.mockReturnValueOnce(
+      makeStatus({
+        lifecycle: 'starting',
+        ready: false,
+        warmingUp: false,
+        ruleQueriesReady: false,
+        cardQueriesReady: false,
+        askReady: false,
+        capabilities: {
+          rules: { allowed: false, reason: 'warming_up', message: 'Service is warming up. Retry in a moment.' },
+          cards: { allowed: false, reason: 'warming_up', message: 'Service is warming up. Retry in a moment.' },
+          ask: { allowed: false, reason: 'warming_up', message: 'Service is warming up. Retry in a moment.' },
+        },
+      }),
+    );
+
+    const res = await app.request('/api/health');
+    const body = await res.json();
+    expect(body.lifecycle).toBe('starting');
+    expect(body.ready).toBe(false);
+  });
+
   it('returns JSON content type', async () => {
     const res = await app.request('/api/health');
     expect(res.headers.get('content-type')).toContain('application/json');
@@ -185,7 +212,8 @@ describe('GET /api/search/rules', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsReady.mockReturnValue(true);
-    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
+    mockGetBootstrapStatus.mockReturnValue(makeStatus());
+    mockEnsureBootstrapStatus.mockResolvedValue(makeStatus());
     mockSearchRules.mockResolvedValue([
       { text: 'Loot: pick up all loot tokens.', source: 'rulebook.pdf:42', score: 0.9 },
     ]);
@@ -216,6 +244,13 @@ describe('GET /api/search/rules', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 400 for missing q before bootstrap gating during startup', async () => {
+    mockIsReady.mockReturnValueOnce(false);
+    const res = await app.request('/api/search/rules', { headers: await auth() });
+    expect(res.status).toBe(400);
+    expect(mockEnsureBootstrapStatus).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when q is empty', async () => {
     const res = await app.request('/api/search/rules?q=', { headers: await auth() });
     expect(res.status).toBe(400);
@@ -228,7 +263,7 @@ describe('GET /api/search/rules', () => {
 
   it('returns 503 with an actionable bootstrap error when embeddings are missing', async () => {
     mockIsReady.mockReturnValueOnce(false);
-    mockGetBootstrapStatus.mockResolvedValueOnce(
+    mockEnsureBootstrapStatus.mockResolvedValueOnce(
       makeStatus({
         lifecycle: 'boot_blocked',
         ready: false,
@@ -267,7 +302,8 @@ describe('GET /api/search/cards', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsReady.mockReturnValue(true);
-    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
+    mockGetBootstrapStatus.mockReturnValue(makeStatus());
+    mockEnsureBootstrapStatus.mockResolvedValue(makeStatus());
     mockSearchCards.mockReturnValue([
       { type: 'monster-stats', data: { name: 'Algox Archer' }, score: 2 },
     ]);
@@ -310,7 +346,7 @@ describe('GET /api/search/cards', () => {
 
   it('returns 503 with an actionable bootstrap error when card data is missing', async () => {
     mockIsReady.mockReturnValueOnce(false);
-    mockGetBootstrapStatus.mockResolvedValueOnce(
+    mockEnsureBootstrapStatus.mockResolvedValueOnce(
       makeStatus({
         lifecycle: 'boot_blocked',
         ready: false,
@@ -348,7 +384,8 @@ describe('GET /api/card-types', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsReady.mockReturnValue(true);
-    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
+    mockGetBootstrapStatus.mockReturnValue(makeStatus());
+    mockEnsureBootstrapStatus.mockResolvedValue(makeStatus());
     mockListCardTypes.mockReturnValue([
       { type: 'monster-stats', count: 10 },
       { type: 'items', count: 5 },
@@ -371,7 +408,8 @@ describe('GET /api/cards', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsReady.mockReturnValue(true);
-    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
+    mockGetBootstrapStatus.mockReturnValue(makeStatus());
+    mockEnsureBootstrapStatus.mockResolvedValue(makeStatus());
     mockListCards.mockReturnValue([{ name: 'Algox Archer' }]);
   });
 
@@ -386,6 +424,13 @@ describe('GET /api/cards', () => {
   it('returns 400 when type is missing', async () => {
     const res = await app.request('/api/cards', { headers: await auth() });
     expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for missing type before bootstrap gating during startup', async () => {
+    mockIsReady.mockReturnValueOnce(false);
+    const res = await app.request('/api/cards', { headers: await auth() });
+    expect(res.status).toBe(400);
+    expect(mockEnsureBootstrapStatus).not.toHaveBeenCalled();
   });
 
   it('passes filter as parsed JSON', async () => {
@@ -408,7 +453,8 @@ describe('GET /api/cards/:type/:id', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsReady.mockReturnValue(true);
-    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
+    mockGetBootstrapStatus.mockReturnValue(makeStatus());
+    mockEnsureBootstrapStatus.mockResolvedValue(makeStatus());
     mockGetCard.mockReturnValue({ name: 'Algox Archer', levelRange: '0-3' });
   });
 
@@ -437,7 +483,8 @@ describe('POST /api/ask', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsReady.mockReturnValue(true);
-    mockGetBootstrapStatus.mockResolvedValue(makeStatus());
+    mockGetBootstrapStatus.mockReturnValue(makeStatus());
+    mockEnsureBootstrapStatus.mockResolvedValue(makeStatus());
     mockAsk.mockResolvedValue('Loot tokens are picked up in your hex.');
   });
 
@@ -470,6 +517,17 @@ describe('POST /api/ask', () => {
       body: JSON.stringify({}),
     });
     expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid JSON before bootstrap gating during startup', async () => {
+    mockIsReady.mockReturnValueOnce(false);
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: '{',
+    });
+    expect(res.status).toBe(400);
+    expect(mockEnsureBootstrapStatus).not.toHaveBeenCalled();
   });
 
   it('returns 400 when question is empty', async () => {
@@ -570,7 +628,7 @@ describe('POST /api/ask', () => {
 
   it('returns 503 JSON before opening the stream when bootstrap is incomplete', async () => {
     mockIsReady.mockReturnValueOnce(false);
-    mockGetBootstrapStatus.mockResolvedValueOnce(
+    mockEnsureBootstrapStatus.mockResolvedValueOnce(
       makeStatus({
         lifecycle: 'boot_blocked',
         ready: false,
@@ -636,6 +694,8 @@ describe('bootstrapErrorResponse fast path', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsReady.mockReturnValue(true);
+    mockGetBootstrapStatus.mockReturnValue(makeStatus());
+    mockEnsureBootstrapStatus.mockResolvedValue(makeStatus());
     mockSearchRules.mockResolvedValue([
       { text: 'Loot: pick up all loot tokens.', source: 'rulebook.pdf:42', score: 0.9 },
     ]);
@@ -644,6 +704,7 @@ describe('bootstrapErrorResponse fast path', () => {
   it('skips bootstrap probes for ready search requests', async () => {
     await app.request('/api/search/rules?q=loot', { headers: await auth() });
     expect(mockGetBootstrapStatus).not.toHaveBeenCalled();
+    expect(mockEnsureBootstrapStatus).not.toHaveBeenCalled();
   });
 
   it('lets a ready request reach the handler via capability middleware', async () => {
@@ -653,7 +714,7 @@ describe('bootstrapErrorResponse fast path', () => {
 
   it('blocks the handler when capability middleware denies the route', async () => {
     mockIsReady.mockReturnValueOnce(false);
-    mockGetBootstrapStatus.mockResolvedValueOnce(
+    mockEnsureBootstrapStatus.mockResolvedValueOnce(
       makeStatus({
         lifecycle: 'boot_blocked',
         ready: false,
@@ -680,11 +741,49 @@ describe('bootstrapErrorResponse fast path', () => {
     expect(res.status).toBe(503);
     expect(mockSearchRules).not.toHaveBeenCalled();
   });
+
+  it('allows rule routes when only card probing has degraded', async () => {
+    mockIsReady.mockReturnValueOnce(false);
+    mockEnsureBootstrapStatus.mockResolvedValueOnce(
+      makeStatus({
+        lifecycle: 'dependency_failed',
+        ready: false,
+        bootstrapReady: false,
+        ruleQueriesReady: true,
+        cardQueriesReady: false,
+        askReady: false,
+        capabilities: {
+          rules: { allowed: true, reason: null, message: null },
+          cards: {
+            allowed: false,
+            reason: 'dependency_unavailable',
+            message: 'card data query failed: connect ECONNREFUSED.',
+          },
+          ask: {
+            allowed: false,
+            reason: 'dependency_unavailable',
+            message: 'card data query failed: connect ECONNREFUSED.',
+          },
+        },
+      }),
+    );
+
+    const res = await app.request('/api/search/rules?q=loot', { headers: await auth() });
+    expect(res.status).toBe(200);
+    expect(mockSearchRules).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ─── Error handling ──────────────────────────────────────────────────────────
 
 describe('error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsReady.mockReturnValue(true);
+    mockGetBootstrapStatus.mockReturnValue(makeStatus());
+    mockEnsureBootstrapStatus.mockResolvedValue(makeStatus());
+  });
+
   it('returns structured 404 for unknown paths', async () => {
     const res = await app.request('/api/nonexistent');
     expect(res.status).toBe(404);

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -772,6 +772,37 @@ describe('bootstrapErrorResponse fast path', () => {
     expect(res.status).toBe(200);
     expect(mockSearchRules).toHaveBeenCalledTimes(1);
   });
+
+  it('blocks rule routes when warmup has failed', async () => {
+    mockIsReady.mockReturnValueOnce(false);
+    mockEnsureBootstrapStatus.mockResolvedValueOnce(
+      makeStatus({
+        lifecycle: 'init_failed',
+        ready: false,
+        bootstrapReady: true,
+        ruleQueriesReady: false,
+        cardQueriesReady: true,
+        askReady: false,
+        capabilities: {
+          rules: {
+            allowed: false,
+            reason: 'init_failed',
+            message: 'embedder cold start failed',
+          },
+          cards: { allowed: true, reason: null, message: null },
+          ask: {
+            allowed: false,
+            reason: 'init_failed',
+            message: 'embedder cold start failed',
+          },
+        },
+      }),
+    );
+
+    const res = await app.request('/api/search/rules?q=loot', { headers: await auth() });
+    expect(res.status).toBe(503);
+    expect(mockSearchRules).not.toHaveBeenCalled();
+  });
 });
 
 // ─── Error handling ──────────────────────────────────────────────────────────

--- a/test/server-oauth.test.ts
+++ b/test/server-oauth.test.ts
@@ -44,6 +44,7 @@ function makeStatus() {
 
 const {
   mockInitialize,
+  mockEnsureBootstrapStatus,
   mockGetBootstrapStatus,
   mockIsReady,
   mockRefreshInitializationIfReady,
@@ -51,6 +52,7 @@ const {
   mockSearchRules,
 } = vi.hoisted(() => ({
   mockInitialize: vi.fn(),
+  mockEnsureBootstrapStatus: vi.fn(),
   mockGetBootstrapStatus: vi.fn(),
   mockIsReady: vi.fn(),
   mockRefreshInitializationIfReady: vi.fn(),
@@ -60,6 +62,7 @@ const {
 
 vi.mock('../src/service.ts', () => ({
   initialize: mockInitialize,
+  ensureBootstrapStatus: mockEnsureBootstrapStatus,
   getBootstrapStatus: mockGetBootstrapStatus,
   isReady: mockIsReady,
   refreshInitializationIfReady: mockRefreshInitializationIfReady,
@@ -87,7 +90,8 @@ beforeAll(async () => {
 beforeEach(() => {
   mockIsReady.mockReturnValue(true);
   mockRefreshInitializationIfReady.mockResolvedValue(undefined);
-  mockGetBootstrapStatus.mockResolvedValue(makeStatus());
+  mockGetBootstrapStatus.mockReturnValue(makeStatus());
+  mockEnsureBootstrapStatus.mockResolvedValue(makeStatus());
 });
 
 afterAll(async () => {

--- a/test/server-oauth.test.ts
+++ b/test/server-oauth.test.ts
@@ -21,15 +21,38 @@ import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vites
 import { CODE_VERIFIER, CODE_CHALLENGE, makeAuthHelpers } from './helpers/server-oauth-helpers.ts';
 import { setupTestDb, resetTestDb, teardownTestDb } from './helpers/db.ts';
 
+function makeStatus() {
+  return {
+    lifecycle: 'ready',
+    ready: true,
+    bootstrapReady: true,
+    warmingUp: false,
+    indexSize: 3,
+    cardCount: 15,
+    ruleQueriesReady: true,
+    cardQueriesReady: true,
+    askReady: true,
+    missingBootstrapSteps: [],
+    errors: [],
+    capabilities: {
+      rules: { allowed: true, reason: null, message: null },
+      cards: { allowed: true, reason: null, message: null },
+      ask: { allowed: true, reason: null, message: null },
+    },
+  };
+}
+
 const {
   mockInitialize,
   mockGetBootstrapStatus,
+  mockIsReady,
   mockRefreshInitializationIfReady,
   mockAsk,
   mockSearchRules,
 } = vi.hoisted(() => ({
   mockInitialize: vi.fn(),
   mockGetBootstrapStatus: vi.fn(),
+  mockIsReady: vi.fn(),
   mockRefreshInitializationIfReady: vi.fn(),
   mockAsk: vi.fn(),
   mockSearchRules: vi.fn(),
@@ -38,6 +61,7 @@ const {
 vi.mock('../src/service.ts', () => ({
   initialize: mockInitialize,
   getBootstrapStatus: mockGetBootstrapStatus,
+  isReady: mockIsReady,
   refreshInitializationIfReady: mockRefreshInitializationIfReady,
   ask: mockAsk,
 }));
@@ -61,19 +85,9 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  mockIsReady.mockReturnValue(true);
   mockRefreshInitializationIfReady.mockResolvedValue(undefined);
-  mockGetBootstrapStatus.mockResolvedValue({
-    ready: true,
-    bootstrapReady: true,
-    warmingUp: false,
-    indexSize: 3,
-    cardCount: 15,
-    ruleQueriesReady: true,
-    cardQueriesReady: true,
-    askReady: true,
-    missingBootstrapSteps: [],
-    errors: [],
-  });
+  mockGetBootstrapStatus.mockResolvedValue(makeStatus());
 });
 
 afterAll(async () => {

--- a/test/server-oauth.test.ts
+++ b/test/server-oauth.test.ts
@@ -21,16 +21,24 @@ import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vites
 import { CODE_VERIFIER, CODE_CHALLENGE, makeAuthHelpers } from './helpers/server-oauth-helpers.ts';
 import { setupTestDb, resetTestDb, teardownTestDb } from './helpers/db.ts';
 
-const { mockInitialize, mockIsReady, mockAsk, mockSearchRules } = vi.hoisted(() => ({
+const {
+  mockInitialize,
+  mockGetBootstrapStatus,
+  mockRefreshInitializationIfReady,
+  mockAsk,
+  mockSearchRules,
+} = vi.hoisted(() => ({
   mockInitialize: vi.fn(),
-  mockIsReady: vi.fn(),
+  mockGetBootstrapStatus: vi.fn(),
+  mockRefreshInitializationIfReady: vi.fn(),
   mockAsk: vi.fn(),
   mockSearchRules: vi.fn(),
 }));
 
 vi.mock('../src/service.ts', () => ({
   initialize: mockInitialize,
-  isReady: mockIsReady,
+  getBootstrapStatus: mockGetBootstrapStatus,
+  refreshInitializationIfReady: mockRefreshInitializationIfReady,
   ask: mockAsk,
 }));
 
@@ -50,6 +58,22 @@ const { auth, resetTestToken } = makeAuthHelpers(app);
 
 beforeAll(async () => {
   await setupTestDb();
+});
+
+beforeEach(() => {
+  mockRefreshInitializationIfReady.mockResolvedValue(undefined);
+  mockGetBootstrapStatus.mockResolvedValue({
+    ready: true,
+    bootstrapReady: true,
+    warmingUp: false,
+    indexSize: 3,
+    cardCount: 15,
+    ruleQueriesReady: true,
+    cardQueriesReady: true,
+    askReady: true,
+    missingBootstrapSteps: [],
+    errors: [],
+  });
 });
 
 afterAll(async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -45,6 +45,7 @@ import {
   isReady,
   ask,
   getBootstrapStatus,
+  refreshBootstrapState,
   refreshInitializationIfReady,
   _resetForTesting,
 } from '../src/service.ts';
@@ -92,14 +93,17 @@ describe('initialize', () => {
       indexSize: 0,
       error: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
       missingStep: 'npm run index',
+      reason: 'missing_index',
     });
     mockListCardTypes.mockResolvedValueOnce([
       { type: 'monster-stats', count: 0 },
       { type: 'items', count: 0 },
     ]);
 
+    await refreshBootstrapState();
     const status = await getBootstrapStatus();
     expect(status.ready).toBe(false);
+    expect(status.lifecycle).toBe('boot_blocked');
     expect(status.missingBootstrapSteps).toEqual(['npm run index', 'npm run seed:cards']);
   });
 
@@ -115,8 +119,35 @@ describe('initialize', () => {
 
     await refreshInitializationIfReady();
 
-    expect(mockInitializeRetrieval).toHaveBeenCalledWith(mockEmbed);
+    await vi.waitFor(() => expect(mockInitializeRetrieval).toHaveBeenCalledWith(mockEmbed));
     expect(isReady()).toBe(true);
+  });
+
+  it('reports warming_up immediately while initialization is in flight', async () => {
+    let resolveWarmup: (() => void) | null = null;
+    mockInitializeRetrieval.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWarmup = resolve;
+        }),
+    );
+
+    const init = initialize();
+    await vi.waitFor(async () => {
+      expect((await getBootstrapStatus()).lifecycle).toBe('warming_up');
+    });
+
+    const status = await getBootstrapStatus();
+    expect(status.lifecycle).toBe('warming_up');
+    expect(status.warmingUp).toBe(true);
+    expect(status.capabilities.ask).toEqual({
+      allowed: false,
+      reason: 'warming_up',
+      message: 'Service is warming up. Retry in a moment.',
+    });
+
+    resolveWarmup?.();
+    await init;
   });
 });
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -107,6 +107,20 @@ describe('initialize', () => {
     expect(status.missingBootstrapSteps).toEqual(['npm run index', 'npm run seed:cards']);
   });
 
+  it('populates the first bootstrap snapshot on demand', async () => {
+    mockGetRetrievalBootstrapStatus.mockResolvedValue({
+      ready: false,
+      indexSize: 0,
+      error: 'database unavailable',
+      reason: 'dependency_unavailable',
+    });
+    mockListCardTypes.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const status = await getBootstrapStatus();
+    expect(status.lifecycle).toBe('dependency_failed');
+    expect(status.errors[0]).toMatch(/database unavailable/);
+  });
+
   it('retries initialization when bootstrap prerequisites later become available', async () => {
     mockGetRetrievalBootstrapStatus.mockResolvedValue({
       ready: true,
@@ -189,5 +203,22 @@ describe('ask', () => {
     await ask('test');
     expect(mockInitializeRetrieval).toHaveBeenCalled();
     expect(mockRunAgentLoop).toHaveBeenCalledWith('test', undefined);
+  });
+
+  it('does not run the agent loop after readiness has regressed', async () => {
+    await initialize();
+
+    mockGetRetrievalBootstrapStatus.mockResolvedValue({
+      ready: false,
+      indexSize: 0,
+      error: 'database unavailable',
+      reason: 'dependency_unavailable',
+    });
+    mockListCardTypes.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    await refreshBootstrapState();
+
+    await expect(ask('test after regression')).rejects.toThrow(/database unavailable/i);
+    expect(mockRunAgentLoop).not.toHaveBeenCalledWith('test after regression', undefined);
   });
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -12,9 +12,9 @@ const {
   mockRunAgentLoop: vi.fn(),
   mockEmbed: vi.fn(),
   mockInitializeRetrieval: vi.fn(),
-    mockGetRetrievalBootstrapStatus: vi.fn(),
+  mockGetRetrievalBootstrapStatus: vi.fn(),
   mockListCardTypes: vi.fn(),
-  }));
+}));
 
 vi.mock('../src/agent.ts', () => ({
   runAgentLoop: mockRunAgentLoop,
@@ -50,6 +50,16 @@ import {
   refreshInitializationIfReady,
   _resetForTesting,
 } from '../src/service.ts';
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 // ─── initialize / isReady ────────────────────────────────────────────────────
 
@@ -92,7 +102,8 @@ describe('initialize', () => {
     mockGetRetrievalBootstrapStatus.mockResolvedValueOnce({
       ready: false,
       indexSize: 0,
-      error: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+      error:
+        'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
       missingStep: 'npm run index',
       reason: 'missing_index',
     });
@@ -146,13 +157,8 @@ describe('initialize', () => {
   });
 
   it('reports warming_up immediately while initialization is in flight', async () => {
-    let resolveWarmup: (() => void) | null = null;
-    mockInitializeRetrieval.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveWarmup = resolve;
-        }),
-    );
+    const warmup = createDeferred<void>();
+    mockInitializeRetrieval.mockImplementation(() => warmup.promise);
 
     const init = initialize();
     await vi.waitFor(async () => {
@@ -168,21 +174,19 @@ describe('initialize', () => {
       message: 'Service is warming up. Retry in a moment.',
     });
 
-    resolveWarmup?.();
+    warmup.resolve();
     await init;
   });
 
   it('reports warming_up when retrying after an init failure', async () => {
     let failWarmup = true;
-    let resolveRetry: (() => void) | null = null;
+    const retryWarmup = createDeferred<void>();
     mockInitializeRetrieval.mockImplementation(() => {
       if (failWarmup) {
         failWarmup = false;
         return Promise.reject(new Error('embedder cold start failed'));
       }
-      return new Promise<void>((resolve) => {
-        resolveRetry = resolve;
-      });
+      return retryWarmup.promise;
     });
 
     await expect(initialize()).rejects.toThrow(/embedder cold start failed/i);
@@ -193,7 +197,7 @@ describe('initialize', () => {
       expect(getBootstrapStatus().lifecycle).toBe('warming_up');
     });
 
-    resolveRetry?.();
+    retryWarmup.resolve();
     await retry;
     expect(getBootstrapStatus().lifecycle).toBe('ready');
   });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -2,21 +2,26 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
-const { mockRunAgentLoop, mockEmbed, mockInitializeRetrieval } = vi.hoisted(() => ({
+const {
+  mockRunAgentLoop,
+  mockEmbed,
+  mockInitializeRetrieval,
+  mockGetRetrievalBootstrapStatus,
+  mockListCardTypes,
+} = vi.hoisted(() => ({
   mockRunAgentLoop: vi.fn(),
   mockEmbed: vi.fn(),
   mockInitializeRetrieval: vi.fn(),
-}));
+    mockGetRetrievalBootstrapStatus: vi.fn(),
+  mockListCardTypes: vi.fn(),
+  }));
 
 vi.mock('../src/agent.ts', () => ({
   runAgentLoop: mockRunAgentLoop,
 }));
 
 vi.mock('../src/tools.ts', () => ({
-  listCardTypes: vi.fn(() => [
-    { type: 'monster-stats', count: 5 },
-    { type: 'items', count: 3 },
-  ]),
+  listCardTypes: mockListCardTypes,
 }));
 
 vi.mock('../src/embedder.ts', () => ({
@@ -24,6 +29,9 @@ vi.mock('../src/embedder.ts', () => ({
 }));
 
 vi.mock('../src/vector-store.ts', () => ({
+  EMBEDDINGS_BOOTSTRAP_MESSAGE:
+    'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+  getRetrievalBootstrapStatus: mockGetRetrievalBootstrapStatus,
   initializeRetrieval: mockInitializeRetrieval,
 }));
 
@@ -32,7 +40,14 @@ vi.mock('../src/extracted-data.ts', () => ({
   load: vi.fn(() => [{ name: 'test' }]),
 }));
 
-import { initialize, isReady, ask, _resetForTesting } from '../src/service.ts';
+import {
+  initialize,
+  isReady,
+  ask,
+  getBootstrapStatus,
+  refreshInitializationIfReady,
+  _resetForTesting,
+} from '../src/service.ts';
 
 // ─── initialize / isReady ────────────────────────────────────────────────────
 
@@ -41,6 +56,11 @@ describe('initialize', () => {
     vi.clearAllMocks();
     _resetForTesting();
     mockInitializeRetrieval.mockResolvedValue(undefined);
+    mockGetRetrievalBootstrapStatus.mockResolvedValue({ ready: true, indexSize: 8 });
+    mockListCardTypes.mockResolvedValue([
+      { type: 'monster-stats', count: 5 },
+      { type: 'items', count: 3 },
+    ]);
     mockEmbed.mockResolvedValue([0.1, 0.2, 0.3]);
   });
 
@@ -65,6 +85,39 @@ describe('initialize', () => {
     mockInitializeRetrieval.mockRejectedValueOnce(new Error('Vector index is empty.'));
     await expect(initialize()).rejects.toThrow(/index is empty/i);
   });
+
+  it('reports missing bootstrap steps when embeddings or cards are absent', async () => {
+    mockGetRetrievalBootstrapStatus.mockResolvedValueOnce({
+      ready: false,
+      indexSize: 0,
+      error: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+      missingStep: 'npm run index',
+    });
+    mockListCardTypes.mockResolvedValueOnce([
+      { type: 'monster-stats', count: 0 },
+      { type: 'items', count: 0 },
+    ]);
+
+    const status = await getBootstrapStatus();
+    expect(status.ready).toBe(false);
+    expect(status.missingBootstrapSteps).toEqual(['npm run index', 'npm run seed:cards']);
+  });
+
+  it('retries initialization when bootstrap prerequisites later become available', async () => {
+    mockGetRetrievalBootstrapStatus.mockResolvedValue({
+      ready: true,
+      indexSize: 8,
+    });
+    mockListCardTypes.mockResolvedValue([
+      { type: 'monster-stats', count: 5 },
+      { type: 'items', count: 3 },
+    ]);
+
+    await refreshInitializationIfReady();
+
+    expect(mockInitializeRetrieval).toHaveBeenCalledWith(mockEmbed);
+    expect(isReady()).toBe(true);
+  });
 });
 
 // ─── ask ─────────────────────────────────────────────────────────────────────
@@ -74,6 +127,11 @@ describe('ask', () => {
     vi.clearAllMocks();
     _resetForTesting();
     mockInitializeRetrieval.mockResolvedValue(undefined);
+    mockGetRetrievalBootstrapStatus.mockResolvedValue({ ready: true, indexSize: 8 });
+    mockListCardTypes.mockResolvedValue([
+      { type: 'monster-stats', count: 5 },
+      { type: 'items', count: 3 },
+    ]);
     mockEmbed.mockResolvedValue([0.1, 0.2, 0.3]);
     mockRunAgentLoop.mockResolvedValue('You pick up loot tokens in your hex.');
   });
@@ -96,22 +154,9 @@ describe('ask', () => {
     expect(mockRunAgentLoop).toHaveBeenCalledWith('Follow-up', options);
   });
 
-  it('throws if not initialized', async () => {
-    vi.resetModules();
-    vi.doMock('../src/agent.ts', () => ({ runAgentLoop: mockRunAgentLoop }));
-    vi.doMock('../src/tools.ts', () => ({
-      listCardTypes: vi.fn(() => [{ type: 'monster-stats', count: 5 }]),
-    }));
-    vi.doMock('../src/embedder.ts', () => ({ embed: mockEmbed }));
-    vi.doMock('../src/vector-store.ts', () => ({
-      initializeRetrieval: mockInitializeRetrieval,
-    }));
-    vi.doMock('../src/extracted-data.ts', () => ({
-      TYPES: ['monster-stats'],
-      load: vi.fn(() => [{ name: 'test' }]),
-    }));
-
-    const { ask: freshAsk } = await import('../src/service.ts');
-    await expect(freshAsk('test')).rejects.toThrow(/not initialized/i);
+  it('initializes lazily when asked before warmup', async () => {
+    await ask('test');
+    expect(mockInitializeRetrieval).toHaveBeenCalled();
+    expect(mockRunAgentLoop).toHaveBeenCalledWith('test', undefined);
   });
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -215,6 +215,25 @@ describe('initialize', () => {
     expect(status.capabilities.cards.allowed).toBe(false);
     expect(status.capabilities.ask.allowed).toBe(false);
   });
+
+  it('blocks rule queries when warmup has failed', async () => {
+    mockInitializeRetrieval.mockRejectedValueOnce(new Error('embedder cold start failed'));
+
+    await expect(initialize()).rejects.toThrow(/embedder cold start failed/i);
+
+    const status = await ensureBootstrapStatus();
+    expect(status.lifecycle).toBe('init_failed');
+    expect(status.capabilities.rules).toEqual({
+      allowed: false,
+      reason: 'init_failed',
+      message: 'embedder cold start failed',
+    });
+    expect(status.capabilities.ask).toEqual({
+      allowed: false,
+      reason: 'init_failed',
+      message: 'embedder cold start failed',
+    });
+  });
 });
 
 // ─── ask ─────────────────────────────────────────────────────────────────────

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -44,6 +44,7 @@ import {
   initialize,
   isReady,
   ask,
+  ensureBootstrapStatus,
   getBootstrapStatus,
   refreshBootstrapState,
   refreshInitializationIfReady,
@@ -101,13 +102,20 @@ describe('initialize', () => {
     ]);
 
     await refreshBootstrapState();
-    const status = await getBootstrapStatus();
+    const status = getBootstrapStatus();
     expect(status.ready).toBe(false);
     expect(status.lifecycle).toBe('boot_blocked');
     expect(status.missingBootstrapSteps).toEqual(['npm run index', 'npm run seed:cards']);
   });
 
-  it('populates the first bootstrap snapshot on demand', async () => {
+  it('returns an immediate starting snapshot before the first live probe', () => {
+    const status = getBootstrapStatus();
+    expect(status.lifecycle).toBe('starting');
+    expect(status.ready).toBe(false);
+    expect(status.errors).toEqual([]);
+  });
+
+  it('populates the first bootstrap snapshot only through the live probe path', async () => {
     mockGetRetrievalBootstrapStatus.mockResolvedValue({
       ready: false,
       indexSize: 0,
@@ -116,7 +124,7 @@ describe('initialize', () => {
     });
     mockListCardTypes.mockRejectedValue(new Error('connect ECONNREFUSED'));
 
-    const status = await getBootstrapStatus();
+    const status = await ensureBootstrapStatus();
     expect(status.lifecycle).toBe('dependency_failed');
     expect(status.errors[0]).toMatch(/database unavailable/);
   });
@@ -148,10 +156,10 @@ describe('initialize', () => {
 
     const init = initialize();
     await vi.waitFor(async () => {
-      expect((await getBootstrapStatus()).lifecycle).toBe('warming_up');
+      expect(getBootstrapStatus().lifecycle).toBe('warming_up');
     });
 
-    const status = await getBootstrapStatus();
+    const status = getBootstrapStatus();
     expect(status.lifecycle).toBe('warming_up');
     expect(status.warmingUp).toBe(true);
     expect(status.capabilities.ask).toEqual({
@@ -162,6 +170,50 @@ describe('initialize', () => {
 
     resolveWarmup?.();
     await init;
+  });
+
+  it('reports warming_up when retrying after an init failure', async () => {
+    let failWarmup = true;
+    let resolveRetry: (() => void) | null = null;
+    mockInitializeRetrieval.mockImplementation(() => {
+      if (failWarmup) {
+        failWarmup = false;
+        return Promise.reject(new Error('embedder cold start failed'));
+      }
+      return new Promise<void>((resolve) => {
+        resolveRetry = resolve;
+      });
+    });
+
+    await expect(initialize()).rejects.toThrow(/embedder cold start failed/i);
+    expect(getBootstrapStatus().lifecycle).toBe('init_failed');
+
+    const retry = initialize();
+    await vi.waitFor(() => {
+      expect(getBootstrapStatus().lifecycle).toBe('warming_up');
+    });
+
+    resolveRetry?.();
+    await retry;
+    expect(getBootstrapStatus().lifecycle).toBe('ready');
+  });
+
+  it('keeps rule queries available when only card bootstrap probing fails', async () => {
+    mockGetRetrievalBootstrapStatus.mockResolvedValue({
+      ready: true,
+      indexSize: 8,
+    });
+    mockListCardTypes.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const status = await ensureBootstrapStatus();
+    expect(status.lifecycle).toBe('dependency_failed');
+    expect(status.capabilities.rules).toEqual({
+      allowed: true,
+      reason: null,
+      message: null,
+    });
+    expect(status.capabilities.cards.allowed).toBe(false);
+    expect(status.capabilities.ask.allowed).toBe(false);
   });
 });
 

--- a/test/start-server.test.ts
+++ b/test/start-server.test.ts
@@ -1,0 +1,162 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+class FakeServer extends EventEmitter {
+  listenCalls: number[] = [];
+
+  listen(port: number): this {
+    this.listenCalls.push(port);
+    queueMicrotask(() => {
+      this.emit('listening');
+    });
+    return this;
+  }
+}
+
+async function loadStartServer(options: {
+  configuredPort?: string;
+  claimedPort?: number;
+  bootstrapImpl?: () => unknown;
+}) {
+  vi.resetModules();
+
+  if (options.configuredPort === undefined) {
+    vi.unstubAllEnvs();
+    delete process.env.PORT;
+  } else {
+    vi.stubEnv('PORT', options.configuredPort);
+  }
+
+  const fakeServer = new FakeServer();
+  const createAdaptorServer = vi.fn(() => fakeServer);
+  const claimRelease = vi.fn().mockResolvedValue(undefined);
+  const claimWorktreePort = vi.fn().mockResolvedValue({
+    port: options.claimedPort ?? 4555,
+    release: claimRelease,
+  });
+  const startBootstrapLifecycle = vi.fn(options.bootstrapImpl ?? (() => undefined));
+
+  vi.doMock('@hono/node-server', () => ({
+    createAdaptorServer,
+  }));
+  vi.doMock('../src/service.ts', () => ({
+    ask: vi.fn(),
+    getBootstrapStatus: vi.fn().mockResolvedValue({
+      lifecycle: 'boot_blocked',
+      ready: false,
+      bootstrapReady: false,
+      warmingUp: false,
+      indexSize: 0,
+      cardCount: 0,
+      ruleQueriesReady: false,
+      cardQueriesReady: false,
+      askReady: false,
+      missingBootstrapSteps: ['npm run index', 'npm run seed:cards'],
+      errors: [
+        'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+        'No card data found in Postgres. Run `npm run seed:cards` first.',
+      ],
+      capabilities: {
+        rules: {
+          allowed: false,
+          reason: 'missing_index',
+          message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+        },
+        cards: {
+          allowed: false,
+          reason: 'missing_cards',
+          message: 'No card data found in Postgres. Run `npm run seed:cards` first.',
+        },
+        ask: {
+          allowed: false,
+          reason: 'missing_index',
+          message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+        },
+      },
+    }),
+    isReady: vi.fn().mockReturnValue(false),
+    startBootstrapLifecycle,
+  }));
+  vi.doMock('../src/db.ts', () => ({
+    getWorktreeRuntime: vi.fn(() => ({
+      checkoutRoot: '/tmp/squire',
+      checkoutSlug: 'squire',
+      isMainCheckout: false,
+    })),
+    shutdownServerPool: vi.fn().mockResolvedValue(undefined),
+  }));
+  vi.doMock('../src/worktree-runtime.ts', () => ({
+    claimWorktreePort,
+  }));
+  vi.doMock('../src/tools.ts', () => ({
+    searchRules: vi.fn(),
+    searchCards: vi.fn(),
+    listCardTypes: vi.fn(),
+    listCards: vi.fn(),
+    getCard: vi.fn(),
+  }));
+  vi.doMock('../src/auth.ts', () => ({
+    registerClient: vi.fn(),
+    createAuthorizationCode: vi.fn(),
+    exchangeAuthorizationCode: vi.fn(),
+    verifyAccessToken: vi.fn().mockResolvedValue({
+      token: 'stub',
+      clientId: 'stub-client',
+      scopes: [],
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    }),
+    getAuthProvider: vi.fn(),
+    resetAuthProvider: vi.fn(),
+    OAuthError: class OAuthError extends Error {},
+  }));
+
+  const mod = await import('../src/server.ts');
+  return {
+    startServer: mod.startServer,
+    fakeServer,
+    createAdaptorServer,
+    claimWorktreePort,
+    startBootstrapLifecycle,
+  };
+}
+
+describe('startServer', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('binds the configured port without awaiting bootstrap warmup', async () => {
+    let resolveBootstrap: (() => void) | null = null;
+    const { startServer, fakeServer, startBootstrapLifecycle } = await loadStartServer({
+      configuredPort: '4123',
+      bootstrapImpl: () =>
+        new Promise<void>((resolve) => {
+          resolveBootstrap = resolve;
+        }),
+    });
+
+    await expect(startServer()).resolves.toBeUndefined();
+
+    expect(fakeServer.listenCalls).toEqual([4123]);
+    expect(startBootstrapLifecycle).toHaveBeenCalledTimes(1);
+
+    resolveBootstrap?.();
+  });
+
+  it('binds a claimed worktree port even when bootstrap prerequisites are missing', async () => {
+    const { startServer, fakeServer, claimWorktreePort, startBootstrapLifecycle } =
+      await loadStartServer({
+        claimedPort: 4555,
+      });
+
+    await expect(startServer()).resolves.toBeUndefined();
+
+    expect(claimWorktreePort).toHaveBeenCalledTimes(1);
+    expect(fakeServer.listenCalls).toEqual([4555]);
+    expect(startBootstrapLifecycle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/start-server.test.ts
+++ b/test/start-server.test.ts
@@ -41,7 +41,40 @@ async function loadStartServer(options: {
   }));
   vi.doMock('../src/service.ts', () => ({
     ask: vi.fn(),
-    getBootstrapStatus: vi.fn().mockResolvedValue({
+    ensureBootstrapStatus: vi.fn().mockResolvedValue({
+      lifecycle: 'boot_blocked',
+      ready: false,
+      bootstrapReady: false,
+      warmingUp: false,
+      indexSize: 0,
+      cardCount: 0,
+      ruleQueriesReady: false,
+      cardQueriesReady: false,
+      askReady: false,
+      missingBootstrapSteps: ['npm run index', 'npm run seed:cards'],
+      errors: [
+        'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+        'No card data found in Postgres. Run `npm run seed:cards` first.',
+      ],
+      capabilities: {
+        rules: {
+          allowed: false,
+          reason: 'missing_index',
+          message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+        },
+        cards: {
+          allowed: false,
+          reason: 'missing_cards',
+          message: 'No card data found in Postgres. Run `npm run seed:cards` first.',
+        },
+        ask: {
+          allowed: false,
+          reason: 'missing_index',
+          message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+        },
+      },
+    }),
+    getBootstrapStatus: vi.fn().mockReturnValue({
       lifecycle: 'boot_blocked',
       ready: false,
       bootstrapReady: false,

--- a/test/start-server.test.ts
+++ b/test/start-server.test.ts
@@ -1,6 +1,16 @@
 import { EventEmitter } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 class FakeServer extends EventEmitter {
   listenCalls: number[] = [];
 
@@ -60,7 +70,8 @@ async function loadStartServer(options: {
         rules: {
           allowed: false,
           reason: 'missing_index',
-          message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+          message:
+            'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
         },
         cards: {
           allowed: false,
@@ -70,7 +81,8 @@ async function loadStartServer(options: {
         ask: {
           allowed: false,
           reason: 'missing_index',
-          message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+          message:
+            'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
         },
       },
     }),
@@ -93,7 +105,8 @@ async function loadStartServer(options: {
         rules: {
           allowed: false,
           reason: 'missing_index',
-          message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+          message:
+            'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
         },
         cards: {
           allowed: false,
@@ -103,7 +116,8 @@ async function loadStartServer(options: {
         ask: {
           allowed: false,
           reason: 'missing_index',
-          message: 'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
+          message:
+            'Embeddings table is empty. Run `npm run index` to populate the rulebook vector store.',
         },
       },
     }),
@@ -163,13 +177,10 @@ describe('startServer', () => {
   });
 
   it('binds the configured port without awaiting bootstrap warmup', async () => {
-    let resolveBootstrap: (() => void) | null = null;
+    const bootstrap = createDeferred<void>();
     const { startServer, fakeServer, startBootstrapLifecycle } = await loadStartServer({
       configuredPort: '4123',
-      bootstrapImpl: () =>
-        new Promise<void>((resolve) => {
-          resolveBootstrap = resolve;
-        }),
+      bootstrapImpl: () => bootstrap.promise,
     });
 
     await expect(startServer()).resolves.toBeUndefined();
@@ -177,7 +188,7 @@ describe('startServer', () => {
     expect(fakeServer.listenCalls).toEqual([4123]);
     expect(startBootstrapLifecycle).toHaveBeenCalledTimes(1);
 
-    resolveBootstrap?.();
+    bootstrap.resolve();
   });
 
   it('binds a claimed worktree port even when bootstrap prerequisites are missing', async () => {


### PR DESCRIPTION
Fixes SQR-84

## Summary
**Bootstrap lifecycle**
- decouple HTTP server startup from embedding-index and card-seed readiness so `npm run serve` can bind its port before bootstrap is complete
- model bootstrap as explicit lifecycle state and return actionable readiness errors from health and query paths instead of crashing at startup
- gate route behavior on lifecycle state instead of treating bootstrap gaps as startup-time fatal errors

**Testing and QA guardrails**
- repair the post-rebase fallout against current `main`, including the dropped `getDb` import and brittle deferred-resolver test patterns
- keep docs and local QA guardrails aligned with the shipped readiness model

## Test Coverage
- added regression coverage for bootstrap lifecycle gating and the updated startup behavior
- updated affected tests after the rebase so the branch typechecks and the readiness flow stays covered

## Pre-Landing Review
No issues found.

## Design Review
No frontend files changed — design review skipped.

## Eval Results
No prompt-related files changed — evals skipped.

## Plan Completion
No relevant plan file detected.

## Verification Results
- local health check reports ready after bootstrap completes
- manual Google sign-in and chat submit succeeded on `http://localhost:5018`

## Test plan
- [x] `npm run check`
- [x] manual Google sign-in and chat submit on `http://localhost:5018`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asynchronous bootstrap lifecycle with background initialization after server port binding.
  * Capability-based API gating returning graceful 503 responses when service dependencies are unavailable.

* **Bug Fixes**
  * Server no longer crashes during startup when embeddings or card data are missing.

* **Documentation**
  * Added startup lifecycle state-machine design documentation.
  * Updated development guide with new bootstrap behavior and API endpoint dependencies.
  * Added PR submission requirements for Linear issue linkage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->