### PR TITLE
feat(agent): add knowledge discovery tools

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -51,7 +51,7 @@ for searching the indexed Frosthaven books and looking up card data. Use the too
 
 Guidelines:
 - Use inspect_sources and schema when you need to discover available kinds, filters, refs, or relations
-- Use resolve_entity to turn natural references into canonical scenario, section, card type, or card refs
+- Use resolve_entity to turn natural references into opener-ready scenario, section, card type, or card refs
 - Use find_scenario when the user names a scenario number or scenario title
 - Use get_scenario once you know the exact canonical scenario ref
 - Use get_section for exact section refs or when a traversal link points to a section
@@ -107,7 +107,7 @@ export const AGENT_TOOLS = [
   {
     name: 'resolve_entity',
     description:
-      'Resolve natural references like "scenario 61", "section 90.2", "Spyglass", or "Blinkblade level 4 cards" to ranked canonical entity refs.',
+      'Resolve natural references like "scenario 61", "section 90.2", "Spyglass", or "Blinkblade level 4 cards" to ranked opener-ready entity refs.',
     input_schema: {
       type: 'object',
       properties: {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -11,6 +11,9 @@ import {
   listCardTypes,
   listCards,
   getCard,
+  inspectSources,
+  getSchema,
+  resolveEntity,
   findScenario,
   getScenario,
   getSection,
@@ -47,6 +50,8 @@ export const AGENT_SYSTEM_PROMPT = `You are a knowledgeable Frosthaven rules ass
 for searching the indexed Frosthaven books and looking up card data. Use the tools to find relevant information before answering.
 
 Guidelines:
+- Use inspect_sources and schema when you need to discover available kinds, filters, refs, or relations
+- Use resolve_entity to turn natural references into canonical scenario, section, card type, or card refs
 - Use find_scenario when the user names a scenario number or scenario title
 - Use get_scenario once you know the exact canonical scenario ref
 - Use get_section for exact section refs or when a traversal link points to a section
@@ -74,6 +79,52 @@ Formatting:
 // extending the label map is a typecheck error, so the consulted-sources
 // footer can never silently drop a tool.
 export const AGENT_TOOLS = [
+  {
+    name: 'inspect_sources',
+    description:
+      'Discover available Frosthaven knowledge sources, entity kinds, relation kinds, and live record counts before choosing a lookup tool.',
+    input_schema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'schema',
+    description:
+      'Inspect fields, filters, ref patterns, examples, and relations for a source kind returned by inspect_sources.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        kind: {
+          type: 'string',
+          description: 'Entity kind or common alias, such as card, item, scenario, or section',
+        },
+      },
+      required: ['kind'],
+    },
+  },
+  {
+    name: 'resolve_entity',
+    description:
+      'Resolve natural references like "scenario 61", "section 90.2", "Spyglass", or "Blinkblade level 4 cards" to ranked canonical entity refs.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Natural-language entity reference' },
+        kinds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional kind filters returned by inspect_sources, plus common aliases',
+        },
+        limit: {
+          type: 'integer',
+          description: 'Maximum candidates (default 6)',
+          default: 6,
+        },
+      },
+      required: ['query'],
+    },
+  },
   {
     name: 'search_rules',
     description:
@@ -231,6 +282,27 @@ export async function executeToolCall(
   input: Record<string, unknown>,
 ): Promise<ToolCallResult> {
   switch (name) {
+    case 'inspect_sources': {
+      return { content: JSON.stringify(await inspectSources(), null, 2) };
+    }
+    case 'schema': {
+      return { content: JSON.stringify(getSchema(input.kind as string), null, 2) };
+    }
+    case 'resolve_entity': {
+      const kinds = Array.isArray(input.kinds)
+        ? input.kinds.filter((kind): kind is string => typeof kind === 'string')
+        : undefined;
+      return {
+        content: JSON.stringify(
+          await resolveEntity(input.query as string, {
+            kinds,
+            limit: input.limit as number | undefined,
+          }),
+          null,
+          2,
+        ),
+      };
+    }
     case 'search_rules': {
       const results = await searchRules(
         input.query as string,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -274,6 +274,12 @@ export interface ToolCallResult {
   sourceBooks?: string[];
 }
 
+const DISCOVERY_ONLY_TOOL_NAMES = new Set<AgentToolName>([
+  'inspect_sources',
+  'schema',
+  'resolve_entity',
+]);
+
 /**
  * Execute a single tool call and return the result content plus any per-result
  * provenance metadata. For search_rules, `sourceBooks` carries the distinct
@@ -480,7 +486,7 @@ export async function runAgentLoop(question: string, options?: AskOptions): Prom
         if (block.type === 'tool_use') {
           if (block.name === 'search_rules') {
             broadRuleSearches += 1;
-          } else {
+          } else if (!DISCOVERY_ONLY_TOOL_NAMES.has(block.name as AgentToolName)) {
             hasUsedNonRuleSearchTool = true;
           }
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -60,7 +60,8 @@ Guidelines:
 - Prefer explicit scenario/section references over search_rules when the question already names a scenario number, scenario title, or section ref
 - Use search_rules for fuzzy book-corpus questions (rules, mechanics, open-ended discovery, or when traversal runs out)
 - Use search_cards for questions about specific cards, monsters, items, or abilities
-- Use get_card for precise lookups when you know the card type and name/number
+- Use get_card for precise lookups only when you know the card type and canonical sourceId
+- If you only know a natural card reference such as a name or number, use resolve_entity, search_cards, or list_cards first to find the canonical sourceId
 - Use list_card_types to discover what data is available
 - Use list_cards to browse or filter cards of a specific type
 - You may call multiple tools or call the same tool multiple times to gather enough context
@@ -118,7 +119,9 @@ export const AGENT_TOOLS = [
         },
         limit: {
           type: 'integer',
-          description: 'Maximum candidates (default 6)',
+          minimum: 1,
+          maximum: 20,
+          description: 'Maximum candidates (1-20, default 6)',
           default: 6,
         },
       },

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -73,7 +73,7 @@ export function createMcpServer(): McpServer {
     'resolve_entity',
     {
       description:
-        'Resolve natural references like "scenario 61", "section 90.2", "Spyglass", or "Blinkblade level 4 cards" to ranked canonical entity refs.',
+        'Resolve natural references like "scenario 61", "section 90.2", "Spyglass", or "Blinkblade level 4 cards" to ranked opener-ready entity refs.',
       inputSchema: {
         query: z.string().describe('Natural-language entity reference'),
         kinds: z

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -13,6 +13,9 @@ import {
   listCardTypes,
   listCards,
   getCard,
+  inspectSources,
+  getSchema,
+  resolveEntity,
   findScenario,
   getScenario,
   getSection,
@@ -30,6 +33,61 @@ export function createMcpServer(): McpServer {
     name: 'squire',
     version: '0.1.0',
   });
+
+  // ─── inspect_sources ──────────────────────────────────────────────────────
+
+  server.registerTool(
+    'inspect_sources',
+    {
+      description:
+        'Discover available Frosthaven knowledge sources, entity kinds, relation kinds, and live record counts before choosing a lookup tool.',
+    },
+    async () => {
+      const result = await inspectSources();
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ─── schema ───────────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'schema',
+    {
+      description:
+        'Inspect fields, filters, ref patterns, examples, and relations for a source kind returned by inspect_sources.',
+      inputSchema: {
+        kind: z
+          .string()
+          .describe('Entity kind or common alias, such as card, item, scenario, or section'),
+      },
+    },
+    async ({ kind }) => {
+      const result = getSchema(kind);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // ─── resolve_entity ───────────────────────────────────────────────────────
+
+  server.registerTool(
+    'resolve_entity',
+    {
+      description:
+        'Resolve natural references like "scenario 61", "section 90.2", "Spyglass", or "Blinkblade level 4 cards" to ranked canonical entity refs.',
+      inputSchema: {
+        query: z.string().describe('Natural-language entity reference'),
+        kinds: z
+          .array(z.string())
+          .optional()
+          .describe('Optional kind filters returned by inspect_sources, plus common aliases'),
+        limit: z.number().int().min(1).max(20).default(6).describe('Maximum candidates'),
+      },
+    },
+    async ({ query, kinds, limit }) => {
+      const result = await resolveEntity(query, { kinds, limit });
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
 
   // ─── search_rules ──────────────────────────────────────────────────────────
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -11,11 +11,16 @@ import { countsByType, load, loadOne, searchExtractedRanked, TYPES } from './ext
 import type { CardType } from './schemas.ts';
 import {
   findScenarios,
+  getScenarioSectionBooksBootstrapStatus,
   getScenario as loadScenario,
   getSection as loadSection,
   followReferences as loadReferences,
 } from './scenario-section-data.ts';
-import type { BookRecordKind, BookReferenceType } from './scenario-section-schemas.ts';
+import {
+  BOOK_REFERENCE_TYPES,
+  type BookRecordKind,
+  type BookReferenceType,
+} from './scenario-section-schemas.ts';
 
 // ─── Result types ────────────────────────────────────────────────────────────
 
@@ -72,6 +77,83 @@ export interface ReferenceResult {
   sequence: number;
 }
 
+export interface InspectSourcesResult {
+  ok: true;
+  games: Array<{ id: string; label: string; default: boolean }>;
+  sources: SourceInfo[];
+  defaultGame: string;
+  warnings?: string[];
+}
+
+export interface SourceInfo {
+  ref: string;
+  label: string;
+  kinds: KnowledgeKind[];
+  searchable: boolean;
+  openable: boolean;
+  relations: string[];
+  counts?: Record<string, number>;
+  freshness?: Record<string, string | number>;
+}
+
+export type KnowledgeKind = 'rules_passage' | 'scenario' | 'section' | 'card_type' | 'card';
+
+export interface SchemaField {
+  name: string;
+  type: string;
+  description: string;
+}
+
+export type SchemaResult =
+  | {
+      ok: true;
+      kind: KnowledgeKind;
+      refPattern: string;
+      fields: SchemaField[];
+      filterFields: string[];
+      relations: string[];
+      examples: Array<{ label: string; ref: string }>;
+      aliases?: string[];
+    }
+  | {
+      ok: false;
+      error: 'unknown_kind';
+      kind: string;
+      hint: string;
+    };
+
+export interface EntityResolutionOptions extends ToolOpts {
+  kinds?: string[];
+  limit?: number;
+}
+
+export interface EntityCandidate {
+  entity: {
+    kind: KnowledgeKind;
+    ref: string;
+    title: string;
+    source: string;
+    sourceLabel: string;
+    data?: Record<string, unknown>;
+  };
+  confidence: number;
+  matchReason: string;
+}
+
+export type EntityResolutionResult =
+  | {
+      ok: true;
+      query: string;
+      candidates: EntityCandidate[];
+    }
+  | {
+      ok: false;
+      error: 'invalid_filter';
+      query: string;
+      hint: string;
+      candidates: [];
+    };
+
 interface ToolOpts {
   /** Campaign variant. Defaults to 'frosthaven'. Reserved for Phase 2. */
   game?: string;
@@ -86,6 +168,287 @@ function stripInternalKeys(record: Record<string, unknown>): Record<string, unkn
     if (!key.startsWith('_')) out[key] = value;
   }
   return out;
+}
+
+const DEFAULT_GAME = 'frosthaven';
+const GAME_INFO = { id: DEFAULT_GAME, label: 'Frosthaven', default: true };
+
+const CARD_KIND_ALIASES: Record<string, CardType[]> = {
+  item: ['items'],
+  items: ['items'],
+  monster: ['monster-stats', 'monster-abilities'],
+  monsters: ['monster-stats', 'monster-abilities'],
+  'monster-stat': ['monster-stats'],
+  'monster-stats': ['monster-stats'],
+  'monster-ability': ['monster-abilities'],
+  'monster-abilities': ['monster-abilities'],
+  ability: ['character-abilities'],
+  abilities: ['character-abilities'],
+  'character-ability': ['character-abilities'],
+  'character-abilities': ['character-abilities'],
+};
+
+const KIND_ALIASES: Record<string, KnowledgeKind> = {
+  rule: 'rules_passage',
+  rules: 'rules_passage',
+  rulebook: 'rules_passage',
+  passage: 'rules_passage',
+  scenario: 'scenario',
+  scenarios: 'scenario',
+  section: 'section',
+  sections: 'section',
+  card_type: 'card_type',
+  'card-type': 'card_type',
+  cardtype: 'card_type',
+  type: 'card_type',
+  card: 'card',
+  cards: 'card',
+  ...Object.fromEntries(Object.keys(CARD_KIND_ALIASES).map((alias) => [alias, 'card'])),
+};
+
+const ACTIVE_KINDS: KnowledgeKind[] = ['rules_passage', 'scenario', 'section', 'card_type', 'card'];
+
+const SCHEMAS: Record<KnowledgeKind, Extract<SchemaResult, { ok: true }>> = {
+  rules_passage: {
+    ok: true,
+    kind: 'rules_passage',
+    refPattern: 'rules_passage:<game>/<source>#<chunk>',
+    fields: [
+      { name: 'text', type: 'string', description: 'Indexed book passage text' },
+      { name: 'sourceLabel', type: 'string', description: 'Human-readable book label' },
+      { name: 'score', type: 'number', description: 'Similarity score from vector search' },
+    ],
+    filterFields: ['game', 'source'],
+    relations: [],
+    examples: [{ label: 'Search loot rules', ref: 'rules_passage:frosthaven/rulebook#0' }],
+    aliases: ['rule', 'rules', 'rulebook', 'passage'],
+  },
+  scenario: {
+    ok: true,
+    kind: 'scenario',
+    refPattern: 'scenario:<game>/<scenario-ref>',
+    fields: [
+      { name: 'scenarioIndex', type: 'string', description: 'Printed scenario number or code' },
+      { name: 'name', type: 'string', description: 'Scenario title' },
+      { name: 'complexity', type: 'number|null', description: 'Printed complexity value' },
+      { name: 'sourcePage', type: 'number|null', description: 'Printed PDF page' },
+    ],
+    filterFields: ['scenarioIndex', 'name', 'scenarioGroup', 'complexity'],
+    relations: [...BOOK_REFERENCE_TYPES],
+    examples: [
+      {
+        label: 'Open scenario 61',
+        ref: 'scenario:frosthaven/gloomhavensecretariat:scenario/061',
+      },
+    ],
+    aliases: ['scenario', 'scenarios'],
+  },
+  section: {
+    ok: true,
+    kind: 'section',
+    refPattern: 'section:<game>/<section-number>.<variant>',
+    fields: [
+      { name: 'text', type: 'string', description: 'Section prose' },
+      { name: 'sectionNumber', type: 'number', description: 'Section number before the dot' },
+      { name: 'sectionVariant', type: 'number', description: 'Section variant after the dot' },
+      { name: 'sourcePage', type: 'number', description: 'Printed PDF page' },
+    ],
+    filterFields: ['sectionNumber', 'sectionVariant'],
+    relations: [...BOOK_REFERENCE_TYPES],
+    examples: [{ label: 'Open section 67.1', ref: 'section:frosthaven/67.1' }],
+    aliases: ['section', 'sections'],
+  },
+  card_type: {
+    ok: true,
+    kind: 'card_type',
+    refPattern: 'card_type:<game>/<card-type>',
+    fields: [
+      { name: 'type', type: 'string', description: 'Card table/type key' },
+      { name: 'count', type: 'number', description: 'Available record count' },
+    ],
+    filterFields: ['type'],
+    relations: ['belongs_to_type'],
+    examples: [{ label: 'Open item card type', ref: 'card_type:frosthaven/items' }],
+    aliases: ['card-type', 'cardtype', 'type'],
+  },
+  card: {
+    ok: true,
+    kind: 'card',
+    refPattern: 'card:<game>/<card-type>/<source-id>',
+    fields: [
+      { name: 'sourceId', type: 'string', description: 'GHS source identifier' },
+      { name: 'name', type: 'string', description: 'Display name when present' },
+      { name: 'cardName', type: 'string', description: 'Ability card name when present' },
+      { name: 'type', type: 'string', description: 'Card type/table key' },
+    ],
+    filterFields: ['type', 'name', 'cardName', 'level', 'class', 'number'],
+    relations: ['belongs_to_type'],
+    examples: [{ label: 'Open item 1', ref: 'card:frosthaven/items/gloomhavensecretariat:item/1' }],
+    aliases: Object.keys(CARD_KIND_ALIASES),
+  },
+};
+
+function normalizeKind(kind: string): KnowledgeKind | null {
+  return KIND_ALIASES[kind.trim().toLowerCase()] ?? null;
+}
+
+function cardTypesForKinds(kinds?: string[]): CardType[] {
+  if (!kinds || kinds.length === 0) return [...TYPES];
+  const out = new Set<CardType>();
+  for (const kind of kinds) {
+    const normalized = kind.trim().toLowerCase();
+    if (normalized === 'card' || normalized === 'cards') {
+      for (const type of TYPES) out.add(type);
+    }
+    if ((TYPES as readonly string[]).includes(normalized)) out.add(normalized as CardType);
+    for (const type of CARD_KIND_ALIASES[normalized] ?? []) out.add(type);
+  }
+  return [...out];
+}
+
+function canonicalScenarioRef(game: string, ref: string): string {
+  return `scenario:${game}/${ref}`;
+}
+
+function canonicalSectionRef(game: string, ref: string): string {
+  return `section:${game}/${ref}`;
+}
+
+function canonicalCardRef(game: string, type: CardType, sourceId: string): string {
+  return `card:${game}/${type}/${sourceId}`;
+}
+
+function displayTitleForCard(record: Record<string, unknown>, type: CardType): string {
+  if (typeof record.name === 'string') return record.name;
+  if (typeof record.cardName === 'string') return record.cardName;
+  if (typeof record.monsterType === 'string') return record.monsterType;
+  if (typeof record.sourceId === 'string') return record.sourceId;
+  return type;
+}
+
+function cardMatchConfidence(
+  query: string,
+  record: Record<string, unknown>,
+  type: CardType,
+): number {
+  const normalizedQuery = query.trim().toLowerCase();
+  const displayTitle = displayTitleForCard(record, type).toLowerCase();
+  if (displayTitle === normalizedQuery) return 0.98;
+  const names = [record.name, record.cardName, record.monsterType, record.sourceId]
+    .filter((v): v is string => typeof v === 'string')
+    .map((v) => v.toLowerCase());
+  if (names.some((name) => name === normalizedQuery)) return 0.9;
+  if (names.some((name) => normalizedQuery.includes(name) || name.includes(normalizedQuery))) {
+    return 0.86;
+  }
+  return 0.68;
+}
+
+function cardMatchReason(query: string, record: Record<string, unknown>, type: CardType): string {
+  const normalizedQuery = query.trim().toLowerCase();
+  const displayTitle = displayTitleForCard(record, type).toLowerCase();
+  if (displayTitle === normalizedQuery) return 'Exact card name';
+  const names = [record.name, record.cardName, record.monsterType, record.sourceId]
+    .filter((v): v is string => typeof v === 'string')
+    .map((v) => v.toLowerCase());
+  return names.some((name) => name === normalizedQuery)
+    ? 'Related card deck match'
+    : 'Card text match';
+}
+
+function extractLevelQuery(query: string): number | null {
+  const match = query.match(/\blevel\s+(\d+)\b/i);
+  return match ? Number(match[1]) : null;
+}
+
+async function resolveCards(
+  query: string,
+  cardTypes: CardType[],
+  limit: number,
+  opts: ToolOpts,
+): Promise<EntityCandidate[]> {
+  const game = opts.game ?? DEFAULT_GAME;
+  const level = extractLevelQuery(query);
+  const lowered = query.toLowerCase();
+  const candidates: EntityCandidate[] = [];
+
+  for (const type of cardTypes) {
+    const records = await load(type, opts);
+    for (const rawRecord of records) {
+      const record = stripInternalKeys(rawRecord);
+      if (level !== null && record.level !== level) continue;
+
+      const searchable = [
+        record.name,
+        record.cardName,
+        record.monsterType,
+        record.characterClass,
+        record.number,
+        record.sourceId,
+      ]
+        .filter((v): v is string | number => typeof v === 'string' || typeof v === 'number')
+        .map((v) => String(v).toLowerCase());
+      const matches = searchable.some(
+        (value) => lowered.includes(value) || value.includes(lowered) || lowered.includes(type),
+      );
+      if (!matches) continue;
+
+      const sourceId = record.sourceId;
+      if (typeof sourceId !== 'string') continue;
+      const title = displayTitleForCard(record, type);
+      candidates.push({
+        entity: {
+          kind: 'card',
+          ref: canonicalCardRef(game, type, sourceId),
+          title,
+          source: `source:${game}/cards`,
+          sourceLabel: 'GHS Card Data',
+          data: { ...record, cardType: type },
+        },
+        confidence: cardMatchConfidence(query, record, type),
+        matchReason: cardMatchReason(query, record, type),
+      });
+    }
+  }
+
+  if (candidates.length === 0) {
+    const ranked = await searchExtractedRanked(query, limit, opts);
+    for (const { record } of ranked) {
+      if (!cardTypes.includes(record._type)) continue;
+      const stripped = stripInternalKeys(record);
+      const sourceId = stripped.sourceId;
+      if (typeof sourceId !== 'string') continue;
+      candidates.push({
+        entity: {
+          kind: 'card',
+          ref: canonicalCardRef(game, record._type, sourceId),
+          title: displayTitleForCard(stripped, record._type),
+          source: `source:${game}/cards`,
+          sourceLabel: 'GHS Card Data',
+          data: { ...stripped, cardType: record._type },
+        },
+        confidence: 0.68,
+        matchReason: 'Card text match',
+      });
+    }
+  }
+
+  return candidates
+    .sort((a, b) => b.confidence - a.confidence || a.entity.title.localeCompare(b.entity.title))
+    .slice(0, limit);
+}
+
+function validateKinds(
+  kinds?: string[],
+): { ok: true; kinds: KnowledgeKind[] } | { ok: false; bad: string } {
+  if (!kinds || kinds.length === 0) return { ok: true, kinds: [...ACTIVE_KINDS] };
+  const resolved: KnowledgeKind[] = [];
+  for (const kind of kinds) {
+    const active = normalizeKind(kind);
+    if (!active) return { ok: false, bad: kind };
+    if (!resolved.includes(active)) resolved.push(active);
+  }
+  return { ok: true, kinds: resolved };
 }
 
 // ─── Tools ───────────────────────────────────────────────────────────────────
@@ -157,6 +520,164 @@ export async function listCards(
   }
 
   return records.map(stripInternalKeys);
+}
+
+export async function inspectSources(opts?: ToolOpts): Promise<InspectSourcesResult> {
+  const game = opts?.game ?? DEFAULT_GAME;
+  const [cardCounts, scenarioSectionStatus] = await Promise.all([
+    countsByType({ game }),
+    getScenarioSectionBooksBootstrapStatus({ game }),
+  ]);
+
+  return {
+    ok: true,
+    games: [GAME_INFO],
+    sources: [
+      {
+        ref: `source:${game}/rulebook`,
+        label: 'Frosthaven Rulebook',
+        kinds: ['rules_passage'],
+        searchable: true,
+        openable: false,
+        relations: [],
+      },
+      {
+        ref: `source:${game}/scenario-section-books`,
+        label: 'Scenario and Section Books',
+        kinds: ['scenario', 'section'],
+        searchable: true,
+        openable: true,
+        relations: [...BOOK_REFERENCE_TYPES],
+        counts: {
+          scenario: scenarioSectionStatus.scenarioCount,
+          section: scenarioSectionStatus.sectionCount,
+          relation: scenarioSectionStatus.linkCount,
+        },
+      },
+      {
+        ref: `source:${game}/cards`,
+        label: 'GHS Card Data',
+        kinds: ['card_type', 'card'],
+        searchable: true,
+        openable: true,
+        relations: ['belongs_to_type'],
+        counts: cardCounts,
+      },
+    ],
+    defaultGame: DEFAULT_GAME,
+    warnings: scenarioSectionStatus.ready
+      ? undefined
+      : [scenarioSectionStatus.error ?? 'Scenario/section book metadata is unavailable.'],
+  };
+}
+
+export function getSchema(kind: string): SchemaResult {
+  const normalized = normalizeKind(kind);
+  if (!normalized) {
+    return {
+      ok: false,
+      error: 'unknown_kind',
+      kind,
+      hint: 'Call inspect_sources first and pass one of the returned kinds.',
+    };
+  }
+  return SCHEMAS[normalized];
+}
+
+export async function resolveEntity(
+  query: string,
+  options: EntityResolutionOptions = {},
+): Promise<EntityResolutionResult> {
+  const validation = validateKinds(options.kinds);
+  if (!validation.ok) {
+    return {
+      ok: false,
+      error: 'invalid_filter',
+      query,
+      hint: `Unknown kind filter: ${validation.bad}. Call inspect_sources first.`,
+      candidates: [],
+    };
+  }
+
+  const game = options.game ?? DEFAULT_GAME;
+  const limit = Math.min(Math.max(options.limit ?? 6, 1), 20);
+  const candidates: EntityCandidate[] = [];
+  const kinds = validation.kinds;
+
+  if (kinds.includes('scenario')) {
+    for (const scenario of await findScenarios(query, limit, { game })) {
+      const exactNumber = query.match(/\bscenario\s*0*(\d{1,3})\b/i)?.[1];
+      const confidence =
+        exactNumber && String(Number(exactNumber)) === scenario.scenarioIndex ? 0.99 : 0.86;
+      candidates.push({
+        entity: {
+          kind: 'scenario',
+          ref: canonicalScenarioRef(game, scenario.ref),
+          title: scenario.name,
+          source: `source:${game}/scenario-section-books`,
+          sourceLabel: formatRetrievalSourceLabel(scenario.sourcePdf ?? 'fh-scenario-book.pdf'),
+          data: scenario,
+        },
+        confidence,
+        matchReason: confidence === 0.99 ? 'Exact scenario number' : 'Scenario name match',
+      });
+    }
+  }
+
+  if (kinds.includes('section')) {
+    const sectionRef = query.match(/\b(?:section\s*)?(\d+\.\d+)\b/i)?.[1];
+    if (sectionRef) {
+      const section = await loadSection(sectionRef, { game });
+      if (section) {
+        candidates.push({
+          entity: {
+            kind: 'section',
+            ref: canonicalSectionRef(game, section.ref),
+            title: `Section ${section.ref}`,
+            source: `source:${game}/scenario-section-books`,
+            sourceLabel: formatRetrievalSourceLabel(section.sourcePdf),
+            data: section,
+          },
+          confidence: 0.99,
+          matchReason: 'Exact section ref',
+        });
+      }
+    }
+  }
+
+  if (kinds.includes('card_type')) {
+    const lowered = query.toLowerCase();
+    for (const type of TYPES) {
+      if (lowered.includes(type) || lowered.includes(type.replaceAll('-', ' '))) {
+        candidates.push({
+          entity: {
+            kind: 'card_type',
+            ref: `card_type:${game}/${type}`,
+            title: type,
+            source: `source:${game}/cards`,
+            sourceLabel: 'GHS Card Data',
+            data: { cardType: type },
+          },
+          confidence: 0.95,
+          matchReason: 'Exact card type',
+        });
+      }
+    }
+  }
+
+  if (kinds.includes('card')) {
+    candidates.push(
+      ...(await resolveCards(query, cardTypesForKinds(options.kinds), limit, { game })),
+    );
+  }
+
+  return {
+    ok: true,
+    query,
+    candidates: candidates
+      .sort((a, b) => b.confidence - a.confidence || a.entity.title.localeCompare(b.entity.title))
+      .slice(0, limit),
+  };
 }
 
 /**

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -226,7 +226,7 @@ const SCHEMAS: Record<KnowledgeKind, Extract<SchemaResult, { ok: true }>> = {
   scenario: {
     ok: true,
     kind: 'scenario',
-    refPattern: 'scenario:<game>/<scenario-ref>',
+    refPattern: '<scenario-ref>',
     fields: [
       { name: 'scenarioIndex', type: 'string', description: 'Printed scenario number or code' },
       { name: 'name', type: 'string', description: 'Scenario title' },
@@ -238,7 +238,7 @@ const SCHEMAS: Record<KnowledgeKind, Extract<SchemaResult, { ok: true }>> = {
     examples: [
       {
         label: 'Open scenario 61',
-        ref: 'scenario:frosthaven/gloomhavensecretariat:scenario/061',
+        ref: 'gloomhavensecretariat:scenario/061',
       },
     ],
     aliases: ['scenario', 'scenarios'],
@@ -246,7 +246,7 @@ const SCHEMAS: Record<KnowledgeKind, Extract<SchemaResult, { ok: true }>> = {
   section: {
     ok: true,
     kind: 'section',
-    refPattern: 'section:<game>/<section-number>.<variant>',
+    refPattern: '<section-number>.<variant>',
     fields: [
       { name: 'text', type: 'string', description: 'Section prose' },
       { name: 'sectionNumber', type: 'number', description: 'Section number before the dot' },
@@ -255,7 +255,7 @@ const SCHEMAS: Record<KnowledgeKind, Extract<SchemaResult, { ok: true }>> = {
     ],
     filterFields: ['sectionNumber', 'sectionVariant'],
     relations: [...BOOK_REFERENCE_TYPES],
-    examples: [{ label: 'Open section 67.1', ref: 'section:frosthaven/67.1' }],
+    examples: [{ label: 'Open section 67.1', ref: '67.1' }],
     aliases: ['section', 'sections'],
   },
   card_type: {
@@ -274,7 +274,7 @@ const SCHEMAS: Record<KnowledgeKind, Extract<SchemaResult, { ok: true }>> = {
   card: {
     ok: true,
     kind: 'card',
-    refPattern: 'card:<game>/<card-type>/<source-id>',
+    refPattern: '<source-id>',
     fields: [
       { name: 'sourceId', type: 'string', description: 'GHS source identifier' },
       { name: 'name', type: 'string', description: 'Display name when present' },
@@ -283,7 +283,7 @@ const SCHEMAS: Record<KnowledgeKind, Extract<SchemaResult, { ok: true }>> = {
     ],
     filterFields: ['type', 'name', 'cardName', 'level', 'class', 'number'],
     relations: ['belongs_to_type'],
-    examples: [{ label: 'Open item 1', ref: 'card:frosthaven/items/gloomhavensecretariat:item/1' }],
+    examples: [{ label: 'Open item 1', ref: 'gloomhavensecretariat:item/1' }],
     aliases: Object.keys(CARD_KIND_ALIASES),
   },
 };
@@ -304,18 +304,6 @@ function cardTypesForKinds(kinds?: string[]): CardType[] {
     for (const type of CARD_KIND_ALIASES[normalized] ?? []) out.add(type);
   }
   return [...out];
-}
-
-function canonicalScenarioRef(game: string, ref: string): string {
-  return `scenario:${game}/${ref}`;
-}
-
-function canonicalSectionRef(game: string, ref: string): string {
-  return `section:${game}/${ref}`;
-}
-
-function canonicalCardRef(game: string, type: CardType, sourceId: string): string {
-  return `card:${game}/${type}/${sourceId}`;
 }
 
 function displayTitleForCard(record: Record<string, unknown>, type: CardType): string {
@@ -401,7 +389,7 @@ async function resolveCards(
       candidates.push({
         entity: {
           kind: 'card',
-          ref: canonicalCardRef(game, type, sourceId),
+          ref: sourceId,
           title,
           source: `source:${game}/cards`,
           sourceLabel: 'GHS Card Data',
@@ -423,7 +411,7 @@ async function resolveCards(
       candidates.push({
         entity: {
           kind: 'card',
-          ref: canonicalCardRef(game, record._type, sourceId),
+          ref: sourceId,
           title: displayTitleForCard(stripped, record._type),
           source: `source:${game}/cards`,
           sourceLabel: 'GHS Card Data',
@@ -607,14 +595,15 @@ export async function resolveEntity(
   const kinds = validation.kinds;
 
   if (kinds.includes('scenario')) {
-    for (const scenario of await findScenarios(query, limit, { game })) {
-      const exactNumber = query.match(/\bscenario\s*0*(\d{1,3})\b/i)?.[1];
+    const exactNumber = query.match(/\bscenario\s*0*(\d{1,3})\b/i)?.[1];
+    const scenarioQuery = exactNumber ? String(Number(exactNumber)) : query;
+    for (const scenario of await findScenarios(scenarioQuery, limit, { game })) {
       const confidence =
         exactNumber && String(Number(exactNumber)) === scenario.scenarioIndex ? 0.99 : 0.86;
       candidates.push({
         entity: {
           kind: 'scenario',
-          ref: canonicalScenarioRef(game, scenario.ref),
+          ref: scenario.ref,
           title: scenario.name,
           source: `source:${game}/scenario-section-books`,
           sourceLabel: formatRetrievalSourceLabel(scenario.sourcePdf ?? 'fh-scenario-book.pdf'),
@@ -634,7 +623,7 @@ export async function resolveEntity(
         candidates.push({
           entity: {
             kind: 'section',
-            ref: canonicalSectionRef(game, section.ref),
+            ref: section.ref,
             title: `Section ${section.ref}`,
             source: `source:${game}/scenario-section-books`,
             sourceLabel: formatRetrievalSourceLabel(section.sourcePdf),

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -367,6 +367,8 @@ async function resolveCards(
   limit: number,
   opts: ToolOpts,
 ): Promise<EntityCandidate[]> {
+  if (query.trim() === '') return [];
+
   const game = opts.game ?? DEFAULT_GAME;
   const level = extractLevelQuery(query);
   const lowered = query.toLowerCase();

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -189,6 +189,7 @@ const CARD_KIND_ALIASES: Record<string, CardType[]> = {
 };
 
 const KIND_ALIASES: Record<string, KnowledgeKind> = {
+  rules_passage: 'rules_passage',
   rule: 'rules_passage',
   rules: 'rules_passage',
   rulebook: 'rules_passage',

--- a/src/web-ui/consulted-footer.ts
+++ b/src/web-ui/consulted-footer.ts
@@ -51,6 +51,9 @@ export const TOOL_SOURCE_FALLBACK_LABEL = 'REFERENCE';
 // (the agent used it to navigate, but the actual content it surfaced
 // came from another tool call that already contributed a label).
 const TOOL_SOURCE_LABELS: Record<AgentToolName, ToolSourceLabel | null> = {
+  inspect_sources: null,
+  schema: null,
+  resolve_entity: null,
   search_rules: 'RULEBOOK',
   search_cards: 'CARD INDEX',
   list_card_types: 'CARD INDEX',

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -8,6 +8,9 @@ const {
   mockSearchRules,
   mockSearchCards,
   mockListCardTypes,
+  mockInspectSources,
+  mockGetSchema,
+  mockResolveEntity,
   mockGetCard,
   mockFindScenario,
   mockGetScenario,
@@ -19,6 +22,9 @@ const {
   mockSearchRules: vi.fn(),
   mockSearchCards: vi.fn(),
   mockListCardTypes: vi.fn(),
+  mockInspectSources: vi.fn(),
+  mockGetSchema: vi.fn(),
+  mockResolveEntity: vi.fn(),
   mockGetCard: vi.fn(),
   mockFindScenario: vi.fn(),
   mockGetScenario: vi.fn(),
@@ -36,6 +42,9 @@ vi.mock('../src/tools.ts', () => ({
   searchRules: mockSearchRules,
   searchCards: mockSearchCards,
   listCardTypes: mockListCardTypes,
+  inspectSources: mockInspectSources,
+  getSchema: mockGetSchema,
+  resolveEntity: mockResolveEntity,
   listCards: vi.fn(() => []),
   getCard: mockGetCard,
   findScenario: mockFindScenario,
@@ -114,6 +123,14 @@ describe('runAgentLoop', () => {
     ]);
     mockSearchCards.mockReturnValue([]);
     mockListCardTypes.mockReturnValue([{ type: 'items', count: 10 }]);
+    mockInspectSources.mockResolvedValue({
+      ok: true,
+      sources: [],
+      games: [],
+      defaultGame: 'frosthaven',
+    });
+    mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
+    mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
     mockGetCard.mockReturnValue({ name: 'Boots of Speed', effect: 'Move +1' });
     mockFindScenario.mockResolvedValue([
       { ref: 'gloomhavensecretariat:scenario/061', scenarioIndex: '61', name: 'Life and Death' },
@@ -419,6 +436,14 @@ describe('executeToolCall', () => {
     mockSearchRules.mockResolvedValue([{ text: 'rule text', source: 'test.pdf:1', score: 0.9 }]);
     mockSearchCards.mockReturnValue([{ type: 'items', data: { name: 'Test' }, score: 1 }]);
     mockListCardTypes.mockReturnValue([{ type: 'items', count: 5 }]);
+    mockInspectSources.mockResolvedValue({
+      ok: true,
+      sources: [],
+      games: [],
+      defaultGame: 'frosthaven',
+    });
+    mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
+    mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
     mockGetCard.mockReturnValue({ name: 'Test Item' });
     mockFindScenario.mockResolvedValue([{ ref: 'gloomhavensecretariat:scenario/061' }]);
     mockGetScenario.mockResolvedValue({ ref: 'gloomhavensecretariat:scenario/061' });
@@ -469,6 +494,40 @@ describe('executeToolCall', () => {
     const result = await executeToolCall('list_card_types', {});
     expect(mockListCardTypes).toHaveBeenCalled();
     expect(JSON.parse(result.content)).toEqual([{ type: 'items', count: 5 }]);
+  });
+
+  it('dispatches inspect_sources', async () => {
+    const result = await executeToolCall('inspect_sources', {});
+    expect(mockInspectSources).toHaveBeenCalled();
+    expect(JSON.parse(result.content)).toEqual({
+      ok: true,
+      sources: [],
+      games: [],
+      defaultGame: 'frosthaven',
+    });
+  });
+
+  it('dispatches schema', async () => {
+    const result = await executeToolCall('schema', { kind: 'item' });
+    expect(mockGetSchema).toHaveBeenCalledWith('item');
+    expect(JSON.parse(result.content)).toEqual({ ok: true, kind: 'card', fields: [] });
+  });
+
+  it('dispatches resolve_entity', async () => {
+    const result = await executeToolCall('resolve_entity', {
+      query: 'Spyglass',
+      kinds: ['card'],
+      limit: 3,
+    });
+    expect(mockResolveEntity).toHaveBeenCalledWith('Spyglass', {
+      kinds: ['card'],
+      limit: 3,
+    });
+    expect(JSON.parse(result.content)).toEqual({
+      ok: true,
+      query: 'Spyglass',
+      candidates: [],
+    });
   });
 
   it('dispatches get_card', async () => {

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -398,6 +398,36 @@ describe('runAgentLoop', () => {
     });
   });
 
+  it('keeps discovery-only tools out of repeated rule search synthesis guard', async () => {
+    mockMessagesCreate
+      .mockResolvedValueOnce(toolUseResponse('search_rules', { query: 'looting rules' }))
+      .mockResolvedValueOnce(toolUseResponse('inspect_sources', {}))
+      .mockResolvedValueOnce(
+        toolUseResponse('search_rules', {
+          query: 'loot ability end-of-turn looting money tokens treasure tiles',
+        }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse('search_rules', {
+          query: 'end-of-turn looting character loot token own hex',
+        }),
+      )
+      .mockResolvedValueOnce(textResponse('Looting means picking up loot tokens.'));
+
+    const result = await runAgentLoop('What is looting?');
+
+    expect(result).toBe('Looting means picking up loot tokens.');
+    expect(mockSearchRules).toHaveBeenCalledTimes(3);
+    expect(mockInspectSources).toHaveBeenCalledTimes(1);
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(5);
+    expect(mockMessagesCreate.mock.calls[4][0]).not.toHaveProperty('tools');
+    expect(mockMessagesCreate.mock.calls[4][0].messages.at(-1)).toEqual({
+      role: 'user',
+      content:
+        'Use the retrieved rulebook context to answer now. Do not search again unless the existing tool results are empty or clearly unrelated.',
+    });
+  });
+
   it('prepends history messages', async () => {
     mockMessagesCreate.mockResolvedValue(textResponse('Follow-up answer'));
     const history = [

--- a/test/mcp-in-process.test.ts
+++ b/test/mcp-in-process.test.ts
@@ -6,6 +6,9 @@ const {
   mockListCardTypes,
   mockListCards,
   mockGetCard,
+  mockInspectSources,
+  mockGetSchema,
+  mockResolveEntity,
   mockFindScenario,
   mockGetScenario,
   mockGetSection,
@@ -16,6 +19,9 @@ const {
   mockListCardTypes: vi.fn(),
   mockListCards: vi.fn(),
   mockGetCard: vi.fn(),
+  mockInspectSources: vi.fn(),
+  mockGetSchema: vi.fn(),
+  mockResolveEntity: vi.fn(),
   mockFindScenario: vi.fn(),
   mockGetScenario: vi.fn(),
   mockGetSection: vi.fn(),
@@ -28,6 +34,9 @@ vi.mock('../src/tools.ts', () => ({
   listCardTypes: mockListCardTypes,
   listCards: mockListCards,
   getCard: mockGetCard,
+  inspectSources: mockInspectSources,
+  getSchema: mockGetSchema,
+  resolveEntity: mockResolveEntity,
   findScenario: mockFindScenario,
   getScenario: mockGetScenario,
   getSection: mockGetSection,
@@ -46,6 +55,14 @@ describe('in-process MCP client', () => {
     mockSearchRules.mockResolvedValue([
       { text: 'Loot: pick up tokens.', source: 'rulebook.pdf:42', score: 0.9 },
     ]);
+    mockInspectSources.mockResolvedValue({
+      ok: true,
+      sources: [],
+      games: [],
+      defaultGame: 'frosthaven',
+    });
+    mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
+    mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
     mockGetCard.mockReturnValue({ name: 'Algox Archer' });
   });
 
@@ -58,8 +75,11 @@ describe('in-process MCP client', () => {
   it('lists tools via in-process transport', async () => {
     const client = await createInProcessClient();
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(9);
+    expect(tools.length).toBe(12);
     const names = tools.map((t) => t.name);
+    expect(names).toContain('inspect_sources');
+    expect(names).toContain('schema');
+    expect(names).toContain('resolve_entity');
     expect(names).toContain('search_rules');
     expect(names).toContain('find_scenario');
     expect(names).toContain('get_scenario');

--- a/test/mcp-transport.test.ts
+++ b/test/mcp-transport.test.ts
@@ -6,6 +6,9 @@ const {
   mockListCardTypes,
   mockListCards,
   mockGetCard,
+  mockInspectSources,
+  mockGetSchema,
+  mockResolveEntity,
   mockFindScenario,
   mockGetScenario,
   mockGetSection,
@@ -16,6 +19,9 @@ const {
   mockListCardTypes: vi.fn(),
   mockListCards: vi.fn(),
   mockGetCard: vi.fn(),
+  mockInspectSources: vi.fn(),
+  mockGetSchema: vi.fn(),
+  mockResolveEntity: vi.fn(),
   mockFindScenario: vi.fn(),
   mockGetScenario: vi.fn(),
   mockGetSection: vi.fn(),
@@ -28,6 +34,9 @@ vi.mock('../src/tools.ts', () => ({
   listCardTypes: mockListCardTypes,
   listCards: mockListCards,
   getCard: mockGetCard,
+  inspectSources: mockInspectSources,
+  getSchema: mockGetSchema,
+  resolveEntity: mockResolveEntity,
   findScenario: mockFindScenario,
   getScenario: mockGetScenario,
   getSection: mockGetSection,
@@ -101,14 +110,25 @@ describe('MCP over Streamable HTTP', () => {
     mockSearchRules.mockResolvedValue([
       { text: 'Loot: pick up tokens.', source: 'rulebook.pdf:42', score: 0.9 },
     ]);
+    mockInspectSources.mockResolvedValue({
+      ok: true,
+      sources: [],
+      games: [],
+      defaultGame: 'frosthaven',
+    });
+    mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
+    mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
     mockGetCard.mockReturnValue({ name: 'Algox Archer' });
   });
 
   it('lists tools via HTTP transport', async () => {
     const client = await createHttpClient();
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(9);
+    expect(tools.length).toBe(12);
     const names = tools.map((t) => t.name);
+    expect(names).toContain('inspect_sources');
+    expect(names).toContain('schema');
+    expect(names).toContain('resolve_entity');
     expect(names).toContain('search_rules');
     expect(names).toContain('find_scenario');
     expect(names).toContain('get_scenario');

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -6,6 +6,9 @@ const {
   mockListCardTypes,
   mockListCards,
   mockGetCard,
+  mockInspectSources,
+  mockGetSchema,
+  mockResolveEntity,
   mockFindScenario,
   mockGetScenario,
   mockGetSection,
@@ -16,6 +19,9 @@ const {
   mockListCardTypes: vi.fn(),
   mockListCards: vi.fn(),
   mockGetCard: vi.fn(),
+  mockInspectSources: vi.fn(),
+  mockGetSchema: vi.fn(),
+  mockResolveEntity: vi.fn(),
   mockFindScenario: vi.fn(),
   mockGetScenario: vi.fn(),
   mockGetSection: vi.fn(),
@@ -28,6 +34,9 @@ vi.mock('../src/tools.ts', () => ({
   listCardTypes: mockListCardTypes,
   listCards: mockListCards,
   getCard: mockGetCard,
+  inspectSources: mockInspectSources,
+  getSchema: mockGetSchema,
+  resolveEntity: mockResolveEntity,
   findScenario: mockFindScenario,
   getScenario: mockGetScenario,
   getSection: mockGetSection,
@@ -107,12 +116,23 @@ describe('MCP tool registration', () => {
         metadata: {},
       },
     ]);
+    mockInspectSources.mockResolvedValue({
+      ok: true,
+      sources: [],
+      games: [],
+      defaultGame: 'frosthaven',
+    });
+    mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
+    mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
   });
 
-  it('registers all 9 tools', async () => {
+  it('registers old tools and the new discovery tools', async () => {
     const client = await connectClient();
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
+    expect(names).toContain('inspect_sources');
+    expect(names).toContain('schema');
+    expect(names).toContain('resolve_entity');
     expect(names).toContain('search_rules');
     expect(names).toContain('find_scenario');
     expect(names).toContain('get_scenario');
@@ -122,7 +142,32 @@ describe('MCP tool registration', () => {
     expect(names).toContain('list_card_types');
     expect(names).toContain('list_cards');
     expect(names).toContain('get_card');
-    expect(tools).toHaveLength(9);
+    expect(tools).toHaveLength(12);
+  });
+
+  it('wires the discovery tools through to handlers', async () => {
+    const client = await connectClient();
+
+    await expect(
+      client.callTool({ name: 'inspect_sources', arguments: {} }),
+    ).resolves.toBeDefined();
+    expect(mockInspectSources).toHaveBeenCalledWith();
+
+    await expect(
+      client.callTool({ name: 'schema', arguments: { kind: 'item' } }),
+    ).resolves.toBeDefined();
+    expect(mockGetSchema).toHaveBeenCalledWith('item');
+
+    await expect(
+      client.callTool({
+        name: 'resolve_entity',
+        arguments: { query: 'Spyglass', kinds: ['card'], limit: 3 },
+      }),
+    ).resolves.toBeDefined();
+    expect(mockResolveEntity).toHaveBeenCalledWith('Spyglass', {
+      kinds: ['card'],
+      limit: 3,
+    });
   });
 
   it('wires the traversal tools through to handlers', async () => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -302,6 +302,13 @@ describe('knowledge discovery tools', () => {
       }),
     );
 
+    expect(getSchema('rules_passage')).toEqual(
+      expect.objectContaining({
+        ok: true,
+        kind: 'rules_passage',
+      }),
+    );
+
     expect(getSchema('item')).toEqual(
       expect.objectContaining({
         ok: true,

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -292,12 +292,12 @@ describe('knowledge discovery tools', () => {
     );
   });
 
-  it('getSchema returns canonical schema metadata and resolves common aliases', () => {
+  it('getSchema returns schema metadata and resolves common aliases', () => {
     expect(getSchema('scenario')).toEqual(
       expect.objectContaining({
         ok: true,
         kind: 'scenario',
-        refPattern: 'scenario:<game>/<scenario-ref>',
+        refPattern: '<scenario-ref>',
         relations: ['conclusion', 'read_now', 'section_link', 'unlock', 'cross_reference'],
       }),
     );
@@ -306,7 +306,7 @@ describe('knowledge discovery tools', () => {
       expect.objectContaining({
         ok: true,
         kind: 'card',
-        refPattern: 'card:<game>/<card-type>/<source-id>',
+        refPattern: '<source-id>',
         filterFields: expect.arrayContaining(['type', 'name', 'level', 'class', 'number']),
       }),
     );
@@ -319,7 +319,7 @@ describe('knowledge discovery tools', () => {
     });
   });
 
-  it('resolveEntity returns ranked canonical candidates for scenarios and sections', async () => {
+  it('resolveEntity returns ranked opener-ready candidates for scenarios and sections', async () => {
     const scenario: EntityResolutionResult = await resolveEntity('scenario 61');
     expect(scenario.ok).toBe(true);
     expect(scenario.candidates[0]).toEqual(
@@ -328,7 +328,7 @@ describe('knowledge discovery tools', () => {
         matchReason: 'Exact scenario number',
         entity: expect.objectContaining({
           kind: 'scenario',
-          ref: 'scenario:frosthaven/gloomhavensecretariat:scenario/061',
+          ref: 'gloomhavensecretariat:scenario/061',
           title: 'Life and Death',
         }),
       }),
@@ -341,7 +341,7 @@ describe('knowledge discovery tools', () => {
         matchReason: 'Exact section ref',
         entity: expect.objectContaining({
           kind: 'section',
-          ref: 'section:frosthaven/90.2',
+          ref: '90.2',
           title: 'Section 90.2',
         }),
       }),
@@ -355,7 +355,7 @@ describe('knowledge discovery tools', () => {
         confidence: expect.any(Number),
         entity: expect.objectContaining({
           kind: 'card',
-          ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+          ref: 'gloomhavensecretariat:item/1',
           title: 'Spyglass',
           data: expect.objectContaining({ cardType: 'items' }),
         }),

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -399,6 +399,14 @@ describe('knowledge discovery tools', () => {
       candidates: [],
     });
   });
+
+  it('resolveEntity returns no card candidates for a blank query', async () => {
+    await expect(resolveEntity('   ', { kinds: ['card'] })).resolves.toEqual({
+      ok: true,
+      query: '   ',
+      candidates: [],
+    });
+  });
 });
 
 describe('scenario/section book tools', () => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -28,6 +28,9 @@ import {
   listCardTypes,
   listCards,
   getCard,
+  inspectSources,
+  getSchema,
+  resolveEntity,
   findScenario,
   getScenario,
   getSection,
@@ -37,6 +40,7 @@ import type {
   RuleResult,
   CardResult,
   CardTypeInfo,
+  EntityResolutionResult,
   ScenarioResult,
   SectionResult,
   ReferenceResult,
@@ -247,6 +251,153 @@ describe('listCards', () => {
   it('returns empty when filter matches nothing', async () => {
     const cards = await listCards('items', { name: 'No Such Item Exists' });
     expect(cards).toEqual([]);
+  });
+});
+
+describe('knowledge discovery tools', () => {
+  it('inspectSources advertises source capabilities and live counts', async () => {
+    const result = await inspectSources();
+
+    expect(result.ok).toBe(true);
+    expect(result.defaultGame).toBe('frosthaven');
+    expect(result.games).toEqual([{ id: 'frosthaven', label: 'Frosthaven', default: true }]);
+    expect(result.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ref: 'source:frosthaven/rulebook',
+          kinds: ['rules_passage'],
+          searchable: true,
+          openable: false,
+        }),
+        expect.objectContaining({
+          ref: 'source:frosthaven/scenario-section-books',
+          kinds: ['scenario', 'section'],
+          relations: ['conclusion', 'read_now', 'section_link', 'unlock', 'cross_reference'],
+          counts: expect.objectContaining({
+            scenario: expect.any(Number),
+            section: expect.any(Number),
+          }),
+        }),
+        expect.objectContaining({
+          ref: 'source:frosthaven/cards',
+          kinds: ['card_type', 'card'],
+          relations: ['belongs_to_type'],
+          counts: expect.objectContaining({
+            items: expect.any(Number),
+            'monster-stats': expect.any(Number),
+            'character-abilities': expect.any(Number),
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it('getSchema returns canonical schema metadata and resolves common aliases', () => {
+    expect(getSchema('scenario')).toEqual(
+      expect.objectContaining({
+        ok: true,
+        kind: 'scenario',
+        refPattern: 'scenario:<game>/<scenario-ref>',
+        relations: ['conclusion', 'read_now', 'section_link', 'unlock', 'cross_reference'],
+      }),
+    );
+
+    expect(getSchema('item')).toEqual(
+      expect.objectContaining({
+        ok: true,
+        kind: 'card',
+        refPattern: 'card:<game>/<card-type>/<source-id>',
+        filterFields: expect.arrayContaining(['type', 'name', 'level', 'class', 'number']),
+      }),
+    );
+
+    expect(getSchema('no-such-kind')).toEqual({
+      ok: false,
+      error: 'unknown_kind',
+      kind: 'no-such-kind',
+      hint: 'Call inspect_sources first and pass one of the returned kinds.',
+    });
+  });
+
+  it('resolveEntity returns ranked canonical candidates for scenarios and sections', async () => {
+    const scenario: EntityResolutionResult = await resolveEntity('scenario 61');
+    expect(scenario.ok).toBe(true);
+    expect(scenario.candidates[0]).toEqual(
+      expect.objectContaining({
+        confidence: 0.99,
+        matchReason: 'Exact scenario number',
+        entity: expect.objectContaining({
+          kind: 'scenario',
+          ref: 'scenario:frosthaven/gloomhavensecretariat:scenario/061',
+          title: 'Life and Death',
+        }),
+      }),
+    );
+
+    const section = await resolveEntity('section 90.2', { kinds: ['section'] });
+    expect(section.candidates[0]).toEqual(
+      expect.objectContaining({
+        confidence: 0.99,
+        matchReason: 'Exact section ref',
+        entity: expect.objectContaining({
+          kind: 'section',
+          ref: 'section:frosthaven/90.2',
+          title: 'Section 90.2',
+        }),
+      }),
+    );
+  });
+
+  it('resolveEntity returns card candidates for items, monsters, and character abilities', async () => {
+    const item = await resolveEntity('Spyglass', { kinds: ['card'] });
+    expect(item.candidates[0]).toEqual(
+      expect.objectContaining({
+        confidence: expect.any(Number),
+        entity: expect.objectContaining({
+          kind: 'card',
+          ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+          title: 'Spyglass',
+          data: expect.objectContaining({ cardType: 'items' }),
+        }),
+      }),
+    );
+
+    const monster = await resolveEntity('Living Bones', { kinds: ['monster'] });
+    expect(monster.candidates[0].entity).toEqual(
+      expect.objectContaining({
+        kind: 'card',
+        title: 'Living Bones',
+        data: expect.objectContaining({ cardType: 'monster-stats' }),
+      }),
+    );
+
+    const ability = await resolveEntity('Blinkblade level 4 cards', {
+      kinds: ['character-ability'],
+    });
+    expect(ability.candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          entity: expect.objectContaining({
+            kind: 'card',
+            data: expect.objectContaining({
+              cardType: 'character-abilities',
+              characterClass: 'Blinkblade',
+              level: 4,
+            }),
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it('resolveEntity validates kind filters against the discovery registry', async () => {
+    await expect(resolveEntity('Spyglass', { kinds: ['nonsense'] })).resolves.toEqual({
+      ok: false,
+      error: 'invalid_filter',
+      query: 'Spyglass',
+      hint: 'Unknown kind filter: nonsense. Call inspect_sources first.',
+      candidates: [],
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Add inspect_sources, schema, and resolve_entity discovery tools on top of the existing rulebook, scenario/section-book, and GHS card stores.
- Expose the new tools through both the agent loop and MCP while keeping the old tools registered.
- Cover source inspection, schema aliases, and entity resolution for scenarios, sections, items, monsters, and character abilities.

## Validation

- npm run check
- QA smoke: local server ready on port 4975; gstack browse loaded the login page with no console errors; /api/health returned ready.
- Review: pre-landing diff review found no issues.

Fixes SQR-117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discovery tools to list available knowledge sources, kinds, relations, and counts
  * Schema lookup to view kind-specific field/relationship metadata
  * Entity-resolution that converts natural references into ranked canonical candidates with kind filters and limits
  * Agent flow updated to route natural references through resolution/search and require canonical IDs for direct retrieval

* **Tests**
  * New unit and integration tests covering discovery, schema, and resolution flows

* **Chores**
  * UI footer hides discovery utilities from provenance labels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->