### PR TITLE
docs: record production agent baseline

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Squire Architecture
 
-**Version:** 1.0.8
+**Version:** 1.0.9
 **Date:** 2026-04-07
-**Last Refreshed:** 2026-04-21
+**Last Refreshed:** 2026-04-26
 **Owner:** Architect
 **Companion doc:** [SPEC.md](SPEC.md) — product / PM concerns (what / why / who / when)
 
@@ -35,6 +35,39 @@ The system is organized as a single Hono server that hosts:
 - A **REST API** (`/api/*`) for non-MCP programmatic clients
 
 All channels (web UI, MCP, REST, future Discord / iMessage) talk to the same knowledge agent and the same atomic tools.
+
+---
+
+## Current Production Baseline
+
+Phase 1 production stays on the current Hono server, Postgres + pgvector
+runtime store, Claude SDK tool loop, conversation service, SSE contract, and
+Langfuse/OpenTelemetry trace path while the retrieval redesign happens. Deep
+Agents and LangSmith Deployment are explicitly deferred until after the Step 3
+eval report. See
+[ADR 0013 — Keep Phase 1 production on the current knowledge-agent path](adr/0013-phase-1-production-agent-baseline.md).
+
+The active baseline is:
+
+- Hono hosts the web UI, REST endpoints, and MCP endpoint in one server.
+- Postgres + pgvector hold the runtime retrieval layers.
+- The knowledge agent uses the current Claude SDK tool loop.
+- The web conversation service owns persisted turns, ownership checks, SSE,
+  and presentation, then delegates domain reasoning to the knowledge agent.
+- `/api/ask`, the in-process service entry, the CLI wrapper, and the eval
+  runner all route through the same service boundary.
+- Langfuse and OpenTelemetry remain the LLM trace and eval path for now.
+
+Existing regression coverage protects the current path:
+
+- `test/agent.test.ts` protects the agent loop and atomic tool use.
+- `test/service.test.ts` protects service readiness and delegation to
+  `runAgentLoop`.
+- `test/conversation.test.ts` protects the web conversation service, stored
+  turns, and browser SSE route.
+- `test/server-api.test.ts` protects REST endpoints and `/api/ask` SSE.
+- `test/mcp.test.ts`, `test/mcp-in-process.test.ts`, and
+  `test/mcp-transport.test.ts` protect the MCP surface.
 
 ---
 
@@ -749,6 +782,9 @@ For developer setup, running the server, working on import scripts locally, and 
 
 - **APM / RUM stack.** Datadog as a one-stop shop for application metrics and real-user monitoring (with Langfuse staying for LLM-specific observability), or stay Langfuse-only and skip APM until volume demands it?
 - **Hosting platform.** Fly.io vs Railway vs Render vs self-hosted VPS — defer until Phase 1 deployment work begins.
+- **Deep Agents / LangSmith Deployment adoption.** Deferred until after the
+  Step 3 eval report from the retrieval redesign. See
+  [ADR 0013](adr/0013-phase-1-production-agent-baseline.md).
 - **Character state ingestion path (Phase 6).** Browser extension vs JSON export vs storyline sync protocol vs screenshot+Vision vs GHS-as-tracker — defer until Phase 6 begins. The GH2 campaign may force this decision earlier than the Frosthaven one.
 - **Storyline GH2 support (Phase 2 prerequisite).** Confirm whether frosthaven-storyline.com supports Gloomhaven 2.0. If not, Brian's GH2 campaign-tracking workflow needs to switch (most likely to GHS).
 
@@ -757,6 +793,12 @@ For developer setup, running the server, working on import scripts locally, and 
 ## Changelog
 
 - **2026-04-26:** SQR-110 added a narrow synthesis guard to the knowledge agent loop. If a turn only calls `search_rules` and reaches three broad rule-corpus searches, the next model call runs without tools and is instructed to answer from the retrieved context. This preserves the full loop budget for scenario traversal and card lookups while preventing simple rules questions from spending all ten iterations on repeated searches. The eval dataset now includes `rule-looting-definition` for the original "What is looting?" failure mode.
+
+- **2026-04-26:** SQR-114 recorded the Phase 1 production-agent
+  baseline while the retrieval redesign runs. Production stays on the current
+  Hono, Postgres + pgvector, Claude SDK tool loop, conversation-service, SSE,
+  Langfuse, and OpenTelemetry path. Deep Agents and LangSmith Deployment are
+  deferred until after the Step 3 eval report.
 
 - **2026-04-21 (v1.0.8):** SQR-105 fixed the consulted footer to show the actual book(s) surfaced by `search_rules` rather than always showing "RULEBOOK". `search_rules` searches all four Frosthaven books; the specific books hit are now extracted from the tool result in `agent.ts` and stored as `ToolSourceLabel` strings in `consulted_sources`, bypassing the old static tool-name → label map for that tool. Added "PUZZLE BOOK" as a recognised provenance label (the Puzzle Book was indexed but never attributed). `aggregateSourceLabels` handles both storage formats (old tool-name strings and new label strings) transparently.
 

--- a/docs/adr/0013-phase-1-production-agent-baseline.md
+++ b/docs/adr/0013-phase-1-production-agent-baseline.md
@@ -1,0 +1,86 @@
+---
+type: ADR
+id: '0013'
+title: 'Keep Phase 1 production on the current knowledge-agent path'
+status: active
+date: 2026-04-26
+---
+
+## Context
+
+Squire is entering an agent-native retrieval redesign. The research
+recommendation is to improve the retrieval surface first, then decide whether
+an agent runtime migration is worth the cost. The current production path is
+already working:
+
+- Hono hosts the web channel, REST endpoints, and MCP endpoint in one server.
+- Postgres + pgvector hold runtime retrieval data.
+- The knowledge agent uses the current Claude SDK tool loop.
+- The web conversation service owns persisted turns, ownership checks, SSE,
+  and presentation while delegating domain reasoning to the knowledge agent.
+- Langfuse and OpenTelemetry remain the trace and eval path.
+
+There are good reasons to keep this stable during the redesign. Moving
+production to LangChain, Deep Agents, LangGraph, or LangSmith Deployment before
+the retrieval work is measured would mix two variables: retrieval quality and
+runtime framework choice. It would also risk changing the web SSE contract,
+MCP/REST surface, and eval path while the main unknown is still whether the
+retrieval contract is good enough.
+
+## Decision
+
+**Phase 1 production stays on the current Hono, Postgres + pgvector, Claude SDK
+tool-loop, conversation-service, SSE, Langfuse, and OpenTelemetry path while the
+retrieval redesign happens. Deep Agents and LangSmith Deployment stay deferred
+until after the Step 3 eval report.**
+
+The redesign may add or reshape atomic retrieval tools and prompts, but it must
+keep production traffic flowing through the existing service and conversation
+boundaries unless a later ADR replaces this decision.
+
+The current path is protected by these existing tests:
+
+- `test/agent.test.ts` protects the Claude SDK tool loop and atomic tool use.
+- `test/service.test.ts` protects service readiness and `ask()` delegation to
+  the knowledge agent loop.
+- `test/conversation.test.ts` protects the web conversation service, persisted
+  turns, non-SSE fallback, and browser SSE route.
+- `test/server-api.test.ts` protects REST search endpoints and `/api/ask` SSE.
+- `test/mcp.test.ts`, `test/mcp-in-process.test.ts`, and
+  `test/mcp-transport.test.ts` protect the MCP atomic-tool surface.
+- `eval/run.ts` runs through `askFrosthaven()` in `src/query.ts`, which
+  delegates to `src/service.ts`, so evals measure the same production
+  knowledge-agent path.
+
+## Options considered
+
+- **Option A (chosen) — keep the current production path as the baseline.**
+  Retrieval changes stay measurable because the server, data store, agent loop,
+  conversation service, SSE contract, MCP/REST surfaces, and trace/eval path
+  remain stable. This avoids framework churn during the highest-risk retrieval
+  work.
+- **Option B — migrate production to LangChain or LangGraph now.** This might
+  help if the current loop were the blocker, but it is not the known blocker.
+  It adds a second major variable before the Step 3 eval report can say whether
+  retrieval quality improved.
+- **Option C — move production to Deep Agents plus LangSmith Deployment now.**
+  This could be useful later if Squire needs managed deployment workflows or a
+  richer agent graph. For Phase 1 it is premature: it would couple runtime
+  deployment choices to an unfinished retrieval-contract redesign.
+- **Option D — run a parallel production path during the redesign.** This gives
+  side-by-side flexibility, but it doubles test and operational surface while
+  the product is still single-maintainer Phase 1. Side experiments can happen
+  in plans or throwaway branches without becoming production.
+
+## Consequences
+
+- Retrieval-redesign work has a stable baseline for eval comparisons.
+- Existing web, REST, MCP, SSE, and eval contracts stay meaningful during the
+  redesign.
+- Deep Agents and LangSmith Deployment are not rejected forever; they are gated
+  on the Step 3 eval report and a later ADR.
+- Any future branch that wants to add LangChain, LangGraph, Deep Agents, or
+  LangSmith to production must first replace this decision with a new ADR.
+- The current Claude SDK loop remains hand-owned code, so Squire keeps owning
+  retry behavior, tool-call event shaping, and prompt/runtime wiring directly.
+  That is acceptable until the eval report shows the next bottleneck.


### PR DESCRIPTION
## Summary

- Add ADR 0013 recording that Phase 1 production stays on the current Hono, Postgres + pgvector, Claude SDK tool loop, conversation-service, SSE, Langfuse, and OpenTelemetry path while retrieval redesign work happens.
- Update `docs/ARCHITECTURE.md` with the current production baseline, the existing tests that protect the real paths, the Deep Agents / LangSmith Deployment gate, and the SQR-114 changelog note.
- Keep Deep Agents and LangSmith Deployment deferred until after the Step 3 eval report.

## Test Coverage

No new tests added. This is a docs/decision-record change; the architecture doc now points at the existing service, agent, SSE, MCP, REST, and eval coverage that protects the current production path.

## Pre-Landing Review

No issues found.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN. The diff records the SQR-114 baseline decision and does not add runtime changes.

## Plan Completion

No plan file detected.

## Verification Results

No manual verification needed for docs-only change.

## Test plan

- [x] `npm run check` passed: 51 test files, 862 tests

Fixes SQR-114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to formalize the current production baseline during ongoing development efforts.
  * Added a new architecture decision record outlining stable operational boundaries and testing practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->