### PR TITLE
fix(web-ui): render ask button as the Squire seal (SQR-99)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -231,7 +231,11 @@ SCEN 14` once Phase 4 character state lands. Always visible. One line,
 5. **Input dock (bottom)** — slim rounded-rectangle input field in `--surface`
    with italic placeholder "Ask the Squire…" in Geist (italic is OK for
    placeholder ephemera; not OK for brand moments). A 44×44 square submit
-   button in `--wax` with a cream arrow glyph. Input is always reachable — we
+   button in `--wax` rendered as the Squire seal — the same monogram "S"
+   (Fraunces 700, `opsz 144 SOFT 80`, cream glyph filling ~85% of the
+   square) as the header mark, scaled to the tap target so the ask
+   affordance reads as a signature interaction rather than a generic
+   button. Input is always reachable — we
    do NOT collapse it after submit. (Earlier "oracle" proposal had the input
    collapse; rejected because the companion posture needs the attendant
    always reachable.)
@@ -523,6 +527,7 @@ attribute on `<html>`. That's the extent of the per-game theming.
 | 2026-04-08 | **`.squire-banner` is a reusable primitive** with `--spoiler` (amber), `--error` (#8b2919), `--sync` (sage) modifiers                                                                                                                                                                                                          | Spoiler banner, error banners (recoverable + non-recoverable), and Phase 6 sync banner all share one CSS component with different accent colors. SQR-67 ships the primitive; SQR-6 / SQR-8 / SQR-13 / SQR-65 reuse it. From plan-design-review Pass 2.                                                                                                                                                                                           |
 | 2026-04-08 | **A11y bundle for SQR-5**: `aria-live="polite"` on `main.squire-surface`, `aria-live="off"` on `footer.squire-toolcall`, skip-link to input dock, `:focus-visible` 2px wax outline, `prefers-reduced-motion` disables pulse/transitions, `env(safe-area-inset-bottom)` on input dock, contrast ratio doc comment in styles.css | Phase 1 ships with WCAG-AA-passing dark-mode contrast, keyboard-navigable, screen-reader-friendly streaming, and iOS home-indicator-aware input dock. From plan-design-review Pass 6.                                                                                                                                                                                                                                                            |
 | 2026-04-08 | **Dark mode is unconditional in Phase 1.** `prefers-color-scheme` is NOT honored. Light mode tokens exist via `[data-theme="light"]` for the Phase 7 user toggle                                                                                                                                                               | Per SPEC's phone-at-the-table primary surface and DESIGN.md §Color "Dark mode is the default." A user-controlled toggle in Phase 7 is the right path; auto-flipping in Phase 1 would surprise users in dim rooms. From plan-design-review Pass 6.                                                                                                                                                                                                |
+| 2026-04-18 | **Submit button is the Squire seal** — same wax-seal monogram "S" (Fraunces 700, `opsz 144 SOFT 80`) as the header mark, scaled to the 44×44 tap target. Rejected plain `Ask` text and the earlier arrow-glyph variant.                                                                                                        | The ask affordance is the single most-used control; making it the brand mark (not a generic arrow or fallback text) turns the primary interaction into a signature moment and keeps the monogram the only thing saying "Squire" at every surface. Text `Ask` read as a generic fallback; a lone arrow read as a developer placeholder. From SQR-99.                                                                                              |
 
 <!-- markdownlint-enable MD060 -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.90.0",
         "@hono/node-server": "^1.19.14",
@@ -8201,7 +8201,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rolldown": {

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -591,7 +591,7 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
                     placeholder="Ask a question..."
                   />
                   <button type="submit" class="squire-input-dock__submit" aria-label="Ask">
-                    Ask
+                    <span aria-hidden="true">S</span>
                   </button>
                 </form>`}
         </div>

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -452,15 +452,31 @@ html {
   font-style: italic;
 }
 
+/* The submit control IS the Squire seal (SQR-99): the same wax-seal "S"
+   tile as the header monogram, scaled to the 44px tap target so the ask
+   affordance reads as a signature interaction rather than a generic
+   button. Typography mirrors `.squire-monogram` — Fraunces 700 with the
+   opsz/SOFT display axes — and the glyph fills ~85% of the square to
+   match the brand mark at other sizes. */
 .squire-input-dock__submit {
   width: 44px;
   height: 44px;
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: var(--wax);
   color: var(--parchment);
   border: none;
   border-radius: 4px;
-  font-size: 20px;
+  font-family: 'Fraunces', 'Georgia', serif;
+  font-weight: 700;
+  font-variation-settings:
+    'opsz' 144,
+    'SOFT' 80;
+  font-size: 38px;
+  line-height: 1;
+  padding: 0 0 3px;
   cursor: pointer;
 }
 

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -247,7 +247,7 @@ describe('GET / — companion-first layout shell (SQR-65)', () => {
     expect(body).toMatch(/<input[^>]*type="hidden"[^>]*name="idempotencyKey"[^>]*value=""/);
     expect(body).toMatch(/placeholder="Ask a question\.\.\."/);
     expect(body).toMatch(
-      /<button[^>]*type="submit"[^>]*class="squire-input-dock__submit"[^>]*aria-label="Ask"[^>]*>\s*Ask\s*<\/button>/,
+      /<button[^>]*type="submit"[^>]*class="squire-input-dock__submit"[^>]*aria-label="Ask"[^>]*>\s*<span aria-hidden="true">S<\/span>\s*<\/button>/,
     );
   });
 


### PR DESCRIPTION
## Summary

The ask/submit control on the authenticated chat surface now renders the
wax-seal monogram "S" at the 44×44 tap target instead of the generic `Ask`
text fallback. The primary interaction now reads as a signature moment that
visually matches the 28px header monogram and the 56px rail masthead.

- [src/web-ui/layout.ts](src/web-ui/layout.ts): button content swapped from the
  text `Ask` to `<span aria-hidden="true">S</span>`. `aria-label="Ask"` is
  preserved so screen readers still announce the action as "Ask".
- [src/web-ui/styles.css](src/web-ui/styles.css): `.squire-input-dock__submit`
  now carries the monogram typography (Fraunces 700, `opsz 144 SOFT 80`,
  `font-size: 38px`, `line-height: 1`, `padding: 0 0 3px` for optical
  centering). Background/border unchanged — `--wax` on a 4px radius.
- [DESIGN.md](DESIGN.md): layout prose updated to describe the seal affordance
  (no more "arrow glyph"), plus a Decisions Log entry recording the choice.
- [test/web-ui-layout.test.ts](test/web-ui-layout.test.ts): regex pinned to the
  new seal markup so future regressions fail loudly.

## Visual check

Rendered against the live dev server CSS at both mobile (390×844) and desktop
(1280×800). Computed styles confirm `background: rgb(199, 62, 29)` (`--wax`),
`font-family: Fraunces, Georgia, serif`, `font-weight: 700`, `font-size: 38px`,
`border-radius: 4px`. DOM: `<button aria-label="Ask"><span aria-hidden="true">S</span></button>`.
No console errors on either viewport.

Screenshots in [`.gstack/qa-reports/screenshots/`](.gstack/qa-reports/screenshots/):

- `sqr99-login.png` — unauthenticated entry (regression)
- `sqr99-authenticated-mobile.png` — full ledger view with the seal dock
- `sqr99-seal-closeup.png` — input dock close-up
- `sqr99-authenticated-desktop.png` — desktop viewport with all three seal sizes visible

## Validation

- `npm run check` green — typecheck, eslint, stylelint, markdownlint,
  prettier, 744 vitest tests all pass.
- CodeRabbit `review --plain` — no findings.
- Exploratory + regression QA per [docs/agent/qa.md](docs/agent/qa.md). Health
  100 → 100, no regressions. Full report at
  [`.gstack/qa-reports/qa-report-sqr99-2026-04-18.md`](.gstack/qa-reports/qa-report-sqr99-2026-04-18.md).

## Test plan

- [x] Unit: `test/web-ui-layout.test.ts` seal markup regex
- [x] Visual: authenticated chat surface on mobile + desktop
- [x] Regression: `/login` + `/` redirect
- [x] Accessible name: screen readers still announce "Ask" (aria-label preserved)

Fixes SQR-99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the mobile input dock submit control to display a branded Squire seal (monogram) as the button icon, replacing the previous plain text and arrow glyph variants for a more distinctive branded interaction.

* **Documentation**
  * Added design decision log entry documenting the seal-based submit button choice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->