### PR TITLE
docs(agent): define self-describing knowledge contract

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Squire Architecture
 
-**Version:** 1.0.9
+**Version:** 1.0.10
 **Date:** 2026-04-07
 **Last Refreshed:** 2026-04-26
 **Owner:** Architect
@@ -484,6 +484,17 @@ The same handful of tools handle every card type via parameter, rather than one 
 - `listCardTypes(opts?)` — discovery. Returns all GHS data types with record counts via a single `UNION ALL` of `count(*)` per table.
 - `listCards(type, filter?, opts?)` — list records of a given type with field-level AND filter, plus optional `opts.game`.
 - `getCard(type, id, opts?)` — exact lookup by canonical `sourceId` via the `(game, source_id)` unique index. The per-type natural-key map was retired in SQR-56 after natural-key verification turned up four collisions.
+
+Squire is moving this public retrieval surface toward the
+[Self-Describing Knowledge Tool Contract](KNOWLEDGE_TOOL_CONTRACT.md). The next
+contract is designed first for the knowledge agent behind `/api/ask`. It keeps
+the existing tools as adapters, but gives that agent discovery, schema
+inspection, entity resolution, exact opening, broad search, and neighbor
+traversal through a smaller set of domain-shaped operations:
+`inspect_sources`, `schema`, `resolve_entity`, `open_entity`,
+`search_knowledge`, and `neighbors`. External MCP names may use a `squire_`
+prefix as a projection detail when clients load tools from many servers. See
+[ADR 0014](adr/0014-self-describing-knowledge-tool-contract.md).
 
 ```mermaid
 graph TB

--- a/docs/KNOWLEDGE_TOOL_CONTRACT.md
+++ b/docs/KNOWLEDGE_TOOL_CONTRACT.md
@@ -1,0 +1,997 @@
+# Self-Describing Knowledge Tool Contract
+
+**Status:** Draft contract for SQR-116  
+**Applies to:** Squire's internal knowledge-agent tool set, with MCP and REST
+compatibility projections  
+**Related ADR:** [ADR 0014](adr/0014-self-describing-knowledge-tool-contract.md)
+
+## Goal
+
+Squire's user-facing entry point is still an ask-question task: the web channel,
+REST callers, and future clients hand the knowledge agent a natural-language
+question and expect a grounded answer.
+
+This contract is for the tools inside that knowledge-agent loop. They should
+describe the domain well enough that the agent can discover what exists, resolve
+fuzzy user language into canonical refs, open exact records, search broad
+knowledge, and traverse related records without a long routing prompt.
+
+The prompt should explain role and answer quality. Tool names, schemas, and
+outputs should explain tool choreography.
+
+## Current Problem
+
+The current tool set works, but it is shaped around known workflows:
+
+- `search_rules`
+- `search_cards`
+- `list_card_types`
+- `list_cards`
+- `get_card`
+- `find_scenario`
+- `get_scenario`
+- `get_section`
+- `follow_links`
+
+The agent prompt currently says when to use each one. That makes routing fragile:
+new data types need prompt edits, exact lookups need special wording, and the
+model has to remember that scenarios, sections, cards, and book passages all use
+different lookup verbs.
+
+## Contract Principles
+
+1. **Refs are the stable address.** Every inspectable entity has a canonical ref.
+2. **Discovery is a tool call, not a prompt paragraph.** Callers ask what sources
+   and kinds exist.
+3. **Resolution never silently guesses.** Ambiguous user text returns candidates
+   with confidence and reasons.
+4. **Opening is exact.** `open_entity(ref)` returns one record or a structured
+   not-found result.
+5. **Search finds, neighbors traverse.** Fuzzy search and graph traversal are
+   separate operations.
+6. **Tools group intent, not endpoints.** Each operation maps to how an agent
+   works: discover, inspect schema, resolve, open, search, traverse.
+7. **Results show the next move.** Outputs include citations, source labels,
+   links, related refs, confidence, and inspectable refs.
+8. **Responses are context-efficient by default.** Tools return concise, relevant
+   context unless the caller asks for detail.
+9. **Old tools can remain adapters.** The new contract changes the public shape,
+   not the production baseline from ADR 0013.
+
+These principles incorporate Anthropic's 2025 guidance on writing tools for
+agents. The MCP guidance only applies when projecting the same contract to
+external MCP callers:
+
+- build a few high-impact tools around agent intent, not one tool per internal
+  endpoint
+- prefer meaningful names and source labels over opaque IDs, while still
+  returning canonical refs for follow-up calls
+- bound large responses with limits, filters, pagination, and truncation hints
+- make validation errors tell the agent exactly how to repair the call
+- evaluate tool use against realistic multi-step tasks, not toy prompts
+
+## Layering
+
+There are three separate surfaces:
+
+1. **Ask-question entry point:** `/api/ask` and the in-process service call. This
+   remains the product API for "answer my Frosthaven question."
+2. **Agent tool contract:** the six operations in this document. These are the
+   tools the knowledge agent uses while answering.
+3. **External MCP projection:** the same operations exposed to MCP-capable
+   clients that want direct tool access instead of Squire's full answer loop.
+
+The contract is designed primarily for layer 2. MCP details must not force the
+internal agent loop into awkward names or payloads.
+
+## Tool Namespacing
+
+The canonical operation names are short because they describe the internal
+agent's work:
+
+- `inspect_sources`
+- `schema`
+- `resolve_entity`
+- `open_entity`
+- `search_knowledge`
+- `neighbors`
+
+External MCP names may use a `squire_` prefix so they remain clear when a client
+loads tools from many MCP servers:
+
+| Agent operation    | Optional MCP projection   |
+| ------------------ | ------------------------- |
+| `inspect_sources`  | `squire_inspect_sources`  |
+| `schema`           | `squire_schema`           |
+| `resolve_entity`   | `squire_resolve_entity`   |
+| `open_entity`      | `squire_open_entity`      |
+| `search_knowledge` | `squire_search_knowledge` |
+| `neighbors`        | `squire_neighbors`        |
+
+If MCP names diverge from agent names, tests must prove both surfaces point at
+the same shared contract definitions.
+
+## Entity Kinds
+
+| Kind            | Meaning                                                                                              | Current source                              | Ref examples                                                    |
+| --------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------- | --------------------------------------------------------------- |
+| `source`        | A knowledge source such as a rulebook, section book, card database, or future campaign record store  | Source metadata                             | `source:frosthaven/rulebook`, `source:frosthaven/cards`         |
+| `rules_passage` | A semantic book-search passage from indexed PDFs                                                     | `searchRules()`                             | `rules:frosthaven/fh-rule-book.pdf#chunk=123`                   |
+| `scenario`      | A scenario-book scenario record                                                                      | `findScenario()`, `getScenario()`           | `scenario:frosthaven/061`, `scenario:gloomhavensecretariat/061` |
+| `section`       | A section-book section record                                                                        | `getSection()`                              | `section:frosthaven/67.1`                                       |
+| `card_type`     | A category of structured GHS card data                                                               | `listCardTypes()`                           | `card-type:frosthaven/items`                                    |
+| `card`          | A structured card, item, monster, event, building, scenario, ability, battle goal, or personal quest | `searchCards()`, `listCards()`, `getCard()` | `card:frosthaven/items/gloomhavensecretariat:item/1`            |
+| `campaign`      | Future campaign state                                                                                | Future Phase 4 data                         | `campaign:frosthaven/<campaign-id>`                             |
+| `character`     | Future character state                                                                               | Future Phase 4 data                         | `character:frosthaven/<character-id>`                           |
+| `party`         | Future party state                                                                                   | Future Phase 4 data                         | `party:frosthaven/<party-id>`                                   |
+
+Refs are URL-safe strings with this formal shape:
+
+```text
+<kind>:<game>/<path>[#<fragment>]
+```
+
+Rules:
+
+- `kind` is one of the active kinds returned by `inspect_sources()`.
+- `game` is one of the active games returned by `inspect_sources()`.
+- `path` is one or more slash-separated segments. Segment values may contain
+  letters, numbers, dots, underscores, hyphens, and colons. This allows GHS
+  source IDs such as `gloomhavensecretariat:item/1` to remain recognizable.
+- `fragment` is optional and uses query-like key/value pairs for sub-record
+  locators, for example `chunk=123`.
+- Parsers must split at the first `:`, the first `/` after that colon, and the
+  first `#`. They must not split `path` on later colons.
+- `open_entity` accepts a closed legacy-ref allowlist during migration, but
+  returns the canonical new ref in the result.
+
+Legacy refs allowed during migration:
+
+| Legacy shape                           | Interpreted as                           | Removal gate                                        |
+| -------------------------------------- | ---------------------------------------- | --------------------------------------------------- |
+| `gloomhavensecretariat:scenario/<nnn>` | `scenario:frosthaven/<nnn>`              | Remove after SQR-117 and SQR-118 eval parity passes |
+| `<section>.<variant>`                  | `section:frosthaven/<section>.<variant>` | Remove after SQR-117 and SQR-118 eval parity passes |
+
+Bare legacy refs are Frosthaven-only. Callers that know the game must send the
+canonical ref.
+
+## Shared Result Shapes
+
+### Entity Ref
+
+```json
+{
+  "kind": "section",
+  "ref": "section:frosthaven/67.1",
+  "title": "Section 67.1",
+  "sourceLabel": "Section Book 62-81"
+}
+```
+
+### Citation
+
+```json
+{
+  "sourceRef": "source:frosthaven/section-book-62-81",
+  "sourceLabel": "Section Book 62-81",
+  "locator": "section 67.1",
+  "quote": "Short excerpt, when useful"
+}
+```
+
+### Related Entity
+
+```json
+{
+  "relation": "conclusion",
+  "target": {
+    "kind": "section",
+    "ref": "section:frosthaven/67.1",
+    "title": "Section 67.1",
+    "sourceLabel": "Section Book 62-81"
+  },
+  "reason": "Scenario conclusion points to this section"
+}
+```
+
+### Failure
+
+Every tool returns structured failures instead of plain text errors:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "not_found",
+    "message": "No section found for section:frosthaven/999.9",
+    "retryable": false
+  }
+}
+```
+
+Allowed error codes:
+
+- `invalid_ref`
+- `unknown_kind`
+- `not_found`
+- `ambiguous`
+- `invalid_filter`
+- `unsupported_relation`
+- `source_unavailable`
+- `internal_error`
+
+Errors should include an actionable repair hint when the caller can recover:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "invalid_ref",
+    "message": "Expected ref shape <kind>:<game>/<id>, got 67-1",
+    "retryable": false,
+    "hint": "Use section:frosthaven/67.1 or call resolve_entity(\"67.1\", [\"section\"]) first"
+  }
+}
+```
+
+### Response Format
+
+Large tools accept a response format parameter:
+
+```json
+{
+  "responseFormat": "concise"
+}
+```
+
+Allowed values:
+
+- `concise`: enough title, snippet, ref, source label, confidence, and next refs
+  for the agent to decide the next step
+- `detailed`: full record fields, citations, links, related records, and raw
+  metadata needed for answer synthesis or follow-up calls
+
+Default behavior:
+
+- discovery and schema tools return detailed metadata because they are already
+  small
+- resolve and search default to `concise`
+- open defaults to `detailed`
+- neighbors defaults to `concise`
+
+Precedence rule:
+
+- `include` controls which optional groups may be returned.
+- `responseFormat` controls how much detail each returned group contains.
+- If `responseFormat: "concise"` and `include` asks for `raw`, the tool returns
+  `invalid_filter` with a hint to use `responseFormat: "detailed"`.
+- If `responseFormat: "detailed"` omits a group from `include`, that group is
+  omitted even though detailed mode could have returned it.
+
+## Tool Contract
+
+### `inspect_sources()`
+
+Discover the knowledge sources and entity kinds Squire can inspect.
+
+Input schema:
+
+```json
+{
+  "type": "object",
+  "properties": {}
+}
+```
+
+Output schema:
+
+```json
+{
+  "ok": true,
+  "games": [
+    {
+      "id": "frosthaven",
+      "label": "Frosthaven",
+      "default": true
+    }
+  ],
+  "sources": [
+    {
+      "ref": "source:frosthaven/rulebook",
+      "label": "Frosthaven Rulebook",
+      "kinds": ["rules_passage"],
+      "searchable": true,
+      "openable": false,
+      "relations": []
+    }
+  ],
+  "defaultGame": "frosthaven"
+}
+```
+
+Example:
+
+```json
+{
+  "ok": true,
+  "games": [
+    {
+      "id": "frosthaven",
+      "label": "Frosthaven",
+      "default": true
+    }
+  ],
+  "sources": [
+    {
+      "ref": "source:frosthaven/rulebook",
+      "label": "Frosthaven Rulebook",
+      "kinds": ["rules_passage"],
+      "searchable": true,
+      "openable": false,
+      "relations": []
+    },
+    {
+      "ref": "source:frosthaven/scenario-section-books",
+      "label": "Scenario and Section Books",
+      "kinds": ["scenario", "section"],
+      "searchable": true,
+      "openable": true,
+      "relations": ["conclusion", "read_now", "section_link", "unlock", "cross_reference"]
+    },
+    {
+      "ref": "source:frosthaven/cards",
+      "label": "GHS Card Data",
+      "kinds": ["card_type", "card"],
+      "searchable": true,
+      "openable": true,
+      "relations": ["belongs_to_type"]
+    }
+  ],
+  "defaultGame": "frosthaven"
+}
+```
+
+Failure behavior:
+
+- Returns `source_unavailable` if the metadata store cannot be read.
+- Returns partial source metadata with `warnings` when one source is down but
+  static sources are still known.
+
+### `schema(kind)`
+
+Inspect the shape, filters, and examples for an entity kind.
+
+Input schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": "string",
+      "description": "Entity kind returned by inspect_sources()."
+    }
+  },
+  "required": ["kind"]
+}
+```
+
+Output schema:
+
+```json
+{
+  "ok": true,
+  "kind": "card",
+  "refPattern": "card:<game>/<card-type>/<source-id>",
+  "fields": [{ "name": "name", "type": "string", "description": "Display name" }],
+  "filterFields": ["type", "name", "level", "class", "prosperity"],
+  "relations": ["belongs_to_type"],
+  "examples": [
+    {
+      "label": "Open item 1",
+      "ref": "card:frosthaven/items/gloomhavensecretariat:item/1"
+    }
+  ]
+}
+```
+
+Example for `section`:
+
+```json
+{
+  "ok": true,
+  "kind": "section",
+  "refPattern": "section:<game>/<section-number>.<variant>",
+  "fields": [
+    { "name": "text", "type": "string", "description": "Section prose" },
+    { "name": "sourcePage", "type": "number", "description": "Printed PDF page" }
+  ],
+  "filterFields": ["sectionNumber", "sectionVariant"],
+  "relations": ["read_now", "section_link", "unlock", "cross_reference"],
+  "examples": [{ "label": "Open section 67.1", "ref": "section:frosthaven/67.1" }]
+}
+```
+
+Failure behavior:
+
+- `unknown_kind` when `kind` is not returned by `inspect_sources()`.
+- `source_unavailable` when a dynamic schema source cannot be inspected.
+
+### `resolve_entity(query, kinds?)`
+
+Turn user language into canonical candidate refs.
+
+Input schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "query": { "type": "string" },
+    "kinds": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Entity kind returned by inspect_sources()."
+      },
+      "description": "Optional kind filter. Omit to search all active kinds."
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["candidates", "single"],
+      "default": "candidates",
+      "description": "Use candidates for normal resolution. Use single only when the caller needs exactly one ref."
+    },
+    "game": { "type": "string", "default": "frosthaven" },
+    "limit": { "type": "integer", "minimum": 1, "maximum": 20, "default": 6 },
+    "responseFormat": {
+      "type": "string",
+      "enum": ["concise", "detailed"],
+      "default": "concise"
+    }
+  },
+  "required": ["query"]
+}
+```
+
+Output schema:
+
+```json
+{
+  "ok": true,
+  "query": "scenario 61",
+  "candidates": [
+    {
+      "entity": {
+        "kind": "scenario",
+        "ref": "scenario:frosthaven/061",
+        "title": "Life and Death",
+        "sourceLabel": "Scenario Book 62-81"
+      },
+      "confidence": 0.99,
+      "matchReason": "Exact scenario number"
+    }
+  ]
+}
+```
+
+Example:
+
+```json
+{
+  "ok": true,
+  "query": "scenario 61",
+  "candidates": [
+    {
+      "entity": {
+        "kind": "scenario",
+        "ref": "scenario:frosthaven/061",
+        "title": "Life and Death",
+        "sourceLabel": "Scenario Book 62-81"
+      },
+      "confidence": 0.99,
+      "matchReason": "Exact scenario number"
+    }
+  ]
+}
+```
+
+Failure behavior:
+
+- Empty `candidates` is a successful miss, not an error.
+- `ambiguous` is only used when `mode: "single"` and multiple candidates are
+  plausible enough that auto-opening would be unsafe.
+- `invalid_filter` when `kinds` contains a kind not returned by
+  `inspect_sources()`.
+
+Confidence policy:
+
+- `0.95-1.0`: exact canonical ref, exact scenario/section number, or exact
+  source ID match. The agent may open the top candidate without asking.
+- `0.75-0.94`: strong name match, but not exact. The agent may open when the
+  user phrasing clearly names one entity.
+- `0.50-0.74`: plausible candidate. The agent should inspect candidates or ask
+  a clarification before opening.
+- `<0.50`: weak match. The agent should search or ask a clarification.
+
+`mode: "single"` returns the entity directly only for the first two bands. It
+returns `ambiguous` with candidates for ties or low-confidence matches.
+
+### `open_entity(ref)`
+
+Open one exact inspectable entity.
+
+Input schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "ref": { "type": "string" },
+    "include": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["citations", "links", "related", "raw"]
+      },
+      "default": ["citations", "links", "related"]
+    },
+    "responseFormat": {
+      "type": "string",
+      "enum": ["concise", "detailed"],
+      "default": "detailed"
+    }
+  },
+  "required": ["ref"]
+}
+```
+
+Output schema:
+
+```json
+{
+  "ok": true,
+  "entity": {
+    "kind": "section",
+    "ref": "section:frosthaven/67.1",
+    "title": "Section 67.1",
+    "sourceLabel": "Section Book 62-81",
+    "data": {}
+  },
+  "citations": [],
+  "links": [],
+  "related": []
+}
+```
+
+Example:
+
+```json
+{
+  "ok": true,
+  "entity": {
+    "kind": "section",
+    "ref": "section:frosthaven/67.1",
+    "title": "Section 67.1",
+    "sourceLabel": "Section Book 62-81",
+    "data": {
+      "text": "Section text...",
+      "sectionNumber": 67,
+      "sectionVariant": 1
+    }
+  },
+  "citations": [
+    {
+      "sourceRef": "source:frosthaven/section-book-62-81",
+      "sourceLabel": "Section Book 62-81",
+      "locator": "section 67.1"
+    }
+  ],
+  "links": [
+    {
+      "relation": "unlock",
+      "target": {
+        "kind": "scenario",
+        "ref": "scenario:frosthaven/116",
+        "title": "Scenario 116",
+        "sourceLabel": "Scenario Book"
+      }
+    }
+  ],
+  "related": []
+}
+```
+
+Failure behavior:
+
+- `invalid_ref` when the string cannot be parsed.
+- `not_found` when the ref parses but no record exists.
+- Legacy refs such as `gloomhavensecretariat:scenario/061` and `67.1` are
+  accepted during migration and normalized in the returned `entity.ref`.
+
+### `search_knowledge(query, scope?, filters?)`
+
+Search broad knowledge across one or more sources.
+
+Input schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "query": { "type": "string" },
+    "scope": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Searchable kind returned by inspect_sources()."
+      },
+      "default": ["rules_passage", "scenario", "section", "card"]
+    },
+    "filters": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "game": { "type": "string", "default": "frosthaven" },
+    "limit": { "type": "integer", "minimum": 1, "maximum": 20, "default": 6 },
+    "responseFormat": {
+      "type": "string",
+      "enum": ["concise", "detailed"],
+      "default": "concise"
+    }
+  },
+  "required": ["query"]
+}
+```
+
+Output schema:
+
+```json
+{
+  "ok": true,
+  "query": "loot action",
+  "results": [
+    {
+      "entity": {
+        "kind": "rules_passage",
+        "ref": "rules:frosthaven/fh-rule-book.pdf#chunk=42",
+        "title": "Loot action",
+        "sourceLabel": "Rulebook"
+      },
+      "score": 0.92,
+      "snippet": "Loot action text...",
+      "citations": [],
+      "nextRefs": []
+    }
+  ]
+}
+```
+
+Example:
+
+```json
+{
+  "ok": true,
+  "query": "what does brittle do",
+  "results": [
+    {
+      "entity": {
+        "kind": "rules_passage",
+        "ref": "rules:frosthaven/fh-rule-book.pdf#chunk=88",
+        "title": "Brittle",
+        "sourceLabel": "Rulebook"
+      },
+      "score": 0.89,
+      "snippet": "A figure with Brittle doubles the next source of damage...",
+      "citations": [
+        {
+          "sourceRef": "source:frosthaven/rulebook",
+          "sourceLabel": "Rulebook",
+          "locator": "rulebook passage"
+        }
+      ],
+      "nextRefs": [
+        {
+          "kind": "rules_passage",
+          "ref": "rules:frosthaven/fh-rule-book.pdf#chunk=88",
+          "title": "Brittle",
+          "sourceLabel": "Rulebook"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Failure behavior:
+
+- Empty `results` is a successful miss.
+- `invalid_filter` when `scope` contains a searchable kind not returned by
+  `inspect_sources()`.
+- `invalid_filter` when filters do not apply to the chosen scope.
+- `source_unavailable` when the requested source cannot be queried.
+- If output is truncated, return `truncated: true` with a hint telling the agent
+  which filter, limit, or exact ref to use next.
+
+Fan-out and budget rules:
+
+- `limit` is a global result limit. Each searched scope gets at most
+  `ceil(limit / scope.length) + 1` provisional hits before final ranking.
+- Broad default search may query rules, scenarios, sections, and cards in
+  parallel, but each scope must have an independent timeout and error entry so
+  one slow store does not hide useful results from another.
+- `truncated: true` is global, and `truncatedScopes` lists which scopes had more
+  available hits.
+- SQR-118 must set concrete latency budgets in tests before implementation. The
+  default broad search target is p95 under 2 seconds in local test fixtures and
+  must not exceed the current `searchRules + searchCards` eval path by more than
+  25% without an explicit follow-up decision.
+
+### `neighbors(ref, relation?)`
+
+Traverse known relationships from one entity.
+
+Input schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "ref": { "type": "string" },
+    "relation": {
+      "type": "string",
+      "description": "Relation advertised by inspect_sources() or schema(kind)."
+    },
+    "limit": { "type": "integer", "minimum": 1, "maximum": 50, "default": 20 },
+    "responseFormat": {
+      "type": "string",
+      "enum": ["concise", "detailed"],
+      "default": "concise"
+    }
+  },
+  "required": ["ref"]
+}
+```
+
+Output schema:
+
+```json
+{
+  "ok": true,
+  "from": {
+    "kind": "scenario",
+    "ref": "scenario:frosthaven/061",
+    "title": "Life and Death",
+    "sourceLabel": "Scenario Book 62-81"
+  },
+  "neighbors": [
+    {
+      "relation": "conclusion",
+      "target": {
+        "kind": "section",
+        "ref": "section:frosthaven/67.1",
+        "title": "Section 67.1",
+        "sourceLabel": "Section Book 62-81"
+      },
+      "reason": "Conclusion link"
+    }
+  ]
+}
+```
+
+Example:
+
+```json
+{
+  "ok": true,
+  "from": {
+    "kind": "scenario",
+    "ref": "scenario:frosthaven/061",
+    "title": "Life and Death",
+    "sourceLabel": "Scenario Book 62-81"
+  },
+  "neighbors": [
+    {
+      "relation": "conclusion",
+      "target": {
+        "kind": "section",
+        "ref": "section:frosthaven/67.1",
+        "title": "Section 67.1",
+        "sourceLabel": "Section Book 62-81"
+      },
+      "reason": "Printed scenario conclusion"
+    }
+  ]
+}
+```
+
+Failure behavior:
+
+- `invalid_ref` when the origin ref cannot be parsed.
+- `not_found` when the origin ref parses but does not exist.
+- `unsupported_relation` when the relation is not advertised by
+  `inspect_sources()` or is not available for the origin kind according to
+  `schema(kind).relations`.
+- Empty `neighbors` is a successful no-neighbor result.
+
+## Migration Map
+
+| Old tool          | New public path                                                                                       | Adapter expectation                                |
+| ----------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `search_rules`    | `search_knowledge(query, scope: ["rules_passage"])`                                                   | Remains an internal adapter over `searchRules()`   |
+| `search_cards`    | `search_knowledge(query, scope: ["card"])`                                                            | Remains an internal adapter over `searchCards()`   |
+| `list_card_types` | `inspect_sources()` and `schema("card_type")`                                                         | Remains an internal adapter over `listCardTypes()` |
+| `list_cards`      | `search_knowledge(query, scope: ["card"], filters)` or `open_entity(card-type ref)` for type browsing | Remains an internal adapter over `listCards()`     |
+| `get_card`        | `open_entity(card ref)`                                                                               | Remains an internal adapter over `getCard()`       |
+| `find_scenario`   | `resolve_entity(query, kinds: ["scenario"])`                                                          | Remains an internal adapter over `findScenario()`  |
+| `get_scenario`    | `open_entity(scenario ref)`                                                                           | Remains an internal adapter over `getScenario()`   |
+| `get_section`     | `open_entity(section ref)`                                                                            | Remains an internal adapter over `getSection()`    |
+| `follow_links`    | `neighbors(ref, relation)`                                                                            | Remains an internal adapter over `followLinks()`   |
+
+Migration sequence:
+
+1. Add shared contract types and ref parsing.
+2. Add new tools beside old tools in agent and MCP surfaces.
+3. Update the agent prompt to prefer the new contract and remove routing
+   choreography.
+4. Keep old tools registered until evals show parity.
+5. Hide or retire old public names only after MCP and REST callers have a
+   compatibility window.
+
+## MCP and REST Compatibility
+
+MCP:
+
+- MCP may expose `squire_*` names beside old tools during migration.
+- Output stays JSON text content for MCP clients, but the JSON payload follows
+  the schemas above.
+- `isError` is reserved for transport or execution errors. Domain misses return
+  `ok: false` inside the JSON payload so the agent can reason about them.
+- Tool descriptions should point callers to `inspect_sources()` and `schema()`
+  instead of embedding long source lists in every description.
+- Tool descriptions should read like instructions to a new teammate: what the
+  tool does, when to use it, what inputs are valid, and what to do after common
+  failures.
+- The production MCP endpoint remains remote and OAuth-protected, but MCP is a
+  secondary direct-tool channel. The primary product entry point remains the
+  ask-question agent path.
+
+REST:
+
+- REST callers can use the same contract through future `/api/knowledge/*`
+  routes or through `/api/ask` indirectly.
+- REST responses should use the same JSON shapes as MCP payloads.
+- Old REST endpoints stay stable unless a later issue explicitly replaces them.
+
+Claude SDK agent loop:
+
+- Anthropic tool schemas should be generated from, or at least tested against,
+  the same contract definitions used by MCP registration.
+- `AGENT_SYSTEM_PROMPT` should stop listing tool order rules once the new tools
+  are available.
+
+Client context efficiency:
+
+- Future MCP clients should load Squire tool definitions on demand when client
+  tool search is available.
+- Complex result filtering should happen in code when the caller has a code
+  sandbox, with only the final relevant refs and snippets returned to model
+  context.
+- Squire may later ship a companion skill for MCP clients that explains common
+  Frosthaven workflows, but the tool contract itself must stand without that
+  skill.
+
+## Shorter Prompt Target
+
+Target prompt shape:
+
+```text
+You answer Frosthaven questions from Squire's knowledge sources.
+
+Use the knowledge tools to inspect available sources, resolve user language into
+canonical refs, open exact records, search broadly when the question is fuzzy,
+and traverse related records when an opened entity points somewhere else.
+
+Ground claims in retrieved data. Cite sources. Say when Squire does not have
+enough information. Do not invent rules, stats, item numbers, or scenario text.
+```
+
+The prompt should not need to say:
+
+- use `find_scenario` before `get_scenario`
+- use `follow_links` after scenario conclusions
+- use `search_rules` for fuzzy book questions
+- use `list_card_types` before browsing card records
+- use `get_card` only after discovering a source ID
+
+Those behaviors should be implied by the contract:
+
+- resolve before exact open
+- open exact refs
+- search fuzzy text
+- traverse neighbors
+- inspect schemas when unsure
+
+## Eval Questions
+
+These should pass without route-specific prompt instructions once SQR-117 and
+SQR-118 implement the contract. The suite must include both training prompts
+used during tool-description tuning and held-out prompts that are not inspected
+until the contract is ready for removal of old prompt choreography.
+
+1. "What sources can you inspect for Frosthaven, and which ones can you open
+   exactly?"
+2. "Show the section I should read at the conclusion of scenario 61."
+3. "Starting from section 103.1, follow the next two read-now links and tell me
+   where I end up."
+4. "What does item 1 do, and what source ID did you use to open it?"
+5. "What are the rules for Brittle? Quote or cite the source you used."
+6. "Find Algox Archer records, then open the best matching monster stat record."
+7. "What scenarios or sections are directly related to scenario 61?"
+8. "I know there is a locked scenario from section 66.2. What scenario ref does
+   that section unlock?"
+9. "For scenario 61, find the conclusion section, open it, and list any
+   scenarios or sections it unlocks or points to next."
+10. "A player asks about Brittle during scenario 61. Answer the rule question,
+    cite the rule source, and mention whether the scenario/section books were
+    needed."
+11. "Find the Algox Archer monster stat record, then search for any ability or
+    card records that mention Algox Archer and explain which records are exact
+    data versus fuzzy matches."
+12. "Resolve section 67.1 in Frosthaven and then try the same bare legacy ref
+    with an explicit Gloomhaven 2 game. The second path should reject or require
+    a canonical game-qualified ref."
+
+Passing behavior:
+
+- The agent calls discovery or schema tools when it does not know the source
+  shape.
+- The agent resolves user language into refs before opening exact records.
+- The agent traverses neighbor refs instead of guessing links from prose.
+- Answers include citations or source labels.
+- Ambiguous names produce candidates or a clarification, not a silent guess.
+
+Evaluation harness requirements:
+
+- Run these as programmatic agent loops against the actual tool schemas, not as
+  static prompt snapshots.
+- Track answer correctness, tool calls, tool errors, runtime, and token use.
+- Keep a held-out set so tool descriptions are not tuned only to these exact
+  prompts.
+- Include multi-step tasks that need several calls; single-call toy prompts are
+  not enough to prove the contract works.
+- Run an A/B before prompt choreography is removed:
+  - A: current production prompt and old tools
+  - B: shortened prompt and new contract tools
+- B must match or beat A on answer correctness for existing production evals and
+  the SQR-116 held-out set.
+- B may use fewer or different tool calls, but it must not increase median tool
+  errors or p95 runtime by more than 25%.
+- The eval report must name every regression and either fix it before migration
+  or file a blocking follow-up issue.
+- Include parity cases for the current rules evals, including the
+  `rule-looting-definition` class of questions that previously caught repeated
+  broad-search behavior.
+
+## Implementation Notes For SQR-117 And SQR-118
+
+- Put contract definitions in a shared module before wiring MCP or Anthropic
+  schemas.
+- Implement one ref parser from the grammar in this document. Do not parse refs
+  separately in individual tools.
+- Add ref parsing and normalization tests first, including path segments that
+  contain colons and slashes from GHS source IDs.
+- Test legacy ref compatibility separately from canonical ref behavior, and keep
+  the legacy allowlist closed.
+- Implement one active kind/relation registry behind `inspect_sources()` and
+  `schema(kind)`. Do not duplicate closed kind or relation enums in each tool.
+- Keep old tool handlers as private adapters until evals pass.
+- Decide MCP projected names separately from internal agent tool names.
+- Add `responseFormat`, `limit`, and actionable error hints before broadening
+  the result payloads.
+- Define the broad-search fan-out and latency tests before implementing
+  `search_knowledge`.
+- Add parity tests that old-tool-backed data and new-tool outputs agree for
+  scenario 61, section 67.1, item 1, and a rulebook search hit.
+- Add eval cases from this document to the eval suite before removing prompt
+  choreography.

--- a/docs/KNOWLEDGE_TOOL_CONTRACT.md
+++ b/docs/KNOWLEDGE_TOOL_CONTRACT.md
@@ -113,17 +113,17 @@ the same shared contract definitions.
 
 ## Entity Kinds
 
-| Kind            | Meaning                                                                                              | Current source                              | Ref examples                                                    |
-| --------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------- | --------------------------------------------------------------- |
-| `source`        | A knowledge source such as a rulebook, section book, card database, or future campaign record store  | Source metadata                             | `source:frosthaven/rulebook`, `source:frosthaven/cards`         |
-| `rules_passage` | A semantic book-search passage from indexed PDFs                                                     | `searchRules()`                             | `rules:frosthaven/fh-rule-book.pdf#chunk=123`                   |
-| `scenario`      | A scenario-book scenario record                                                                      | `findScenario()`, `getScenario()`           | `scenario:frosthaven/061`, `scenario:gloomhavensecretariat/061` |
-| `section`       | A section-book section record                                                                        | `getSection()`                              | `section:frosthaven/67.1`                                       |
-| `card_type`     | A category of structured GHS card data                                                               | `listCardTypes()`                           | `card-type:frosthaven/items`                                    |
-| `card`          | A structured card, item, monster, event, building, scenario, ability, battle goal, or personal quest | `searchCards()`, `listCards()`, `getCard()` | `card:frosthaven/items/gloomhavensecretariat:item/1`            |
-| `campaign`      | Future campaign state                                                                                | Future Phase 4 data                         | `campaign:frosthaven/<campaign-id>`                             |
-| `character`     | Future character state                                                                               | Future Phase 4 data                         | `character:frosthaven/<character-id>`                           |
-| `party`         | Future party state                                                                                   | Future Phase 4 data                         | `party:frosthaven/<party-id>`                                   |
+| Kind            | Meaning                                                                                              | Current source                              | Ref examples                                            |
+| --------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------- |
+| `source`        | A knowledge source such as a rulebook, section book, card database, or future campaign record store  | Source metadata                             | `source:frosthaven/rulebook`, `source:frosthaven/cards` |
+| `rules_passage` | A semantic book-search passage from indexed PDFs                                                     | `searchRules()`                             | `rules:frosthaven/fh-rule-book.pdf#chunk=123`           |
+| `scenario`      | A scenario-book scenario record                                                                      | `findScenario()`, `getScenario()`           | `scenario:frosthaven/061`                               |
+| `section`       | A section-book section record                                                                        | `getSection()`                              | `section:frosthaven/67.1`                               |
+| `card_type`     | A category of structured GHS card data                                                               | `listCardTypes()`                           | `card-type:frosthaven/items`                            |
+| `card`          | A structured card, item, monster, event, building, scenario, ability, battle goal, or personal quest | `searchCards()`, `listCards()`, `getCard()` | `card:frosthaven/items/gloomhavensecretariat:item/1`    |
+| `campaign`      | Future campaign state                                                                                | Future Phase 4 data                         | `campaign:frosthaven/<campaign-id>`                     |
+| `character`     | Future character state                                                                               | Future Phase 4 data                         | `character:frosthaven/<character-id>`                   |
+| `party`         | Future party state                                                                                   | Future Phase 4 data                         | `party:frosthaven/<party-id>`                           |
 
 Refs are URL-safe strings with this formal shape:
 
@@ -474,6 +474,22 @@ Output schema:
   ]
 }
 ```
+
+`include` field meanings:
+
+- `citations` returns source attribution for facts in `entity.data`.
+- `links` returns explicit refs found in the opened record, such as scenario
+  conclusions, unlocks, anchors, or source-authored cross references.
+- `related` returns inferred nearby entities from indexes or relationship
+  expansion. It is useful for exploration, but answers should not treat it as a
+  source-authored link unless a follow-up `open_entity()` call provides
+  citations.
+- `raw` returns implementation metadata needed for debugging or migration, not
+  normal answer synthesis.
+
+`neighbors()` traverses the same explicit relationship graph exposed through
+`links`, but starts from a ref and can filter by relation without opening the
+full entity payload.
 
 Example:
 

--- a/docs/adr/0014-self-describing-knowledge-tool-contract.md
+++ b/docs/adr/0014-self-describing-knowledge-tool-contract.md
@@ -1,0 +1,112 @@
+---
+type: ADR
+id: '0014'
+title: 'Adopt a self-describing knowledge tool contract'
+status: active
+date: 2026-04-26
+---
+
+## Context
+
+Squire's current retrieval tools work, but the public shape is too tied to the
+first workflows that created them. The knowledge agent sees tools like
+`find_scenario`, `get_section`, `search_rules`, and `get_card`, then relies on
+the system prompt to explain when to call each one and in what order.
+
+That approach does not scale cleanly. Scenario and section lookup already need
+several prompt rules. Card lookup needs a different discovery path. Future
+campaign and character records would add more routing text. The result is a
+prompt that teaches tool choreography instead of answer quality.
+
+ADR 0013 keeps Phase 1 production on the current Hono, Postgres, Claude SDK,
+conversation-service, SSE, MCP, REST, Langfuse, and OpenTelemetry path while
+retrieval is redesigned. This decision must improve the retrieval contract
+without changing that production baseline.
+
+## Decision
+
+Squire will add a versioned, self-describing knowledge tool contract for the
+internal knowledge-agent loop. The product entry point remains an ask-question
+task through `/api/ask` and the in-process service boundary. The contract
+defines the retrieval tools the agent can use while answering.
+
+The contract is built around six intent-grouped operations:
+
+- `inspect_sources()`
+- `schema(kind)`
+- `resolve_entity(query, kinds?)`
+- `open_entity(ref)`
+- `search_knowledge(query, scope?, filters?)`
+- `neighbors(ref, relation?)`
+
+External MCP tool names may use a `squire_` prefix
+(`squire_inspect_sources`, `squire_open_entity`, and so on) so agents can
+distinguish Squire tools when many MCP servers are loaded. That is a projection
+detail for external direct-tool callers. The short operation names are the
+canonical internal agent contract.
+
+Every inspectable record gets a canonical ref with a formal parser contract.
+Active entity kinds and relations are discovered through the contract instead
+of copied into every tool schema. Reserved future kinds such as `campaign`,
+`character`, and `party` can appear when their sources become active.
+
+Result shapes will support concise and detailed response modes where payloads
+can grow large. Search and resolution default to concise output; exact opens
+default to detailed output. Errors include repair hints when the caller can fix
+the request. Broad search must define fan-out and latency budgets before old
+prompt choreography is removed.
+
+The old tools stay available as internal adapters during migration:
+
+- `search_rules`
+- `search_cards`
+- `list_card_types`
+- `list_cards`
+- `get_card`
+- `find_scenario`
+- `get_scenario`
+- `get_section`
+- `follow_links`
+
+The new contract is documented in
+[Self-Describing Knowledge Tool Contract](../KNOWLEDGE_TOOL_CONTRACT.md). The
+Claude SDK agent loop is the primary consumer. MCP and REST projections should
+reuse the same result shapes and failure semantics when they expose direct tool
+access.
+
+## Options Considered
+
+- **Option A, chosen: self-describing contract over the existing adapters.**
+  This keeps production stable, moves routing knowledge into tool affordances,
+  and gives SQR-117 and SQR-118 a clear target.
+- **Option B: keep the current nine public tools and keep improving prompt
+  routing.** This is lowest effort now, but every new source adds more prompt
+  text and more chances for the model to pick the wrong path.
+- **Option C: replace the nine tools with one large `ask_knowledge` or
+  `research` tool.** This hides routing from the model, but it also hides
+  inspection and traversal. The agent loses the ability to reason step by step
+  over exact refs.
+- **Option D: migrate to a new agent runtime first.** ADR 0013 rejects this for
+  Phase 1 until retrieval quality is measured. Runtime churn would mix the
+  variables.
+
+## Consequences
+
+- The system prompt can shrink toward role, answer quality, citations, and
+  honesty when data is missing.
+- MCP and REST direct-tool callers can reuse the same domain contract as the
+  Claude SDK agent loop without becoming the design center.
+- MCP clients may get namespaced Squire tools instead of generic names that
+  collide with other servers.
+- Tool outputs become more token-efficient because high-volume operations can
+  return concise context by default and detailed context on request.
+- SQR-117 and SQR-118 can implement the new tools incrementally while old
+  callers keep working.
+- Ref parsing, dynamic kind/relation validation, and result shapes become
+  load-bearing API surface and need direct tests.
+- Eval coverage must measure realistic multi-call tasks, tool errors, runtime,
+  token use, held-out prompts, and A/B parity against the current production
+  prompt before old prompt choreography is removed.
+- The contract reserves campaign and character refs before those sources exist,
+  so future work has a place to attach state without inventing another lookup
+  model.

--- a/docs/plans/sqr-116-self-describing-knowledge-contract-eng-review.md
+++ b/docs/plans/sqr-116-self-describing-knowledge-contract-eng-review.md
@@ -1,0 +1,230 @@
+# SQR-116 Eng Review: Self-Describing Knowledge Tool Contract
+
+**Issue:** SQR-116  
+**Branch:** `bcm/sqr-116-design-the-self-describing-knowledge-tool-contract`  
+**Date:** 2026-04-26  
+**Status:** Clean, proceed to implementation
+
+## Scope
+
+Design the next knowledge-tool contract so Squire can expose discovery,
+resolution, opening, search, and graph traversal without teaching the model a
+long choreography prompt.
+
+The implementation for this issue is documentation only:
+
+- write the checked-in tool contract
+- link it from architecture docs
+- capture the contract decision in an ADR
+- define eval questions for later implementation tickets
+
+## Step 0: Scope Challenge
+
+Scope accepted as-is.
+
+The ticket should not implement tools yet. SQR-117 and SQR-118 are already
+blocked by this issue and should consume the contract after it lands.
+
+## Architecture Review
+
+No blocking issues, moving on.
+
+The right architecture is a versioned contract over the existing retrieval
+surfaces:
+
+```text
+Ask-question entry point
+/api/ask or in-process service call
+  |
+  v
+Knowledge agent
+  |
+  v
+self-describing internal tools
+  |
+  +-- inspect_sources()
+  +-- schema(kind)
+  +-- resolve_entity(...)
+  +-- open_entity(ref)
+  +-- search_knowledge(...)
+  +-- neighbors(ref, ...)
+  |
+  v
+existing adapters
+  |
+  +-- searchRules()
+  +-- findScenario() / getScenario() / getSection() / followLinks()
+  +-- searchCards() / listCardTypes() / listCards() / getCard()
+
+Optional external MCP projection:
+  inspect_sources() -> squire_inspect_sources()
+  open_entity(ref) -> squire_open_entity(ref)
+```
+
+The contract should preserve ADR 0013: the current Hono, Postgres + pgvector,
+Claude SDK loop, conversation service, SSE, MCP, REST, Langfuse, and
+OpenTelemetry path remains the production baseline during the redesign.
+
+Anthropic's agent-tool guidance changes the plan in four concrete ways:
+
+- expose a few intent-grouped tools instead of mirroring every existing
+  endpoint
+- add `responseFormat`, `limit`, and truncation hints so search and traversal do
+  not dump low-value context into the model
+- return actionable validation errors, not bare error codes
+- prove the contract with realistic multi-call evals, held-out prompts, and an
+  A/B against the current production prompt before removing prompt choreography
+
+Anthropic's MCP production guidance applies only to the optional external MCP
+projection. It should not drive the internal agent tool names. If Squire exposes
+the new tools directly over MCP, `squire_` names are reasonable there.
+
+## Code Quality Review
+
+No blocking issues, moving on.
+
+The main quality requirement is to avoid duplicating schemas separately in
+`src/agent.ts` and `src/mcp.ts` when implementation begins. SQR-117 should add
+shared contract definitions once, then adapt both Anthropic tool schemas and MCP
+schemas from the same source where practical.
+
+The shared definitions must include the ref parser, active kind registry, and
+relation registry. Tool input schemas should validate kind and relation strings
+against `inspect_sources()` / `schema(kind)` rather than duplicating closed enum
+lists across tools.
+
+Tool descriptions should read like instructions to a new teammate: what the
+tool does, when to use it, what inputs are valid, what comes back, and what to
+try after a recoverable failure.
+
+## Test Review
+
+The review target is a documentation feature, but the implementation tickets
+need test coverage for every contract path.
+
+```text
+CODE PATHS                                            USER FLOWS
+[+] docs contract                                     [+] Agent asks "what can I inspect?"
+  +-- [GAP] inspect_sources examples                    +-- [GAP] [->EVAL] discovers sources without prompt choreography
+  +-- [GAP] schema(kind) examples                       +-- [GAP] [->EVAL] asks for scenario 61 and opens exact records
+  +-- [GAP] resolve_entity examples                     +-- [GAP] [->EVAL] asks for a card by name and resolves sourceId
+  +-- [GAP] open_entity examples                        +-- [GAP] [->EVAL] follows scenario conclusion links
+  +-- [GAP] search_knowledge examples                   +-- [GAP] [->EVAL] mixes fuzzy rules search with exact refs
+  +-- [GAP] neighbors examples                          +-- [GAP] [->EVAL] asks what can be inspected next
+
+COVERAGE: 0/12 paths tested (0%) before implementation
+QUALITY: gaps are expected because SQR-116 is the design source for SQR-117/SQR-118
+```
+
+SQR-116 must include multi-step eval questions in the contract doc. SQR-117 and
+SQR-118 must turn those into actual eval cases, plus unit tests for shared
+schemas, ref parsing, adapter dispatch, not-found behavior, dynamic
+kind/relation validation, and MCP registration.
+
+The eval harness should record answer correctness, tool-call count, tool errors,
+runtime, and token use. It should avoid overfitting by keeping held-out prompts
+that are not used while tuning descriptions. Before migration, it must compare
+the current production prompt plus old tools against the shortened prompt plus
+new contract tools and block removal of old choreography on any unexplained
+answer-quality regression.
+
+## Performance Review
+
+No blocking issues, moving on.
+
+The contract should keep result payloads bounded by default and make high-volume
+expansion explicit:
+
+- `search_knowledge` defaults to a small top-K result set.
+- `open_entity` returns one entity by canonical ref, not arbitrary fan-out.
+- `neighbors` returns relation summaries and refs, not full recursively opened
+  entities.
+- `inspect_sources` and `schema` are static or cheap metadata calls.
+- high-volume tools accept `responseFormat: "concise" | "detailed"` and return
+  `truncated: true` with a repair hint when output is capped.
+- `search_knowledge` must define per-scope fan-out and latency budgets before
+  implementation, because broad search crosses pgvector and Postgres FTS.
+
+## NOT In Scope
+
+- Implementing the new tools in `src/tools.ts`: deferred to SQR-117 and SQR-118.
+- Replacing the production agent loop: forbidden by ADR 0013 until the Step 3
+  eval report.
+- Removing old tools from MCP: old names stay as adapters during migration.
+- Campaign-state implementation: only reserve refs and kinds for future campaign
+  records.
+- UI changes to consulted-source chips: no user-visible web changes in SQR-116.
+
+## What Already Exists
+
+- `src/tools.ts` already contains data access primitives for rules passages,
+  scenarios, sections, references, and card records.
+- `src/mcp.ts` already exposes those primitives over MCP.
+- `src/agent.ts` already exposes those primitives to the Claude SDK tool loop,
+  but it carries too much routing logic in `AGENT_SYSTEM_PROMPT`.
+- `docs/ARCHITECTURE.md` already describes atomic tools and the production
+  baseline.
+- `docs/adr/0013-phase-1-production-agent-baseline.md` already constrains this
+  work to retrieval-surface changes, not runtime migration.
+
+## Failure Modes
+
+| Codepath           | Production failure                                          | Test?   | Handling?                                     | User impact                             |
+| ------------------ | ----------------------------------------------------------- | ------- | --------------------------------------------- | --------------------------------------- |
+| `resolve_entity`   | Ambiguous name resolves the wrong card or scenario          | SQR-117 | Must return candidates, not guess             | Wrong rule answer with false confidence |
+| `open_entity`      | Unknown ref returns empty text instead of a structured miss | SQR-117 | Must return not-found with expected ref shape | Agent keeps searching blindly           |
+| `neighbors`        | Recursive traversal explodes into too much context          | SQR-118 | Must cap and expose pagination or limits      | Slow answer, noisy prompt               |
+| `schema`           | Tool schema drifts from runtime output                      | SQR-117 | Shared definitions plus tests                 | MCP callers parse stale docs            |
+| `search_knowledge` | Search result lacks citations/source labels                 | SQR-118 | Result shape requires citations               | User cannot verify answer               |
+| MCP projection     | Generic MCP names collide with another server's tools       | SQR-117 | Consider `squire_` only on MCP surface        | External agent picks the wrong source   |
+| Ref parser         | Canonical and legacy refs parse differently across tools    | SQR-117 | One parser, explicit legacy allowlist         | Agent opens the wrong game/source       |
+| Dynamic validation | New kinds or relations require editing multiple schemas     | SQR-117 | Validate against discovered registries        | Contract stops being self-describing    |
+
+Critical silent gaps: none for this docs-only issue. The implementation tickets
+must not ship with any silent not-found or ambiguous-resolution path.
+
+## Worktree Parallelization Strategy
+
+Sequential implementation, no parallelization opportunity for SQR-116.
+
+Follow-on implementation can split:
+
+| Step                               | Modules touched                                       | Depends on          |
+| ---------------------------------- | ----------------------------------------------------- | ------------------- |
+| SQR-117 source/schema/resolve/open | `src/tools.ts`, `src/mcp.ts`, `src/agent.ts`, `test/` | SQR-116             |
+| SQR-118 search/neighbors           | `src/tools.ts`, `src/mcp.ts`, `src/agent.ts`, `test/` | SQR-117             |
+| eval conversion                    | `eval/`, `test/fixtures/`                             | SQR-117 and SQR-118 |
+
+Execution order: finish SQR-116, then SQR-117, then SQR-118 plus eval work.
+
+## TODO Candidates
+
+No separate `TODOS.md` items proposed. The work is already tracked by SQR-117
+and SQR-118.
+
+## Completion Summary
+
+- Step 0: Scope Challenge: scope accepted as-is
+- Architecture Review: 0 issues found
+- Code Quality Review: 0 issues found
+- Test Review: diagram produced, 12 planned implementation gaps identified
+- Performance Review: 0 issues found
+- NOT in scope: written
+- What already exists: written
+- TODOS.md updates: 0 items proposed
+- Failure modes: 0 critical gaps flagged for SQR-116 docs-only scope
+- Outside voice: skipped
+- Parallelization: sequential for SQR-116
+- Lake Score: 1/1 recommendations chose complete option
+
+## GSTACK REVIEW REPORT
+
+| Review        | Trigger               | Why                        | Runs | Status  | Findings                                   |
+| ------------- | --------------------- | -------------------------- | ---- | ------- | ------------------------------------------ |
+| CEO Review    | `/plan-ceo-review`    | Scope and strategy         | 0    | not run | Not required for docs-only contract design |
+| Codex Review  | `/codex review`       | Independent second opinion | 0    | not run | Not required before first draft            |
+| Eng Review    | `/plan-eng-review`    | Architecture and tests     | 1    | clean   | Proceed with documentation implementation  |
+| Design Review | `/plan-design-review` | UI/UX gaps                 | 0    | not run | No visual scope                            |
+| DX Review     | `/plan-devex-review`  | Developer experience gaps  | 0    | not run | MCP/REST caller DX covered in contract     |
+
+Plan status: eng review cleared.


### PR DESCRIPTION
## Summary

- Adds a checked-in self-describing knowledge tool contract for Squire's internal knowledge-agent loop.
- Records ADR 0014 for the contract decision and migration approach.
- Adds the SQR-116 eng-review artifact with scope, test, failure-mode, and follow-on implementation guidance.
- Links the contract and ADR from `docs/ARCHITECTURE.md`.

## Validation

- `npm run check` passed
  - typecheck passed
  - eslint passed
  - stylelint passed
  - markdownlint passed
  - prettier check passed
  - vitest: 51 files passed, 862 tests passed
- Fresh markdown lint after commit hook formatting: `npm run lint:md -- docs/KNOWLEDGE_TOOL_CONTRACT.md docs/adr/0014-self-describing-knowledge-tool-contract.md docs/plans/sqr-116-self-describing-knowledge-contract-eng-review.md docs/ARCHITECTURE.md` passed with 0 errors
- Pre-landing review: clean, 0 findings

## Notes

- Docs-only change. No runtime code paths changed.
- No frontend files changed, design review skipped.
- No `VERSION` or `CHANGELOG.md` change per Squire shipping guidance for ordinary feature PRs.

Fixes SQR-116


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture docs to v1.0.10 with expanded retrieval/agent guidance.
  * Added a standardized knowledge-tool contract describing six intent-based operations, canonical refs, responseFormat modes, error semantics with repair hints, and migration notes.
  * Created an ADR formalizing the contract, namespacing guidance, and transition consequences.
  * Added engineering review and test/eval plans for staged implementation and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->