### PR TITLE
feat(agent): add Claude Code worktree bootstrap hook

### DIFF
--- a/.claude/hooks/worktree-setup.sh
+++ b/.claude/hooks/worktree-setup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Bootstrap a Claude Code git worktree: node version, .env symlink, deps,
+# docker services, db migrations. Fires on SessionStart(startup) — steps are
+# idempotent so re-running on later sessions is near-instant.
+
+set -euo pipefail
+
+git_dir="$(git rev-parse --git-dir 2>/dev/null || true)"
+git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+
+# Not a git repo, or this is the main checkout — nothing to bootstrap.
+[[ -n "$git_dir" && -n "$git_common_dir" ]] || exit 0
+[[ "$(cd "$git_dir" && pwd)" != "$(cd "$git_common_dir" && pwd)" ]] || exit 0
+
+source_tree="$(cd "$git_common_dir/.." && pwd)"
+worktree="$(pwd)"
+
+log() { printf '[worktree-setup] %s\n' "$*" >&2; }
+
+log "worktree: $worktree"
+log "source:   $source_tree"
+
+if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+  # shellcheck disable=SC1091
+  . "$HOME/.nvm/nvm.sh"
+  nvm use >/dev/null
+fi
+
+if [[ ! -e .env && -e "$source_tree/.env" ]]; then
+  log "symlinking .env from source tree"
+  ln -sfn "$source_tree/.env" .env
+fi
+
+if [[ ! -d node_modules ]]; then
+  log "installing npm deps"
+  npm install --ignore-scripts
+fi
+
+log "ensuring docker services are up"
+# Pin COMPOSE_PROJECT_NAME so every worktree shares the one squire-postgres
+# container. (Codex worktrees all bottom-out in a dir named "squire", so
+# compose auto-picks the same project name; Claude Code worktrees live at
+# .claude/worktrees/<name>, so without this pin compose would try to spin
+# up a per-worktree stack and collide on container_name/host port.)
+# Per-worktree DB and port isolation happens at app startup via
+# src/worktree-runtime.ts, not here.
+COMPOSE_PROJECT_NAME=squire docker compose up -d >/dev/null
+
+log "running migrations"
+npm run --silent db:migrate
+npm run --silent db:migrate:test
+
+log "done"

--- a/.claude/hooks/worktree-setup.sh
+++ b/.claude/hooks/worktree-setup.sh
@@ -5,6 +5,15 @@
 
 set -euo pipefail
 
+# Anchor to the project root before doing anything with relative paths. Claude
+# Code hooks inherit the cwd at the time the event fires, which can be any
+# subdirectory of the checkout. CLAUDE_PROJECT_DIR is the absolute repo-root
+# path Claude Code sets for project hooks; fall back to two levels up from
+# this script if the hook is invoked outside Claude Code (e.g., manual run).
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+project_root="${CLAUDE_PROJECT_DIR:-$(cd "$script_dir/../.." && pwd)}"
+cd "$project_root"
+
 git_dir="$(git rev-parse --git-dir 2>/dev/null || true)"
 git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
 
@@ -13,7 +22,7 @@ git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null || true)"
 [[ "$(cd "$git_dir" && pwd)" != "$(cd "$git_common_dir" && pwd)" ]] || exit 0
 
 source_tree="$(cd "$git_common_dir/.." && pwd)"
-worktree="$(pwd)"
+worktree="$project_root"
 
 log() { printf '[worktree-setup] %s\n' "$*" >&2; }
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-setup.sh\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/docs/agent/agent-baseline.md
+++ b/docs/agent/agent-baseline.md
@@ -21,6 +21,7 @@ Read these on demand:
 | When you're about to...                                                    | Read                                             |
 | -------------------------------------------------------------------------- | ------------------------------------------------ |
 | Start work in a fresh checkout or linked worktree, or get one bootstrapped | [../DEVELOPMENT.md](../DEVELOPMENT.md)           |
+| Add/change a command in the Codex or Claude Code worktree bootstrap script | [worktree-setup.md](./worktree-setup.md)         |
 | Start work on a Linear issue                                               | [issue-workflow.md](./issue-workflow.md)         |
 | Write or modify tests                                                      | [testing.md](./testing.md)                       |
 | Run QA, browser verification, or ship-readiness testing                    | [qa.md](./qa.md)                                 |

--- a/docs/agent/worktree-setup.md
+++ b/docs/agent/worktree-setup.md
@@ -1,0 +1,109 @@
+# Worktree setup adapters
+
+How Codex and Claude Code bootstrap a fresh linked worktree so it is ready for
+development. The isolation design itself lives in the app — see below — so the
+adapter's only job is to run the same handful of commands in a fresh checkout.
+
+## Where isolation actually comes from
+
+The **app** handles per-worktree isolation at startup, not the setup script.
+[src/worktree-runtime.ts](../../src/worktree-runtime.ts) derives a stable slug
+(`sha256(checkoutRoot).slice(0, 8)`) from the checkout path and uses it to
+compute:
+
+- Dev DB name: `squire_<slug>` (or bare `squire` for the main checkout)
+- Test DB name: `squire_<slug>_test`
+- Preferred port: `4000 + (slug_hex % 2000)` (3000 for main)
+- Port claim file: `<PORT_CLAIM_DIR>/<port>.json`, created with `open(… 'wx')`
+  for atomic lock semantics, with dead-pid cleanup on collision
+
+The port claim directory defaults to `~/.codex/port-claims/squire/` and is
+overridable via `SQUIRE_PORT_CLAIM_DIR`. The `~/.codex/` path is historical —
+the registry is shared across every agent adapter and is not Codex-specific.
+
+The user-facing view of this (env overrides, managed DB names, reset semantics)
+lives in [DEVELOPMENT.md](../DEVELOPMENT.md#local-environment).
+
+## What the setup script has to do
+
+Given the app handles isolation, bootstrap is small:
+
+1. Activate the project's Node version (`nvm use` against `.nvmrc`).
+2. Symlink `.env` from the source tree so the worktree inherits secrets.
+3. `npm install --ignore-scripts` (husky hooks would otherwise refuse to
+   install into a linked worktree).
+4. Bring up the **one** shared `squire-postgres` container.
+5. Run `db:migrate` and `db:migrate:test` — both are worktree-aware and create
+   `squire_<slug>` / `squire_<slug>_test` on first run.
+
+Step 4 is the only subtle one: `docker-compose.yml` hardcodes
+`container_name: squire-postgres` and binds host port `5432:5432`, so every
+checkout must share the same container. The setup script must run
+`docker compose up -d` against the project name `squire`.
+
+## Codex adapter
+
+Defined in [`.codex/environments/environment.toml`](../../.codex/environments/environment.toml).
+Codex runs `setup.script` on worktree creation.
+
+```toml
+[setup]
+script = '''
+source "$HOME/.nvm/nvm.sh"
+nvm use
+ln -sfn "$CODEX_SOURCE_TREE_PATH/.env" .env
+npm install --ignore-scripts
+docker compose up -d
+npm run db:migrate
+npm run db:migrate:test
+'''
+```
+
+Codex worktrees live at `~/.codex/worktrees/<hash>/squire/` — the directory
+basename is always `squire`, so Docker Compose auto-derives the project name
+`squire` from cwd and converges on the shared `squire-postgres` container
+without any explicit pinning.
+
+Codex exposes `CODEX_SOURCE_TREE_PATH` and `CODEX_WORKTREE_PATH` to the
+script.
+
+## Claude Code adapter
+
+Defined in [`.claude/hooks/worktree-setup.sh`](../../.claude/hooks/worktree-setup.sh)
+and wired via `SessionStart` matcher `"startup"` in
+[`.claude/settings.json`](../../.claude/settings.json). Claude Code has no
+dedicated "worktree created" event, so the hook fires on first session startup
+in the worktree. Each step is idempotent, so subsequent startups are a ~2 s
+no-op (migrations are the only part that runs every time).
+
+Two intentional differences from the Codex script:
+
+1. **Source-tree detection**. The hook derives `$source_tree` from
+   `git rev-parse --git-common-dir` instead of relying on an injected
+   `CODEX_SOURCE_TREE_PATH`. It no-ops in the main checkout (where
+   `--git-dir` equals `--git-common-dir`).
+
+2. **`COMPOSE_PROJECT_NAME=squire` is pinned explicitly**. Claude Code
+   worktrees live at `.claude/worktrees/<random-name>/` — the basename is
+   different for every worktree, so Compose would derive a different project
+   name each time and try to stand up a second `squire-postgres` alongside
+   the one from the source tree or another worktree. Pinning the project
+   name forces every worktree onto the one shared container, matching
+   Codex's implicit behavior.
+
+Other than those two points, the commands are identical. Both adapters are
+safe to run concurrently on the same machine: the port-claim registry in
+`~/.codex/port-claims/squire/` cooperates across tools, and different
+checkout paths produce different slugs, so the DB namespaces never collide.
+
+## When to update both adapters
+
+Changes to bootstrap commands (new `db:*` scripts, new services, new env
+symlinks) must land in **both** the Codex TOML and the Claude shell script
+in the same PR. Please update this doc's "What the setup script has to do"
+section at the same time so the single source of truth for the bootstrap
+contract stays in sync.
+
+Changes to isolation mechanics (slug derivation, port range, claim
+registry) belong in [src/worktree-runtime.ts](../../src/worktree-runtime.ts)
+and its tests, not in the adapters.

--- a/docs/agent/worktree-setup.md
+++ b/docs/agent/worktree-setup.md
@@ -71,10 +71,14 @@ script.
 
 Defined in [`.claude/hooks/worktree-setup.sh`](../../.claude/hooks/worktree-setup.sh)
 and wired via `SessionStart` matcher `"startup"` in
-[`.claude/settings.json`](../../.claude/settings.json). Claude Code has no
-dedicated "worktree created" event, so the hook fires on first session startup
-in the worktree. Each step is idempotent, so subsequent startups are a ~2 s
-no-op (migrations are the only part that runs every time).
+[`.claude/settings.json`](../../.claude/settings.json). Claude Code does
+expose a `WorktreeCreate` hook, but configuring it **replaces** Claude's
+default `git worktree` flow — the hook becomes responsible for actually
+producing the worktree and emitting its path. We want Claude's built-in
+worktree creation, just with bootstrap on top, so we run the same
+idempotent setup on the first `SessionStart` in the new worktree instead.
+Subsequent startups are a ~2 s no-op (migrations are the only part that
+runs every time).
 
 Two intentional differences from the Codex script:
 


### PR DESCRIPTION
## Summary

Mirror the existing Codex worktree setup in Claude Code so new Claude-created worktrees self-bootstrap on first session startup. No code changes to the app — this is pure agent-adapter plumbing plus a doc that captures the design for future edits.

- `.claude/hooks/worktree-setup.sh` — idempotent bootstrap: `nvm use`, symlink `.env` from the source tree, `npm install --ignore-scripts`, bring up the shared `squire-postgres`, run `db:migrate` + `db:migrate:test`.
- `.claude/settings.json` — wires the script to `SessionStart` matcher `"startup"`.
- `docs/agent/worktree-setup.md` — captures the isolation design (app-level, `src/worktree-runtime.ts`), both adapters (Codex TOML + Claude shell), and the `COMPOSE_PROJECT_NAME=squire` pin and why Claude needs it but Codex does not.
- `docs/agent/agent-baseline.md` — adds a routing-table row so future edits to either bootstrap script get pointed at the new doc.

## Why the Codex pin is needed for Claude but not Codex

Codex worktrees live at `~/.codex/worktrees/<hash>/squire/` — the cwd basename is always `squire`, so `docker compose` auto-derives project name `squire`. Claude Code worktrees live at `.claude/worktrees/<random-name>/`, so without the explicit `COMPOSE_PROJECT_NAME=squire` pin each worktree would try to stand up its own `squire-postgres` and collide on the hardcoded `container_name` and host port 5432.

## Isolation is unchanged

Per-worktree DB naming (`squire_<slug>`) and port selection (`4000 + slug_hex % 2000`) still come from [`src/worktree-runtime.ts`](src/worktree-runtime.ts) at app startup. Port claims still live in `~/.codex/port-claims/squire/` and cooperate across both adapters via atomic file locks with dead-pid cleanup.

## Verification

- `npm run check` green: typecheck, eslint, stylelint, markdownlint, prettier all clean; 727 tests pass across 46 files.
- Ran `./.claude/hooks/worktree-setup.sh` end-to-end in this worktree: symlinked `.env`, installed deps, reused the shared `squire-postgres` container, created and migrated `squire_e94e7189` and `squire_e94e7189_test`. Re-ran to confirm idempotency — second pass was a ~2 s no-op (container already running, migrations idempotent).
- The `SessionStart`/`"startup"` wiring itself cannot be exercised from inside the current session — it will run on first session entry in the next fresh Claude worktree. The settings.json block mirrors the existing `PreToolUse`/Skill hook that works today.

## Test plan

- [x] `npm run check` passes
- [x] Hook runs end-to-end on a fresh worktree (manual verification)
- [x] Hook is idempotent on re-run (manual verification)
- [ ] First real Claude worktree created after merge confirms automatic SessionStart dispatch

Fixes SQR-104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated development-worktree bootstrap on session start: ensures Node version, installs dependencies, starts shared Docker services, and runs DB migrations (idempotent; subsequent starts are fast).

* **Documentation**
  * Added comprehensive docs describing the worktree bootstrap flow, port/DB isolation behavior, and adapter setup/coordination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->