### PR TITLE
docs(auth): fix stale comment in dev-login handler JSDoc

### DIFF
--- a/src/auth/dev-login.ts
+++ b/src/auth/dev-login.ts
@@ -19,9 +19,10 @@
  *    not even exist in production — you can grep prod logs / the route table
  *    and find nothing.
  *
- * 3. The handler itself re-checks the local-DB gate at request time, so
- *    a config-only change (e.g., setting `DATABASE_URL` to a remote host
- *    after the server started) neutralises the route without a restart.
+ * 3. The handler itself re-checks all three gates via `shouldRegisterDevLogin()`
+ *    at request time, so a config-only change (e.g., clearing `SQUIRE_DEV_LOGIN`
+ *    or setting `DATABASE_URL` to a remote host after the server started)
+ *    neutralises the route without a restart.
  *
  * 4. A same-origin Origin-header check blocks cross-site POSTs. The three-gate
  *    registration check is already enough to keep this route out of any hostile


### PR DESCRIPTION
## Summary

- Corrects point 3 in `src/auth/dev-login.ts` module JSDoc: the handler re-checks **all three gates** via `shouldRegisterDevLogin()` at request time, not just the local-DB gate
- Adds the `SQUIRE_DEV_LOGIN` example to the comment so the runtime-config neutralisation story is complete

Caught by CodeRabbit during the SQR-106 PR review.

## Test plan

- [ ] `grep -n 'shouldRegisterDevLogin' src/auth/dev-login.ts` confirms the handler calls the full gate function
- [ ] Comment text matches actual behaviour in the handler body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal authentication documentation to accurately reflect how security gates are evaluated at request time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->