### PR TITLE
Address redesigned tool review nits

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -22,6 +22,7 @@ import {
   followLinks,
   neighbors,
 } from './tools.ts';
+import type { KnowledgeEntityKind } from './tools.ts';
 import { CARD_TYPES, type CardType } from './schemas.ts';
 import type { AskOptions, HistoryMessage, EmitFn } from './service.ts';
 import {
@@ -457,7 +458,7 @@ export async function executeToolCall(
       return { content: JSON.stringify(results, null, 2) };
     }
     case 'search_knowledge': {
-      const scope = Array.isArray(input.scope) ? (input.scope as never[]) : undefined;
+      const scope = Array.isArray(input.scope) ? (input.scope as KnowledgeEntityKind[]) : undefined;
       const result = await searchKnowledge(input.query as string, {
         scope,
         limit: (input.limit as number | undefined) ?? 6,

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -635,6 +635,7 @@ describe('POST /api/ask', () => {
       body: JSON.stringify({ question: 'test', toolSurface: 'old' }),
     });
     expect(res.status).toBe(400);
+    expect(mockAsk).not.toHaveBeenCalled();
   });
 
   it('returns 400 for non-UUID campaignId', async () => {


### PR DESCRIPTION
## Summary
- tighten the `search_knowledge` scope cast to the actual knowledge entity kind type
- assert invalid `toolSurface` requests do not call `ask()`

## Validation
- `npm run check`

Follow-up to #283 / SQR-119.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened API validation testing to ensure invalid requests are rejected before service execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->