### PR TITLE
feat(chat): add selected-message ledger route

### DIFF
--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -369,7 +369,7 @@ export async function loadSelectedConversation(input: {
   }> = [];
 
   for (const message of loaded.messages) {
-    if (message.role === 'assistant' && message.responseToMessageId) {
+    if (message.role === 'assistant' && message.responseToMessageId && !message.isError) {
       assistantResponses.set(message.responseToMessageId, message);
     }
   }
@@ -390,6 +390,8 @@ export async function loadSelectedConversation(input: {
   if (selectedIndex === -1) return null;
 
   const selectedTurn = completedTurns[selectedIndex]!;
+  const userMessages = loaded.messages.filter((message) => message.role === 'user');
+  const latestUserMessage = userMessages.at(-1);
   const recentQuestions = completedTurns
     .filter((turn) => turn.userMessage.id !== input.messageId)
     .slice()
@@ -410,7 +412,7 @@ export async function loadSelectedConversation(input: {
     selectedTurn: {
       userMessage: selectedTurn.userMessage,
       assistantMessage: selectedTurn.assistantMessage,
-      isEarlierQuestion: selectedIndex !== completedTurns.length - 1,
+      isEarlierQuestion: latestUserMessage?.id !== selectedTurn.userMessage.id,
     },
     recentQuestions,
   };

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -16,6 +16,24 @@ export interface PendingConversationTurn {
   currentUserMessage: ConversationMessage | null;
 }
 
+export interface SelectedConversationQuestion {
+  messageId: string;
+  question: string;
+  askedAt: Date;
+}
+
+export interface SelectedConversationTurn {
+  userMessage: ConversationMessage;
+  assistantMessage: ConversationMessage;
+  isEarlierQuestion: boolean;
+}
+
+export interface SelectedConversationProjection {
+  conversation: Conversation;
+  selectedTurn: SelectedConversationTurn;
+  recentQuestions: SelectedConversationQuestion[];
+}
+
 function isRetryableTransportError(err: unknown): boolean {
   if (typeof err !== 'object' || err === null) {
     return false;
@@ -331,4 +349,69 @@ export async function loadConversation(input: {
   });
 
   return { conversation, messages };
+}
+
+export async function loadSelectedConversation(input: {
+  conversationId: string;
+  messageId: string;
+  userId: string;
+}): Promise<SelectedConversationProjection | null> {
+  const loaded = await loadConversation({
+    conversationId: input.conversationId,
+    userId: input.userId,
+  });
+  if (!loaded) return null;
+
+  const assistantResponses = new Map<string, ConversationMessage>();
+  const completedTurns: Array<{
+    userMessage: ConversationMessage;
+    assistantMessage: ConversationMessage;
+  }> = [];
+
+  for (const message of loaded.messages) {
+    if (message.role === 'assistant' && message.responseToMessageId) {
+      assistantResponses.set(message.responseToMessageId, message);
+    }
+  }
+
+  for (const message of loaded.messages) {
+    if (message.role !== 'user') continue;
+
+    const assistantMessage = assistantResponses.get(message.id);
+    if (!assistantMessage) continue;
+
+    completedTurns.push({
+      userMessage: message,
+      assistantMessage,
+    });
+  }
+
+  const selectedIndex = completedTurns.findIndex((turn) => turn.userMessage.id === input.messageId);
+  if (selectedIndex === -1) return null;
+
+  const selectedTurn = completedTurns[selectedIndex]!;
+  const recentQuestions = completedTurns
+    .filter((turn) => turn.userMessage.id !== input.messageId)
+    .slice()
+    .sort((left, right) => {
+      const timestampDiff =
+        right.userMessage.createdAt.getTime() - left.userMessage.createdAt.getTime();
+      if (timestampDiff !== 0) return timestampDiff;
+      return right.userMessage.id.localeCompare(left.userMessage.id);
+    })
+    .map((turn) => ({
+      messageId: turn.userMessage.id,
+      question: turn.userMessage.content,
+      askedAt: turn.userMessage.createdAt,
+    }));
+
+  return {
+    conversation: loaded.conversation,
+    selectedTurn: {
+      userMessage: selectedTurn.userMessage,
+      assistantMessage: selectedTurn.assistantMessage,
+      isEarlierQuestion: selectedIndex !== completedTurns.length - 1,
+    },
+    recentQuestions,
+  };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,10 +59,12 @@ import {
   renderConversationTranscript,
   renderConversationTranscriptWithPendingTurn,
   renderConversationPage,
+  renderConversationTranscriptWithRecentQuestions,
   renderHomePage,
   renderLoginPage,
   renderNotInvitedPage,
   renderPendingTurnShell,
+  renderRecentQuestionsNav,
 } from './web-ui/layout.ts';
 import { renderAssistantContentHtml } from './web-ui/assistant-content.ts';
 import { getAppCss, getHtmxJs, getSquireJs } from './web-ui/assets.ts';
@@ -600,12 +602,25 @@ app.get('/chat/:conversationId/messages/:messageId', async (c) => {
   if (!loaded) return c.notFound();
 
   const selectedMessages = [loaded.selectedTurn.userMessage, loaded.selectedTurn.assistantMessage];
+  const recentQuestionsNav = renderRecentQuestionsNav(
+    loaded.recentQuestions.map((question) => ({
+      href: `/chat/${loaded.conversation.id}/messages/${question.messageId}`,
+      label: question.question,
+    })),
+    { oob: isHtmxRequest(c) },
+  );
 
   c.header('Cache-Control', 'no-store');
   c.header('Vary', 'Cookie');
 
   if (isHtmxRequest(c)) {
-    return c.html(renderConversationTranscript(loaded.conversation.id, selectedMessages));
+    return c.html(
+      renderConversationTranscriptWithRecentQuestions({
+        conversationId: loaded.conversation.id,
+        messages: selectedMessages,
+        recentQuestionsNav,
+      }),
+    );
   }
 
   return c.html(
@@ -614,6 +629,7 @@ app.get('/chat/:conversationId/messages/:messageId', async (c) => {
       csrfToken: createCsrfToken(session.id),
       conversationId: loaded.conversation.id,
       messages: selectedMessages,
+      recentQuestionsNav,
     }),
   );
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -695,6 +695,7 @@ app.post('/chat/:conversationId/messages', async (c) => {
 
     c.header('Cache-Control', 'no-store');
     c.header('Vary', 'Cookie');
+    c.header('HX-Push-Url', `/chat/${pending.conversation.id}`);
     const loaded = await loadConversation({
       conversationId: pending.conversation.id,
       userId: session.userId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,6 +73,7 @@ import {
   GENERIC_FAILURE_MESSAGE,
   loadConversation,
   loadConversationMessage,
+  loadSelectedConversation,
   startConversation,
   streamAssistantTurn,
 } from './chat/conversation-service.ts';
@@ -585,6 +586,34 @@ app.get('/chat/:conversationId', async (c) => {
       csrfToken: createCsrfToken(session.id),
       conversationId: loaded.conversation.id,
       messages: loaded.messages,
+    }),
+  );
+});
+
+app.get('/chat/:conversationId/messages/:messageId', async (c) => {
+  const session = c.get('session')!;
+  const loaded = await loadSelectedConversation({
+    conversationId: c.req.param('conversationId'),
+    messageId: c.req.param('messageId'),
+    userId: session.userId,
+  });
+  if (!loaded) return c.notFound();
+
+  const selectedMessages = [loaded.selectedTurn.userMessage, loaded.selectedTurn.assistantMessage];
+
+  c.header('Cache-Control', 'no-store');
+  c.header('Vary', 'Cookie');
+
+  if (isHtmxRequest(c)) {
+    return c.html(renderConversationTranscript(loaded.conversation.id, selectedMessages));
+  }
+
+  return c.html(
+    await renderConversationPage({
+      session,
+      csrfToken: createCsrfToken(session.id),
+      conversationId: loaded.conversation.id,
+      messages: selectedMessages,
     }),
   );
 });

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -58,11 +58,17 @@ export interface LayoutShellOptions {
   csrfToken?: string;
   chatFormAction?: string;
   chatFormHiddenFields?: Array<{ name: string; value: string }>;
+  recentQuestionsNav?: HtmlEscapedString;
 }
 
 export interface PendingTurnShellOptions {
   question: string;
   streamUrl: string;
+}
+
+export interface RecentQuestionNavItem {
+  href: string;
+  label: string;
 }
 
 interface DocumentOptions {
@@ -167,6 +173,21 @@ function renderPendingAnswerSkeleton(): HtmlEscapedString {
   </article>` as HtmlEscapedString;
 }
 
+export function renderRecentQuestionsNav(
+  items: RecentQuestionNavItem[],
+  options?: { oob?: boolean },
+): HtmlEscapedString {
+  return html`<nav
+    id="squire-recent-questions"
+    class="squire-recent"
+    aria-label="Recent questions"
+    ${options?.oob ? html`hx-swap-oob="outerHTML"` : html``}
+    ${items.length === 0 ? html`hidden` : html``}
+  >
+    ${items.map((item) => html`<a class="squire-chip" href="${item.href}">${item.label}</a>`)}
+  </nav>` as HtmlEscapedString;
+}
+
 /**
  * Render the full HTML document for the companion-first layout. Stable
  * selectors (`squire-header`, `squire-surface`, `squire-toolcall`,
@@ -235,6 +256,13 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
         <p class="squire-banner__body">${options.errorBanner.message}</p>
       </div>`
     : (options.mainContent ?? emptyStateAndStubs);
+  const recentQuestionsNav =
+    options.recentQuestionsNav ??
+    renderRecentQuestionsNav([
+      { href: '#', label: 'Looting' },
+      { href: '#', label: 'Element infusion' },
+      { href: '#', label: 'Negative scenario effects' },
+    ]);
 
   return renderDocument({
     authenticated,
@@ -286,11 +314,7 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
             : html`<footer class="squire-toolcall" aria-live="off">
                   CONSULTED · RULEBOOK P.47 · SCENARIO BOOK §14
                 </footer>
-                <nav class="squire-recent" aria-label="Recent questions">
-                  <span class="squire-chip">Looting</span>
-                  <span class="squire-chip">Element infusion</span>
-                  <span class="squire-chip">Negative scenario effects</span>
-                </nav>
+                ${recentQuestionsNav}
                 <form
                   class="squire-input-dock"
                   method="post"
@@ -437,6 +461,7 @@ export async function renderConversationPage(options: {
   csrfToken: string;
   conversationId: string;
   messages: ConversationMessage[];
+  recentQuestionsNav?: HtmlEscapedString;
 }): Promise<HtmlEscapedString> {
   const transcript = renderConversationTranscript(options.conversationId, options.messages);
 
@@ -445,6 +470,7 @@ export async function renderConversationPage(options: {
     csrfToken: options.csrfToken,
     mainContent: transcript as HtmlEscapedString,
     chatFormAction: `/chat/${options.conversationId}/messages`,
+    recentQuestionsNav: options.recentQuestionsNav,
   });
 }
 
@@ -481,6 +507,15 @@ export function renderConversationTranscriptWithPendingTurn(options: {
     ${options.messages.map((message) => renderConversationTurn(message))}
     ${renderPendingAnswerSkeleton()}
   </section>` as HtmlEscapedString;
+}
+
+export function renderConversationTranscriptWithRecentQuestions(options: {
+  conversationId: string;
+  messages: ConversationMessage[];
+  recentQuestionsNav: HtmlEscapedString;
+}): HtmlEscapedString {
+  return html`${renderConversationTranscript(options.conversationId, options.messages)}
+  ${options.recentQuestionsNav}` as HtmlEscapedString;
 }
 
 export function renderPendingTurnShell(options: PendingTurnShellOptions): HtmlEscapedString {

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -78,7 +78,7 @@ function syncChatFormAction() {
   var form = document.querySelector('.squire-input-dock');
   if (!form) return;
 
-  var match = window.location.pathname.match(/^\/chat\/([0-9a-f-]+)$/);
+  var match = window.location.pathname.match(/^\/chat\/([0-9a-f-]+)(?:\/messages\/[0-9a-f-]+)?$/);
   var action = match ? '/chat/' + match[1] + '/messages' : '/chat';
   form.setAttribute('action', action);
   form.setAttribute('hx-post', action);

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -1311,7 +1311,91 @@ describe('selected-message projection', () => {
     });
 
     expect(projection).not.toBeNull();
-    expect(projection?.selectedTurn.isEarlierQuestion).toBe(false);
+    expect(projection?.selectedTurn.isEarlierQuestion).toBe(true);
     expect(projection?.recentQuestions).toEqual([]);
+  });
+
+  it('excludes error assistant turns from selected-message history', async () => {
+    const auth = await createAuthContext();
+    const { db } = getDb('server');
+    const [conversation] = await db
+      .insert(conversations)
+      .values({ userId: auth.userId })
+      .returning();
+
+    const [olderUserMessage] = await db
+      .insert(messages)
+      .values({
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'Older completed question',
+      })
+      .returning();
+    await db.insert(messages).values({
+      conversationId: conversation.id,
+      role: 'assistant',
+      content: 'Older completed answer',
+      responseToMessageId: olderUserMessage.id,
+    });
+    const [failedUserMessage] = await db
+      .insert(messages)
+      .values({
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'Failed question',
+      })
+      .returning();
+    const [failedAssistantMessage] = await db
+      .insert(messages)
+      .values({
+        conversationId: conversation.id,
+        role: 'assistant',
+        content: 'I hit an error and could not answer that.',
+        isError: true,
+        responseToMessageId: failedUserMessage.id,
+      })
+      .returning();
+
+    await db
+      .update(conversations)
+      .set({ lastMessageAt: failedAssistantMessage.createdAt })
+      .where(sql`${conversations.id} = ${conversation.id}`);
+
+    const selectedFailedTurn = await loadSelectedConversation({
+      conversationId: conversation.id,
+      messageId: failedUserMessage.id,
+      userId: auth.userId,
+    });
+    expect(selectedFailedTurn).toBeNull();
+
+    const projection = await loadSelectedConversation({
+      conversationId: conversation.id,
+      messageId: olderUserMessage.id,
+      userId: auth.userId,
+    });
+
+    expect(projection).not.toBeNull();
+    expect(projection?.recentQuestions).toEqual([]);
+  });
+
+  it('marks the latest completed turn as earlier when a newer user question is pending', async () => {
+    const auth = await createAuthContext();
+    const seeded = await seedConversationWithTurns(auth, [
+      { question: 'Oldest completed question', answer: 'Oldest completed answer' },
+      { question: 'Latest completed question', answer: 'Latest completed answer' },
+      { question: 'Newest pending question' },
+    ]);
+
+    const projection = await loadSelectedConversation({
+      conversationId: seeded.conversationId,
+      messageId: seeded.userMessages[1]!.id,
+      userId: auth.userId,
+    });
+
+    expect(projection).not.toBeNull();
+    expect(projection?.selectedTurn.isEarlierQuestion).toBe(true);
+    expect(projection?.recentQuestions.map((question) => question.messageId)).toEqual([
+      seeded.userMessages[0]!.id,
+    ]);
   });
 });

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -54,6 +54,7 @@ import { createCsrfToken } from '../src/auth/csrf.ts';
 import { SESSION_COOKIE_NAME, getSessionSecret } from '../src/auth/session-middleware.ts';
 import * as SessionRepository from '../src/db/repositories/session-repository.ts';
 import { SESSION_LIFETIME_MS } from '../src/db/repositories/session-repository.ts';
+import { loadSelectedConversation } from '../src/chat/conversation-service.ts';
 import { users } from '../src/db/schema/core.ts';
 import { conversations, messages } from '../src/db/schema/conversations.ts';
 
@@ -127,6 +128,64 @@ function requireLocation(response: Response): string {
   const location = response.headers.get('location');
   expect(location).toBeTruthy();
   return location!;
+}
+
+async function seedConversationWithTurns(
+  auth: AuthContext,
+  turns: Array<{ question: string; answer?: string }>,
+): Promise<{
+  conversationId: string;
+  userMessages: Array<{ id: string; content: string }>;
+  assistantMessages: Array<{ id: string; content: string; responseToMessageId: string }>;
+}> {
+  const { db } = getDb('server');
+  const [conversation] = await db.insert(conversations).values({ userId: auth.userId }).returning();
+
+  const userMessages: Array<{ id: string; content: string }> = [];
+  const assistantMessages: Array<{ id: string; content: string; responseToMessageId: string }> = [];
+  let lastMessageAt = conversation.lastMessageAt;
+
+  for (const turn of turns) {
+    const [userMessage] = await db
+      .insert(messages)
+      .values({
+        conversationId: conversation.id,
+        role: 'user',
+        content: turn.question,
+      })
+      .returning();
+    userMessages.push({ id: userMessage.id, content: userMessage.content });
+    lastMessageAt = userMessage.createdAt;
+
+    if (turn.answer !== undefined) {
+      const [assistantMessage] = await db
+        .insert(messages)
+        .values({
+          conversationId: conversation.id,
+          role: 'assistant',
+          content: turn.answer,
+          responseToMessageId: userMessage.id,
+        })
+        .returning();
+      assistantMessages.push({
+        id: assistantMessage.id,
+        content: assistantMessage.content,
+        responseToMessageId: assistantMessage.responseToMessageId!,
+      });
+      lastMessageAt = assistantMessage.createdAt;
+    }
+  }
+
+  await db
+    .update(conversations)
+    .set({ lastMessageAt })
+    .where(sql`${conversations.id} = ${conversation.id}`);
+
+  return {
+    conversationId: conversation.id,
+    userMessages,
+    assistantMessages,
+  };
 }
 
 function parseSse(text: string): Array<{ event: string; data: unknown }> {
@@ -226,6 +285,105 @@ describe('conversation web backend', () => {
     const location = requireLocation(createRes);
     const intruderRes = await requestWithAuth(intruder, `http://localhost:3000${location}`);
     expect(intruderRes.status).toBe(404);
+  });
+
+  it('renders the canonical selected-message page for the conversation owner', async () => {
+    const auth = await createAuthContext();
+    const seeded = await seedConversationWithTurns(auth, [
+      { question: 'How does looting work?', answer: 'Loot tokens in your hex are picked up.' },
+      { question: 'When do elements wane?', answer: 'At end of round.' },
+    ]);
+
+    const pageRes = await requestWithAuth(
+      auth,
+      `http://localhost:3000/chat/${seeded.conversationId}/messages/${seeded.userMessages[0]!.id}`,
+    );
+
+    expect(pageRes.status).toBe(200);
+    expect(pageRes.headers.get('cache-control')).toBe('no-store');
+    expect(pageRes.headers.get('vary')).toBe('Cookie');
+
+    const page = await pageRes.text();
+    expect(page).toContain('How does looting work?');
+    expect(page).toContain('Loot tokens in your hex are picked up.');
+    expect(page).not.toContain('When do elements wane?');
+    expect(page).not.toContain('At end of round.');
+  });
+
+  it('renders the canonical selected-message route as an HTMX fragment', async () => {
+    const auth = await createAuthContext();
+    const seeded = await seedConversationWithTurns(auth, [
+      { question: 'What does muddle do?', answer: 'It forces disadvantage on attacks.' },
+      { question: 'What does strengthen do?', answer: 'It grants advantage on attacks.' },
+    ]);
+
+    const fragmentRes = await requestWithAuth(
+      auth,
+      `http://localhost:3000/chat/${seeded.conversationId}/messages/${seeded.userMessages[1]!.id}`,
+      {
+        headers: { 'hx-request': 'true' },
+      },
+    );
+
+    expect(fragmentRes.status).toBe(200);
+    expect(fragmentRes.headers.get('cache-control')).toBe('no-store');
+    expect(fragmentRes.headers.get('vary')).toBe('Cookie');
+
+    const fragment = await fragmentRes.text();
+    expect(fragment).toContain('What does strengthen do?');
+    expect(fragment).toContain('It grants advantage on attacks.');
+    expect(fragment).not.toContain('<!doctype html>');
+    expect(fragment).not.toContain('What does muddle do?');
+  });
+
+  it("returns 404 when one user requests another user's selected-message URL", async () => {
+    const owner = await createAuthContext();
+    const intruder = await createAuthContext({
+      email: 'mallory@example.com',
+      googleSub: 'google-sub-mallory',
+      name: 'Mallory',
+    });
+    const seeded = await seedConversationWithTurns(owner, [
+      { question: 'Owner-only question', answer: 'Owner-only answer.' },
+    ]);
+
+    const response = await requestWithAuth(
+      intruder,
+      `http://localhost:3000/chat/${seeded.conversationId}/messages/${seeded.userMessages[0]!.id}`,
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when the selected-message URL targets an assistant message id', async () => {
+    const auth = await createAuthContext();
+    const seeded = await seedConversationWithTurns(auth, [
+      { question: 'Question', answer: 'Answer' },
+    ]);
+
+    const response = await requestWithAuth(
+      auth,
+      `http://localhost:3000/chat/${seeded.conversationId}/messages/${seeded.assistantMessages[0]!.id}`,
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 when the selected-message URL mixes conversation and message ids', async () => {
+    const auth = await createAuthContext();
+    const firstConversation = await seedConversationWithTurns(auth, [
+      { question: 'First question', answer: 'First answer' },
+    ]);
+    const secondConversation = await seedConversationWithTurns(auth, [
+      { question: 'Second question', answer: 'Second answer' },
+    ]);
+
+    const response = await requestWithAuth(
+      auth,
+      `http://localhost:3000/chat/${firstConversation.conversationId}/messages/${secondConversation.userMessages[0]!.id}`,
+    );
+
+    expect(response.status).toBe(404);
   });
 
   it('persists the user turn and a generic assistant failure turn when ask fails', async () => {
@@ -1106,5 +1264,54 @@ describe('conversation web backend', () => {
       },
     ]);
     expect(mockAsk).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('selected-message projection', () => {
+  it('returns the selected completed turn and recent completed questions newest-to-oldest', async () => {
+    const auth = await createAuthContext();
+    const seeded = await seedConversationWithTurns(auth, [
+      { question: 'Oldest completed question', answer: 'Oldest completed answer' },
+      { question: 'Middle completed question', answer: 'Middle completed answer' },
+      { question: 'Newest completed question', answer: 'Newest completed answer' },
+      { question: 'Pending question only' },
+    ]);
+
+    const projection = await loadSelectedConversation({
+      conversationId: seeded.conversationId,
+      messageId: seeded.userMessages[1]!.id,
+      userId: auth.userId,
+    });
+
+    expect(projection).not.toBeNull();
+    expect(projection?.selectedTurn.userMessage.content).toBe('Middle completed question');
+    expect(projection?.selectedTurn.assistantMessage.content).toBe('Middle completed answer');
+    expect(projection?.selectedTurn.isEarlierQuestion).toBe(true);
+    expect(projection?.recentQuestions.map((question) => question.messageId)).toEqual([
+      seeded.userMessages[2]!.id,
+      seeded.userMessages[0]!.id,
+    ]);
+    expect(projection?.recentQuestions.map((question) => question.question)).toEqual([
+      'Newest completed question',
+      'Oldest completed question',
+    ]);
+  });
+
+  it('returns no recent questions when there are no other completed questions', async () => {
+    const auth = await createAuthContext();
+    const seeded = await seedConversationWithTurns(auth, [
+      { question: 'Only completed question', answer: 'Only completed answer' },
+      { question: 'Still pending' },
+    ]);
+
+    const projection = await loadSelectedConversation({
+      conversationId: seeded.conversationId,
+      messageId: seeded.userMessages[0]!.id,
+      userId: auth.userId,
+    });
+
+    expect(projection).not.toBeNull();
+    expect(projection?.selectedTurn.isEarlierQuestion).toBe(false);
+    expect(projection?.recentQuestions).toEqual([]);
   });
 });

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -304,10 +304,14 @@ describe('conversation web backend', () => {
     expect(pageRes.headers.get('vary')).toBe('Cookie');
 
     const page = await pageRes.text();
-    expect(page).toContain('How does looting work?');
-    expect(page).toContain('Loot tokens in your hex are picked up.');
-    expect(page).not.toContain('When do elements wane?');
-    expect(page).not.toContain('At end of round.');
+    const transcript = page.match(/<section[^>]*class="squire-transcript"[\s\S]*?<\/section>/)?.[0];
+    expect(transcript).toContain('How does looting work?');
+    expect(transcript).toContain('Loot tokens in your hex are picked up.');
+    expect(transcript).not.toContain('When do elements wane?');
+    expect(transcript).not.toContain('At end of round.');
+    const recentNav = page.match(/<nav[^>]*id="squire-recent-questions"[\s\S]*?<\/nav>/)?.[0];
+    expect(recentNav).toContain('When do elements wane?');
+    expect(recentNav).not.toContain('How does looting work?');
   });
 
   it('renders the canonical selected-message route as an HTMX fragment', async () => {
@@ -330,10 +334,16 @@ describe('conversation web backend', () => {
     expect(fragmentRes.headers.get('vary')).toBe('Cookie');
 
     const fragment = await fragmentRes.text();
-    expect(fragment).toContain('What does strengthen do?');
-    expect(fragment).toContain('It grants advantage on attacks.');
+    const transcript = fragment.match(
+      /<section[^>]*class="squire-transcript"[\s\S]*?<\/section>/,
+    )?.[0];
+    expect(transcript).toContain('What does strengthen do?');
+    expect(transcript).toContain('It grants advantage on attacks.');
     expect(fragment).not.toContain('<!doctype html>');
-    expect(fragment).not.toContain('What does muddle do?');
+    const recentNav = fragment.match(/<nav[^>]*id="squire-recent-questions"[\s\S]*?<\/nav>/)?.[0];
+    expect(recentNav).toContain('hx-swap-oob="outerHTML"');
+    expect(recentNav).toContain('What does muddle do?');
+    expect(recentNav).not.toContain('What does strengthen do?');
   });
 
   it("returns 404 when one user requests another user's selected-message URL", async () => {

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -396,6 +396,31 @@ describe('conversation web backend', () => {
     expect(response.status).toBe(404);
   });
 
+  it('pushes the canonical conversation URL when posting a follow-up from a selected-message page', async () => {
+    const auth = await createAuthContext();
+    const seeded = await seedConversationWithTurns(auth, [
+      { question: 'First question', answer: 'First answer' },
+      { question: 'Second question', answer: 'Second answer' },
+    ]);
+
+    const response = await requestWithAuth(
+      auth,
+      `http://localhost:3000/chat/${seeded.conversationId}/messages`,
+      {
+        method: 'POST',
+        csrf: true,
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          'hx-request': 'true',
+        },
+        body: formBody({ question: 'Newest question' }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('HX-Push-Url')).toBe(`/chat/${seeded.conversationId}`);
+  });
+
   it('persists the user turn and a generic assistant failure turn when ask fails', async () => {
     mockAsk.mockRejectedValueOnce(new Error('upstream exploded'));
     const auth = await createAuthContext();

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import vm from 'node:vm';
+import { readFileSync } from 'node:fs';
+
+const scriptSource = readFileSync(new URL('../src/web-ui/squire.js', import.meta.url), 'utf8');
+
+function runSquireScript(pathname: string): Record<string, string> {
+  const listeners = new Map<string, Array<() => void>>();
+  const attributes: Record<string, string> = {};
+  const form = {
+    setAttribute(name: string, value: string) {
+      attributes[name] = value;
+    },
+    querySelector() {
+      return null;
+    },
+  };
+
+  const document = {
+    addEventListener(event: string, callback: () => void) {
+      listeners.set(event, [...(listeners.get(event) ?? []), callback]);
+    },
+    querySelector(selector: string) {
+      return selector === '.squire-input-dock' ? form : null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+  };
+
+  const context = vm.createContext({
+    document,
+    window: {
+      location: { pathname },
+      crypto: {},
+      EventSource: function () {},
+    },
+  });
+
+  vm.runInContext(scriptSource, context);
+  for (const callback of listeners.get('DOMContentLoaded') ?? []) {
+    callback();
+  }
+
+  return attributes;
+}
+
+describe('squire.js selected-message retargeting', () => {
+  it('retargets the ask form to the current conversation on selected-message URLs', () => {
+    // Regression: ISSUE-QA-001 — selected-message pages posted follow-ups to /chat
+    // Found by /qa on 2026-04-11
+    // Report: .gstack/qa-reports/qa-report-localhost-4306-2026-04-11.md
+    const attributes = runSquireScript(
+      '/chat/c7b7ac29-2173-48c5-9f6f-4d618e555db5/messages/7b8eaa3a-7f08-4c2c-90cc-76ad1ce587ec',
+    );
+
+    expect(attributes.action).toBe('/chat/c7b7ac29-2173-48c5-9f6f-4d618e555db5/messages');
+    expect(attributes['hx-post']).toBe('/chat/c7b7ac29-2173-48c5-9f6f-4d618e555db5/messages');
+  });
+});


### PR DESCRIPTION
## Summary
- add the canonical selected-message route under `/chat/:conversationId/messages/:messageId`
- project selected completed turns plus recent-question navigation for both full-page and HTMX renders
- preserve selected-message follow-up submits, including canonical URL pushback and QA regression coverage

## Validation
- `npm run check`
- `npm test -- test/conversation.test.ts test/web-ui-squire.regression-1.test.ts`
- browser QA on `http://localhost:4306` covering selected-message render, recent-question nav updates, and follow-up submit from a selected-message page

Fixes SQR-93


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing and linking directly to specific conversation messages with full context
  * Introduced a recent questions navigation panel displaying other questions from the conversation for easy exploration and reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->