### PR TITLE
feat(auth): require SQUIRE_DEV_LOGIN=1 to register /dev/login route (SQR-106)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ LANGFUSE_PUBLIC_KEY=
 LANGFUSE_SECRET_KEY=
 LANGFUSE_BASEURL=https://us.cloud.langfuse.com
 
+# Server environment — development enables dev-only routes and no-cache asset serving
+NODE_ENV=development
+
 # Optional server overrides
 # PORT defaults to 3000 in the main checkout and a managed derived port in linked worktrees
 # PORT=3000

--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,9 @@ LANGFUSE_BASEURL=https://us.cloud.langfuse.com
 
 # Advanced local override for worktree port-claim bookkeeping
 # SQUIRE_PORT_CLAIM_DIR=/absolute/path/to/port-claims
+
+# Opt in to the /dev/login route (plain POST to mint a session without Google OAuth).
+# Required since SQR-106 as a third positive gate alongside NODE_ENV and DATABASE_URL.
+# scripts/preview-serve.sh sets this automatically for Claude Code preview.
+# Set it here only if you also want it available when running `npm run serve` directly.
+# SQUIRE_DEV_LOGIN=1

--- a/docs/agent/preview-testing.md
+++ b/docs/agent/preview-testing.md
@@ -46,18 +46,32 @@ The preview sandbox refuses to follow the Google OAuth redirect:
 directly. No round-trip to Google.
 
 Production safety is enforced at registration time by
-`shouldRegisterDevLogin()` in [../../src/auth/dev-login.ts](../../src/auth/dev-login.ts)
-— the route is only attached to the app when `NODE_ENV` is explicitly
-`development` or `test` AND `DATABASE_URL` resolves to a managed-local
-DB. Anything else (unset, empty, `staging`, `production`) fails the
-gate. A same-origin `Origin` header check stands in for CSRF. See the
-module header for the full security argument.
+`shouldRegisterDevLogin()` in [../../src/auth/dev-login.ts](../../src/auth/dev-login.ts).
+The route is only attached to the app when **all three** conditions hold:
 
-If the dev-login button is missing, it means the gate refused to
-register the route on startup. The server only logs a `[dev]` line
-when the route IS live — no log line means either `NODE_ENV` isn't
-`development`/`test` or your DB URL isn't a managed-local one. Check
-`echo $NODE_ENV` and `cat .env | grep DATABASE_URL`.
+1. `SQUIRE_DEV_LOGIN=1` is explicitly set in the environment.
+2. `NODE_ENV` is exactly `development` or `test`.
+3. `DATABASE_URL` resolves to a managed-local DB.
+
+`scripts/preview-serve.sh` exports `SQUIRE_DEV_LOGIN=1` automatically, so
+preview mode works without any extra config. Plain `npm run serve` does
+**not** set it — a developer on a shared/exposed host won't accidentally
+open the route. A same-origin `Origin` header check stands in for CSRF.
+See the module header for the full security argument.
+
+If the dev-login button is missing, the gate refused to register the route
+on startup. The server only logs a `[dev]` line when the route IS live — no
+log line means one of the three conditions failed. Check:
+
+```sh
+echo $SQUIRE_DEV_LOGIN   # must be "1"
+echo $NODE_ENV           # must be "development" or "test"
+cat .env | grep DATABASE_URL
+```
+
+If you're running via `preview-serve.sh` this is handled for you. If running
+`npm run serve` directly, add `SQUIRE_DEV_LOGIN=1` to your `.env` (see
+`.env.example` for the commented-out template).
 
 ## Verify without browser DevTools
 

--- a/scripts/preview-serve.sh
+++ b/scripts/preview-serve.sh
@@ -18,6 +18,7 @@ if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
 fi
 
 export PORT="$port"
+export NODE_ENV=development
 # Opt in to the dev-login route (SQUIRE_DEV_LOGIN gate added in SQR-106).
 # preview-serve.sh is the only launcher that sets this — plain `npm run serve`
 # does not, so a developer on a shared/exposed host won't accidentally open

--- a/scripts/preview-serve.sh
+++ b/scripts/preview-serve.sh
@@ -18,4 +18,9 @@ if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
 fi
 
 export PORT="$port"
+# Opt in to the dev-login route (SQUIRE_DEV_LOGIN gate added in SQR-106).
+# preview-serve.sh is the only launcher that sets this — plain `npm run serve`
+# does not, so a developer on a shared/exposed host won't accidentally open
+# the route without knowing they've opted in.
+export SQUIRE_DEV_LOGIN=1
 exec npm run serve

--- a/src/auth/dev-login.ts
+++ b/src/auth/dev-login.ts
@@ -6,21 +6,27 @@
  *
  * Production safety (belt and suspenders):
  *
- * 1. `shouldRegisterDevLogin()` returns false when `NODE_ENV === 'production'`
- *    OR when the active `DATABASE_URL` points at anything other than a
- *    managed-local dev/test database. `src/server.ts` only calls
- *    `registerDevLoginRoute()` when this returns true, so the route does
- *    not even exist in production — you can grep prod logs / the route
- *    table and find nothing.
+ * 1. `shouldRegisterDevLogin()` returns false unless `SQUIRE_DEV_LOGIN=1` is
+ *    explicitly set in the environment. On a shared dev host (CI runner,
+ *    cloud IDE, LAN-exposed machine) this prevents the route from appearing
+ *    just because NODE_ENV happens to be "development". `scripts/preview-serve.sh`
+ *    sets this automatically; plain `npm run serve` does not.
  *
- * 2. The handler itself re-checks the local-DB gate at request time, so
+ * 2. `shouldRegisterDevLogin()` also returns false when `NODE_ENV !== 'development'`
+ *    and `NODE_ENV !== 'test'`, and when the active `DATABASE_URL` points at
+ *    anything other than a managed-local dev/test database. `src/server.ts` only
+ *    calls `registerDevLoginRoute()` when this returns true, so the route does
+ *    not even exist in production — you can grep prod logs / the route table
+ *    and find nothing.
+ *
+ * 3. The handler itself re-checks the local-DB gate at request time, so
  *    a config-only change (e.g., setting `DATABASE_URL` to a remote host
  *    after the server started) neutralises the route without a restart.
  *
- * 3. A same-origin Origin-header check blocks cross-site POSTs. The NODE_ENV
- *    + local-DB gate is already enough to keep this route out of any
- *    hostile network, but the check costs nothing and protects the dev
- *    machine from a malicious tab.
+ * 4. A same-origin Origin-header check blocks cross-site POSTs. The three-gate
+ *    registration check is already enough to keep this route out of any hostile
+ *    network, but the check costs nothing and protects the dev machine from a
+ *    malicious tab.
  *
  * The real security boundary is the registration gate — the other two are
  * defence in depth.
@@ -42,19 +48,21 @@ import { eq } from 'drizzle-orm';
  * tables are part of the server's attack surface. A non-existent route is
  * strictly safer than a registered one with runtime checks.
  *
- * Hardened after a pre-landing adversarial review 2026-04-21 flagged that
- * the prior `NODE_ENV !== 'production'` gate was a deny-list:
+ * Hardened in two rounds:
  *
- * - Unset or empty NODE_ENV would pass the check
- * - If the default managed-local DB URL also matched (fresh machine with a
- *   stray local Postgres instance), the route would register on a host that
- *   the operator may not have realised was running in dev mode
+ * Round 1 (2026-04-21 adversarial review): tightened from `!== 'production'`
+ * deny-list to an allowlist requiring `NODE_ENV === 'development' | 'test'`
+ * plus a managed-local DB URL.
  *
- * This check is now a positive allowlist — `NODE_ENV` must explicitly be
- * `development` or `test`, and the DB URL must still resolve to a
- * managed-local name. Both conditions have to hold.
+ * Round 2 (SQR-106, 2026-04-21): added a third positive gate —
+ * `SQUIRE_DEV_LOGIN=1`. On a shared dev host (CI runner, cloud IDE, LAN-exposed
+ * machine) the NODE_ENV + DB checks alone don't prevent exposure: any process
+ * with `NODE_ENV=development` and a local Postgres instance would pass them.
+ * The explicit opt-in closes that window without breaking LAN testing (unlike
+ * binding 127.0.0.1 would).
  */
 export function shouldRegisterDevLogin(): boolean {
+  if (process.env.SQUIRE_DEV_LOGIN !== '1') return false;
   const nodeEnv = process.env.NODE_ENV;
   if (nodeEnv !== 'development' && nodeEnv !== 'test') return false;
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -285,7 +285,7 @@ function loginRedirectWithError(message: string): string {
 const DEV_LOGIN_ENABLED = shouldRegisterDevLogin();
 if (DEV_LOGIN_ENABLED) {
   console.warn(
-    '[dev] POST /dev/login route is registered (NODE_ENV !== production and DATABASE_URL points at a managed-local DB). This route never ships to production.',
+    '[dev] POST /dev/login route is registered (SQUIRE_DEV_LOGIN=1, NODE_ENV=development/test, DATABASE_URL points at a managed-local DB). This route never ships to production.',
   );
   registerDevLoginRoute(app);
 }

--- a/test/dev-login.test.ts
+++ b/test/dev-login.test.ts
@@ -184,6 +184,22 @@ describe('POST /dev/login (local DB + dev NODE_ENV)', () => {
     expect(res.status).toBe(403);
   });
 
+  it('returns 404 at handler time when SQUIRE_DEV_LOGIN is cleared after registration', async () => {
+    // The route was registered at startup (SQUIRE_DEV_LOGIN=1 from vitest.config).
+    // If the env var is cleared post-startup (e.g. a config change), the handler-level
+    // recheck should close the gate without requiring a server restart.
+    delete process.env.SQUIRE_DEV_LOGIN;
+    try {
+      const res = await app.request('http://localhost:3000/dev/login', {
+        method: 'POST',
+        headers: { origin: 'http://localhost:3000', host: 'localhost:3000' },
+      });
+      expect(res.status).toBe(404);
+    } finally {
+      process.env.SQUIRE_DEV_LOGIN = '1';
+    }
+  });
+
   it('blocks a request with no Origin header', async () => {
     const res = await app.request('http://localhost:3000/dev/login', {
       method: 'POST',

--- a/test/dev-login.test.ts
+++ b/test/dev-login.test.ts
@@ -37,6 +37,7 @@ process.env.SESSION_SECRET = 'test-session-secret-must-be-at-least-32-characters
 // now," which is what `shouldRegisterDevLogin` actually inspects.
 const originalNodeEnv = process.env.NODE_ENV;
 const originalTestDatabaseUrl = process.env.TEST_DATABASE_URL;
+const originalSquireDevLogin = process.env.SQUIRE_DEV_LOGIN;
 
 describe('shouldRegisterDevLogin', () => {
   afterEach(() => {
@@ -44,6 +45,8 @@ describe('shouldRegisterDevLogin', () => {
     else process.env.NODE_ENV = originalNodeEnv;
     if (originalTestDatabaseUrl === undefined) delete process.env.TEST_DATABASE_URL;
     else process.env.TEST_DATABASE_URL = originalTestDatabaseUrl;
+    if (originalSquireDevLogin === undefined) delete process.env.SQUIRE_DEV_LOGIN;
+    else process.env.SQUIRE_DEV_LOGIN = originalSquireDevLogin;
   });
 
   it('returns false when NODE_ENV is production, regardless of DB', () => {
@@ -82,10 +85,26 @@ describe('shouldRegisterDevLogin', () => {
     expect(shouldRegisterDevLogin()).toBe(false);
   });
 
-  it('returns true when NODE_ENV is development and DB is a managed-local test DB', () => {
-    // Default TEST_DATABASE_URL under vitest is the managed-local test DB,
-    // so the gate should open. This mirrors the shape of `npm run serve`
-    // pointed at the worktree's dev DB.
+  it('returns false when SQUIRE_DEV_LOGIN is unset, even with development NODE_ENV and managed-local DB', () => {
+    // SQR-106: explicit opt-in required. NODE_ENV + DB alone is not enough —
+    // a shared dev host with NODE_ENV=development and a local Postgres would
+    // otherwise pass those two gates without the operator realising the route
+    // is exposed.
+    delete process.env.SQUIRE_DEV_LOGIN;
+    process.env.NODE_ENV = 'development';
+    delete process.env.TEST_DATABASE_URL;
+    expect(shouldRegisterDevLogin()).toBe(false);
+  });
+
+  it('returns false when SQUIRE_DEV_LOGIN is set to a non-"1" truthy value', () => {
+    process.env.SQUIRE_DEV_LOGIN = 'true';
+    process.env.NODE_ENV = 'development';
+    delete process.env.TEST_DATABASE_URL;
+    expect(shouldRegisterDevLogin()).toBe(false);
+  });
+
+  it('returns true when SQUIRE_DEV_LOGIN=1, NODE_ENV is development, and DB is managed-local', () => {
+    process.env.SQUIRE_DEV_LOGIN = '1';
     process.env.NODE_ENV = 'development';
     delete process.env.TEST_DATABASE_URL;
     expect(shouldRegisterDevLogin()).toBe(true);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,11 @@ import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // SQUIRE_DEV_LOGIN=1 is required since SQR-106 for the dev-login route to
+    // register. Setting it here (not in .env) keeps the gate meaningful: the
+    // test suite always has the route live against the test DB, but plain
+    // `npm run serve` does not expose it unless the operator explicitly opts in.
+    env: { SQUIRE_DEV_LOGIN: '1' },
     // `.claude/worktrees/**` keeps gstack worktrees from being picked up by
     // the parent repo's vitest run. Without this, a stale worktree at a
     // pre-migration commit would silently double the suite and run its older


### PR DESCRIPTION
## Summary

Adds a third positive gate to `shouldRegisterDevLogin()` — `SQUIRE_DEV_LOGIN=1` must be explicitly set alongside the existing `NODE_ENV` and managed-local-DB checks. Closes the shared-host exposure window (CI runner, cloud IDE, LAN-exposed machine) where an attacker who could reach the port could forge a same-origin `Origin` header and mint a valid session without credentials.

- `scripts/preview-serve.sh` exports both `NODE_ENV=development` and `SQUIRE_DEV_LOGIN=1` automatically — no config change needed for Claude Code preview or manual browser testing
- Plain `npm run serve` on a shared host does NOT register the route unless the operator adds `SQUIRE_DEV_LOGIN=1` to their `.env`
- `vitest.config.ts` sets `SQUIRE_DEV_LOGIN=1` so the test suite keeps the route live against the test DB
- `.env.example` documents `NODE_ENV=development` (uncommented) and `SQUIRE_DEV_LOGIN=1` (commented out as explicit opt-in)

## Validation

- Manual: confirmed button absent at `/login` with `SQUIRE_DEV_LOGIN` unset, present after re-enabling; login → redirect to `/` → already-authed redirect → logout → chat flow all verified
- `npm run check` clean: typecheck, lint, markdownlint, prettier, 835 tests passing (15 in dev-login suite including 3 new gate tests + 1 new handler-recheck test)
- Pre-push gstack `/review`: one missing test found (handler-level runtime recheck) — fixed inline before push

Fixes SQR-106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added explicit opt-in requirement for the development login feature, enhancing security controls
  * Updated development scripts and environment configuration templates with new setup variable

* **Documentation**
  * Updated development environment setup guides with new configuration requirements and troubleshooting steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->