### PR TITLE
Handle interrupted first-send retries without stranding conversations

### DIFF
--- a/docs/SSE_CONTRACT.md
+++ b/docs/SSE_CONTRACT.md
@@ -6,11 +6,11 @@ Squire chat streams.
 Scope:
 
 - `GET /chat/:conversationId/messages/:messageId/stream` in
-  [src/server.ts](/Users/bcm/.codex/worktrees/059e/squire/src/server.ts)
+  [src/server.ts](../src/server.ts)
 - pending transcript handling in
-  [src/web-ui/squire.js](/Users/bcm/.codex/worktrees/059e/squire/src/web-ui/squire.js)
+  [src/web-ui/squire.js](../src/web-ui/squire.js)
 - regression coverage in
-  [test/conversation.test.ts](/Users/bcm/.codex/worktrees/059e/squire/test/conversation.test.ts)
+  [test/conversation.test.ts](../test/conversation.test.ts)
 
 ## Browser-visible events
 

--- a/docs/SSE_CONTRACT.md
+++ b/docs/SSE_CONTRACT.md
@@ -1,0 +1,86 @@
+# SSE Contract
+
+This document defines the browser-facing Server-Sent Events contract for
+Squire chat streams.
+
+Scope:
+
+- `GET /chat/:conversationId/messages/:messageId/stream` in
+  [src/server.ts](/Users/bcm/.codex/worktrees/059e/squire/src/server.ts)
+- pending transcript handling in
+  [src/web-ui/squire.js](/Users/bcm/.codex/worktrees/059e/squire/src/web-ui/squire.js)
+- regression coverage in
+  [test/conversation.test.ts](/Users/bcm/.codex/worktrees/059e/squire/test/conversation.test.ts)
+
+## Browser-visible events
+
+The browser consumes these SSE event names:
+
+- `text-delta`
+  - Appends assistant answer text.
+  - Payload: `{ "delta": string }`
+- `tool-start`
+  - Adds or updates an in-progress tool row.
+  - Payload: `{ "id": string, "label": string }`
+- `tool-result`
+  - Marks a tool row complete or failed.
+  - Payload: `{ "id": string, "label": string, "ok": boolean }`
+- `done`
+  - Marks the stream complete and clears the pending answer UI.
+  - Payload: `{}`
+- `error`
+  - Replaces the pending answer UI with an error banner.
+  - Payload: `{ "kind": string, "message": string, "recoverable": boolean }`
+
+## Required success-path invariants
+
+For every successful stream:
+
+1. The browser must receive the full assistant answer text through one or more
+   `text-delta` events.
+2. The browser must receive exactly one terminal `done` event.
+3. Any `text-delta` events must arrive before `done`.
+4. Tool events may appear before completion, but they do not count as answer
+   text.
+
+Important:
+
+- A provider/backend success does not imply that incremental text events were
+  emitted.
+- If the backend returns a final persisted assistant message without any prior
+  `text` emits, the stream route must synthesize a fallback `text-delta` from
+  the persisted message before sending `done`.
+
+## Error-path invariants
+
+For every failed stream:
+
+1. The browser must receive exactly one terminal `error` event.
+2. `done` must not be sent after `error`.
+3. Partial `text-delta` events may have been sent before the failure.
+
+## Translation rules
+
+The conversation service emits internal events like `text`, `tool_call`,
+`tool_result`, and `done`. The HTTP stream route is responsible for translating
+those into the browser contract above.
+
+The route, not the provider, owns the final browser ordering guarantees:
+
+- provider/internal `text` -> browser `text-delta`
+- provider/internal `tool_call` -> browser `tool-start`
+- provider/internal `tool_result` -> browser `tool-result`
+- provider/internal `done` is only a completion signal
+- browser `done` is emitted by the route after it has confirmed whether
+  fallback answer text is needed
+
+## Testing guidance
+
+Regression tests should assert browser-visible behavior, not only persistence:
+
+- successful streams without incremental text still send visible answer content
+  plus `done`
+- tool-only success paths still send fallback answer text if the assistant
+  message contains content
+- transport/bootstrap failures end in `error`
+- repaired first-send retries satisfy the same stream contract as normal flows

--- a/docs/agent/agent-baseline.md
+++ b/docs/agent/agent-baseline.md
@@ -23,6 +23,7 @@ Read these on demand:
 | Start work in a fresh checkout or linked worktree, or get one bootstrapped | [../DEVELOPMENT.md](../DEVELOPMENT.md)           |
 | Start work on a Linear issue                                               | [issue-workflow.md](./issue-workflow.md)         |
 | Write or modify tests                                                      | [testing.md](./testing.md)                       |
+| Run QA, browser verification, or ship-readiness testing                    | [qa.md](./qa.md)                                 |
 | Make a non-obvious design choice                                           | [code-quality.md](./code-quality.md)             |
 | Touch anything visual — fonts, color, spacing, layout, copy tone           | [../../DESIGN.md](../../DESIGN.md)               |
 | Ship a PR                                                                  | [shipping.md](./shipping.md)                     |

--- a/docs/agent/qa.md
+++ b/docs/agent/qa.md
@@ -1,0 +1,133 @@
+<!-- Indexed from agent-baseline.md — see the routing table there. -->
+
+# QA Workflow
+
+QA in Squire has two separate jobs. Do both.
+
+1. **Issue-specific exploratory QA**
+   - Exercise the scenario the ticket or branch actually changes.
+   - Try the obvious success path, the failure path, and the edge that motivated
+     the fix.
+2. **Always-run regression QA**
+   - Re-run a small shared-product sweep so we do not miss adjacent regressions
+     in auth, chat flow, or browser wiring.
+
+Do not treat exploratory QA as a substitute for the regression sweep. The
+SQR-88 follow-up-submit bug is the exact failure mode this doc is meant to
+prevent: the branch-fixed behavior worked, but a nearby shared chat path broke
+and would only show up if you asked a second question in the same conversation.
+
+## Preconditions
+
+Before authenticated browser QA in a fresh linked worktree, follow the
+bootstrap in [../DEVELOPMENT.md](../DEVELOPMENT.md):
+
+```bash
+npm install
+docker compose up -d
+npm run db:migrate
+npm run db:migrate:test
+npm run index
+npm run seed:dev
+```
+
+Also make sure:
+
+- the worktree `.env` includes `SESSION_SECRET`
+- local commands use Node 24 if your shell defaults to another version
+- the dev server is running on the current worktree's port
+
+## Mandatory regression sweep
+
+Run these in addition to issue-specific QA unless the branch is purely
+documentation or process-only.
+
+### 1. Unauthenticated entry
+
+- Open `/login`
+- Confirm the page renders cleanly
+- Confirm there are no browser console errors
+- Open `/`
+- Confirm unauthenticated users redirect back to `/login`
+
+### 2. Authenticated landing
+
+- Sign in with a valid allowed account or equivalent local dev session
+- Confirm the authenticated home page loads
+- Confirm there are no browser console errors
+
+### 3. First-turn chat flow
+
+- Ask one simple question from the home page
+- Confirm the app moves onto a conversation URL
+- Confirm the user message appears
+- Confirm the assistant response appears
+- Confirm the UI does not remain stuck in a pending state
+
+### 4. Follow-up chat flow
+
+- Ask a second question in the same conversation
+- Confirm the request stays on the same conversation page
+- Confirm the second user message appears
+- Confirm the second assistant response appears
+- Confirm the UI does not silently no-op
+
+If the branch touches form submission, HTMX wiring, keyboard handling, or input
+components, exercise both:
+
+- Enter-key submit
+- submit-button click
+
+### 5. Existing transcript rendering
+
+- Open an existing conversation directly, either via a seeded transcript or a
+  conversation created during QA
+- Confirm persisted user and assistant turns render correctly
+
+### 6. Branch-specific scenario
+
+- Run the ticket-specific flow that motivated the change
+- If the branch changes retry, streaming, auth, routing, or other shared
+  infrastructure, include the adjacent user flow most likely to break
+
+## When to widen the sweep
+
+Broaden QA beyond the minimum matrix when the branch touches shared boundaries:
+
+- `src/web-ui/squire.js` or other browser event wiring
+  - re-run first-turn and follow-up chat flows
+- `src/server.ts` route handling or SSE/event translation
+  - re-run chat creation, follow-up messages, and stream completion behavior
+- auth/session/CSRF code
+  - re-run login, logout, redirect behavior, and an authenticated POST
+- layout or rendering primitives
+  - re-run the key pages affected by those primitives, not just the target page
+
+The rule is simple: if the changed code is shared, QA the neighboring flow, not
+just the ticket flow.
+
+## Evidence expectations
+
+Capture enough evidence that another engineer can trust the result:
+
+- screenshots for the key verified states
+- console errors if anything fails
+- network evidence when browser behavior contradicts the visible DOM
+- the exact local port and branch under test
+
+When a bug appears browser-side, inspect both:
+
+- the DOM state after the action
+- the actual request sent on submit/stream start
+
+Do not assume the DOM and the request path match.
+
+## Testing versus QA
+
+Automated tests and manual QA are different gates:
+
+- automated tests prove known contracts
+- QA catches integration and browser-state failures that tests may not model yet
+
+If QA finds a regression that should never recur, add an automated regression
+test before shipping.

--- a/src/server.ts
+++ b/src/server.ts
@@ -680,6 +680,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
 
   return streamSSE(c, async (stream) => {
     const toolIds = new Map<string, string[]>();
+    let sentDoneEvent = false;
     const nextToolId = (name: string) => {
       const queue = toolIds.get(name) ?? [];
       const id = `${name}-${queue.length + 1}`;
@@ -740,6 +741,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
         }
 
         if (event === 'done') {
+          sentDoneEvent = true;
           await stream.writeSSE({
             event: 'done',
             data: JSON.stringify({}),
@@ -759,6 +761,11 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
               : assistantMessage.content,
           recoverable: true,
         }),
+      });
+    } else if (!sentDoneEvent) {
+      await stream.writeSSE({
+        event: 'done',
+        data: JSON.stringify({}),
       });
     }
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -678,6 +678,10 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
     });
   }
 
+  // Browser SSE semantics are documented in docs/SSE_CONTRACT.md. This route
+  // owns the final user-visible ordering guarantees, including fallback
+  // text-delta emission when the provider returns a persisted answer without
+  // incremental text events.
   return streamSSE(c, async (stream) => {
     const toolIds = new Map<string, string[]>();
     let sentTextDelta = false;

--- a/src/server.ts
+++ b/src/server.ts
@@ -680,7 +680,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
 
   return streamSSE(c, async (stream) => {
     const toolIds = new Map<string, string[]>();
-    let sentDoneEvent = false;
+    let sentTextDelta = false;
     const nextToolId = (name: string) => {
       const queue = toolIds.get(name) ?? [];
       const id = `${name}-${queue.length + 1}`;
@@ -706,6 +706,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
       currentUserMessageId: loaded.message.id,
       onEvent: async (event, data) => {
         if (event === 'text') {
+          sentTextDelta = true;
           await stream.writeSSE({
             event: 'text-delta',
             data: JSON.stringify(data),
@@ -741,11 +742,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
         }
 
         if (event === 'done') {
-          sentDoneEvent = true;
-          await stream.writeSSE({
-            event: 'done',
-            data: JSON.stringify({}),
-          });
+          return;
         }
       },
     });
@@ -762,7 +759,14 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
           recoverable: true,
         }),
       });
-    } else if (!sentDoneEvent) {
+    } else {
+      if (!sentTextDelta && assistantMessage.content) {
+        await stream.writeSSE({
+          event: 'text-delta',
+          data: JSON.stringify({ delta: assistantMessage.content }),
+        });
+      }
+
       await stream.writeSSE({
         event: 'done',
         data: JSON.stringify({}),

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -210,6 +210,15 @@ document.addEventListener('htmx:configRequest', function (event) {
   var form = event.detail && event.detail.elt;
   if (!form || !form.matches || !form.matches('.squire-input-dock')) return;
 
+  // HTMX can hold onto the original hx-post path even after the form action is
+  // retargeted from "/chat" to "/chat/:conversationId/messages". Force the
+  // request path from the live DOM action on every submit so Enter-key follow-ups
+  // hit the current conversation instead of starting over.
+  var action = form.getAttribute('action');
+  if (action && event.detail) {
+    event.detail.path = action;
+  }
+
   var idempotencyKey = ensureIdempotencyKey(form);
   if (idempotencyKey && event.detail && event.detail.parameters) {
     event.detail.parameters.idempotencyKey = idempotencyKey;

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -116,6 +116,8 @@ function renderPendingError(answerEl, label, message) {
 function handlePendingTranscript(transcript) {
   if (!transcript) return;
 
+  // Browser event expectations live in docs/SSE_CONTRACT.md. Text is rendered
+  // only from text-delta, while done/error are terminal UI state changes.
   var streamUrl = transcript.getAttribute('data-stream-url');
   if (!streamUrl) return;
   if (activeStream && activeStream.url === streamUrl) return;

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -513,7 +513,7 @@ describe('conversation web backend', () => {
       `http://localhost:3000/chat/${conversation.id}/messages/${userMessage.id}/stream`,
     );
     expect(streamRes.status).toBe(200);
-    expect(parseSse(await streamRes.text())).toEqual([]);
+    expect(parseSse(await streamRes.text())).toEqual([{ event: 'done', data: {} }]);
 
     const storedMessages = await db.execute(sql`
       select role, content, response_to_message_id as "responseToMessageId"

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -399,6 +399,206 @@ describe('conversation web backend', () => {
     expect(mockAsk).toHaveBeenCalledTimes(1);
   });
 
+  it('repairs a stranded classic first-send retry after only the user turn was persisted', async () => {
+    mockAsk.mockResolvedValueOnce('Recovered after retry.');
+    const auth = await createAuthContext();
+    const { db } = getDb('server');
+
+    const [conversation] = await db
+      .insert(conversations)
+      .values({
+        userId: auth.userId,
+        creationIdempotencyKey: 'idem-stranded-classic',
+      })
+      .returning();
+
+    const [userMessage] = await db
+      .insert(messages)
+      .values({
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'Stranded question',
+      })
+      .returning();
+
+    await db
+      .update(conversations)
+      .set({ lastMessageAt: userMessage.createdAt })
+      .where(sql`${conversations.id} = ${conversation.id}`);
+
+    const retryRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'Stranded question',
+        idempotencyKey: 'idem-stranded-classic',
+      }),
+      redirect: 'manual',
+    });
+
+    expect(retryRes.status).toBe(302);
+    expect(requireLocation(retryRes)).toBe(`/chat/${conversation.id}`);
+    expect(mockAsk).toHaveBeenCalledTimes(1);
+    expect(mockAsk).toHaveBeenCalledWith('Stranded question', {
+      history: [],
+      userId: auth.userId,
+    });
+
+    const storedMessages = await db.execute(sql`
+      select role, content, response_to_message_id as "responseToMessageId"
+      from messages
+      order by created_at asc, id asc
+    `);
+    expect(storedMessages.rows).toEqual([
+      { role: 'user', content: 'Stranded question', responseToMessageId: null },
+      {
+        role: 'assistant',
+        content: 'Recovered after retry.',
+        responseToMessageId: userMessage.id,
+      },
+    ]);
+  });
+
+  it('repairs a stranded HTMX first send by returning a pending shell and completing the stream', async () => {
+    mockAsk.mockResolvedValueOnce('Recovered over SSE.');
+    const auth = await createAuthContext();
+    const { db } = getDb('server');
+
+    const [conversation] = await db
+      .insert(conversations)
+      .values({
+        userId: auth.userId,
+        creationIdempotencyKey: 'idem-stranded-htmx',
+      })
+      .returning();
+
+    const [userMessage] = await db
+      .insert(messages)
+      .values({
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'Recover this pending turn',
+      })
+      .returning();
+
+    await db
+      .update(conversations)
+      .set({ lastMessageAt: userMessage.createdAt })
+      .where(sql`${conversations.id} = ${conversation.id}`);
+
+    const retryRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'hx-request': 'true',
+      },
+      body: formBody({
+        question: 'Recover this pending turn',
+        idempotencyKey: 'idem-stranded-htmx',
+      }),
+    });
+
+    expect(retryRes.status).toBe(200);
+    expect(retryRes.headers.get('HX-Push-Url')).toBe(`/chat/${conversation.id}`);
+    const body = await retryRes.text();
+    expect(body).toContain('Recover this pending turn');
+    expect(body).toContain(
+      `data-stream-url="/chat/${conversation.id}/messages/${userMessage.id}/stream"`,
+    );
+
+    const streamRes = await requestWithAuth(
+      auth,
+      `http://localhost:3000/chat/${conversation.id}/messages/${userMessage.id}/stream`,
+    );
+    expect(streamRes.status).toBe(200);
+    expect(parseSse(await streamRes.text())).toEqual([]);
+
+    const storedMessages = await db.execute(sql`
+      select role, content, response_to_message_id as "responseToMessageId"
+      from messages
+      order by created_at asc, id asc
+    `);
+    expect(storedMessages.rows).toEqual([
+      { role: 'user', content: 'Recover this pending turn', responseToMessageId: null },
+      {
+        role: 'assistant',
+        content: 'Recovered over SSE.',
+        responseToMessageId: userMessage.id,
+      },
+    ]);
+  });
+
+  it('does not duplicate the assistant turn across repeated same-key recovery attempts', async () => {
+    mockAsk.mockResolvedValueOnce('One repaired answer.');
+    const auth = await createAuthContext();
+    const { db } = getDb('server');
+
+    const [conversation] = await db
+      .insert(conversations)
+      .values({
+        userId: auth.userId,
+        creationIdempotencyKey: 'idem-repair-repeat',
+      })
+      .returning();
+
+    const [userMessage] = await db
+      .insert(messages)
+      .values({
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'Recover me once',
+      })
+      .returning();
+
+    await db
+      .update(conversations)
+      .set({ lastMessageAt: userMessage.createdAt })
+      .where(sql`${conversations.id} = ${conversation.id}`);
+
+    const firstRetry = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'Recover me once',
+        idempotencyKey: 'idem-repair-repeat',
+      }),
+      redirect: 'manual',
+    });
+    const secondRetry = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: formBody({
+        question: 'Recover me once',
+        idempotencyKey: 'idem-repair-repeat',
+      }),
+      redirect: 'manual',
+    });
+
+    expect(firstRetry.status).toBe(302);
+    expect(secondRetry.status).toBe(302);
+    expect(requireLocation(firstRetry)).toBe(`/chat/${conversation.id}`);
+    expect(requireLocation(secondRetry)).toBe(`/chat/${conversation.id}`);
+    expect(mockAsk).toHaveBeenCalledTimes(1);
+
+    const assistantMessages = await db.execute(sql`
+      select id, content, response_to_message_id as "responseToMessageId"
+      from messages
+      where role = 'assistant'
+      order by created_at asc, id asc
+    `);
+    expect(assistantMessages.rows).toEqual([
+      {
+        id: assistantMessages.rows[0].id,
+        content: 'One repaired answer.',
+        responseToMessageId: userMessage.id,
+      },
+    ]);
+  });
+
   it('reuses an already-persisted assistant response without calling ask again', async () => {
     const { streamAssistantTurn } = await import('../src/chat/conversation-service.ts');
     const auth = await createAuthContext();

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -513,7 +513,10 @@ describe('conversation web backend', () => {
       `http://localhost:3000/chat/${conversation.id}/messages/${userMessage.id}/stream`,
     );
     expect(streamRes.status).toBe(200);
-    expect(parseSse(await streamRes.text())).toEqual([{ event: 'done', data: {} }]);
+    expect(parseSse(await streamRes.text())).toEqual([
+      { event: 'text-delta', data: { delta: 'Recovered over SSE.' } },
+      { event: 'done', data: {} },
+    ]);
 
     const storedMessages = await db.execute(sql`
       select role, content, response_to_message_id as "responseToMessageId"
@@ -861,6 +864,10 @@ describe('conversation web backend', () => {
       {
         event: 'tool-result',
         data: { id: 'search_rules-1', label: 'SEARCH RULES', ok: false },
+      },
+      {
+        event: 'text-delta',
+        data: { delta: 'Fallback answer.' },
       },
       {
         event: 'done',

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -130,6 +130,8 @@ function requireLocation(response: Response): string {
 }
 
 function parseSse(text: string): Array<{ event: string; data: unknown }> {
+  // Keep these assertions aligned with docs/SSE_CONTRACT.md, which defines the
+  // browser-visible event model rather than the service's internal emit API.
   return text
     .trim()
     .split('\n\n')

--- a/test/web-ui-htmx.regression-1.test.ts
+++ b/test/web-ui-htmx.regression-1.test.ts
@@ -14,4 +14,13 @@ describe('squire.js HTMX first-turn submit regression', () => {
     expect(squireJs).toContain('event.detail.parameters.idempotencyKey = idempotencyKey');
     expect(squireJs).toContain('ensureIdempotencyKey(form)');
   });
+
+  it('retargets HTMX follow-up submits from the live form action', () => {
+    // Regression: ISSUE-002 — follow-up chat submits kept posting to /chat
+    // Found by /qa on 2026-04-11
+    // Report: .gstack/qa-reports/qa-report-localhost-5018-2026-04-11.md
+    expect(squireJs).toContain("document.addEventListener('htmx:configRequest'");
+    expect(squireJs).toContain("var action = form.getAttribute('action');");
+    expect(squireJs).toContain('event.detail.path = action;');
+  });
 });


### PR DESCRIPTION
## Summary
- harden the HTMX/SSE first-send recovery path so repaired conversations always emit visible assistant content and a terminal stream event
- fix follow-up chat submits to retarget from the live conversation form action instead of a stale `/chat` HTMX path
- add stranded first-send regression coverage plus an explicit QA workflow doc for mandatory shared-flow checks

## Validation
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" npx vitest run test/conversation.test.ts --reporter=verbose`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" npx vitest run test/web-ui-htmx.regression-1.test.ts --reporter=verbose`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" npm run check`
- manual QA on `http://localhost:5018` covering login, first-turn chat, same-conversation follow-up chat, and stream completion behavior

Fixes SQR-88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat streams now emit fallback answer text when incremental text is absent.
  * Follow-up submissions are retargeted to the current conversation endpoint to avoid stale routing.

* **Documentation**
  * Formal browser-facing chat stream event contract and ordering requirements added.
  * New QA workflow and routing guidance for agent QA and regression coverage.

* **Tests**
  * Added regression and recovery tests for stream behavior, first-send scenarios, idempotency, and HTMX retargeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->