### PR TITLE
Use redesigned agent tool surface

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -390,8 +390,8 @@ _Phase 5 (with the recommendation engine). See [SPEC.md](SPEC.md). Curated URL l
   `tool_result` events on every write path (SSE and the plain-form POST
   fallback). `aggregateSourceLabels` in `src/web-ui/consulted-footer.ts`
   handles both storage formats transparently so no migration is required.
-  The tool-name → label map is pinned to `AgentToolName` so adding a tool
-  to `AGENT_TOOLS` without extending the map is a typecheck failure. `null`
+  The tool-name → label map is pinned to `AgentToolName` so adding a selectable
+  tool without extending the map is a typecheck failure. `null`
   means "no source tools fired" or "pre-SQR-98 row"; both render with the
   footer hidden
 - Browser streaming contract:

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -49,7 +49,27 @@ const MAX_HISTORY_TURNS = 20;
 const FORCE_SYNTHESIS_PROMPT =
   'Use the retrieved rulebook context to answer now. Do not search again unless the existing tool results are empty or clearly unrelated.';
 
-export const AGENT_SYSTEM_PROMPT = `You are a knowledgeable Frosthaven rules assistant with access to tools \
+const ANSWER_FORMATTING_PROMPT = `Formatting:
+- Use *italics* only for named Frosthaven game terms — mechanics, abilities, conditions, status effects, keyword phrases (e.g., *Muddle*, *Shield 1*, *Retaliate*, *Loot 2*, *Move 3*). The UI renders these as a highlighted rule-term chip, so emphasizing prose words like *not* or *however* turns ordinary stress into a false rule citation. Use **bold** for general emphasis instead.
+- Use > blockquotes when you reproduce literal rulebook text. Don't wrap quoted sentences in italics.`;
+
+export const AGENT_SYSTEM_PROMPT = `You are Squire, a Frosthaven rules assistant. Answer the user's question using the provided knowledge tools.
+
+Grounding rules:
+- Use tools before answering factual rules, scenario, section, card, monster, item, or ability questions.
+- Treat tool results as the source of truth. Do not invent rules, stats, item numbers, section text, or scenario outcomes.
+- If the available data does not answer the question, say what is missing instead of guessing.
+- Resolve natural user language to refs when exact records are needed, then open or traverse those refs.
+- Follow explicit links between records when the answer depends on connected scenario or section text.
+
+Citations and answer shape:
+- Cite the book, section, scenario, or card source when the tool result provides one.
+- Be concise, but include enough detail for the table to act on the answer.
+- When quoting rules text, quote only the relevant sentence or short passage.
+
+${ANSWER_FORMATTING_PROMPT}`;
+
+export const LEGACY_AGENT_SYSTEM_PROMPT = `You are a knowledgeable Frosthaven rules assistant with access to tools \
 for searching the indexed Frosthaven books and looking up card data. Use the tools to find relevant information before answering.
 
 Guidelines:
@@ -75,9 +95,7 @@ Guidelines:
 - Do not invent rules, stats, or item numbers.
 - Be concise but complete.
 
-Formatting:
-- Use *italics* only for named Frosthaven game terms — mechanics, abilities, conditions, status effects, keyword phrases (e.g., *Muddle*, *Shield 1*, *Retaliate*, *Loot 2*, *Move 3*). The UI renders these as a highlighted rule-term chip, so emphasizing prose words like *not* or *however* turns ordinary stress into a false rule citation. Use **bold** for general emphasis instead.
-- Use > blockquotes when you reproduce literal rulebook text. Don't wrap quoted sentences in italics.`;
+${ANSWER_FORMATTING_PROMPT}`;
 
 // `as const satisfies readonly Tool[]` lets us derive `AgentToolName` below
 // as a literal union of the tool names. That union is what powers the
@@ -181,6 +199,9 @@ export const AGENT_TOOLS = [
       required: ['ref'],
     },
   },
+] as const satisfies readonly Tool[];
+
+export const LEGACY_AGENT_TOOLS = [
   {
     name: 'search_rules',
     description:
@@ -318,8 +339,28 @@ export const AGENT_TOOLS = [
   },
 ] as const satisfies readonly Tool[];
 
-/** Union of every tool name exposed to the agent. Keeps dependent maps honest. */
-export type AgentToolName = (typeof AGENT_TOOLS)[number]['name'];
+export const ALL_AGENT_TOOLS = [...AGENT_TOOLS, ...LEGACY_AGENT_TOOLS] as const;
+
+/** Union of every selectable tool name. Keeps dependent maps honest. */
+export type AgentToolName = (typeof ALL_AGENT_TOOLS)[number]['name'];
+
+type AgentToolSurface = 'redesigned' | 'legacy';
+
+function selectedAgentSurface(surface: AgentToolSurface | undefined): {
+  system: string;
+  tools: readonly Tool[];
+} {
+  if (surface === 'legacy') {
+    return {
+      system: LEGACY_AGENT_SYSTEM_PROMPT,
+      tools: LEGACY_AGENT_TOOLS,
+    };
+  }
+  return {
+    system: AGENT_SYSTEM_PROMPT,
+    tools: AGENT_TOOLS,
+  };
+}
 
 export interface ToolCallResult {
   content: string;
@@ -490,23 +531,24 @@ export async function executeToolCall(
 async function callClaude(
   messages: MessageParam[],
   emit?: EmitFn,
-  opts: { allowTools?: boolean } = {},
+  opts: { allowTools?: boolean; toolSurface?: AgentToolSurface } = {},
 ): Promise<Message> {
   const allowTools = opts.allowTools ?? true;
+  const surface = selectedAgentSurface(opts.toolSurface);
   const params = {
     model: 'claude-sonnet-4-6' as const,
     max_tokens: 4096,
-    system: AGENT_SYSTEM_PROMPT,
+    system: surface.system,
     messages,
   };
 
   const paramsWithTools = allowTools
     ? {
         ...params,
-        // Spread into a mutable array so the readonly AGENT_TOOLS tuple
+        // Spread into a mutable array so the readonly tool tuples
         // (declared `as const` to power the AgentToolName union) satisfies
         // the Anthropic SDK's `ToolUnion[]` signature.
-        tools: [...AGENT_TOOLS],
+        tools: [...surface.tools],
       }
     : params;
 
@@ -531,6 +573,7 @@ async function callClaude(
 export async function runAgentLoop(question: string, options?: AskOptions): Promise<string> {
   const history = options?.history;
   const emit = options?.emit;
+  const toolSurface = options?.toolSurface;
   const truncatedHistory = history ? history.slice(-MAX_HISTORY_TURNS) : [];
 
   const messages: MessageParam[] = [
@@ -547,7 +590,10 @@ export async function runAgentLoop(question: string, options?: AskOptions): Prom
   let forceSynthesis = false;
 
   for (let i = 0; i < MAX_AGENT_ITERATIONS; i++) {
-    const response = await callClaude(messages, emit, { allowTools: !forceSynthesis });
+    const response = await callClaude(messages, emit, {
+      allowTools: !forceSynthesis,
+      toolSurface,
+    });
     const hasToolUse = response.content.some((block) => block.type === 'tool_use');
 
     // Collect all text content from this response

--- a/src/db/repositories/types.ts
+++ b/src/db/repositories/types.ts
@@ -96,12 +96,10 @@ export interface CreateConversationMessageInput {
   /**
    * Write-side accepts plain strings because the capture wrapper in
    * persistAssistantOutcome reads raw tool names off the agent's emit
-   * stream — the agent only ever emits names from AGENT_TOOLS, but the
-   * event payload type is `string`, so forcing AgentToolName[] here
-   * would require a cast at every call site for no safety gain. The
-   * read-side ConversationMessage.consultedSources narrows to
-   * AgentToolName[] after toDomain, which is where the contract is
-   * actually useful (render path).
+   * stream — the agent only ever emits known AgentToolName values, but the
+   * event payload type is `string`, so forcing AgentToolName[] here would
+   * require a cast at every call site for no safety gain. The render path
+   * validates and aggregates the strings before showing provenance.
    */
   consultedSources?: string[] | null;
 }

--- a/src/db/schema/conversations.ts
+++ b/src/db/schema/conversations.ts
@@ -45,7 +45,7 @@ export const messages = pgTable(
     responseToMessageId: uuid('response_to_message_id').references((): AnyPgColumn => messages.id, {
       onDelete: 'cascade',
     }),
-    // SQR-98: tool names (from AGENT_TOOLS in src/agent.ts) that fired with
+    // SQR-98: selectable agent tool names that fired with
     // ok:true during this answer's turn. Rendered into the footer as
     // provenance labels. Null for user messages and for any assistant
     // message written before SQR-98 landed (pre-migration rows); both

--- a/src/server.ts
+++ b/src/server.ts
@@ -1140,6 +1140,7 @@ const AskRequestSchema = z.object({
     .optional(),
   campaignId: z.string().uuid().optional(),
   userId: z.string().uuid().optional(),
+  toolSurface: z.enum(['redesigned', 'legacy']).optional(),
 });
 
 app.post('/api/ask', async (c) => {

--- a/src/service.ts
+++ b/src/service.ts
@@ -515,6 +515,11 @@ export type EmitFn = (event: string, data: unknown) => Promise<void>;
 
 export interface AskOptions {
   history?: HistoryMessage[];
+  /**
+   * Default uses the redesigned self-describing knowledge tools. `legacy`
+   * keeps the old tool surface selectable until eval parity closes Step 3.
+   */
+  toolSurface?: 'redesigned' | 'legacy';
   /** Campaign UUID — reserved for future campaign context loading. */
   campaignId?: string;
   /** User UUID — reserved for future player context loading. */

--- a/src/web-ui/consulted-footer.ts
+++ b/src/web-ui/consulted-footer.ts
@@ -17,7 +17,7 @@
  * and label strings (new rows) — so no migration is required.
  *
  * Keeping `TOOL_SOURCE_LABELS` typed against `AgentToolName` means adding a
- * tool to `AGENT_TOOLS` without extending the map is a typecheck failure.
+ * selectable tool without extending the map is a typecheck failure.
  */
 
 import type { AgentToolName } from '../agent.ts';

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -62,7 +62,15 @@ vi.mock('../src/tools.ts', () => ({
   neighbors: mockNeighbors,
 }));
 
-import { runAgentLoop, executeToolCall, AGENT_TOOLS, MAX_AGENT_ITERATIONS } from '../src/agent.ts';
+import {
+  runAgentLoop,
+  executeToolCall,
+  AGENT_TOOLS,
+  LEGACY_AGENT_TOOLS,
+  AGENT_SYSTEM_PROMPT,
+  LEGACY_AGENT_SYSTEM_PROMPT,
+  MAX_AGENT_ITERATIONS,
+} from '../src/agent.ts';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -195,7 +203,7 @@ describe('runAgentLoop', () => {
 
   it('returns text immediately when Claude responds without tool use', async () => {
     mockMessagesCreate.mockResolvedValue(textResponse('Loot tokens are picked up in your hex.'));
-    const result = await runAgentLoop('What is the loot action?');
+    const result = await runAgentLoop('What is the loot action?', { toolSurface: 'legacy' });
     expect(result).toBe('Loot tokens are picked up in your hex.');
     expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
   });
@@ -206,9 +214,118 @@ describe('runAgentLoop', () => {
     expect(mockMessagesCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: AGENT_TOOLS,
-        system: expect.stringContaining('Frosthaven rules assistant'),
+        system: AGENT_SYSTEM_PROMPT,
       }),
     );
+  });
+
+  it('uses only the redesigned tools by default', async () => {
+    expect(AGENT_TOOLS.map((tool) => tool.name)).toEqual([
+      'inspect_sources',
+      'schema',
+      'resolve_entity',
+      'open_entity',
+      'search_knowledge',
+      'neighbors',
+    ]);
+    expect(AGENT_SYSTEM_PROMPT).not.toContain('search_rules');
+    expect(AGENT_SYSTEM_PROMPT).not.toContain('find_scenario');
+    expect(AGENT_SYSTEM_PROMPT).not.toContain('follow_links');
+  });
+
+  it('can select the legacy tool surface while evals are pending', async () => {
+    mockMessagesCreate.mockResolvedValue(textResponse('Answer'));
+    await runAgentLoop('test', { toolSurface: 'legacy' });
+
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: LEGACY_AGENT_TOOLS,
+        system: LEGACY_AGENT_SYSTEM_PROMPT,
+      }),
+    );
+    expect(LEGACY_AGENT_TOOLS.map((tool) => tool.name)).toEqual([
+      'search_rules',
+      'search_cards',
+      'list_card_types',
+      'list_cards',
+      'get_card',
+      'find_scenario',
+      'get_scenario',
+      'get_section',
+      'follow_links',
+    ]);
+  });
+
+  it('uses the redesigned traversal tools for an exact scenario conclusion lookup', async () => {
+    mockNeighbors.mockResolvedValueOnce({
+      ok: true,
+      from: {
+        kind: 'scenario',
+        ref: 'scenario:frosthaven/061',
+        title: 'Life and Death',
+        sourceLabel: 'Scenario Book',
+      },
+      neighbors: [
+        {
+          relation: 'conclusion',
+          target: {
+            kind: 'section',
+            ref: 'section:frosthaven/67.1',
+            title: 'Section 67.1',
+            sourceLabel: 'Section Book',
+          },
+          reason: 'Scenario conclusion points to this section',
+        },
+      ],
+    });
+
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('resolve_entity', { query: 'scenario 61', kinds: ['scenario'] }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse('neighbors', {
+          ref: 'scenario:frosthaven/061',
+          relation: 'conclusion',
+        }),
+      )
+      .mockResolvedValueOnce(toolUseResponse('open_entity', { ref: 'section:frosthaven/67.1' }))
+      .mockResolvedValueOnce(textResponse('Read section 67.1.'));
+
+    const result = await runAgentLoop(
+      'show the full text of the section to read at the conclusion of scenario 61',
+    );
+
+    expect(result).toBe('Read section 67.1.');
+    expect(mockResolveEntity).toHaveBeenCalledWith('scenario 61', {
+      kinds: ['scenario'],
+      limit: undefined,
+    });
+    expect(mockNeighbors).toHaveBeenCalledWith('scenario:frosthaven/061', {
+      relation: 'conclusion',
+      limit: 20,
+    });
+    expect(mockOpenEntity).toHaveBeenCalledWith('section:frosthaven/67.1');
+  });
+
+  it('uses the redesigned broad search tool for mixed rules and cards discovery', async () => {
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'loot and item interactions',
+          scope: ['rules_passage', 'card'],
+          limit: 4,
+        }),
+      )
+      .mockResolvedValueOnce(textResponse('Loot rules and item results are grounded together.'));
+
+    const result = await runAgentLoop('How do loot rules interact with items?');
+
+    expect(result).toBe('Loot rules and item results are grounded together.');
+    expect(mockSearchKnowledge).toHaveBeenCalledWith('loot and item interactions', {
+      scope: ['rules_passage', 'card'],
+      limit: 4,
+    });
   });
 
   it('executes tool calls and loops until text response', async () => {
@@ -218,7 +335,7 @@ describe('runAgentLoop', () => {
       // Second call: Claude returns text answer
       .mockResolvedValueOnce(textResponse('You pick up loot tokens.'));
 
-    const result = await runAgentLoop('What is the loot action?');
+    const result = await runAgentLoop('What is the loot action?', { toolSurface: 'legacy' });
     expect(result).toBe('You pick up loot tokens.');
     expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
     expect(mockSearchRules).toHaveBeenCalledWith('loot action', 6);
@@ -233,7 +350,9 @@ describe('runAgentLoop', () => {
       )
       .mockResolvedValueOnce(textResponse('Read section 67.1.'));
 
-    const result = await runAgentLoop('What section unlocks scenario 61?');
+    const result = await runAgentLoop('What section unlocks scenario 61?', {
+      toolSurface: 'legacy',
+    });
     expect(result).toBe('Read section 67.1.');
   });
 
@@ -249,7 +368,7 @@ describe('runAgentLoop', () => {
       })
       .mockResolvedValueOnce(textResponse('Here is what I found about loot.'));
 
-    const result = await runAgentLoop('Tell me about loot');
+    const result = await runAgentLoop('Tell me about loot', { toolSurface: 'legacy' });
     expect(result).toBe('Here is what I found about loot.');
     expect(mockSearchRules).toHaveBeenCalledWith('loot', 6);
     expect(mockSearchCards).toHaveBeenCalledWith('loot', 6);
@@ -260,7 +379,7 @@ describe('runAgentLoop', () => {
       .mockResolvedValueOnce(toolUseResponse('get_card', { type: 'items', id: 'Boots of Speed' }))
       .mockResolvedValueOnce(textResponse('Boots of Speed grants Move +1.'));
 
-    const result = await runAgentLoop('What does Boots of Speed do?');
+    const result = await runAgentLoop('What does Boots of Speed do?', { toolSurface: 'legacy' });
     expect(result).toBe('Boots of Speed grants Move +1.');
     expect(mockGetCard).toHaveBeenCalledWith('items', 'Boots of Speed');
   });
@@ -270,7 +389,7 @@ describe('runAgentLoop', () => {
       .mockResolvedValueOnce(toolUseResponse('list_card_types', {}))
       .mockResolvedValueOnce(textResponse('There are items and more.'));
 
-    const result = await runAgentLoop('What card types are available?');
+    const result = await runAgentLoop('What card types are available?', { toolSurface: 'legacy' });
     expect(result).toBe('There are items and more.');
     expect(mockListCardTypes).toHaveBeenCalled();
   });
@@ -290,6 +409,7 @@ describe('runAgentLoop', () => {
 
     const result = await runAgentLoop(
       'show the full text of the section to read at the conclusion of scenario 61',
+      { toolSurface: 'legacy' },
     );
     expect(result).toBe('Read section 67.1.');
     expect(mockFindScenario).toHaveBeenCalledWith('scenario 61');
@@ -344,6 +464,7 @@ describe('runAgentLoop', () => {
 
     const result = await runAgentLoop(
       'Starting from section 103.1, which section do I end up reading after following the next two explicit read instructions?',
+      { toolSurface: 'legacy' },
     );
 
     expect(result).toBe('The chain goes 103.1 -> 11.5 -> 155.1.');
@@ -386,7 +507,7 @@ describe('runAgentLoop', () => {
       .mockResolvedValueOnce(toolUseResponse('search_rules', { query: 'loot' }))
       .mockResolvedValueOnce(textResponse('I encountered an error but can still help.'));
 
-    const result = await runAgentLoop('What is loot?');
+    const result = await runAgentLoop('What is loot?', { toolSurface: 'legacy' });
     expect(result).toBe('I encountered an error but can still help.');
     // The tool result should have been sent back as an error
     const toolResultMsg = mockMessagesCreate.mock.calls[1][0].messages.at(-1);
@@ -398,7 +519,7 @@ describe('runAgentLoop', () => {
     // Claude keeps calling tools forever
     mockMessagesCreate.mockResolvedValue(toolUseResponse('search_rules', { query: 'loop' }));
 
-    const result = await runAgentLoop('infinite loop question');
+    const result = await runAgentLoop('infinite loop question', { toolSurface: 'legacy' });
     expect(mockMessagesCreate).toHaveBeenCalledTimes(MAX_AGENT_ITERATIONS);
     expect(result).toContain('unable to produce an answer');
   });
@@ -418,7 +539,7 @@ describe('runAgentLoop', () => {
       )
       .mockResolvedValueOnce(textResponse('Looting means picking up loot tokens.'));
 
-    const result = await runAgentLoop('What is looting?');
+    const result = await runAgentLoop('What is looting?', { toolSurface: 'legacy' });
 
     expect(result).toBe('Looting means picking up loot tokens.');
     expect(mockSearchRules).toHaveBeenCalledTimes(3);
@@ -447,7 +568,7 @@ describe('runAgentLoop', () => {
       )
       .mockResolvedValueOnce(textResponse('Looting means picking up loot tokens.'));
 
-    const result = await runAgentLoop('What is looting?');
+    const result = await runAgentLoop('What is looting?', { toolSurface: 'legacy' });
 
     expect(result).toBe('Looting means picking up loot tokens.');
     expect(mockSearchRules).toHaveBeenCalledTimes(3);
@@ -768,7 +889,7 @@ describe('runAgentLoop with emit (streaming)', () => {
     mockMessagesStream.mockReturnValue(mockStream(msg, ['Streamed ', 'answer']));
     const emit = vi.fn().mockResolvedValue(undefined);
 
-    await runAgentLoop('test', { emit });
+    await runAgentLoop('test', { emit, toolSurface: 'legacy' });
     expect(mockMessagesStream).toHaveBeenCalledTimes(1);
     expect(mockMessagesCreate).not.toHaveBeenCalled();
   });
@@ -813,6 +934,45 @@ describe('runAgentLoop with emit (streaming)', () => {
     expect(emit).toHaveBeenCalledWith('done', {});
   });
 
+  it('emits tool visibility for redesigned tool calls', async () => {
+    mockSearchKnowledge.mockResolvedValueOnce({
+      ok: true,
+      query: 'loot',
+      results: [
+        {
+          entity: {
+            kind: 'rules_passage',
+            ref: 'rules:frosthaven/fh-rule-book.pdf#chunk=0',
+            title: 'fh-rule-book.pdf chunk 0',
+            sourceLabel: 'Rulebook',
+          },
+          score: 0.9,
+          snippet: 'Loot action',
+          citations: [{ sourceRef: 'source:frosthaven/rulebook', sourceLabel: 'Rulebook' }],
+          nextRefs: [],
+        },
+      ],
+    });
+    const toolMsg = toolUseResponse('search_knowledge', { query: 'loot' });
+    const finalMsg = textResponse('Answer');
+    mockMessagesStream
+      .mockReturnValueOnce(mockStream(toolMsg))
+      .mockReturnValueOnce(mockStream(finalMsg, ['Answer']));
+    const emit = vi.fn().mockResolvedValue(undefined);
+
+    await runAgentLoop('test', { emit });
+    expect(emit).toHaveBeenCalledWith('tool_call', {
+      name: 'search_knowledge',
+      input: { query: 'loot' },
+    });
+    expect(emit).toHaveBeenCalledWith('tool_result', {
+      name: 'search_knowledge',
+      ok: true,
+      sourceBooks: ['Rulebook'],
+    });
+    expect(emit).toHaveBeenCalledWith('done', {});
+  });
+
   it('does not treat streamed scratch text before tool use as the final answer', async () => {
     const toolMsg = textAndToolUseResponse('Let me look that up.', 'search_rules', {
       query: 'scenario 61 conclusion',
@@ -823,7 +983,7 @@ describe('runAgentLoop with emit (streaming)', () => {
       .mockReturnValueOnce(mockStream(finalMsg, ['Read section 67.1.']));
     const emit = vi.fn().mockResolvedValue(undefined);
 
-    const result = await runAgentLoop('test', { emit });
+    const result = await runAgentLoop('test', { emit, toolSurface: 'legacy' });
     expect(result).toBe('Read section 67.1.');
   });
 });

--- a/test/consulted-footer.test.ts
+++ b/test/consulted-footer.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for src/web-ui/consulted-footer.ts (SQR-98).
  *
  * The typed-union drift guard on `TOOL_SOURCE_LABELS` is enforced at
- * compile time — adding a tool to AGENT_TOOLS without a matching label
+ * compile time — adding a selectable tool without a matching label
  * entry would fail `npm run typecheck` before reaching runtime. These
  * tests cover the concrete mapping values (which TS can't assert),
  * plus the aggregation + formatting helpers used by both the SSE route
@@ -12,7 +12,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { AGENT_TOOLS } from '../src/agent.ts';
+import { ALL_AGENT_TOOLS } from '../src/agent.ts';
 import {
   aggregateSourceLabels,
   formatConsultedFooter,
@@ -165,7 +165,7 @@ describe('JS ↔ TS label drift guard', () => {
     // in messages.consulted_sources) back to labels without going through
     // the server. This JS map must stay in sync with TOOL_SOURCE_LABELS
     // in src/web-ui/consulted-footer.ts. If a new tool is added to
-    // AGENT_TOOLS + TOOL_SOURCE_LABELS but not to TOOL_NAME_TO_LABEL,
+    // ALL_AGENT_TOOLS + TOOL_SOURCE_LABELS but not to TOOL_NAME_TO_LABEL,
     // replayed turns that used the new tool render a blank footer.
     const jsSrc = readFileSync(
       fileURLToPath(new URL('../src/web-ui/squire.js', import.meta.url)),
@@ -178,11 +178,11 @@ describe('JS ↔ TS label drift guard', () => {
       jsMap.set((entry[1] ?? entry[2])!, entry[3]!);
     }
 
-    // Derive from AGENT_TOOLS, filtering to the tools that actually map to
+    // Derive from ALL_AGENT_TOOLS, filtering to the tools that actually map to
     // a provenance label. Same drift guarantee as the first drift test:
-    // a new tool added to AGENT_TOOLS that should surface in the footer
+    // a new tool added to ALL_AGENT_TOOLS that should surface in the footer
     // must also be added to TOOL_NAME_TO_LABEL, or this loop fails.
-    const toolNames = AGENT_TOOLS.map((tool) => tool.name).filter(
+    const toolNames = ALL_AGENT_TOOLS.map((tool) => tool.name).filter(
       (name) => toolSourceLabel(name) !== null,
     );
     for (const name of toolNames) {
@@ -191,7 +191,7 @@ describe('JS ↔ TS label drift guard', () => {
     }
     // Null-mapped tools (traversal/utility like follow_links) must NOT appear
     // in the JS map — they aren't provenance sources on either side.
-    for (const tool of AGENT_TOOLS) {
+    for (const tool of ALL_AGENT_TOOLS) {
       if (toolSourceLabel(tool.name) === null) {
         expect(
           jsMap.has(tool.name),

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -616,6 +616,27 @@ describe('POST /api/ask', () => {
     );
   });
 
+  it('passes toolSurface to ask()', async () => {
+    await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'What is loot?', toolSurface: 'legacy' }),
+    });
+    expect(mockAsk).toHaveBeenCalledWith(
+      'What is loot?',
+      expect.objectContaining({ toolSurface: 'legacy' }),
+    );
+  });
+
+  it('returns 400 for invalid toolSurface', async () => {
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'test', toolSurface: 'old' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
   it('returns 400 for non-UUID campaignId', async () => {
     const res = await app.request('/api/ask', {
       method: 'POST',


### PR DESCRIPTION
## Summary

- Switch the default Claude agent loop to the redesigned six-tool knowledge surface.
- Keep the legacy tool surface selectable with `toolSurface: "legacy"` until eval parity is complete.
- Pass `toolSurface` through `/api/ask` and keep consulted-source provenance typing aligned across default and legacy tools.

## Validation

- `npm run check`
- Browser QA on `http://localhost:4827` covering login, unauth redirect, first-turn chat, follow-up chat, direct transcript reload, consulted-source footers, and console errors.
- Pre-landing review: no remaining issues after stale provenance comments were fixed.

Fixes SQR-119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent now supports switching between redesigned and legacy tool configurations through a new `toolSurface` parameter in API requests.

* **Tests**
  * Enhanced test coverage for agent tool surface selection and prompt validation across both configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->