### PR TITLE
Add canonical knowledge traversal tools

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -8,16 +8,19 @@ import Anthropic from '@anthropic-ai/sdk';
 import {
   searchRules,
   searchCards,
+  searchKnowledge,
   listCardTypes,
   listCards,
   getCard,
   inspectSources,
   getSchema,
   resolveEntity,
+  openEntity,
   findScenario,
   getScenario,
   getSection,
   followLinks,
+  neighbors,
 } from './tools.ts';
 import { CARD_TYPES, type CardType } from './schemas.ts';
 import type { AskOptions, HistoryMessage, EmitFn } from './service.ts';
@@ -52,6 +55,9 @@ for searching the indexed Frosthaven books and looking up card data. Use the too
 Guidelines:
 - Use inspect_sources and schema when you need to discover available kinds, filters, refs, or relations
 - Use resolve_entity to turn natural references into opener-ready scenario, section, card type, or card refs
+- Prefer search_knowledge for broad discovery across rules, scenarios, sections, and cards
+- Use open_entity when you have an exact canonical ref
+- Use neighbors to traverse explicit scenario/section links from a canonical ref
 - Use find_scenario when the user names a scenario number or scenario title
 - Use get_scenario once you know the exact canonical scenario ref
 - Use get_section for exact section refs or when a traversal link points to a section
@@ -126,6 +132,53 @@ export const AGENT_TOOLS = [
         },
       },
       required: ['query'],
+    },
+  },
+  {
+    name: 'open_entity',
+    description:
+      'Open one exact Squire entity by canonical ref: rules passage, scenario, section, or card.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Canonical inspectable ref' },
+      },
+      required: ['ref'],
+    },
+  },
+  {
+    name: 'search_knowledge',
+    description:
+      'Search rules passages, scenarios, sections, and cards. Results include openable refs, citations, source labels, and next refs.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query' },
+        scope: {
+          type: 'array',
+          items: { type: 'string', enum: ['rules_passage', 'scenario', 'section', 'card'] },
+          description: 'Optional searchable kind filter',
+        },
+        limit: { type: 'integer', description: 'Global result limit (default 6)', default: 6 },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'neighbors',
+    description: 'Traverse known outgoing relationships from a scenario or section ref.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Canonical traversable ref' },
+        relation: {
+          type: 'string',
+          enum: [...BOOK_REFERENCE_TYPES],
+          description: 'Optional relation filter like "conclusion" or "section_link"',
+        },
+        limit: { type: 'integer', description: 'Maximum neighbors (default 20)', default: 20 },
+      },
+      required: ['ref'],
     },
   },
   {
@@ -270,8 +323,30 @@ export type AgentToolName = (typeof AGENT_TOOLS)[number]['name'];
 
 export interface ToolCallResult {
   content: string;
-  /** Distinct provenance labels for the books actually hit — only set by search_rules. */
+  /** Distinct provenance labels for dynamic result sources. */
   sourceBooks?: string[];
+}
+
+function sourceLabelsFromResult(value: unknown): string[] {
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  const add = (label: unknown) => {
+    if (typeof label !== 'string' || seen.has(label)) return;
+    seen.add(label);
+    labels.push(label);
+  };
+
+  if (!value || typeof value !== 'object') return labels;
+  const result = value as {
+    citations?: Array<{ sourceLabel?: unknown }>;
+    results?: Array<{ citations?: Array<{ sourceLabel?: unknown }> }>;
+  };
+
+  for (const citation of result.citations ?? []) add(citation.sourceLabel);
+  for (const hit of result.results ?? []) {
+    for (const citation of hit.citations ?? []) add(citation.sourceLabel);
+  }
+  return labels;
 }
 
 const DISCOVERY_ONLY_TOOL_NAMES = new Set<AgentToolName>([
@@ -282,9 +357,9 @@ const DISCOVERY_ONLY_TOOL_NAMES = new Set<AgentToolName>([
 
 /**
  * Execute a single tool call and return the result content plus any per-result
- * provenance metadata. For search_rules, `sourceBooks` carries the distinct
- * retrieval source labels (e.g. "Rulebook", "Section Book A") so callers can
- * surface accurate book provenance instead of a static tool-name label.
+ * provenance metadata. Dynamic search/open tools return distinct source labels
+ * (e.g. "Rulebook", "Section Book 62-81") so callers can surface accurate
+ * provenance instead of a static tool-name label.
  */
 export async function executeToolCall(
   name: string,
@@ -339,6 +414,31 @@ export async function executeToolCall(
         (input.topK as number | undefined) ?? 6,
       );
       return { content: JSON.stringify(results, null, 2) };
+    }
+    case 'search_knowledge': {
+      const scope = Array.isArray(input.scope) ? (input.scope as never[]) : undefined;
+      const result = await searchKnowledge(input.query as string, {
+        scope,
+        limit: (input.limit as number | undefined) ?? 6,
+      });
+      return {
+        content: JSON.stringify(result, null, 2),
+        sourceBooks: sourceLabelsFromResult(result),
+      };
+    }
+    case 'open_entity': {
+      const result = await openEntity(input.ref as string);
+      return {
+        content: JSON.stringify(result, null, 2),
+        sourceBooks: sourceLabelsFromResult(result),
+      };
+    }
+    case 'neighbors': {
+      const result = await neighbors(input.ref as string, {
+        relation: input.relation as (typeof BOOK_REFERENCE_TYPES)[number] | undefined,
+        limit: (input.limit as number | undefined) ?? 20,
+      });
+      return { content: JSON.stringify(result, null, 2) };
     }
     case 'list_card_types': {
       return { content: JSON.stringify(await listCardTypes(), null, 2) };

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -10,16 +10,19 @@ import { z } from 'zod';
 import {
   searchRules,
   searchCards,
+  searchKnowledge,
   listCardTypes,
   listCards,
   getCard,
   inspectSources,
   getSchema,
   resolveEntity,
+  openEntity,
   findScenario,
   getScenario,
   getSection,
   followLinks,
+  neighbors,
 } from './tools.ts';
 import { CARD_TYPES, type CardType } from './schemas.ts';
 import {
@@ -271,6 +274,65 @@ export function createMcpServer(): McpServer {
     async ({ fromKind, fromRef, linkType }) => {
       const links = await followLinks(fromKind as BookRecordKind, fromRef, linkType);
       return { content: [{ type: 'text', text: JSON.stringify(links, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    'open_entity',
+    {
+      description:
+        'Open one exact Squire entity by canonical ref: rules passage, scenario, section, or card.',
+      inputSchema: {
+        ref: z.string().describe('Canonical inspectable ref'),
+      },
+    },
+    async ({ ref }) => {
+      const result = await openEntity(ref);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        isError: !result.ok,
+      };
+    },
+  );
+
+  server.registerTool(
+    'search_knowledge',
+    {
+      description: 'Search rules passages, scenarios, sections, and cards with openable refs.',
+      inputSchema: {
+        query: z.string().describe('Search query'),
+        scope: z
+          .array(z.enum(['rules_passage', 'scenario', 'section', 'card']))
+          .optional()
+          .describe('Optional searchable kind filter'),
+        limit: z.number().int().min(1).max(20).default(6).describe('Global result limit'),
+      },
+    },
+    async ({ query, scope, limit }) => {
+      const result = await searchKnowledge(query, { scope, limit });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        isError: !result.ok,
+      };
+    },
+  );
+
+  server.registerTool(
+    'neighbors',
+    {
+      description: 'Traverse known outgoing relationships from a scenario or section ref.',
+      inputSchema: {
+        ref: z.string().describe('Canonical traversable ref'),
+        relation: z.enum(BOOK_REFERENCE_TYPES).optional().describe('Optional relation filter'),
+        limit: z.number().int().min(1).max(50).default(20).describe('Maximum neighbors'),
+      },
+    },
+    async ({ ref, relation, limit }) => {
+      const result = await neighbors(ref, { relation, limit });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        isError: !result.ok,
+      };
     },
   );
 

--- a/src/scenario-section-data.ts
+++ b/src/scenario-section-data.ts
@@ -197,6 +197,39 @@ export async function getSection(
   return row ? { ...row, metadata: normalizeJsonObject(row.metadata) } : null;
 }
 
+export async function searchSections(
+  query: string,
+  limit = 6,
+  opts: LoadOpts = {},
+): Promise<SectionBookSection[]> {
+  const { db } = getDb();
+  const game = opts.game ?? 'frosthaven';
+  const normalized = query.trim();
+  if (normalized.length === 0) return [];
+  const likePattern = `%${normalized.toLowerCase()}%`;
+
+  const rows = await db.execute<SectionBookSection>(sql`
+    SELECT
+      ref,
+      section_number AS "sectionNumber",
+      section_variant AS "sectionVariant",
+      source_pdf AS "sourcePdf",
+      source_page AS "sourcePage",
+      text,
+      metadata
+    FROM ${sectionBookSections}
+    WHERE game = ${game}
+      AND lower(text) LIKE ${likePattern}
+    ORDER BY section_number, section_variant
+    LIMIT ${limit}
+  `);
+
+  return rows.rows.map((row) => ({
+    ...row,
+    metadata: normalizeJsonObject(row.metadata),
+  }));
+}
+
 export async function followReferences(
   fromKind: BookRecordKind,
   fromRef: string,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -5,7 +5,7 @@
 
 import { embed } from './embedder.ts';
 import { formatRetrievalSourceLabel } from './retrieval-source.ts';
-import { search } from './vector-store.ts';
+import { getEntryBySourceChunk, search } from './vector-store.ts';
 import type { ScoredEntry } from './vector-store.ts';
 import { countsByType, load, loadOne, searchExtractedRanked, TYPES } from './extracted-data.ts';
 import type { CardType } from './schemas.ts';
@@ -14,6 +14,7 @@ import {
   getScenarioSectionBooksBootstrapStatus,
   getScenario as loadScenario,
   getSection as loadSection,
+  searchSections as loadSections,
   followReferences as loadReferences,
 } from './scenario-section-data.ts';
 import {
@@ -153,6 +154,86 @@ export type EntityResolutionResult =
       hint: string;
       candidates: [];
     };
+
+export type KnowledgeEntityKind = 'rules_passage' | 'scenario' | 'section' | 'card';
+
+export interface KnowledgeEntitySummary {
+  kind: KnowledgeEntityKind;
+  ref: string;
+  title: string;
+  sourceLabel: string;
+}
+
+export interface KnowledgeCitation {
+  sourceRef: string;
+  sourceLabel: string;
+  locator: string;
+}
+
+export interface KnowledgeLink {
+  relation: string;
+  target: KnowledgeEntitySummary;
+  reason?: string;
+}
+
+export interface KnowledgeEntity extends KnowledgeEntitySummary {
+  data: Record<string, unknown>;
+}
+
+export interface KnowledgeError {
+  code: 'invalid_ref' | 'not_found' | 'ambiguous' | 'invalid_filter' | 'unsupported_relation';
+  message: string;
+  hint?: string;
+  candidates?: KnowledgeEntitySummary[];
+}
+
+export type KnowledgeOpenResult =
+  | {
+      ok: true;
+      entity: KnowledgeEntity;
+      citations: KnowledgeCitation[];
+      links: KnowledgeLink[];
+      related: KnowledgeLink[];
+    }
+  | { ok: false; error: KnowledgeError };
+
+export interface KnowledgeSearchHit {
+  entity: KnowledgeEntitySummary;
+  score: number;
+  snippet: string;
+  citations: KnowledgeCitation[];
+  nextRefs: KnowledgeEntitySummary[];
+}
+
+export type KnowledgeSearchResult =
+  | {
+      ok: true;
+      query: string;
+      results: KnowledgeSearchHit[];
+      truncated?: boolean;
+      truncatedScopes?: KnowledgeEntityKind[];
+    }
+  | { ok: false; error: KnowledgeError };
+
+export type KnowledgeNeighborsResult =
+  | {
+      ok: true;
+      from: KnowledgeEntitySummary;
+      neighbors: KnowledgeLink[];
+      truncated?: boolean;
+    }
+  | { ok: false; error: KnowledgeError };
+
+export interface SearchKnowledgeOptions extends ToolOpts {
+  scope?: KnowledgeEntityKind[];
+  filters?: Record<string, unknown>;
+  limit?: number;
+}
+
+export interface NeighborsOptions extends ToolOpts {
+  relation?: BookReferenceType;
+  limit?: number;
+}
 
 interface ToolOpts {
   /** Campaign variant. Defaults to 'frosthaven'. Reserved for Phase 2. */
@@ -442,6 +523,180 @@ function validateKinds(
   return { ok: true, kinds: resolved };
 }
 
+function sourceRefForPdf(game: string, source: string): string {
+  return `source:${game}/${source.replace(/\.pdf$/i, '')}`;
+}
+
+function canonicalScenarioRef(ref: string, game = DEFAULT_GAME): string {
+  const match = ref.match(/(\d{1,3}[A-Z]?)$/i);
+  const scenarioId = match ? match[1].padStart(3, '0') : ref;
+  return `scenario:${game}/${scenarioId}`;
+}
+
+function scenarioStorageRef(ref: string): string {
+  const match = ref.match(/^scenario:([^/]+)\/(.+)$/);
+  if (!match) return ref;
+  return `gloomhavensecretariat:scenario/${match[2].padStart(3, '0')}`;
+}
+
+function sectionStorageRef(ref: string): string {
+  return ref.replace(/^section:[^/]+\//, '');
+}
+
+function canonicalSectionRef(ref: string, game = DEFAULT_GAME): string {
+  return `section:${game}/${sectionStorageRef(ref)}`;
+}
+
+function canonicalCardRef(type: CardType, sourceId: string, game = DEFAULT_GAME): string {
+  return `card:${game}/${type}/${sourceId}`;
+}
+
+function summarizeScenario(scenario: ScenarioResult, game = DEFAULT_GAME): KnowledgeEntitySummary {
+  return {
+    kind: 'scenario',
+    ref: canonicalScenarioRef(scenario.ref, game),
+    title: scenario.name || `Scenario ${scenario.scenarioIndex}`,
+    sourceLabel: scenario.sourcePdf
+      ? formatRetrievalSourceLabel(scenario.sourcePdf)
+      : 'Scenario Book',
+  };
+}
+
+function summarizeSection(section: SectionResult, game = DEFAULT_GAME): KnowledgeEntitySummary {
+  return {
+    kind: 'section',
+    ref: canonicalSectionRef(section.ref, game),
+    title: `Section ${section.ref}`,
+    sourceLabel: formatRetrievalSourceLabel(section.sourcePdf),
+  };
+}
+
+function summarizeRule(hit: ScoredEntry, game = DEFAULT_GAME): KnowledgeEntitySummary {
+  return {
+    kind: 'rules_passage',
+    ref: `rules:${game}/${hit.source}#chunk=${hit.chunkIndex}`,
+    title: `${formatRetrievalSourceLabel(hit.source)} passage ${hit.chunkIndex + 1}`,
+    sourceLabel: formatRetrievalSourceLabel(hit.source),
+  };
+}
+
+function summarizeCard(
+  type: CardType,
+  card: Record<string, unknown>,
+  game = DEFAULT_GAME,
+): KnowledgeEntitySummary {
+  const sourceId = String(card.sourceId ?? '');
+  return {
+    kind: 'card',
+    ref: canonicalCardRef(type, sourceId, game),
+    title: displayTitleForCard(card, type),
+    sourceLabel: 'Card Index',
+  };
+}
+
+function citationForScenario(scenario: ScenarioResult, game = DEFAULT_GAME): KnowledgeCitation[] {
+  if (!scenario.sourcePdf) return [];
+  return [
+    {
+      sourceRef: sourceRefForPdf(game, scenario.sourcePdf),
+      sourceLabel: formatRetrievalSourceLabel(scenario.sourcePdf),
+      locator: `scenario ${scenario.scenarioIndex}`,
+    },
+  ];
+}
+
+function citationForSection(section: SectionResult, game = DEFAULT_GAME): KnowledgeCitation[] {
+  return [
+    {
+      sourceRef: sourceRefForPdf(game, section.sourcePdf),
+      sourceLabel: formatRetrievalSourceLabel(section.sourcePdf),
+      locator: `section ${section.ref}`,
+    },
+  ];
+}
+
+function citationForRule(hit: ScoredEntry, game = DEFAULT_GAME): KnowledgeCitation[] {
+  return [
+    {
+      sourceRef: sourceRefForPdf(game, hit.source),
+      sourceLabel: formatRetrievalSourceLabel(hit.source),
+      locator: `chunk ${hit.chunkIndex}`,
+    },
+  ];
+}
+
+function citationForCard(
+  type: CardType,
+  sourceId: string,
+  game = DEFAULT_GAME,
+): KnowledgeCitation[] {
+  return [
+    {
+      sourceRef: `source:${game}/cards/${type}`,
+      sourceLabel: 'Card Index',
+      locator: sourceId,
+    },
+  ];
+}
+
+function parseRulesRef(
+  ref: string,
+): { ok: true; game: string; source: string; chunkIndex: number } | { ok: false } {
+  const match = ref.match(/^rules:([^/]+)\/(.+)#chunk=(\d+)$/);
+  if (!match) return { ok: false };
+  return { ok: true, game: match[1], source: match[2], chunkIndex: Number(match[3]) };
+}
+
+function parseCardRef(
+  ref: string,
+): { ok: true; game: string; type: CardType; sourceId: string } | { ok: false } {
+  const match = ref.match(/^card:([^/]+)\/([^/]+)\/(.+)$/);
+  if (!match || !TYPES.includes(match[2] as CardType)) return { ok: false };
+  return { ok: true, game: match[1], type: match[2] as CardType, sourceId: match[3] };
+}
+
+async function targetSummary(
+  kind: BookRecordKind,
+  ref: string,
+  game = DEFAULT_GAME,
+): Promise<KnowledgeEntitySummary> {
+  if (kind === 'scenario') {
+    const scenario = await getScenario(canonicalScenarioRef(ref, game), { game });
+    if (scenario) return summarizeScenario(scenario, game);
+    return {
+      kind: 'scenario',
+      ref: canonicalScenarioRef(ref, game),
+      title: `Scenario ${ref.match(/(\d{1,3}[A-Z]?)$/i)?.[1] ?? ref}`,
+      sourceLabel: 'Scenario Book',
+    };
+  }
+
+  const section = await getSection(canonicalSectionRef(ref, game), { game });
+  if (section) return summarizeSection(section, game);
+  return {
+    kind: 'section',
+    ref: canonicalSectionRef(ref, game),
+    title: `Section ${sectionStorageRef(ref)}`,
+    sourceLabel: 'Section Book',
+  };
+}
+
+async function linksFor(
+  kind: BookRecordKind,
+  ref: string,
+  opts?: ToolOpts,
+): Promise<KnowledgeLink[]> {
+  const game = opts?.game ?? DEFAULT_GAME;
+  const links = await followLinks(kind, ref, undefined, opts);
+  return Promise.all(
+    links.map(async (link) => ({
+      relation: link.linkType,
+      target: await targetSummary(link.toKind, link.toRef, game),
+      reason: link.rawLabel ?? link.rawContext ?? undefined,
+    })),
+  );
+}
+
 // ─── Tools ───────────────────────────────────────────────────────────────────
 
 /**
@@ -699,11 +954,19 @@ export async function findScenario(query: string, opts?: ToolOpts): Promise<Scen
 }
 
 export async function getScenario(ref: string, opts?: ToolOpts): Promise<ScenarioResult | null> {
-  return loadScenario(ref, opts);
+  return loadScenario(scenarioStorageRef(ref), opts);
 }
 
 export async function getSection(ref: string, opts?: ToolOpts): Promise<SectionResult | null> {
-  return loadSection(ref, opts);
+  return loadSection(sectionStorageRef(ref), opts);
+}
+
+export async function searchSections(
+  query: string,
+  limit = 6,
+  opts?: ToolOpts,
+): Promise<SectionResult[]> {
+  return loadSections(query, limit, opts);
 }
 
 export async function followLinks(
@@ -712,5 +975,299 @@ export async function followLinks(
   linkType?: BookReferenceType,
   opts?: ToolOpts,
 ): Promise<ReferenceResult[]> {
-  return loadReferences(fromKind, fromRef, linkType, opts);
+  const normalizedRef =
+    fromKind === 'scenario' ? scenarioStorageRef(fromRef) : sectionStorageRef(fromRef);
+  return loadReferences(fromKind, normalizedRef, linkType, opts);
+}
+
+export async function openEntity(ref: string, opts?: ToolOpts): Promise<KnowledgeOpenResult> {
+  const game = opts?.game ?? DEFAULT_GAME;
+
+  if (/^\d+$/.test(ref.trim())) {
+    return {
+      ok: false,
+      error: {
+        code: 'ambiguous',
+        message: `Ref "${ref}" is ambiguous.`,
+        hint: 'Use scenario:frosthaven/061, section:frosthaven/61.1, or a card ref.',
+      },
+    };
+  }
+
+  const ruleRef = parseRulesRef(ref);
+  if (ruleRef.ok) {
+    const hit = await getEntryBySourceChunk(ruleRef.source, ruleRef.chunkIndex, {
+      game: ruleRef.game,
+    });
+    if (!hit) {
+      return { ok: false, error: { code: 'not_found', message: `Rule passage not found: ${ref}` } };
+    }
+    const entity = summarizeRule(hit, ruleRef.game);
+    return {
+      ok: true,
+      entity: {
+        ...entity,
+        data: {
+          text: hit.text,
+          source: hit.source,
+          chunkIndex: hit.chunkIndex,
+        },
+      },
+      citations: citationForRule(hit, ruleRef.game),
+      links: [],
+      related: [],
+    };
+  }
+
+  if (ref.startsWith('scenario:') || ref.startsWith('gloomhavensecretariat:scenario/')) {
+    const scenario = await getScenario(
+      ref.startsWith('scenario:') ? ref : canonicalScenarioRef(ref, game),
+      {
+        game,
+      },
+    );
+    if (!scenario) {
+      return { ok: false, error: { code: 'not_found', message: `Scenario not found: ${ref}` } };
+    }
+    const entity = summarizeScenario(scenario, game);
+    return {
+      ok: true,
+      entity: {
+        ...entity,
+        data: {
+          scenarioGroup: scenario.scenarioGroup,
+          scenarioIndex: scenario.scenarioIndex,
+          name: scenario.name,
+          complexity: scenario.complexity,
+          flowChartGroup: scenario.flowChartGroup,
+          initial: scenario.initial,
+          sourcePdf: scenario.sourcePdf,
+          sourcePage: scenario.sourcePage,
+          rawText: scenario.rawText,
+          metadata: scenario.metadata,
+        },
+      },
+      citations: citationForScenario(scenario, game),
+      links: await linksFor('scenario', scenario.ref, { game }),
+      related: [],
+    };
+  }
+
+  if (ref.startsWith('section:') || /^\d+\.\d+$/.test(ref)) {
+    const section = await getSection(ref, { game });
+    if (!section) {
+      return { ok: false, error: { code: 'not_found', message: `Section not found: ${ref}` } };
+    }
+    const entity = summarizeSection(section, game);
+    return {
+      ok: true,
+      entity: {
+        ...entity,
+        data: {
+          sectionNumber: section.sectionNumber,
+          sectionVariant: section.sectionVariant,
+          sourcePdf: section.sourcePdf,
+          sourcePage: section.sourcePage,
+          text: section.text,
+          metadata: section.metadata,
+        },
+      },
+      citations: citationForSection(section, game),
+      links: await linksFor('section', section.ref, { game }),
+      related: [],
+    };
+  }
+
+  const cardRef = parseCardRef(ref);
+  if (cardRef.ok) {
+    const card = await getCard(cardRef.type, cardRef.sourceId, { game: cardRef.game });
+    if (!card)
+      return { ok: false, error: { code: 'not_found', message: `Card not found: ${ref}` } };
+    const entity = summarizeCard(cardRef.type, card, cardRef.game);
+    const sourceId = String(card.sourceId ?? cardRef.sourceId);
+    return {
+      ok: true,
+      entity: {
+        ...entity,
+        data: {
+          ...card,
+          type: cardRef.type,
+          sourceId,
+          displayName: displayTitleForCard(card, cardRef.type),
+        },
+      },
+      citations: citationForCard(cardRef.type, sourceId, cardRef.game),
+      links: [],
+      related: [],
+    };
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: 'invalid_ref',
+      message: `Ref is not inspectable: ${ref}`,
+      hint: 'Expected rules:<game>/<source>#chunk=N, scenario:<game>/<id>, section:<game>/<id>, or card:<game>/<type>/<sourceId>.',
+    },
+  };
+}
+
+export async function searchKnowledge(
+  query: string,
+  options: SearchKnowledgeOptions = {},
+): Promise<KnowledgeSearchResult> {
+  const game = options.game ?? DEFAULT_GAME;
+  const scope = options.scope ?? ['rules_passage', 'scenario', 'section', 'card'];
+  const limit = Math.min(Math.max(options.limit ?? 6, 1), 20);
+  const allowed = new Set<KnowledgeEntityKind>(['rules_passage', 'scenario', 'section', 'card']);
+  const invalid = scope.find((kind) => !allowed.has(kind));
+  if (invalid) {
+    return {
+      ok: false,
+      error: { code: 'invalid_filter', message: `Unsupported search scope: ${invalid}` },
+    };
+  }
+
+  const perScope = Math.ceil(limit / scope.length) + 1;
+  const hits: KnowledgeSearchHit[] = [];
+
+  if (scope.includes('rules_passage')) {
+    const queryEmbedding = await embed(query);
+    const rules = await search(queryEmbedding, perScope, { game });
+    hits.push(
+      ...rules.map((rule) => {
+        const entity = summarizeRule(rule, game);
+        return {
+          entity,
+          score: rule.score,
+          snippet: rule.text,
+          citations: citationForRule(rule, game),
+          nextRefs: [entity],
+        };
+      }),
+    );
+  }
+
+  if (scope.includes('scenario')) {
+    const scenarios = await findScenario(query, { game });
+    hits.push(
+      ...scenarios.slice(0, perScope).map((scenario) => {
+        const entity = summarizeScenario(scenario, game);
+        return {
+          entity,
+          score: 0.85,
+          snippet: scenario.rawText ?? scenario.name,
+          citations: citationForScenario(scenario, game),
+          nextRefs: [entity],
+        };
+      }),
+    );
+  }
+
+  if (scope.includes('section')) {
+    const sectionQuery = query.trim();
+    if (/^\d+\.\d+$/.test(sectionQuery)) {
+      const section = await getSection(sectionQuery, { game });
+      if (section) {
+        const entity = summarizeSection(section, game);
+        hits.push({
+          entity,
+          score: 0.95,
+          snippet: section.text,
+          citations: citationForSection(section, game),
+          nextRefs: [entity],
+        });
+      }
+    } else {
+      const sections = await searchSections(query, perScope, { game });
+      hits.push(
+        ...sections.map((section) => {
+          const entity = summarizeSection(section, game);
+          return {
+            entity,
+            score: 0.8,
+            snippet: section.text,
+            citations: citationForSection(section, game),
+            nextRefs: [entity],
+          };
+        }),
+      );
+    }
+  }
+
+  if (scope.includes('card')) {
+    const cards = await searchCards(query, perScope, { game });
+    hits.push(
+      ...cards.map((card) => {
+        const sourceId = String(card.data.sourceId ?? '');
+        const entity = summarizeCard(card.type, card.data, game);
+        return {
+          entity,
+          score: card.score,
+          snippet: JSON.stringify(card.data),
+          citations: citationForCard(card.type, sourceId, game),
+          nextRefs: [entity],
+        };
+      }),
+    );
+  }
+
+  hits.sort((a, b) => b.score - a.score);
+  return {
+    ok: true,
+    query,
+    results: hits.slice(0, limit),
+    truncated: hits.length > limit || undefined,
+  };
+}
+
+export async function neighbors(
+  ref: string,
+  options: NeighborsOptions = {},
+): Promise<KnowledgeNeighborsResult> {
+  const game = options.game ?? DEFAULT_GAME;
+  const relation = options.relation;
+  if (relation && !BOOK_REFERENCE_TYPES.includes(relation)) {
+    return {
+      ok: false,
+      error: { code: 'unsupported_relation', message: `Unsupported relation: ${relation}` },
+    };
+  }
+
+  let kind: BookRecordKind;
+  let storageRef: string;
+  if (ref.startsWith('scenario:') || ref.startsWith('gloomhavensecretariat:scenario/')) {
+    kind = 'scenario';
+    storageRef = scenarioStorageRef(ref);
+  } else if (ref.startsWith('section:') || /^\d+\.\d+$/.test(ref)) {
+    kind = 'section';
+    storageRef = sectionStorageRef(ref);
+  } else if (ref.includes(':')) {
+    return { ok: false, error: { code: 'not_found', message: `No neighbors for ref: ${ref}` } };
+  } else {
+    return { ok: false, error: { code: 'invalid_ref', message: `Ref is not traversable: ${ref}` } };
+  }
+
+  const opened = await openEntity(ref, { game });
+  if (!opened.ok) return opened;
+  if (opened.entity.kind !== 'scenario' && opened.entity.kind !== 'section') {
+    return { ok: false, error: { code: 'not_found', message: `No neighbors for ref: ${ref}` } };
+  }
+
+  const links = await followLinks(kind, storageRef, relation, { game });
+  const limit = Math.min(Math.max(options.limit ?? 20, 1), 50);
+  const mapped = await Promise.all(
+    links.slice(0, limit).map(async (link) => ({
+      relation: link.linkType,
+      target: await targetSummary(link.toKind, link.toRef, game),
+      reason: link.rawLabel ?? link.rawContext ?? undefined,
+    })),
+  );
+
+  return {
+    ok: true,
+    from: opened.entity,
+    neighbors: mapped,
+    truncated: links.length > limit || undefined,
+  };
 }

--- a/src/vector-store.ts
+++ b/src/vector-store.ts
@@ -185,6 +185,45 @@ export async function search(
   }
 }
 
+export async function getEntryBySourceChunk(
+  source: string,
+  chunkIndex: number,
+  opts: SearchOptions = {},
+): Promise<ScoredEntry | null> {
+  const game = opts.game ?? DEFAULT_GAME;
+
+  try {
+    const { db } = getDb('server');
+    const result = await db.execute<{
+      id: string;
+      source: string;
+      chunk_index: number;
+      text: string;
+      game: string;
+    }>(sql`
+      SELECT id, source, chunk_index, text, game
+      FROM embeddings
+      WHERE game = ${game}
+        AND source = ${source}
+        AND chunk_index = ${chunkIndex}
+      LIMIT 1
+    `);
+
+    const row = result.rows[0];
+    if (!row) return null;
+    return {
+      id: row.id,
+      source: row.source,
+      chunkIndex: Number(row.chunk_index),
+      text: row.text,
+      game: row.game,
+      score: 1,
+    };
+  } catch (err) {
+    throw wrapDbError(err);
+  }
+}
+
 function wrapDbError(err: unknown): Error {
   const msg = (err as Error).message ?? String(err);
   return new Error(

--- a/src/web-ui/consulted-footer.ts
+++ b/src/web-ui/consulted-footer.ts
@@ -54,6 +54,9 @@ const TOOL_SOURCE_LABELS: Record<AgentToolName, ToolSourceLabel | null> = {
   inspect_sources: null,
   schema: null,
   resolve_entity: null,
+  open_entity: null,
+  search_knowledge: null,
+  neighbors: null,
   search_rules: 'RULEBOOK',
   search_cards: 'CARD INDEX',
   list_card_types: 'CARD INDEX',
@@ -78,6 +81,7 @@ const TOOL_SOURCE_LABELS: Record<AgentToolName, ToolSourceLabel | null> = {
 export function retrievalSourceLabelToFooterLabel(label: string): ToolSourceLabel | null {
   if (label === 'Rulebook') return 'RULEBOOK';
   if (label === 'Puzzle Book') return 'PUZZLE BOOK';
+  if (label === 'Card Index') return 'CARD INDEX';
   if (label.startsWith('Scenario Book')) return 'SCENARIO BOOK';
   if (label.startsWith('Section Book')) return 'SECTION BOOK';
   return null;

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -7,7 +7,9 @@ const {
   mockMessagesStream,
   mockSearchRules,
   mockSearchCards,
+  mockSearchKnowledge,
   mockListCardTypes,
+  mockOpenEntity,
   mockInspectSources,
   mockGetSchema,
   mockResolveEntity,
@@ -16,12 +18,15 @@ const {
   mockGetScenario,
   mockGetSection,
   mockFollowLinks,
+  mockNeighbors,
 } = vi.hoisted(() => ({
   mockMessagesCreate: vi.fn(),
   mockMessagesStream: vi.fn(),
   mockSearchRules: vi.fn(),
   mockSearchCards: vi.fn(),
+  mockSearchKnowledge: vi.fn(),
   mockListCardTypes: vi.fn(),
+  mockOpenEntity: vi.fn(),
   mockInspectSources: vi.fn(),
   mockGetSchema: vi.fn(),
   mockResolveEntity: vi.fn(),
@@ -30,6 +35,7 @@ const {
   mockGetScenario: vi.fn(),
   mockGetSection: vi.fn(),
   mockFollowLinks: vi.fn(),
+  mockNeighbors: vi.fn(),
 }));
 
 vi.mock('@anthropic-ai/sdk', () => ({
@@ -41,7 +47,9 @@ vi.mock('@anthropic-ai/sdk', () => ({
 vi.mock('../src/tools.ts', () => ({
   searchRules: mockSearchRules,
   searchCards: mockSearchCards,
+  searchKnowledge: mockSearchKnowledge,
   listCardTypes: mockListCardTypes,
+  openEntity: mockOpenEntity,
   inspectSources: mockInspectSources,
   getSchema: mockGetSchema,
   resolveEntity: mockResolveEntity,
@@ -51,6 +59,7 @@ vi.mock('../src/tools.ts', () => ({
   getScenario: mockGetScenario,
   getSection: mockGetSection,
   followLinks: mockFollowLinks,
+  neighbors: mockNeighbors,
 }));
 
 import { runAgentLoop, executeToolCall, AGENT_TOOLS, MAX_AGENT_ITERATIONS } from '../src/agent.ts';
@@ -122,6 +131,7 @@ describe('runAgentLoop', () => {
       { text: 'Loot: pick up all loot tokens.', source: 'rulebook.pdf:42', score: 0.9 },
     ]);
     mockSearchCards.mockReturnValue([]);
+    mockSearchKnowledge.mockResolvedValue({ ok: true, query: 'loot', results: [] });
     mockListCardTypes.mockReturnValue([{ type: 'items', count: 10 }]);
     mockInspectSources.mockResolvedValue({
       ok: true,
@@ -131,6 +141,19 @@ describe('runAgentLoop', () => {
     });
     mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
     mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
+    mockOpenEntity.mockResolvedValue({
+      ok: true,
+      entity: {
+        kind: 'section',
+        ref: 'section:frosthaven/67.1',
+        title: 'Section 67.1',
+        sourceLabel: 'Section Book',
+        data: {},
+      },
+      citations: [],
+      links: [],
+      related: [],
+    });
     mockGetCard.mockReturnValue({ name: 'Boots of Speed', effect: 'Move +1' });
     mockFindScenario.mockResolvedValue([
       { ref: 'gloomhavensecretariat:scenario/061', scenarioIndex: '61', name: 'Life and Death' },
@@ -158,6 +181,16 @@ describe('runAgentLoop', () => {
         sequence: 0,
       },
     ]);
+    mockNeighbors.mockResolvedValue({
+      ok: true,
+      from: {
+        kind: 'scenario',
+        ref: 'scenario:frosthaven/061',
+        title: 'Life and Death',
+        sourceLabel: 'Scenario Book',
+      },
+      neighbors: [],
+    });
   });
 
   it('returns text immediately when Claude responds without tool use', async () => {
@@ -465,6 +498,7 @@ describe('executeToolCall', () => {
     vi.clearAllMocks();
     mockSearchRules.mockResolvedValue([{ text: 'rule text', source: 'test.pdf:1', score: 0.9 }]);
     mockSearchCards.mockReturnValue([{ type: 'items', data: { name: 'Test' }, score: 1 }]);
+    mockSearchKnowledge.mockResolvedValue({ ok: true, query: 'loot', results: [] });
     mockListCardTypes.mockReturnValue([{ type: 'items', count: 5 }]);
     mockInspectSources.mockResolvedValue({
       ok: true,
@@ -474,11 +508,34 @@ describe('executeToolCall', () => {
     });
     mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
     mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
+    mockOpenEntity.mockResolvedValue({
+      ok: true,
+      entity: {
+        kind: 'section',
+        ref: 'section:frosthaven/67.1',
+        title: 'Section 67.1',
+        sourceLabel: 'Section Book',
+        data: {},
+      },
+      citations: [],
+      links: [],
+      related: [],
+    });
     mockGetCard.mockReturnValue({ name: 'Test Item' });
     mockFindScenario.mockResolvedValue([{ ref: 'gloomhavensecretariat:scenario/061' }]);
     mockGetScenario.mockResolvedValue({ ref: 'gloomhavensecretariat:scenario/061' });
     mockGetSection.mockResolvedValue({ ref: '67.1' });
     mockFollowLinks.mockResolvedValue([{ toRef: '67.1' }]);
+    mockNeighbors.mockResolvedValue({
+      ok: true,
+      from: {
+        kind: 'scenario',
+        ref: 'scenario:frosthaven/061',
+        title: 'Life and Death',
+        sourceLabel: 'Scenario Book',
+      },
+      neighbors: [],
+    });
   });
 
   it('dispatches search_rules', async () => {
@@ -518,6 +575,66 @@ describe('executeToolCall', () => {
     const result = await executeToolCall('search_cards', { query: 'boots' });
     expect(mockSearchCards).toHaveBeenCalledWith('boots', 6);
     expect(JSON.parse(result.content)).toHaveLength(1);
+  });
+
+  it('dispatches search_knowledge and collects citation source labels', async () => {
+    mockSearchKnowledge.mockResolvedValueOnce({
+      ok: true,
+      query: 'loot',
+      results: [
+        {
+          entity: {
+            kind: 'rules_passage',
+            ref: 'rules:frosthaven/fh-rule-book.pdf#chunk=0',
+            title: 'fh-rule-book.pdf chunk 0',
+            sourceLabel: 'Rulebook',
+          },
+          score: 0.9,
+          snippet: 'Loot action',
+          citations: [
+            { sourceRef: 'rules:frosthaven/fh-rule-book.pdf', sourceLabel: 'Rulebook' },
+            { sourceRef: 'card-index:frosthaven/items', sourceLabel: 'Card Index' },
+          ],
+          nextRefs: [],
+        },
+      ],
+    });
+    const result = await executeToolCall('search_knowledge', {
+      query: 'loot',
+      scope: ['rules_passage'],
+      limit: 3,
+    });
+    expect(mockSearchKnowledge).toHaveBeenCalledWith('loot', {
+      scope: ['rules_passage'],
+      limit: 3,
+    });
+    expect(result.sourceBooks).toEqual(['Rulebook', 'Card Index']);
+  });
+
+  it('dispatches open_entity and collects citation source labels', async () => {
+    mockOpenEntity.mockResolvedValueOnce({
+      ok: true,
+      entity: {
+        kind: 'section',
+        ref: 'section:frosthaven/67.1',
+        title: 'Section 67.1',
+        sourceLabel: 'Section Book 62-81',
+        data: {},
+      },
+      citations: [
+        {
+          sourceRef: 'source:frosthaven/fh-section-book-62-81.pdf',
+          sourceLabel: 'Section Book 62-81',
+          locator: 'p. 1',
+        },
+      ],
+      links: [],
+      related: [],
+    });
+    const result = await executeToolCall('open_entity', { ref: 'section:frosthaven/67.1' });
+    expect(mockOpenEntity).toHaveBeenCalledWith('section:frosthaven/67.1');
+    expect(JSON.parse(result.content).entity.ref).toBe('section:frosthaven/67.1');
+    expect(result.sourceBooks).toEqual(['Section Book 62-81']);
   });
 
   it('dispatches list_card_types', async () => {
@@ -604,6 +721,28 @@ describe('executeToolCall', () => {
       'conclusion',
     );
     expect(JSON.parse(result.content)).toEqual([{ toRef: '67.1' }]);
+  });
+
+  it('dispatches neighbors', async () => {
+    const result = await executeToolCall('neighbors', {
+      ref: 'scenario:frosthaven/061',
+      relation: 'conclusion',
+      limit: 5,
+    });
+    expect(mockNeighbors).toHaveBeenCalledWith('scenario:frosthaven/061', {
+      relation: 'conclusion',
+      limit: 5,
+    });
+    expect(JSON.parse(result.content)).toEqual({
+      ok: true,
+      from: {
+        kind: 'scenario',
+        ref: 'scenario:frosthaven/061',
+        title: 'Life and Death',
+        sourceLabel: 'Scenario Book',
+      },
+      neighbors: [],
+    });
   });
 
   it('returns error for unknown tool', async () => {

--- a/test/consulted-footer.test.ts
+++ b/test/consulted-footer.test.ts
@@ -36,7 +36,13 @@ describe('toolSourceLabel', () => {
     expect(toolSourceLabel(tool)).toBe(label);
   });
 
-  it('returns null for follow_links (traversal tool, not a source)', () => {
+  it('returns null for tools whose dynamic results carry source labels', () => {
+    expect(toolSourceLabel('open_entity')).toBeNull();
+    expect(toolSourceLabel('search_knowledge')).toBeNull();
+  });
+
+  it('returns null for traversal tools that are not sources', () => {
+    expect(toolSourceLabel('neighbors')).toBeNull();
     expect(toolSourceLabel('follow_links')).toBeNull();
   });
 
@@ -50,6 +56,7 @@ describe('retrievalSourceLabelToFooterLabel', () => {
   it.each([
     ['Rulebook', 'RULEBOOK'],
     ['Puzzle Book', 'PUZZLE BOOK'],
+    ['Card Index', 'CARD INDEX'],
     ['Scenario Book 1', 'SCENARIO BOOK'],
     ['Scenario Book A', 'SCENARIO BOOK'],
     ['Section Book A', 'SECTION BOOK'],

--- a/test/mcp-in-process.test.ts
+++ b/test/mcp-in-process.test.ts
@@ -3,9 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const {
   mockSearchRules,
   mockSearchCards,
+  mockSearchKnowledge,
   mockListCardTypes,
   mockListCards,
   mockGetCard,
+  mockOpenEntity,
   mockInspectSources,
   mockGetSchema,
   mockResolveEntity,
@@ -13,12 +15,15 @@ const {
   mockGetScenario,
   mockGetSection,
   mockFollowLinks,
+  mockNeighbors,
 } = vi.hoisted(() => ({
   mockSearchRules: vi.fn(),
   mockSearchCards: vi.fn(),
+  mockSearchKnowledge: vi.fn(),
   mockListCardTypes: vi.fn(),
   mockListCards: vi.fn(),
   mockGetCard: vi.fn(),
+  mockOpenEntity: vi.fn(),
   mockInspectSources: vi.fn(),
   mockGetSchema: vi.fn(),
   mockResolveEntity: vi.fn(),
@@ -26,14 +31,17 @@ const {
   mockGetScenario: vi.fn(),
   mockGetSection: vi.fn(),
   mockFollowLinks: vi.fn(),
+  mockNeighbors: vi.fn(),
 }));
 
 vi.mock('../src/tools.ts', () => ({
   searchRules: mockSearchRules,
   searchCards: mockSearchCards,
+  searchKnowledge: mockSearchKnowledge,
   listCardTypes: mockListCardTypes,
   listCards: mockListCards,
   getCard: mockGetCard,
+  openEntity: mockOpenEntity,
   inspectSources: mockInspectSources,
   getSchema: mockGetSchema,
   resolveEntity: mockResolveEntity,
@@ -41,6 +49,7 @@ vi.mock('../src/tools.ts', () => ({
   getScenario: mockGetScenario,
   getSection: mockGetSection,
   followLinks: mockFollowLinks,
+  neighbors: mockNeighbors,
 }));
 
 import { createInProcessClient } from '../src/mcp.ts';
@@ -64,6 +73,30 @@ describe('in-process MCP client', () => {
     mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
     mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
     mockGetCard.mockReturnValue({ name: 'Algox Archer' });
+    mockSearchKnowledge.mockResolvedValue({ ok: true, query: 'loot', results: [] });
+    mockOpenEntity.mockResolvedValue({
+      ok: true,
+      entity: {
+        kind: 'section',
+        ref: 'section:frosthaven/67.1',
+        title: 'Section 67.1',
+        sourceLabel: 'Section Book',
+        data: {},
+      },
+      citations: [],
+      links: [],
+      related: [],
+    });
+    mockNeighbors.mockResolvedValue({
+      ok: true,
+      from: {
+        kind: 'scenario',
+        ref: 'scenario:frosthaven/061',
+        title: 'Life and Death',
+        sourceLabel: 'Scenario Book',
+      },
+      neighbors: [],
+    });
   });
 
   it('creates a connected MCP client', async () => {
@@ -75,7 +108,7 @@ describe('in-process MCP client', () => {
   it('lists tools via in-process transport', async () => {
     const client = await createInProcessClient();
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(12);
+    expect(tools.length).toBe(15);
     const names = tools.map((t) => t.name);
     expect(names).toContain('inspect_sources');
     expect(names).toContain('schema');
@@ -85,6 +118,9 @@ describe('in-process MCP client', () => {
     expect(names).toContain('get_scenario');
     expect(names).toContain('get_section');
     expect(names).toContain('follow_links');
+    expect(names).toContain('open_entity');
+    expect(names).toContain('search_knowledge');
+    expect(names).toContain('neighbors');
     expect(names).toContain('list_card_types');
     expect(names).toContain('get_card');
     await client.close();

--- a/test/mcp-transport.test.ts
+++ b/test/mcp-transport.test.ts
@@ -3,9 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const {
   mockSearchRules,
   mockSearchCards,
+  mockSearchKnowledge,
   mockListCardTypes,
   mockListCards,
   mockGetCard,
+  mockOpenEntity,
   mockInspectSources,
   mockGetSchema,
   mockResolveEntity,
@@ -13,12 +15,15 @@ const {
   mockGetScenario,
   mockGetSection,
   mockFollowLinks,
+  mockNeighbors,
 } = vi.hoisted(() => ({
   mockSearchRules: vi.fn(),
   mockSearchCards: vi.fn(),
+  mockSearchKnowledge: vi.fn(),
   mockListCardTypes: vi.fn(),
   mockListCards: vi.fn(),
   mockGetCard: vi.fn(),
+  mockOpenEntity: vi.fn(),
   mockInspectSources: vi.fn(),
   mockGetSchema: vi.fn(),
   mockResolveEntity: vi.fn(),
@@ -26,14 +31,17 @@ const {
   mockGetScenario: vi.fn(),
   mockGetSection: vi.fn(),
   mockFollowLinks: vi.fn(),
+  mockNeighbors: vi.fn(),
 }));
 
 vi.mock('../src/tools.ts', () => ({
   searchRules: mockSearchRules,
   searchCards: mockSearchCards,
+  searchKnowledge: mockSearchKnowledge,
   listCardTypes: mockListCardTypes,
   listCards: mockListCards,
   getCard: mockGetCard,
+  openEntity: mockOpenEntity,
   inspectSources: mockInspectSources,
   getSchema: mockGetSchema,
   resolveEntity: mockResolveEntity,
@@ -41,6 +49,7 @@ vi.mock('../src/tools.ts', () => ({
   getScenario: mockGetScenario,
   getSection: mockGetSection,
   followLinks: mockFollowLinks,
+  neighbors: mockNeighbors,
 }));
 
 vi.mock('../src/service.ts', () => ({
@@ -119,12 +128,36 @@ describe('MCP over Streamable HTTP', () => {
     mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
     mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
     mockGetCard.mockReturnValue({ name: 'Algox Archer' });
+    mockSearchKnowledge.mockResolvedValue({ ok: true, query: 'loot', results: [] });
+    mockOpenEntity.mockResolvedValue({
+      ok: true,
+      entity: {
+        kind: 'section',
+        ref: 'section:frosthaven/67.1',
+        title: 'Section 67.1',
+        sourceLabel: 'Section Book',
+        data: {},
+      },
+      citations: [],
+      links: [],
+      related: [],
+    });
+    mockNeighbors.mockResolvedValue({
+      ok: true,
+      from: {
+        kind: 'scenario',
+        ref: 'scenario:frosthaven/061',
+        title: 'Life and Death',
+        sourceLabel: 'Scenario Book',
+      },
+      neighbors: [],
+    });
   });
 
   it('lists tools via HTTP transport', async () => {
     const client = await createHttpClient();
     const { tools } = await client.listTools();
-    expect(tools.length).toBe(12);
+    expect(tools.length).toBe(15);
     const names = tools.map((t) => t.name);
     expect(names).toContain('inspect_sources');
     expect(names).toContain('schema');
@@ -134,6 +167,9 @@ describe('MCP over Streamable HTTP', () => {
     expect(names).toContain('get_scenario');
     expect(names).toContain('get_section');
     expect(names).toContain('follow_links');
+    expect(names).toContain('open_entity');
+    expect(names).toContain('search_knowledge');
+    expect(names).toContain('neighbors');
     expect(names).toContain('list_card_types');
     await client.close();
   });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -3,9 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const {
   mockSearchRules,
   mockSearchCards,
+  mockSearchKnowledge,
   mockListCardTypes,
   mockListCards,
   mockGetCard,
+  mockOpenEntity,
   mockInspectSources,
   mockGetSchema,
   mockResolveEntity,
@@ -13,12 +15,15 @@ const {
   mockGetScenario,
   mockGetSection,
   mockFollowLinks,
+  mockNeighbors,
 } = vi.hoisted(() => ({
   mockSearchRules: vi.fn(),
   mockSearchCards: vi.fn(),
+  mockSearchKnowledge: vi.fn(),
   mockListCardTypes: vi.fn(),
   mockListCards: vi.fn(),
   mockGetCard: vi.fn(),
+  mockOpenEntity: vi.fn(),
   mockInspectSources: vi.fn(),
   mockGetSchema: vi.fn(),
   mockResolveEntity: vi.fn(),
@@ -26,14 +31,17 @@ const {
   mockGetScenario: vi.fn(),
   mockGetSection: vi.fn(),
   mockFollowLinks: vi.fn(),
+  mockNeighbors: vi.fn(),
 }));
 
 vi.mock('../src/tools.ts', () => ({
   searchRules: mockSearchRules,
   searchCards: mockSearchCards,
+  searchKnowledge: mockSearchKnowledge,
   listCardTypes: mockListCardTypes,
   listCards: mockListCards,
   getCard: mockGetCard,
+  openEntity: mockOpenEntity,
   inspectSources: mockInspectSources,
   getSchema: mockGetSchema,
   resolveEntity: mockResolveEntity,
@@ -41,6 +49,7 @@ vi.mock('../src/tools.ts', () => ({
   getScenario: mockGetScenario,
   getSection: mockGetSection,
   followLinks: mockFollowLinks,
+  neighbors: mockNeighbors,
 }));
 
 import { createMcpServer } from '../src/mcp.ts';
@@ -124,9 +133,33 @@ describe('MCP tool registration', () => {
     });
     mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
     mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
+    mockOpenEntity.mockResolvedValue({
+      ok: true,
+      entity: {
+        kind: 'section',
+        ref: 'section:frosthaven/67.1',
+        title: 'Section 67.1',
+        sourceLabel: 'Section Book',
+        data: {},
+      },
+      citations: [],
+      links: [],
+      related: [],
+    });
+    mockSearchKnowledge.mockResolvedValue({ ok: true, query: 'loot', results: [] });
+    mockNeighbors.mockResolvedValue({
+      ok: true,
+      from: {
+        kind: 'scenario',
+        ref: 'scenario:frosthaven/061',
+        title: 'Life and Death',
+        sourceLabel: 'Scenario Book',
+      },
+      neighbors: [],
+    });
   });
 
-  it('registers old tools and the new discovery tools', async () => {
+  it('registers old tools, discovery tools, and canonical knowledge tools', async () => {
     const client = await connectClient();
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
@@ -138,11 +171,14 @@ describe('MCP tool registration', () => {
     expect(names).toContain('get_scenario');
     expect(names).toContain('get_section');
     expect(names).toContain('follow_links');
+    expect(names).toContain('open_entity');
+    expect(names).toContain('search_knowledge');
+    expect(names).toContain('neighbors');
     expect(names).toContain('search_cards');
     expect(names).toContain('list_card_types');
     expect(names).toContain('list_cards');
     expect(names).toContain('get_card');
-    expect(tools).toHaveLength(12);
+    expect(tools).toHaveLength(15);
   });
 
   it('wires the discovery tools through to handlers', async () => {
@@ -202,6 +238,30 @@ describe('MCP tool registration', () => {
       'gloomhavensecretariat:scenario/061',
       undefined,
     );
+
+    await expect(
+      client.callTool({ name: 'open_entity', arguments: { ref: 'section:frosthaven/67.1' } }),
+    ).resolves.toBeDefined();
+    expect(mockOpenEntity).toHaveBeenCalledWith('section:frosthaven/67.1');
+
+    await expect(
+      client.callTool({ name: 'search_knowledge', arguments: { query: 'loot', limit: 3 } }),
+    ).resolves.toBeDefined();
+    expect(mockSearchKnowledge).toHaveBeenCalledWith('loot', {
+      scope: undefined,
+      limit: 3,
+    });
+
+    await expect(
+      client.callTool({
+        name: 'neighbors',
+        arguments: { ref: 'scenario:frosthaven/061', relation: 'conclusion' },
+      }),
+    ).resolves.toBeDefined();
+    expect(mockNeighbors).toHaveBeenCalledWith('scenario:frosthaven/061', {
+      relation: 'conclusion',
+      limit: 20,
+    });
   });
 });
 

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -10,12 +10,14 @@
 import { beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
 import { sql } from 'drizzle-orm';
 
-const { mockSearch } = vi.hoisted(() => ({
+const { mockSearch, mockGetEntryBySourceChunk } = vi.hoisted(() => ({
   mockSearch: vi.fn(),
+  mockGetEntryBySourceChunk: vi.fn(),
 }));
 
 vi.mock('../src/vector-store.ts', () => ({
   search: mockSearch,
+  getEntryBySourceChunk: mockGetEntryBySourceChunk,
 }));
 
 vi.mock('../src/embedder.ts', () => ({
@@ -25,9 +27,11 @@ vi.mock('../src/embedder.ts', () => ({
 import {
   searchRules,
   searchCards,
+  searchKnowledge,
   listCardTypes,
   listCards,
   getCard,
+  openEntity,
   inspectSources,
   getSchema,
   resolveEntity,
@@ -35,6 +39,7 @@ import {
   getScenario,
   getSection,
   followLinks,
+  neighbors,
 } from '../src/tools.ts';
 import type {
   RuleResult,
@@ -44,6 +49,9 @@ import type {
   ScenarioResult,
   SectionResult,
   ReferenceResult,
+  KnowledgeOpenResult,
+  KnowledgeSearchResult,
+  KnowledgeNeighborsResult,
 } from '../src/tools.ts';
 import { findScenarios } from '../src/scenario-section-data.ts';
 import { getDb } from '../src/db.ts';
@@ -82,6 +90,12 @@ const FAKE_RULE_HITS = [
 beforeAll(async () => {
   await setupTestDb();
   mockSearch.mockImplementation(async (_v: number[], k = 6) => FAKE_RULE_HITS.slice(0, k));
+  mockGetEntryBySourceChunk.mockImplementation(async (source: string, chunkIndex: number) => {
+    const hit = FAKE_RULE_HITS.find(
+      (entry) => entry.source === source && entry.chunkIndex === chunkIndex,
+    );
+    return hit ?? null;
+  });
 });
 
 afterAll(async () => {
@@ -139,6 +153,221 @@ describe('searchRules', () => {
     expect(mockSearch).toHaveBeenCalledTimes(1);
     const callArgs = mockSearch.mock.calls[0];
     expect(callArgs[2]).toEqual({ game: 'gloomhaven' });
+  });
+});
+
+describe('openEntity', () => {
+  it('opens a scenario with source metadata and inspectable next links', async () => {
+    const result: KnowledgeOpenResult = await openEntity('scenario:frosthaven/061');
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+
+    expect(result.entity).toMatchObject({
+      kind: 'scenario',
+      ref: 'scenario:frosthaven/061',
+      title: 'Life and Death',
+      sourceLabel: 'Scenario Book 62-81',
+    });
+    expect(result.entity.data).toMatchObject({
+      scenarioIndex: '61',
+      sourcePdf: 'fh-scenario-book-62-81.pdf',
+    });
+    expect(result.citations).toEqual([
+      expect.objectContaining({
+        sourceRef: 'source:frosthaven/fh-scenario-book-62-81',
+        sourceLabel: 'Scenario Book 62-81',
+        locator: 'scenario 61',
+      }),
+    ]);
+    expect(result.links).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          relation: 'conclusion',
+          target: expect.objectContaining({
+            kind: 'section',
+            ref: 'section:frosthaven/67.1',
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it('opens a section with exact text, source metadata, and outgoing links', async () => {
+    const result = await openEntity('section:frosthaven/66.2');
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+
+    expect(result.entity).toMatchObject({
+      kind: 'section',
+      ref: 'section:frosthaven/66.2',
+      title: 'Section 66.2',
+      sourceLabel: 'Section Book 62-81',
+    });
+    expect(result.entity.data.text).toContain('Caravan Guards116');
+    expect(result.links).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          relation: 'unlock',
+          target: expect.objectContaining({
+            kind: 'scenario',
+            ref: 'scenario:frosthaven/116',
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it('opens a card with canonical ID, card type, display name, and source fields', async () => {
+    const result = await openEntity('card:frosthaven/items/gloomhavensecretariat:item/1');
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+
+    expect(result.entity.kind).toBe('card');
+    expect(result.entity.ref).toBe('card:frosthaven/items/gloomhavensecretariat:item/1');
+    expect(result.entity.title).toBe('Spyglass');
+    expect(result.entity.sourceLabel).toBe('Card Index');
+    expect(result.entity.data).toMatchObject({
+      type: 'items',
+      sourceId: 'gloomhavensecretariat:item/1',
+      displayName: 'Spyglass',
+    });
+    expect(result.citations).toEqual([
+      expect.objectContaining({
+        sourceRef: 'source:frosthaven/cards/items',
+        sourceLabel: 'Card Index',
+        locator: 'gloomhavensecretariat:item/1',
+      }),
+    ]);
+  });
+
+  it('opens a rule passage by canonical source and chunk ref', async () => {
+    const result = await openEntity('rules:frosthaven/fh-rule-book.pdf#chunk=0');
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+
+    expect(result.entity).toMatchObject({
+      kind: 'rules_passage',
+      ref: 'rules:frosthaven/fh-rule-book.pdf#chunk=0',
+      sourceLabel: 'Rulebook',
+    });
+    expect(result.entity.data.text).toContain('Loot action');
+  });
+
+  it('returns structured not_found and invalid_ref failures', async () => {
+    await expect(openEntity('section:frosthaven/9999.9')).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'not_found' },
+    });
+    await expect(openEntity('nonsense')).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'invalid_ref' },
+    });
+  });
+
+  it('returns ambiguous for underspecified legacy refs', async () => {
+    await expect(openEntity('61')).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'ambiguous' },
+    });
+  });
+});
+
+describe('searchKnowledge', () => {
+  it('searches across scopes with openable refs, metadata, citations, and next refs', async () => {
+    const result: KnowledgeSearchResult = await searchKnowledge('loot action', {
+      scope: ['rules_passage', 'card'],
+      limit: 4,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.results.length).toBeGreaterThan(0);
+    expect(result.results[0]).toMatchObject({
+      entity: expect.objectContaining({
+        kind: expect.stringMatching(/^(rules_passage|card)$/),
+        ref: expect.any(String),
+        sourceLabel: expect.any(String),
+      }),
+      score: expect.any(Number),
+      snippet: expect.any(String),
+      citations: expect.any(Array),
+      nextRefs: expect.any(Array),
+    });
+  });
+
+  it('returns an empty successful result set for no-result searches', async () => {
+    const result = await searchKnowledge('zzzzzzz-no-such-token-zzzzzzz', {
+      scope: ['card'],
+    });
+    expect(result).toMatchObject({ ok: true, results: [] });
+  });
+
+  it('searches section text and returns openable section refs', async () => {
+    const result = await searchKnowledge('Moonshard answers', {
+      scope: ['section'],
+      limit: 3,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          entity: expect.objectContaining({
+            kind: 'section',
+            ref: 'section:frosthaven/67.1',
+          }),
+          snippet: expect.stringContaining('Moonshard answers'),
+        }),
+      ]),
+    );
+  });
+
+  it('rejects invalid scopes with structured errors', async () => {
+    const result = await searchKnowledge('loot', {
+      scope: ['bogus' as never],
+    });
+    expect(result).toMatchObject({
+      ok: false,
+      error: { code: 'invalid_filter' },
+    });
+  });
+});
+
+describe('neighbors', () => {
+  it('traverses scenario conclusion links as openable neighbors', async () => {
+    const result: KnowledgeNeighborsResult = await neighbors('scenario:frosthaven/061', {
+      relation: 'conclusion',
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+
+    expect(result.from).toMatchObject({
+      kind: 'scenario',
+      ref: 'scenario:frosthaven/061',
+      sourceLabel: 'Scenario Book 62-81',
+    });
+    expect(result.neighbors).toEqual([
+      expect.objectContaining({
+        relation: 'conclusion',
+        target: expect.objectContaining({
+          kind: 'section',
+          ref: 'section:frosthaven/67.1',
+        }),
+      }),
+    ]);
+  });
+
+  it('returns structured errors for invalid refs and unsupported relations', async () => {
+    await expect(neighbors('nonsense')).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'invalid_ref' },
+    });
+    await expect(
+      neighbors('scenario:frosthaven/061', { relation: 'not_a_relation' as never }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'unsupported_relation' },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Add canonical `open_entity`, `search_knowledge`, and `neighbors` tools for rules passages, scenarios, sections, and cards.
- Register the new tools for both MCP and the Anthropic agent while preserving the SQR-117 discovery tools from `main`.
- Add canonical refs, citations, related links, and consulted-source handling for dynamic tool results.

## Validation

- `npm run check`
- Browser QA with symlinked `.env` from `~/Projects/maz/squire/.env`: dev login, first-turn question, real Anthropic response, no console errors.

Fixes SQR-118


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added knowledge search capability to explore rules, scenarios, sections, and cards.
  * Added entity lookup to view specific information by reference.
  * Added relationship traversal to discover connections between entities.
  * Enhanced source attribution tracking for search and lookup results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->