### PR TITLE
Instrument agent tool trajectories

### DIFF
--- a/eval/run.ts
+++ b/eval/run.ts
@@ -117,7 +117,15 @@ function buildEvaluators(anthropic: Anthropic) {
     }) => {
       const question = (input as { question: string }).question;
       const exp = expectedOutput as { answer: string; grading: string };
-      const actual = typeof output === 'string' ? output : (output as { answer: string }).answer;
+      const actual =
+        typeof output === 'string'
+          ? output
+          : output !== null &&
+              typeof output === 'object' &&
+              'answer' in output &&
+              typeof output.answer === 'string'
+            ? output.answer
+            : String(output ?? '');
 
       const verdict = await judgeAnswer(anthropic, question, exp.answer, exp.grading, actual);
 

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -15,7 +15,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import Anthropic from '@anthropic-ai/sdk';
 import { LangfuseClient } from '@langfuse/client';
-import { askFrosthaven } from '../src/query.ts';
+import { askFrosthavenWithTrajectory } from '../src/query.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -117,7 +117,7 @@ function buildEvaluators(anthropic: Anthropic) {
     }) => {
       const question = (input as { question: string }).question;
       const exp = expectedOutput as { answer: string; grading: string };
-      const actual = output as string;
+      const actual = typeof output === 'string' ? output : (output as { answer: string }).answer;
 
       const verdict = await judgeAnswer(anthropic, question, exp.answer, exp.grading, actual);
 
@@ -187,7 +187,7 @@ async function runOnDataset(langfuse: LangfuseClient, runName: string): Promise<
       const question = (item.input as { question: string }).question;
       const meta = item.metadata as { id?: string } | undefined;
       process.stdout.write(`  ${meta?.id ?? '?'}... `);
-      return askFrosthaven(question);
+      return askFrosthavenWithTrajectory(question);
     },
     evaluators: buildEvaluators(anthropic),
     runEvaluators: buildRunEvaluators(),
@@ -220,7 +220,7 @@ async function runFiltered(
       const question = (item.input as { question: string }).question;
       const meta = item.metadata as { id?: string } | undefined;
       process.stdout.write(`  ${meta?.id ?? '?'}... `);
-      return askFrosthaven(question);
+      return askFrosthavenWithTrajectory(question);
     },
     evaluators: buildEvaluators(anthropic),
     runEvaluators: buildRunEvaluators(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@langfuse/otel": "^5.1.0",
         "@langfuse/tracing": "^5.2.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.215.0",
         "@opentelemetry/instrumentation-pg": "^0.67.0",
         "@opentelemetry/sdk-node": "^0.215.0",
@@ -1376,9 +1377,9 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@langfuse/otel": "^5.1.0",
     "@langfuse/tracing": "^5.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/instrumentation": "^0.215.0",
     "@opentelemetry/instrumentation-pg": "^0.67.0",
     "@opentelemetry/sdk-node": "^0.215.0",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -5,6 +5,7 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
+import { SpanStatusCode, trace } from '@opentelemetry/api';
 import {
   searchRules,
   searchCards,
@@ -35,8 +36,10 @@ type MessageParam = Anthropic.MessageParam;
 type Tool = Anthropic.Tool;
 type ContentBlockParam = Anthropic.ContentBlockParam;
 type Message = Anthropic.Message;
+type StopReason = Message['stop_reason'];
 
 const client = new Anthropic();
+const tracer = trace.getTracer('squire.agent');
 
 /** Maximum agent loop iterations to prevent runaway tool calls. */
 export const MAX_AGENT_ITERATIONS = 10;
@@ -369,6 +372,95 @@ export interface ToolCallResult {
   sourceBooks?: string[];
 }
 
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export interface ToolTrajectoryStep {
+  iteration: number;
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+  ok: boolean;
+  outputSummary: string;
+  sourceLabels: string[];
+  canonicalRefs: string[];
+  error?: string;
+  startedAt: string;
+  endedAt: string;
+  durationMs: number;
+}
+
+export interface AgentRunTrajectory {
+  toolCalls: ToolTrajectoryStep[];
+  finalAnswer: string;
+  tokenUsage: TokenUsage;
+  model: string;
+  iterations: number;
+  stopReason: StopReason | 'iteration_limit' | null;
+}
+
+export interface AgentRunResult {
+  answer: string;
+  trajectory: AgentRunTrajectory;
+}
+
+const AGENT_MODEL = 'claude-sonnet-4-6' as const;
+const MAX_ATTRIBUTE_TEXT_LENGTH = 2_000;
+
+function truncateForAttribute(value: string, maxLength = MAX_ATTRIBUTE_TEXT_LENGTH): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+
+function addUsage(total: TokenUsage, response: Message): void {
+  total.inputTokens += response.usage.input_tokens;
+  total.outputTokens += response.usage.output_tokens;
+  total.totalTokens = total.inputTokens + total.outputTokens;
+}
+
+function collectCanonicalRefs(value: unknown, refs = new Set<string>()): Set<string> {
+  if (!value || typeof value !== 'object') return refs;
+  if (Array.isArray(value)) {
+    for (const item of value) collectCanonicalRefs(item, refs);
+    return refs;
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    if ((key === 'ref' || key === 'sourceId') && typeof nested === 'string') {
+      refs.add(nested);
+    } else {
+      collectCanonicalRefs(nested, refs);
+    }
+  }
+  return refs;
+}
+
+function summarizeToolOutput(content: string): { summary: string; canonicalRefs: string[] } {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    const canonicalRefs = [...collectCanonicalRefs(parsed)];
+    if (Array.isArray(parsed)) {
+      return {
+        summary: `json array (${parsed.length} item${parsed.length === 1 ? '' : 's'})`,
+        canonicalRefs,
+      };
+    }
+    if (parsed && typeof parsed === 'object') {
+      const keys = Object.keys(parsed).slice(0, 8);
+      return {
+        summary: `json object (${keys.join(', ') || 'no keys'})`,
+        canonicalRefs,
+      };
+    }
+    return { summary: `json ${typeof parsed}`, canonicalRefs };
+  } catch {
+    return { summary: truncateForAttribute(content, 240), canonicalRefs: [] };
+  }
+}
+
 function sourceLabelsFromResult(value: unknown): string[] {
   const seen = new Set<string>();
   const labels: string[] = [];
@@ -537,7 +629,7 @@ async function callClaude(
   const allowTools = opts.allowTools ?? true;
   const surface = selectedAgentSurface(opts.toolSurface);
   const params = {
-    model: 'claude-sonnet-4-6' as const,
+    model: AGENT_MODEL,
     max_tokens: 4096,
     system: surface.system,
     messages,
@@ -572,6 +664,43 @@ async function callClaude(
  * and tool activity is emitted as events.
  */
 export async function runAgentLoop(question: string, options?: AskOptions): Promise<string> {
+  const result = await runAgentLoopWithTrajectory(question, options);
+  return result.answer;
+}
+
+export async function runAgentLoopWithTrajectory(
+  question: string,
+  options?: AskOptions,
+): Promise<AgentRunResult> {
+  return tracer.startActiveSpan('squire.agent.run', async (runSpan) => {
+    try {
+      const result = await runAgentLoopInternal(question, options);
+      runSpan.setAttributes({
+        'squire.agent.model': result.trajectory.model,
+        'squire.agent.iterations': result.trajectory.iterations,
+        'squire.agent.tool_call_count': result.trajectory.toolCalls.length,
+        'squire.agent.stop_reason': result.trajectory.stopReason ?? 'unknown',
+        'squire.agent.input_tokens': result.trajectory.tokenUsage.inputTokens,
+        'squire.agent.output_tokens': result.trajectory.tokenUsage.outputTokens,
+      });
+      return result;
+    } catch (err) {
+      runSpan.recordException(err as Error);
+      runSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    } finally {
+      runSpan.end();
+    }
+  });
+}
+
+async function runAgentLoopInternal(
+  question: string,
+  options?: AskOptions,
+): Promise<AgentRunResult> {
   const history = options?.history;
   const emit = options?.emit;
   const toolSurface = options?.toolSurface;
@@ -589,12 +718,41 @@ export async function runAgentLoop(question: string, options?: AskOptions): Prom
   let broadRuleSearches = 0;
   let hasUsedNonRuleSearchTool = false;
   let forceSynthesis = false;
+  const toolCalls: ToolTrajectoryStep[] = [];
+  const tokenUsage: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  let iterations = 0;
 
   for (let i = 0; i < MAX_AGENT_ITERATIONS; i++) {
-    const response = await callClaude(messages, emit, {
-      allowTools: !forceSynthesis,
-      toolSurface,
+    iterations = i + 1;
+    const response = await tracer.startActiveSpan('squire.agent.iteration', async (span) => {
+      try {
+        span.setAttributes({
+          'squire.agent.iteration': i + 1,
+          'squire.agent.allow_tools': !forceSynthesis,
+          'squire.agent.message_count': messages.length,
+        });
+        const message = await callClaude(messages, emit, {
+          allowTools: !forceSynthesis,
+          toolSurface,
+        });
+        span.setAttributes({
+          'squire.agent.stop_reason': message.stop_reason ?? 'unknown',
+          'squire.agent.input_tokens': message.usage.input_tokens,
+          'squire.agent.output_tokens': message.usage.output_tokens,
+        });
+        return message;
+      } catch (err) {
+        span.recordException(err as Error);
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      } finally {
+        span.end();
+      }
     });
+    addUsage(tokenUsage, response);
     const hasToolUse = response.content.some((block) => block.type === 'tool_use');
 
     // Collect all text content from this response
@@ -614,7 +772,17 @@ export async function runAgentLoop(question: string, options?: AskOptions): Prom
     // If the model is done (no more tool calls), return the answer
     if (response.stop_reason === 'end_turn' || response.stop_reason === 'stop_sequence') {
       if (emit) await emit('done', {});
-      return lastTextContent;
+      return {
+        answer: lastTextContent,
+        trajectory: {
+          toolCalls,
+          finalAnswer: lastTextContent,
+          tokenUsage,
+          model: AGENT_MODEL,
+          iterations,
+          stopReason: response.stop_reason,
+        },
+      };
     }
 
     // Max tokens or pause — append partial response and continue for more
@@ -641,16 +809,66 @@ export async function runAgentLoop(question: string, options?: AskOptions): Prom
             await emit('tool_call', { name: block.name, input: block.input });
           }
 
+          const toolStartedAtMs = Date.now();
+          const toolStartedAt = new Date(toolStartedAtMs).toISOString();
           let toolResult: ToolCallResult;
           let isError = false;
+          let errorMessage: string | undefined;
           try {
-            toolResult = await executeToolCall(block.name, block.input as Record<string, unknown>);
+            toolResult = await tracer.startActiveSpan('squire.agent.tool', async (span) => {
+              try {
+                span.setAttributes({
+                  'squire.agent.iteration': i + 1,
+                  'squire.agent.tool.id': block.id,
+                  'squire.agent.tool.name': block.name,
+                  'squire.agent.tool.input': truncateForAttribute(JSON.stringify(block.input)),
+                });
+                const result = await executeToolCall(
+                  block.name,
+                  block.input as Record<string, unknown>,
+                );
+                const { summary, canonicalRefs } = summarizeToolOutput(result.content);
+                span.setAttributes({
+                  'squire.agent.tool.ok': true,
+                  'squire.agent.tool.output_summary': summary,
+                  'squire.agent.tool.source_labels': result.sourceBooks ?? [],
+                  'squire.agent.tool.canonical_refs': canonicalRefs,
+                });
+                return result;
+              } catch (err) {
+                span.recordException(err as Error);
+                span.setStatus({
+                  code: SpanStatusCode.ERROR,
+                  message: err instanceof Error ? err.message : String(err),
+                });
+                throw err;
+              } finally {
+                span.end();
+              }
+            });
           } catch (err) {
+            errorMessage = err instanceof Error ? err.message : String(err);
             toolResult = {
-              content: `Tool error: ${err instanceof Error ? err.message : String(err)}`,
+              content: `Tool error: ${errorMessage}`,
             };
             isError = true;
           }
+          const toolEndedAtMs = Date.now();
+          const { summary, canonicalRefs } = summarizeToolOutput(toolResult.content);
+          toolCalls.push({
+            iteration: i + 1,
+            id: block.id,
+            name: block.name,
+            input: block.input as Record<string, unknown>,
+            ok: !isError,
+            outputSummary: summary,
+            sourceLabels: toolResult.sourceBooks ?? [],
+            canonicalRefs,
+            ...(errorMessage ? { error: errorMessage } : {}),
+            startedAt: toolStartedAt,
+            endedAt: new Date(toolEndedAtMs).toISOString(),
+            durationMs: toolEndedAtMs - toolStartedAtMs,
+          });
 
           if (emit) {
             await emit('tool_result', {
@@ -682,10 +900,33 @@ export async function runAgentLoop(question: string, options?: AskOptions): Prom
 
     // Unrecoverable stop reasons (refusal, context window exceeded, etc.)
     if (emit) await emit('done', {});
-    return lastTextContent || 'I was unable to answer this question.';
+    const answer = lastTextContent || 'I was unable to answer this question.';
+    return {
+      answer,
+      trajectory: {
+        toolCalls,
+        finalAnswer: answer,
+        tokenUsage,
+        model: AGENT_MODEL,
+        iterations,
+        stopReason: response.stop_reason,
+      },
+    };
   }
 
   // Iteration limit reached
   if (emit) await emit('done', {});
-  return lastTextContent || 'I was unable to produce an answer within the allowed number of steps.';
+  const answer =
+    lastTextContent || 'I was unable to produce an answer within the allowed number of steps.';
+  return {
+    answer,
+    trajectory: {
+      toolCalls,
+      finalAnswer: answer,
+      tokenUsage,
+      model: AGENT_MODEL,
+      iterations,
+      stopReason: 'iteration_limit',
+    },
+  };
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -4,7 +4,7 @@
  */
 
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { LangfuseSpanProcessor } from '@langfuse/otel';
+import { LangfuseSpanProcessor, isDefaultExportSpan } from '@langfuse/otel';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
 
 export const LANGFUSE_DEFAULT_BASE_URL = 'https://us.cloud.langfuse.com';
@@ -13,6 +13,8 @@ const sdk = new NodeSDK({
   spanProcessors: [
     new LangfuseSpanProcessor({
       baseUrl: process.env.LANGFUSE_BASEURL ?? LANGFUSE_DEFAULT_BASE_URL,
+      shouldExportSpan: ({ otelSpan }) =>
+        otelSpan.name.startsWith('squire.agent.') || isDefaultExportSpan(otelSpan),
     }),
   ],
   // Auto-instrument node-postgres so every Drizzle query gets a span. Drizzle

--- a/src/query.ts
+++ b/src/query.ts
@@ -7,6 +7,7 @@
 
 import 'dotenv/config';
 import { sdk } from './instrumentation.ts';
+import { runAgentLoopWithTrajectory, type AgentRunResult } from './agent.ts';
 import { initialize, ask } from './service.ts';
 
 /**
@@ -16,6 +17,11 @@ import { initialize, ask } from './service.ts';
 export async function askFrosthaven(question: string): Promise<string> {
   await initialize();
   return ask(question);
+}
+
+export async function askFrosthavenWithTrajectory(question: string): Promise<AgentRunResult> {
+  await initialize();
+  return runAgentLoopWithTrajectory(question);
 }
 
 // CLI entrypoint

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -64,6 +64,7 @@ vi.mock('../src/tools.ts', () => ({
 
 import {
   runAgentLoop,
+  runAgentLoopWithTrajectory,
   executeToolCall,
   AGENT_TOOLS,
   LEGACY_AGENT_TOOLS,
@@ -341,6 +342,88 @@ describe('runAgentLoop', () => {
     expect(mockSearchRules).toHaveBeenCalledWith('loot action', 6);
   });
 
+  it('captures a structured trajectory for successful tool calls', async () => {
+    mockSearchRules.mockResolvedValueOnce([
+      {
+        text: 'Loot: pick up all loot tokens.',
+        source: 'rulebook.pdf:42',
+        score: 0.9,
+        sourceLabel: 'Rulebook',
+        ref: 'fh-rule-book.pdf::42',
+      },
+    ]);
+    mockMessagesCreate
+      .mockResolvedValueOnce(toolUseResponse('search_rules', { query: 'loot action' }))
+      .mockResolvedValueOnce(textResponse('You pick up loot tokens.'));
+
+    const result = await runAgentLoopWithTrajectory('What is the loot action?', {
+      toolSurface: 'legacy',
+    });
+
+    expect(result.answer).toBe('You pick up loot tokens.');
+    expect(result.trajectory.finalAnswer).toBe('You pick up loot tokens.');
+    expect(result.trajectory.model).toBe('claude-sonnet-4-6');
+    expect(result.trajectory.iterations).toBe(2);
+    expect(result.trajectory.stopReason).toBe('end_turn');
+    expect(result.trajectory.tokenUsage).toEqual({
+      inputTokens: 200,
+      outputTokens: 100,
+      totalTokens: 300,
+    });
+    expect(result.trajectory.toolCalls).toMatchObject([
+      {
+        iteration: 1,
+        id: 'tool_1',
+        name: 'search_rules',
+        input: { query: 'loot action' },
+        ok: true,
+        outputSummary: 'json array (1 item)',
+        sourceLabels: ['Rulebook'],
+        canonicalRefs: ['fh-rule-book.pdf::42'],
+      },
+    ]);
+    expect(result.trajectory.toolCalls[0]?.startedAt).toEqual(expect.any(String));
+    expect(result.trajectory.toolCalls[0]?.endedAt).toEqual(expect.any(String));
+    expect(result.trajectory.toolCalls[0]?.durationMs).toEqual(expect.any(Number));
+  });
+
+  it('captures a structured trajectory for redesigned tool calls', async () => {
+    mockSearchKnowledge.mockResolvedValueOnce({
+      ok: true,
+      query: 'Jump',
+      results: [
+        {
+          ref: 'rules:frosthaven/fh-rule-book.pdf#chunk=87',
+          citations: [{ sourceLabel: 'Rulebook' }],
+        },
+      ],
+    });
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'Jump',
+          scope: ['rules_passage'],
+        }),
+      )
+      .mockResolvedValueOnce(textResponse('Jump ignores terrain except in the last hex.'));
+
+    const result = await runAgentLoopWithTrajectory('What is Jump?');
+
+    expect(result.answer).toBe('Jump ignores terrain except in the last hex.');
+    expect(result.trajectory.toolCalls).toMatchObject([
+      {
+        iteration: 1,
+        id: 'tool_1',
+        name: 'search_knowledge',
+        input: { query: 'Jump', scope: ['rules_passage'] },
+        ok: true,
+        outputSummary: 'json object (ok, query, results)',
+        sourceLabels: ['Rulebook'],
+        canonicalRefs: ['rules:frosthaven/fh-rule-book.pdf#chunk=87'],
+      },
+    ]);
+  });
+
   it('does not persist scratch text from a tool-use turn as the final answer', async () => {
     mockMessagesCreate
       .mockResolvedValueOnce(
@@ -513,6 +596,30 @@ describe('runAgentLoop', () => {
     const toolResultMsg = mockMessagesCreate.mock.calls[1][0].messages.at(-1);
     expect(toolResultMsg.content[0].is_error).toBe(true);
     expect(toolResultMsg.content[0].content).toContain('Embedder failed');
+  });
+
+  it('captures a structured trajectory for tool errors', async () => {
+    mockSearchRules.mockRejectedValueOnce(new Error('Embedder failed'));
+    mockMessagesCreate
+      .mockResolvedValueOnce(toolUseResponse('search_rules', { query: 'loot' }))
+      .mockResolvedValueOnce(textResponse('I encountered an error but can still help.'));
+
+    const result = await runAgentLoopWithTrajectory('What is loot?', { toolSurface: 'legacy' });
+
+    expect(result.answer).toBe('I encountered an error but can still help.');
+    expect(result.trajectory.toolCalls).toMatchObject([
+      {
+        iteration: 1,
+        id: 'tool_1',
+        name: 'search_rules',
+        input: { query: 'loot' },
+        ok: false,
+        outputSummary: 'Tool error: Embedder failed',
+        sourceLabels: [],
+        canonicalRefs: [],
+        error: 'Embedder failed',
+      },
+    ]);
   });
 
   it('respects iteration limit', async () => {


### PR DESCRIPTION
## Summary
- Capture structured agent run trajectories alongside the existing string answer path.
- Record ordered tool calls with inputs, output summaries, source labels, canonical refs, timing, errors, token usage, model, iterations, and stop reason.
- Export `squire.agent.run`, `squire.agent.iteration`, and `squire.agent.tool` OpenTelemetry spans to Langfuse, including custom span filtering so these spans are actually sent.
- Let evals consume trajectory objects while keeping answer grading unchanged.

## Validation
- `npm run check`
- `npm test -- test/agent.test.ts`
- `npm test`
- `git diff --check`
- Browser QA with gstack browse: dev login, first chat turn, and same-conversation follow-up all passed with no console errors.
- Langfuse API verified trace `cb985252dbeb1eb3a4d5af6946933c73` contains `squire.agent.run`, `squire.agent.iteration`, and `squire.agent.tool` observations with tool input/output metadata.

Fixes SQR-121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent runs now record rich execution trajectories: per-iteration token usage, per-tool metadata (inputs, outcomes, summaries, timing), iteration counts, and stop reasons.
  * Improved error capture for failed tool calls, surfaced in execution traces.

* **Chores**
  * Added OpenTelemetry API dependency to enable enhanced tracing.

* **Tests**
  * Added tests validating trajectory structure, metadata and error-handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->