### PR TITLE
docs: sync SQR-61 security and streaming docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ serves:
   (`/app.<hash>.css`) with immutable caching. See
   [ADR 0011](docs/adr/0011-on-demand-asset-pipeline.md)). Authenticated chat
   runs on `/chat` and `/chat/:conversationId`, with persisted per-user
-  conversations in Postgres.
+  conversations in Postgres. Live streaming stays plain text until completion;
+  the final assistant answer is then swapped in as server-rendered sanitized
+  HTML under an HTML-only Content Security Policy.
 - **REST API** — `GET /api/health`, `/api/search/rules`, `/api/search/cards`,
   `/api/card-types`, `/api/cards`, `/api/cards/:type/:id`, `POST /api/ask`
 - **MCP endpoint** — `POST/GET/DELETE /mcp` (Streamable HTTP transport)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,7 +56,9 @@ Squire's web channel separates **conversation** from **knowledge**:
 
 - **Conversation agent** — thin session manager. Owns persisted chat history,
   failure persistence, ownership checks, streaming via Server-Sent Events, and
-  presentation (Hono JSX rendering, citations, tool call visibility). Real
+  presentation (Hono JSX rendering, citations, tool call visibility). In the
+  web UI, live deltas stay plain text until the stream completes; the terminal
+  `done` event swaps in one sanitized server-rendered HTML fragment. Real
   context compaction and summarization remain future work (SQR-12). One per
   client session.
 - **Knowledge agent** — the actual agent loop. Owns retrieval strategy (which atomic tools to call, in what order), reference resolution (turning "what items work with it?" into "Blinkblade items" via conversation history), campaign context loading (per Phase 4+), and answer generation. Stateless per request. Shared by all clients.
@@ -89,7 +91,15 @@ Agents shouldn't need hard-coded knowledge of what data Squire has. They discove
 
 - **Server framework:** Hono (`@hono/node-server`)
 - **UI rendering:** Hono JSX (server-rendered) + HTMX for interactivity + Tailwind CSS compiled in-process via `@tailwindcss/node`
+- **Assistant rendering boundary:** `markdown-it` on the server, with raw HTML
+  disabled, non-HTTPS links rejected, and one shared renderer reused for both
+  persisted transcript pages and final post-stream answer fragments
 - **Build pipeline:** no JavaScript bundler and no client-side build step. `GET /app.css` compiles `src/web-ui/styles.css` in-process via `@tailwindcss/node` on first request and caches the result in a module-level variable; dev keys the cache on source-file mtime so edits show up on the next request, prod compiles exactly once per process. Prod serves the compiled CSS at a content-hashed URL (`/app.<hash>.css`) with `Cache-Control: public, max-age=31536000, immutable` so Cloudflare and browsers can cache forever and invalidation is automatic on content change; dev serves the bare `/app.css` path with `Cache-Control: no-cache`. A parallel `/squire.js` handler serves vanilla-JS islands (currently the SQR-66 cite tap-toggle) with the same caching pattern. No `public/` build output, no `npm run build:css` — every fresh clone renders correctly without a build prerequisite.
+
+HTML responses also carry a shared Content Security Policy set in
+`src/server.ts`. The policy is `self`-only except for the current Google Fonts
+carve-out in `style-src` / `font-src`. JSON, SSE, and JS/CSS asset responses do
+not get the HTML CSP header.
 
 _Rationale: chosen to keep the stack simple and lightweight — single language end-to-end, no JS bundler, no client build pipeline. Secondary goal: learn new application tech (already deeply familiar with React SPAs)._
 
@@ -306,6 +316,11 @@ _Phase 5 (with the recommendation engine). See [SPEC.md](SPEC.md). Curated URL l
   agent
 - History forwarded into `ask()` is capped to the most recent 20 non-error
   messages. Real compaction and summarization remain deferred to SQR-12
+- Browser streaming contract:
+  - `text-delta` appends inert plain text only
+  - terminal `done` carries the sanitized final HTML fragment
+  - the same server-side renderer is used for persisted reloads and final
+    post-stream replacement
 
 ---
 
@@ -502,7 +517,13 @@ An earlier design considered using **internal MCP** as the transport between the
   stored conversation history, campaign ID
 - Does **not** call MCP tools directly — delegates domain reasoning to the knowledge agent
 - Owns session management: persisted chat history, ownership checks, failure
-  persistence, and presentation. Context compaction remains future work
+  persistence, and presentation
+- Maintains the web trust boundary:
+  - incremental stream text is inserted as plain text only
+  - final answer formatting is derived on the server and inserted as sanitized
+    HTML at stream completion
+  - persisted reloads use that same renderer rather than a separate browser path
+- Context compaction remains future work
 
 **External MCP clients:**
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -202,6 +202,8 @@ HTML/JS and are rendered unsanitized, prompt injection becomes XSS.
   - `default-src 'self'`
   - `script-src 'self'`
   - `style-src 'self' https://fonts.googleapis.com`
+  - `img-src 'self' data:`
+  - `connect-src 'self'`
   - `font-src 'self' https://fonts.gstatic.com`
   - `object-src 'none'`
   - `base-uri 'none'`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -196,6 +196,25 @@ exposed.
 The web UI renders LLM responses with HTMX. If responses contain
 HTML/JS and are rendered unsanitized, prompt injection becomes XSS.
 
+**Current state (SQR-61 shipped):**
+
+- HTML responses now carry a shared Content Security Policy:
+  - `default-src 'self'`
+  - `script-src 'self'`
+  - `style-src 'self' https://fonts.googleapis.com`
+  - `font-src 'self' https://fonts.gstatic.com`
+  - `object-src 'none'`
+  - `base-uri 'none'`
+  - `frame-ancestors 'none'`
+  - `form-action 'self'`
+- Live assistant streaming stays plain text in the browser via `textContent`.
+- Final assistant rendering is server-owned: the browser swaps in one sanitized
+  HTML fragment only at SSE completion.
+- Persisted assistant messages are re-rendered through the same shared
+  sanitizing renderer on reload.
+- Adversarial regression tests cover hostile `<script>`, `<img onerror>`,
+  `javascript:` links, stored reloads, and streamed completion payloads.
+
 **Attack scenarios:**
 
 - Attacker crafts a prompt injection that causes the LLM to output
@@ -214,6 +233,13 @@ HTML/JS and are rendered unsanitized, prompt injection becomes XSS.
 - HttpOnly, Secure, SameSite=Lax cookies
 - User-owned conversation lookups return indistinguishable `404`s, so a
   guessed conversation ID does not disclose whether the resource exists
+
+**Residual risk / follow-up work:**
+
+- The web UI still allows Google Fonts domains in CSP (`fonts.googleapis.com`,
+  `fonts.gstatic.com`) rather than serving fonts from `self`.
+- Safe markdown is preserved, so the sanitizing renderer remains a security
+  boundary and must keep adversarial test coverage as it evolves.
 
 ### 8. Supply Chain / Data Pipeline
 

--- a/docs/SSE_CONTRACT.md
+++ b/docs/SSE_CONTRACT.md
@@ -27,7 +27,7 @@ The browser consumes these SSE event names:
   - Payload: `{ "id": string, "label": string, "ok": boolean }`
 - `done`
   - Marks the stream complete and clears the pending answer UI.
-  - Payload: `{}`
+  - Payload: `{ "html": string }`
 - `error`
   - Replaces the pending answer UI with an error banner.
   - Payload: `{ "kind": string, "message": string, "recoverable": boolean }`
@@ -42,14 +42,17 @@ For every successful stream:
 3. Any `text-delta` events must arrive before `done`.
 4. Tool events may appear before completion, but they do not count as answer
    text.
+5. The terminal `done` event carries the final server-rendered sanitized HTML
+   fragment, which replaces the pending plain-text transcript in the browser.
 
 Important:
 
 - A provider/backend success does not imply that incremental text events were
   emitted.
-- If the backend returns a final persisted assistant message without any prior
-  `text` emits, the stream route must synthesize a fallback `text-delta` from
-  the persisted message before sending `done`.
+- The browser treats `text-delta` as inert plain text only; rich formatting is
+  introduced exclusively through the final sanitized `done.html` fragment.
+- If the backend finishes without any prior incremental text, the route may
+  still complete successfully with only a terminal `done.html` payload.
 
 ## Error-path invariants
 
@@ -71,16 +74,17 @@ The route, not the provider, owns the final browser ordering guarantees:
 - provider/internal `tool_call` -> browser `tool-start`
 - provider/internal `tool_result` -> browser `tool-result`
 - provider/internal `done` is only a completion signal
-- browser `done` is emitted by the route after it has confirmed whether
-  fallback answer text is needed
+- browser `done` is emitted by the route with the final sanitized HTML derived
+  from the persisted assistant message
 
 ## Testing guidance
 
 Regression tests should assert browser-visible behavior, not only persistence:
 
-- successful streams without incremental text still send visible answer content
-  plus `done`
-- tool-only success paths still send fallback answer text if the assistant
-  message contains content
+- successful streams without incremental text still end with a visible
+  `done.html` fragment
+- `text-delta` content remains inert plain text even when it contains hostile
+  markup
+- `done.html` is sanitized before browser insertion
 - transport/bootstrap failures end in `error`
 - repaired first-send retries satisfy the same stream contract as normal flows

--- a/docs/SSE_CONTRACT.md
+++ b/docs/SSE_CONTRACT.md
@@ -36,8 +36,9 @@ The browser consumes these SSE event names:
 
 For every successful stream:
 
-1. The browser must receive the full assistant answer text through one or more
-   `text-delta` events.
+1. The browser may receive zero or more `text-delta` events before completion.
+   If present, their concatenation represents the plain-text incremental
+   answer.
 2. The browser must receive exactly one terminal `done` event.
 3. Any `text-delta` events must arrive before `done`.
 4. Tool events may appear before completion, but they do not count as answer


### PR DESCRIPTION
## Summary
- update README to describe the shipped web trust boundary for chat rendering
- sync the SSE contract with the actual `done` payload and plain-text streaming behavior
- record the implemented SQR-61 CSP and sanitization boundary in ARCHITECTURE and SECURITY

## Testing
- PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" npm run check
- npx markdownlint-cli2 README.md docs/SSE_CONTRACT.md docs/SECURITY.md docs/ARCHITECTURE.md

Fixes SQR-61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified chat streaming: live deltas are plain text; final assistant output replaces them with a single server-sanitized HTML fragment on stream completion.
  * Added a Browser Streaming Contract and updated SSE contract to carry final sanitized HTML in the terminal event.
  * Expanded security guidance and tests for XSS, CSP behavior, renderer reuse, and residual risks (fonts/CSP caveats).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->