### PR TITLE
SQR-120 Add trajectory eval coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.5] - 2026-04-28
+
+### Added
+
+- Added trajectory-only Langfuse eval cases for Frosthaven tool-path quality, with schema validation, stale remote dataset checks, and trajectory scoring for required tools, tool kinds, refs, and call budgets.
+- Added eval tests covering the new dataset shape, stale Langfuse dataset detection, and trajectory ref normalization.
+
 ## [0.1.4] - 2026-04-21
 
 ### Fixed

--- a/eval/dataset.json
+++ b/eval/dataset.json
@@ -3,136 +3,333 @@
     "id": "rule-long-rest-init",
     "category": "rulebook",
     "question": "What is the initiative value of a long rest in Frosthaven?",
-    "expected": "99",
-    "grading": "The answer must state the initiative is 99.",
+    "finalAnswer": {
+      "expected": "99",
+      "grading": "The answer must state the initiative is 99."
+    },
     "source": "fh-rule-book.pdf"
   },
   {
     "id": "rule-long-rest-steps",
     "category": "rulebook",
     "question": "What are the steps a character performs when taking a long rest in Frosthaven?",
-    "expected": "1. Lose one card from discard pile, return remaining to hand. 2. Perform Heal 2 self (optional). 3. Recover all spent items.",
-    "grading": "Must mention all three steps: losing a card from discard (mandatory), Heal 2 self (optional), and recovering spent items. Order matters.",
+    "finalAnswer": {
+      "expected": "1. Lose one card from discard pile, return remaining to hand. 2. Perform Heal 2 self (optional). 3. Recover all spent items.",
+      "grading": "Must mention all three steps: losing a card from discard (mandatory), Heal 2 self (optional), and recovering spent items. Order matters."
+    },
     "source": "fh-rule-book.pdf"
   },
   {
     "id": "rule-scenario-level",
     "category": "rulebook",
     "question": "How is the recommended scenario level calculated in Frosthaven?",
-    "expected": "Average level of the characters divided by 2, rounded up.",
-    "grading": "Must mention dividing average character level by 2 and rounding up.",
+    "finalAnswer": {
+      "expected": "Average level of the characters divided by 2, rounded up.",
+      "grading": "Must mention dividing average character level by 2 and rounding up."
+    },
     "source": "fh-rule-book.pdf"
   },
   {
     "id": "rule-poison",
     "category": "rulebook",
     "question": "What does the Poison condition do in Frosthaven?",
-    "expected": "All attacks targeting the figure gain +1 Attack. Poison is removed when healed, but prevents the heal from increasing hit points.",
-    "grading": "Must mention +1 Attack on attacks targeting the figure AND that poison prevents healing from increasing HP while being removed by healing.",
+    "finalAnswer": {
+      "expected": "All attacks targeting the figure gain +1 Attack. Poison is removed when healed, but prevents the heal from increasing hit points.",
+      "grading": "Must mention +1 Attack on attacks targeting the figure AND that poison prevents healing from increasing HP while being removed by healing."
+    },
     "source": "fh-rule-book.pdf"
   },
   {
     "id": "rule-brittle",
     "category": "rulebook",
     "question": "What does the Brittle condition do in Frosthaven?",
-    "expected": "Next time the figure would suffer damage, they suffer double that damage instead, then brittle is removed. Also removed by healing.",
-    "grading": "Must mention double damage on next damage source and removal after triggering. Should mention healing also removes it.",
+    "finalAnswer": {
+      "expected": "Next time the figure would suffer damage, they suffer double that damage instead, then brittle is removed. Also removed by healing.",
+      "grading": "Must mention double damage on next damage source and removal after triggering. Should mention healing also removes it."
+    },
     "source": "fh-rule-book.pdf"
   },
   {
     "id": "rule-advantage",
     "category": "rulebook",
     "question": "How does advantage work with attack modifier cards in Frosthaven?",
-    "expected": "Draw two modifiers and use one. Monsters always use the better one. Characters may use either one.",
-    "grading": "Must mention drawing two modifiers. Must distinguish that monsters use the better one while characters may choose either.",
+    "finalAnswer": {
+      "expected": "Draw two modifiers and use one. Monsters always use the better one. Characters may use either one.",
+      "grading": "Must mention drawing two modifiers. Must distinguish that monsters use the better one while characters may choose either."
+    },
     "source": "fh-rule-book.pdf"
   },
   {
     "id": "rule-small-items",
     "category": "rulebook",
     "question": "How many small items can a character bring into a Frosthaven scenario?",
-    "expected": "Half their level, rounded up.",
-    "grading": "Must state half the character's level rounded up.",
+    "finalAnswer": {
+      "expected": "Half their level, rounded up.",
+      "grading": "Must state half the character's level rounded up."
+    },
     "source": "fh-rule-book.pdf"
   },
   {
     "id": "rule-looting-definition",
     "category": "rulebook",
     "question": "What is looting?",
-    "expected": "Characters loot by using Loot X abilities to collect loot tokens and treasure tiles within range X, and by automatically looting loot tokens in their own hex at the end of their turn. Looted loot tokens draw from the loot deck; monsters can loot tokens with Loot abilities but do not draw loot cards and cannot loot treasure tiles.",
-    "grading": "Must define looting as collecting loot tokens and treasure tiles. Must mention Loot X range or automatic end-of-turn looting. Must not answer with step-budget exhaustion or an inability to answer.",
+    "finalAnswer": {
+      "expected": "Characters loot by using Loot X abilities to collect loot tokens and treasure tiles within range X, and by automatically looting loot tokens in their own hex at the end of their turn. Looted loot tokens draw from the loot deck; monsters can loot tokens with Loot abilities but do not draw loot cards and cannot loot treasure tiles.",
+      "grading": "Must define looting as collecting loot tokens and treasure tiles. Must mention Loot X range or automatic end-of-turn looting. Must not answer with step-budget exhaustion or an inability to answer."
+    },
     "source": "fh-rule-book.pdf"
   },
   {
     "id": "monster-vermling-scout",
     "category": "monster-stats",
     "question": "What are the stats of a normal Vermling Scout at level 1 in Frosthaven?",
-    "expected": "HP 3, Move 3, Attack 1.",
-    "grading": "Must include all three stats: HP 3, Move 3, Attack 1. Range is not a stat card value — do not penalize for omitting it.",
+    "finalAnswer": {
+      "expected": "HP 3, Move 3, Attack 1.",
+      "grading": "Must include all three stats: HP 3, Move 3, Attack 1. Range is not a stat card value; do not penalize for omitting it."
+    },
     "source": "data/extracted/monster-stats.json"
   },
   {
     "id": "monster-living-bones-immunity",
     "category": "monster-stats",
     "question": "What conditions are Living Bones immune to in Frosthaven?",
-    "expected": "Poison and wound.",
-    "grading": "Must mention both poison and wound immunity.",
+    "finalAnswer": {
+      "expected": "Poison and wound.",
+      "grading": "Must mention both poison and wound immunity."
+    },
     "source": "data/extracted/monster-stats.json"
   },
   {
     "id": "monster-flame-demon-elite",
     "category": "monster-stats",
     "question": "What are the stats of an elite Flame Demon at level 0 in Frosthaven?",
-    "expected": "HP 3, Move 3, Attack 2. Shield 3.",
-    "grading": "Must include HP 3, Move 3, Attack 2. Shield 3 is a bonus. Range is not a stat card value — do not penalize for omitting it.",
+    "finalAnswer": {
+      "expected": "HP 3, Move 3, Attack 2. Shield 3.",
+      "grading": "Must include HP 3, Move 3, Attack 2. Shield 3 is a bonus. Range is not a stat card value; do not penalize for omitting it."
+    },
     "source": "data/extracted/monster-stats.json"
   },
   {
     "id": "building-alchemist",
     "category": "buildings",
     "question": "What does the Alchemist building cost to build at level 1 in Frosthaven?",
-    "expected": "1 gold, 2 lumber, 2 metal, 1 hide.",
-    "grading": "Must mention the four resources: 1 gold, 2 lumber, 2 metal, 1 hide.",
+    "finalAnswer": {
+      "expected": "1 gold, 2 lumber, 2 metal, 1 hide.",
+      "grading": "Must mention the four resources: 1 gold, 2 lumber, 2 metal, 1 hide."
+    },
     "source": "data/extracted/buildings.json"
   },
   {
     "id": "item-spyglass",
     "category": "items",
     "question": "What does the Spyglass item do in Frosthaven, and what is its item number?",
-    "expected": "Item #001. During your attack ability, gain advantage on one attack. Costs 40 gold, small item slot, 2 uses.",
-    "grading": "Must state item number 001 (not 082). Must mention gaining advantage on an attack. Cost of 40 gold is a bonus.",
+    "finalAnswer": {
+      "expected": "Item #001. During your attack ability, gain advantage on one attack. Costs 40 gold, small item slot, 2 uses.",
+      "grading": "Must state item number 001 (not 082). Must mention gaining advantage on an attack. Cost of 40 gold is a bonus."
+    },
     "source": "data/extracted/items.json (note: extracted number is wrong, correct is 001 from filename)"
   },
   {
     "id": "item-crude-boots",
     "category": "items",
     "question": "What does the Crude Boots item do in Frosthaven?",
-    "expected": "Legs slot, costs 2 gold. During your move ability, add +1 movement.",
-    "grading": "Must mention +1 movement during move ability. Cost of 2 gold is a bonus.",
+    "finalAnswer": {
+      "expected": "Legs slot, costs 2 gold. During your move ability, add +1 movement.",
+      "grading": "Must mention +1 movement during move ability. Cost of 2 gold is a bonus."
+    },
     "source": "data/extracted/items.json"
   },
   {
     "id": "scenario-61-unlock",
     "category": "scenarios",
     "question": "What section text unlocks scenario 61 (Life and Death) in Frosthaven?",
-    "expected": "Section 67.1 links to Life and Death (scenario 61). The section involves escaping shadows with Moonshard.",
-    "grading": "Must reference section 67 or the narrative context that leads to scenario 61. Mentioning 'Life and Death' as the scenario name is a bonus.",
+    "finalAnswer": {
+      "expected": "Section 67.1 links to Life and Death (scenario 61). The section involves escaping shadows with Moonshard.",
+      "grading": "Must reference section 67 or the narrative context that leads to scenario 61. Mentioning 'Life and Death' as the scenario name is a bonus."
+    },
     "source": "fh-section-book-62-81.pdf"
   },
   {
     "id": "rule-wound",
     "category": "rulebook",
     "question": "What does the Wound condition do in Frosthaven?",
-    "expected": "The figure suffers 1 damage at the start of each of their turns. Wound is removed when the figure is healed.",
-    "grading": "Must mention 1 damage at start of turns and removal by healing.",
+    "finalAnswer": {
+      "expected": "The figure suffers 1 damage at the start of each of their turns. Wound is removed when the figure is healed.",
+      "grading": "Must mention 1 damage at start of turns and removal by healing."
+    },
     "source": "fh-rule-book.pdf"
   },
   {
     "id": "tool-free-assistant-game",
     "category": "tool-free",
     "question": "What game is this assistant for? Answer in one short sentence.",
-    "expected": "This assistant is for Frosthaven.",
-    "grading": "Must clearly say the assistant is for Frosthaven in one short sentence. Answers that hedge, mention another game, or say it does not know should fail.",
+    "finalAnswer": {
+      "expected": "This assistant is for Frosthaven.",
+      "grading": "Must clearly say the assistant is for Frosthaven in one short sentence. Answers that hedge, mention another game, or say it does not know should fail."
+    },
     "source": "src/agent.ts"
+  },
+  {
+    "id": "traj-source-discovery",
+    "category": "trajectory",
+    "question": "What sources can you inspect for Frosthaven, and which ones can you open exactly?",
+    "trajectory": {
+      "requiredTools": ["inspect_sources"],
+      "requiredToolKinds": ["discovery"],
+      "forbiddenToolKinds": ["traversal"],
+      "requiredRefs": [],
+      "maxToolCalls": 3,
+      "notes": "A source-shape question should use discovery, not answer from prompt memory."
+    },
+    "source": "docs/KNOWLEDGE_TOOL_CONTRACT.md"
+  },
+  {
+    "id": "traj-scenario-conclusion-open",
+    "category": "trajectory",
+    "question": "Show the section I should read at the conclusion of scenario 61.",
+    "trajectory": {
+      "requiredTools": ["resolve_entity", "open_entity", "neighbors"],
+      "requiredToolKinds": ["resolution", "open", "traversal"],
+      "forbiddenTools": ["search_rules"],
+      "requiredRefs": ["scenario:frosthaven/061", "section:frosthaven/67.1"],
+      "maxToolCalls": 5
+    },
+    "source": "fh-scenario-book-62-81.pdf"
+  },
+  {
+    "id": "traj-section-read-now-chain",
+    "category": "trajectory",
+    "question": "Starting from section 103.1, follow the next two read-now links and tell me where I end up.",
+    "trajectory": {
+      "requiredTools": ["open_entity", "neighbors"],
+      "requiredToolKinds": ["open", "traversal"],
+      "forbiddenTools": ["search_rules"],
+      "requiredRefs": ["section:frosthaven/103.1"],
+      "maxToolCalls": 7
+    },
+    "source": "fh-section-book-102-121.pdf"
+  },
+  {
+    "id": "traj-exact-item-open",
+    "category": "trajectory",
+    "question": "What does item 1 do, and what source ID did you use to open it?",
+    "trajectory": {
+      "requiredTools": ["resolve_entity", "open_entity"],
+      "requiredToolKinds": ["resolution", "open"],
+      "forbiddenTools": ["search_rules"],
+      "requiredRefs": ["card:frosthaven/items/gloomhavensecretariat:item/1"],
+      "maxToolCalls": 6
+    },
+    "source": "data/extracted/items.json"
+  },
+  {
+    "id": "traj-rule-brittle-citation",
+    "category": "trajectory",
+    "question": "What are the rules for Brittle? Quote or cite the source you used.",
+    "trajectory": {
+      "requiredTools": ["search_knowledge"],
+      "requiredToolKinds": ["search"],
+      "forbiddenTools": ["get_card", "find_scenario"],
+      "requiredRefs": [],
+      "maxToolCalls": 4
+    },
+    "source": "fh-rule-book.pdf"
+  },
+  {
+    "id": "traj-ambiguous-algox-archer",
+    "category": "trajectory",
+    "question": "Find Algox Archer records, then open the best matching monster stat record.",
+    "trajectory": {
+      "requiredTools": ["resolve_entity", "open_entity"],
+      "requiredToolKinds": ["resolution", "open"],
+      "forbiddenToolKinds": ["traversal"],
+      "requiredRefs": [
+        "card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/0-3"
+      ],
+      "maxToolCalls": 5
+    },
+    "source": "data/extracted/monster-stats.json"
+  },
+  {
+    "id": "traj-scenario-neighbors",
+    "category": "trajectory",
+    "question": "What scenarios or sections are directly related to scenario 61?",
+    "trajectory": {
+      "requiredTools": ["resolve_entity", "neighbors"],
+      "requiredToolKinds": ["resolution", "traversal"],
+      "forbiddenTools": ["search_rules"],
+      "requiredRefs": ["scenario:frosthaven/061"],
+      "maxToolCalls": 6
+    },
+    "source": "fh-scenario-book-62-81.pdf"
+  },
+  {
+    "id": "traj-section-unlocks-scenario",
+    "category": "trajectory",
+    "question": "I know there is a locked scenario from section 66.2. What scenario ref does that section unlock?",
+    "trajectory": {
+      "requiredTools": ["resolve_entity", "neighbors"],
+      "requiredToolKinds": ["resolution", "traversal"],
+      "forbiddenTools": ["search_rules"],
+      "requiredRefs": ["section:frosthaven/66.2", "scenario:frosthaven/116"],
+      "maxToolCalls": 4
+    },
+    "source": "fh-section-book-62-81.pdf"
+  },
+  {
+    "id": "traj-scenario-conclusion-next-links",
+    "category": "trajectory",
+    "question": "For scenario 61, find the conclusion section, open it, and list any scenarios or sections it unlocks or points to next.",
+    "trajectory": {
+      "requiredTools": ["resolve_entity", "open_entity", "neighbors"],
+      "requiredToolKinds": ["resolution", "open", "traversal"],
+      "forbiddenTools": ["search_rules"],
+      "requiredRefs": ["scenario:frosthaven/061", "section:frosthaven/67.1"],
+      "maxToolCalls": 7
+    },
+    "source": "fh-scenario-book-62-81.pdf"
+  },
+  {
+    "id": "traj-rule-during-scenario",
+    "category": "trajectory",
+    "question": "A player asks about Brittle during scenario 61. Answer the rule question, cite the rule source, and mention whether the scenario/section books were needed.",
+    "trajectory": {
+      "requiredTools": ["search_knowledge"],
+      "requiredToolKinds": ["search"],
+      "forbiddenToolKinds": ["traversal"],
+      "requiredRefs": [],
+      "maxToolCalls": 5,
+      "notes": "The scenario mention is incidental; the answer should not traverse scenario books just because a scenario number appears."
+    },
+    "source": "fh-rule-book.pdf"
+  },
+  {
+    "id": "traj-card-fuzzy-vs-exact",
+    "category": "trajectory",
+    "question": "Find the Algox Archer monster stat record, then search for any ability or card records that mention Algox Archer and explain which records are exact data versus fuzzy matches.",
+    "trajectory": {
+      "requiredTools": ["resolve_entity", "open_entity", "search_knowledge"],
+      "requiredToolKinds": ["resolution", "open", "search"],
+      "forbiddenTools": ["search_rules"],
+      "requiredRefs": [
+        "card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/0-3"
+      ],
+      "maxToolCalls": 8
+    },
+    "source": "data/extracted/monster-stats.json"
+  },
+  {
+    "id": "traj-invalid-cross-game-ref",
+    "category": "trajectory",
+    "question": "Resolve section 67.1 in Frosthaven and then try the same bare legacy ref with an explicit Gloomhaven 2 game. The second path should reject or require a canonical game-qualified ref.",
+    "trajectory": {
+      "requiredTools": ["resolve_entity", "open_entity"],
+      "requiredToolKinds": ["resolution", "open"],
+      "forbiddenTools": ["search_rules"],
+      "requiredRefs": ["section:frosthaven/67.1"],
+      "maxToolCalls": 6,
+      "notes": "This covers missing-data and invalid-ref behavior without letting the agent silently reuse Frosthaven data for another game."
+    },
+    "source": "docs/KNOWLEDGE_TOOL_CONTRACT.md"
   }
 ]

--- a/eval/dataset.json
+++ b/eval/dataset.json
@@ -322,12 +322,16 @@
     "id": "traj-invalid-cross-game-ref",
     "category": "trajectory",
     "question": "Resolve section 67.1 in Frosthaven and then try the same bare legacy ref with an explicit Gloomhaven 2 game. The second path should reject or require a canonical game-qualified ref.",
+    "finalAnswer": {
+      "expected": "Frosthaven section 67.1 can be resolved and opened. The explicit Gloomhaven 2 section 67.1 lookup should fail or be reported as unavailable, and the assistant must not silently reuse the Frosthaven section for Gloomhaven 2.",
+      "grading": "Must distinguish the Frosthaven section from the explicit Gloomhaven 2 lookup. Must state that the Gloomhaven 2 path is rejected, unavailable, or requires a valid game-qualified ref. Answers that reuse Frosthaven data for Gloomhaven 2 should fail."
+    },
     "trajectory": {
       "requiredTools": ["resolve_entity", "open_entity"],
       "requiredToolKinds": ["resolution", "open"],
       "forbiddenTools": ["search_rules"],
-      "requiredRefs": ["section:frosthaven/67.1"],
-      "maxToolCalls": 6,
+      "requiredRefs": ["section:frosthaven/67.1", "section:gloomhaven2/67.1"],
+      "maxToolCalls": 8,
       "notes": "This covers missing-data and invalid-ref behavior without letting the agent silently reuse Frosthaven data for another game."
     },
     "source": "docs/KNOWLEDGE_TOOL_CONTRACT.md"

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -16,18 +16,24 @@ import { fileURLToPath } from 'node:url';
 import Anthropic from '@anthropic-ai/sdk';
 import { LangfuseClient } from '@langfuse/client';
 import { askFrosthavenWithTrajectory } from '../src/query.ts';
+import {
+  EvalDatasetSchema,
+  evalCaseHasFinalAnswer,
+  scoreTrajectory,
+  validateRemoteDatasetShape,
+  type EvalCase,
+  type FinalAnswerExpectation,
+  type TrajectoryExpectation,
+} from './schema.ts';
+import type { AgentRunResult } from '../src/agent.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const DATASET_NAME = 'frosthaven-qa';
 
-interface EvalCase {
-  id: string;
-  category: string;
-  question: string;
-  expected: string;
-  grading: string;
-  source: string;
+interface EvalRunOutput {
+  answer: string;
+  trajectory: AgentRunResult['trajectory'];
 }
 
 const JUDGE_PROMPT = `You are an evaluation judge for a Frosthaven board game rules assistant.
@@ -94,8 +100,17 @@ async function seedDataset(langfuse: LangfuseClient, cases: EvalCase[]): Promise
       datasetName: DATASET_NAME,
       id: c.id,
       input: { question: c.question },
-      expectedOutput: { answer: c.expected, grading: c.grading },
-      metadata: { id: c.id, category: c.category, source: c.source },
+      expectedOutput: {
+        finalAnswer: c.finalAnswer,
+        trajectory: c.trajectory,
+      },
+      metadata: {
+        id: c.id,
+        category: c.category,
+        source: c.source,
+        hasFinalAnswer: !!c.finalAnswer,
+        hasTrajectory: !!c.trajectory,
+      },
     });
     process.stdout.write('.');
   }
@@ -115,36 +130,81 @@ function buildEvaluators(anthropic: Anthropic) {
       output: unknown;
       expectedOutput?: unknown;
     }) => {
-      const question = (input as { question: string }).question;
-      const exp = expectedOutput as { answer: string; grading: string };
-      const actual =
-        typeof output === 'string'
-          ? output
-          : output !== null &&
-              typeof output === 'object' &&
-              'answer' in output &&
-              typeof output.answer === 'string'
-            ? output.answer
-            : String(output ?? '');
+      const exp = expectedOutput as
+        | { finalAnswer?: FinalAnswerExpectation; trajectory?: TrajectoryExpectation }
+        | undefined;
+      const runOutput =
+        output && typeof output === 'object' && 'answer' in output
+          ? (output as EvalRunOutput)
+          : {
+              answer: output as string,
+              trajectory: {
+                toolCalls: [],
+                finalAnswer: output as string,
+                tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+                model: 'unknown',
+                iterations: 0,
+                stopReason: null,
+              },
+            };
+      const evaluations = [];
 
-      const verdict = await judgeAnswer(anthropic, question, exp.answer, exp.grading, actual);
-
-      const icon = verdict.pass ? '\u2713' : '\u2717';
-      console.log(`${icon} (${verdict.score}/5)`);
-
-      return [
-        {
-          name: 'correctness',
-          value: verdict.score / 5,
-          dataType: 'NUMERIC' as const,
-          comment: verdict.reasoning,
-        },
-        {
-          name: 'pass',
-          value: verdict.pass ? 'pass' : 'fail',
+      if (!exp?.finalAnswer) {
+        evaluations.push({
+          name: 'final_answer',
+          value: 'not_applicable',
           dataType: 'CATEGORICAL' as const,
-        },
-      ];
+          comment: 'This case defines trajectory expectations only.',
+        });
+      } else {
+        const question = (input as { question: string }).question;
+        const verdict = await judgeAnswer(
+          anthropic,
+          question,
+          exp.finalAnswer.expected,
+          exp.finalAnswer.grading,
+          runOutput.answer,
+        );
+
+        const icon = verdict.pass ? '\u2713' : '\u2717';
+        console.log(`${icon} (${verdict.score}/5)`);
+
+        evaluations.push(
+          {
+            name: 'correctness',
+            value: verdict.score / 5,
+            dataType: 'NUMERIC' as const,
+            comment: verdict.reasoning,
+          },
+          {
+            name: 'pass',
+            value: verdict.pass ? 'pass' : 'fail',
+            dataType: 'CATEGORICAL' as const,
+          },
+        );
+      }
+
+      if (exp?.trajectory) {
+        const trajectory = scoreTrajectory(exp.trajectory, runOutput.trajectory.toolCalls);
+        evaluations.push(
+          {
+            name: 'trajectory',
+            value: trajectory.pass ? 1 : 0,
+            dataType: 'NUMERIC' as const,
+            comment:
+              trajectory.failures.length === 0
+                ? `${runOutput.trajectory.toolCalls.length} tool call(s) matched expectations`
+                : trajectory.failures.join('; '),
+          },
+          {
+            name: 'trajectory_pass',
+            value: trajectory.pass ? 'pass' : 'fail',
+            dataType: 'CATEGORICAL' as const,
+          },
+        );
+      }
+
+      return evaluations;
     },
   ];
 }
@@ -164,18 +224,29 @@ function buildRunEvaluators() {
       const passCount = itemResults
         .flatMap((r) => r.evaluations)
         .filter((e) => e.name === 'pass' && e.value === 'pass').length;
+      const trajectoryScores = itemResults
+        .flatMap((r) => r.evaluations)
+        .filter((e) => e.name === 'trajectory')
+        .map((e) => e.value as number);
+      const trajectoryPassCount = itemResults
+        .flatMap((r) => r.evaluations)
+        .filter((e) => e.name === 'trajectory_pass' && e.value === 'pass').length;
 
       console.log(`\n--- Summary ---`);
+      const scoredCount = scores.length;
       console.log(
-        `Pass rate: ${passCount}/${itemResults.length} (${((passCount / itemResults.length) * 100).toFixed(0)}%)`,
+        `Pass rate: ${passCount}/${scoredCount} (${scoredCount === 0 ? '0' : ((passCount / scoredCount) * 100).toFixed(0)}%)`,
       );
       console.log(`Avg correctness: ${(avg * 5).toFixed(2)}/5`);
+      if (trajectoryScores.length > 0) {
+        console.log(`Trajectory pass rate: ${trajectoryPassCount}/${trajectoryScores.length}`);
+      }
 
       return {
         name: 'avg_correctness',
         value: avg,
         dataType: 'NUMERIC' as const,
-        comment: `${passCount}/${itemResults.length} passed`,
+        comment: `${passCount}/${scoredCount} final-answer cases passed`,
       };
     },
   ];
@@ -187,6 +258,7 @@ async function runOnDataset(langfuse: LangfuseClient, runName: string): Promise<
   const anthropic = new Anthropic();
   const dataset = await langfuse.dataset.get(DATASET_NAME);
   console.log(`Dataset has ${dataset.items.length} items`);
+  validateRemoteDatasetShape(dataset.items, allCases.length, DATASET_NAME);
 
   const result = await dataset.runExperiment({
     name: runName,
@@ -216,8 +288,14 @@ async function runFiltered(
 
   const data = cases.map((c) => ({
     input: { question: c.question },
-    expectedOutput: { answer: c.expected, grading: c.grading },
-    metadata: { id: c.id, category: c.category, source: c.source },
+    expectedOutput: { finalAnswer: c.finalAnswer, trajectory: c.trajectory },
+    metadata: {
+      id: c.id,
+      category: c.category,
+      source: c.source,
+      hasFinalAnswer: !!c.finalAnswer,
+      hasTrajectory: !!c.trajectory,
+    },
   }));
 
   const result = await langfuse.experiment.run({
@@ -247,7 +325,9 @@ const runName =
   args.find((a) => a.startsWith('--name='))?.split('=')[1] ??
   `eval-${new Date().toISOString().slice(0, 16)}`;
 
-const allCases: EvalCase[] = JSON.parse(readFileSync(join(__dirname, 'dataset.json'), 'utf-8'));
+const allCases: EvalCase[] = EvalDatasetSchema.parse(
+  JSON.parse(readFileSync(join(__dirname, 'dataset.json'), 'utf-8')),
+);
 const isFiltered = !!(categoryFilter || idFilter);
 
 let cases = allCases;
@@ -257,6 +337,13 @@ if (idFilter) cases = cases.filter((c) => c.id === idFilter);
 if (cases.length === 0) {
   console.error('No matching eval cases found.');
   process.exit(1);
+}
+
+if (shouldSeed) {
+  const finalAnswerCount = allCases.filter(evalCaseHasFinalAnswer).length;
+  console.log(
+    `Loaded ${allCases.length} eval case(s): ${finalAnswerCount} final-answer, ${allCases.length - finalAnswerCount} trajectory-only.`,
+  );
 }
 
 const langfuse = new LangfuseClient({

--- a/eval/schema.ts
+++ b/eval/schema.ts
@@ -1,0 +1,187 @@
+import { z } from 'zod';
+
+const ToolKindSchema = z.enum(['discovery', 'resolution', 'search', 'open', 'traversal']);
+
+export const TrajectoryExpectationSchema = z
+  .object({
+    requiredTools: z.array(z.string().min(1)).default([]),
+    requiredToolKinds: z.array(ToolKindSchema).default([]),
+    forbiddenTools: z.array(z.string().min(1)).default([]),
+    forbiddenToolKinds: z.array(ToolKindSchema).default([]),
+    requiredRefs: z.array(z.string().min(1)).default([]),
+    maxToolCalls: z.number().int().positive(),
+    notes: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const FinalAnswerExpectationSchema = z
+  .object({
+    expected: z.string().min(1),
+    grading: z.string().min(1),
+  })
+  .strict();
+
+export const EvalCaseSchema = z
+  .object({
+    id: z.string().min(1),
+    category: z.string().min(1),
+    question: z.string().min(1),
+    source: z.string().min(1),
+    finalAnswer: FinalAnswerExpectationSchema.optional(),
+    trajectory: TrajectoryExpectationSchema.optional(),
+  })
+  .strict()
+  .refine((evalCase) => evalCase.finalAnswer || evalCase.trajectory, {
+    message: 'Eval cases must define finalAnswer, trajectory, or both.',
+  });
+
+export const EvalDatasetSchema = z.array(EvalCaseSchema);
+
+export type ToolKind = z.infer<typeof ToolKindSchema>;
+export type TrajectoryExpectation = z.infer<typeof TrajectoryExpectationSchema>;
+export type FinalAnswerExpectation = z.infer<typeof FinalAnswerExpectationSchema>;
+export type EvalCase = z.infer<typeof EvalCaseSchema>;
+
+export interface ObservedToolCall {
+  name: string;
+  input: unknown;
+  canonicalRefs?: string[];
+}
+
+export interface TrajectoryScore {
+  pass: boolean;
+  failures: string[];
+}
+
+export interface RemoteDatasetItemShape {
+  expectedOutput?: unknown;
+}
+
+const TOOL_KIND_BY_NAME = new Map<string, ToolKind>([
+  ['inspect_sources', 'discovery'],
+  ['schema', 'discovery'],
+  ['list_card_types', 'discovery'],
+  ['resolve_entity', 'resolution'],
+  ['find_scenario', 'resolution'],
+  ['search_knowledge', 'search'],
+  ['search_rules', 'search'],
+  ['search_cards', 'search'],
+  ['list_cards', 'search'],
+  ['open_entity', 'open'],
+  ['get_card', 'open'],
+  ['get_scenario', 'open'],
+  ['get_section', 'open'],
+  ['neighbors', 'traversal'],
+  ['follow_links', 'traversal'],
+]);
+
+export function evalCaseHasFinalAnswer(
+  evalCase: EvalCase,
+): evalCase is EvalCase & { finalAnswer: FinalAnswerExpectation } {
+  return evalCase.finalAnswer !== undefined;
+}
+
+export function evalCaseHasTrajectory(
+  evalCase: EvalCase,
+): evalCase is EvalCase & { trajectory: TrajectoryExpectation } {
+  return evalCase.trajectory !== undefined;
+}
+
+export function countTrajectoryCases(cases: EvalCase[]): number {
+  return cases.filter(evalCaseHasTrajectory).length;
+}
+
+export function validateRemoteDatasetShape(
+  remoteItems: RemoteDatasetItemShape[],
+  expectedLocalCount: number,
+  datasetName: string,
+): void {
+  if (remoteItems.length !== expectedLocalCount) {
+    throw new Error(
+      `Remote Langfuse dataset "${datasetName}" has ${remoteItems.length} item(s), but local eval/dataset.json has ${expectedLocalCount}. Run \`node eval/run.ts --seed\` before running the full dataset.`,
+    );
+  }
+
+  const staleItems = remoteItems.filter((item) => {
+    const expected = item.expectedOutput;
+    return (
+      !expected ||
+      typeof expected !== 'object' ||
+      (!('finalAnswer' in expected) && !('trajectory' in expected))
+    );
+  });
+  if (staleItems.length > 0) {
+    throw new Error(
+      `Remote Langfuse dataset "${datasetName}" still uses the old expected-output shape for ${staleItems.length} item(s). Run \`node eval/run.ts --seed\` before running the full dataset.`,
+    );
+  }
+}
+
+export function normalizeTrajectoryRef(ref: string): string {
+  const scenarioMatch = ref.match(
+    /^(?:scenario:frosthaven\/|gloomhavensecretariat:scenario\/)(\d+)$/,
+  );
+  if (scenarioMatch) {
+    return `scenario:frosthaven/${scenarioMatch[1].padStart(3, '0')}`;
+  }
+
+  const sectionMatch = ref.match(/^(?:section:frosthaven\/|section:)?(\d+\.\d+)$/);
+  if (sectionMatch) {
+    return `section:frosthaven/${sectionMatch[1]}`;
+  }
+
+  return ref;
+}
+
+function refMatches(actual: string, expected: string): boolean {
+  return normalizeTrajectoryRef(actual) === normalizeTrajectoryRef(expected);
+}
+
+function inputContainsRef(input: unknown, ref: string): boolean {
+  if (typeof input === 'string') return refMatches(input, ref);
+  if (Array.isArray(input)) return input.some((item) => inputContainsRef(item, ref));
+  if (!input || typeof input !== 'object') return false;
+  return Object.values(input).some((value) => inputContainsRef(value, ref));
+}
+
+export function scoreTrajectory(
+  expected: TrajectoryExpectation,
+  actual: ObservedToolCall[],
+): TrajectoryScore {
+  const failures: string[] = [];
+  const names = actual.map((call) => call.name);
+  const kinds = actual.map((call) => TOOL_KIND_BY_NAME.get(call.name)).filter((kind) => !!kind);
+
+  if (actual.length > expected.maxToolCalls) {
+    failures.push(`expected at most ${expected.maxToolCalls} tool call(s), saw ${actual.length}`);
+  }
+
+  for (const tool of expected.requiredTools) {
+    if (!names.includes(tool)) failures.push(`missing required tool: ${tool}`);
+  }
+
+  for (const tool of expected.forbiddenTools) {
+    if (names.includes(tool)) failures.push(`used forbidden tool: ${tool}`);
+  }
+
+  for (const kind of expected.requiredToolKinds) {
+    if (!kinds.includes(kind)) failures.push(`missing required tool kind: ${kind}`);
+  }
+
+  for (const kind of expected.forbiddenToolKinds) {
+    if (kinds.includes(kind)) failures.push(`used forbidden tool kind: ${kind}`);
+  }
+
+  for (const ref of expected.requiredRefs) {
+    const hasRef = actual.some(
+      (call) =>
+        inputContainsRef(call.input, ref) ||
+        (call.canonicalRefs ?? []).some((actualRef) => refMatches(actualRef, ref)),
+    );
+    if (!hasRef) {
+      failures.push(`missing required ref: ${ref}`);
+    }
+  }
+
+  return { pass: failures.length === 0, failures };
+}

--- a/eval/schema.ts
+++ b/eval/schema.ts
@@ -37,6 +37,16 @@ export const EvalCaseSchema = z
 
 export const EvalDatasetSchema = z.array(EvalCaseSchema);
 
+const RemoteExpectedOutputSchema = z
+  .object({
+    finalAnswer: FinalAnswerExpectationSchema.optional(),
+    trajectory: TrajectoryExpectationSchema.optional(),
+  })
+  .strict()
+  .refine((expectedOutput) => expectedOutput.finalAnswer || expectedOutput.trajectory, {
+    message: 'Remote expectedOutput must define finalAnswer, trajectory, or both.',
+  });
+
 export type ToolKind = z.infer<typeof ToolKindSchema>;
 export type TrajectoryExpectation = z.infer<typeof TrajectoryExpectationSchema>;
 export type FinalAnswerExpectation = z.infer<typeof FinalAnswerExpectationSchema>;
@@ -102,14 +112,9 @@ export function validateRemoteDatasetShape(
     );
   }
 
-  const staleItems = remoteItems.filter((item) => {
-    const expected = item.expectedOutput;
-    return (
-      !expected ||
-      typeof expected !== 'object' ||
-      (!('finalAnswer' in expected) && !('trajectory' in expected))
-    );
-  });
+  const staleItems = remoteItems.filter(
+    (item) => !RemoteExpectedOutputSchema.safeParse(item.expectedOutput).success,
+  );
   if (staleItems.length > 0) {
     throw new Error(
       `Remote Langfuse dataset "${datasetName}" still uses the old expected-output shape for ${staleItems.length} item(s). Run \`node eval/run.ts --seed\` before running the full dataset.`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
         "@hono/node-server": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "scripts": {

--- a/src/query.ts
+++ b/src/query.ts
@@ -9,14 +9,15 @@ import 'dotenv/config';
 import { sdk } from './instrumentation.ts';
 import { runAgentLoopWithTrajectory, type AgentRunResult } from './agent.ts';
 import { initialize, ask } from './service.ts';
+import type { AskOptions } from './service.ts';
 
 /**
  * Answer a Frosthaven rules question using RAG + structured card data.
  * Delegates to service.ts for all logic.
  */
-export async function askFrosthaven(question: string): Promise<string> {
+export async function askFrosthaven(question: string, options?: AskOptions): Promise<string> {
   await initialize();
-  return ask(question);
+  return options ? ask(question, options) : ask(question);
 }
 
 export async function askFrosthavenWithTrajectory(question: string): Promise<AgentRunResult> {

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -21,8 +21,16 @@ describe('eval dataset', () => {
     const cases = EvalDatasetSchema.parse(dataset);
 
     expect(cases).toHaveLength(29);
-    expect(cases.filter(evalCaseHasFinalAnswer)).toHaveLength(17);
+    expect(cases.filter(evalCaseHasFinalAnswer)).toHaveLength(18);
     expect(countTrajectoryCases(cases)).toBeGreaterThanOrEqual(10);
+  });
+
+  it('makes the cross-game ref case assert both the attempt and rejection', () => {
+    const cases = EvalDatasetSchema.parse(dataset);
+    const evalCase = cases.find((candidate) => candidate.id === 'traj-invalid-cross-game-ref');
+
+    expect(evalCase?.finalAnswer?.grading).toMatch(/Gloomhaven 2 path is rejected/);
+    expect(evalCase?.trajectory?.requiredRefs).toContain('section:gloomhaven2/67.1');
   });
 
   it('defines flexible tool-path expectations for trajectory cases', () => {
@@ -60,5 +68,18 @@ describe('eval dataset', () => {
         'frosthaven-qa',
       ),
     ).toThrow(/has 1 item/);
+  });
+
+  it('rejects malformed remote Langfuse expected outputs', () => {
+    expect(() =>
+      validateRemoteDatasetShape(
+        [
+          { expectedOutput: { finalAnswer: {} } },
+          { expectedOutput: { trajectory: { maxToolCalls: '3' } } },
+        ],
+        2,
+        'frosthaven-qa',
+      ),
+    ).toThrow(/old expected-output shape/);
   });
 });

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  EvalDatasetSchema,
+  countTrajectoryCases,
+  evalCaseHasFinalAnswer,
+  evalCaseHasTrajectory,
+  validateRemoteDatasetShape,
+} from '../eval/schema.ts';
+
+const dataset = JSON.parse(readFileSync(join(process.cwd(), 'eval/dataset.json'), 'utf-8'));
+
+describe('eval dataset', () => {
+  it('matches the final-answer and trajectory fixture schema', () => {
+    expect(() => EvalDatasetSchema.parse(dataset)).not.toThrow();
+  });
+
+  it('keeps the existing final-answer cases and adds enough trajectory coverage', () => {
+    const cases = EvalDatasetSchema.parse(dataset);
+
+    expect(cases).toHaveLength(29);
+    expect(cases.filter(evalCaseHasFinalAnswer)).toHaveLength(17);
+    expect(countTrajectoryCases(cases)).toBeGreaterThanOrEqual(10);
+  });
+
+  it('defines flexible tool-path expectations for trajectory cases', () => {
+    const cases = EvalDatasetSchema.parse(dataset).filter(evalCaseHasTrajectory);
+
+    expect(cases.length).toBeGreaterThanOrEqual(10);
+    for (const evalCase of cases) {
+      expect(evalCase.trajectory.maxToolCalls).toBeGreaterThan(0);
+      expect(
+        evalCase.trajectory.requiredTools.length +
+          evalCase.trajectory.requiredToolKinds.length +
+          evalCase.trajectory.requiredRefs.length,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('rejects stale remote Langfuse dataset shapes before a full run', () => {
+    expect(() =>
+      validateRemoteDatasetShape(
+        [
+          { expectedOutput: { answer: 'old answer', grading: 'old grading' } },
+          { expectedOutput: { answer: 'old answer', grading: 'old grading' } },
+        ],
+        2,
+        'frosthaven-qa',
+      ),
+    ).toThrow(/old expected-output shape/);
+  });
+
+  it('rejects remote Langfuse datasets with a stale item count', () => {
+    expect(() =>
+      validateRemoteDatasetShape(
+        [{ expectedOutput: { finalAnswer: { expected: 'ok', grading: 'ok' } } }],
+        2,
+        'frosthaven-qa',
+      ),
+    ).toThrow(/has 1 item/);
+  });
+});

--- a/test/eval-trajectory.test.ts
+++ b/test/eval-trajectory.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { scoreTrajectory } from '../eval/schema.ts';
+
+describe('scoreTrajectory', () => {
+  it('passes flexible required tools, kinds, refs, and budget checks', () => {
+    const result = scoreTrajectory(
+      {
+        requiredTools: ['resolve_entity', 'open_entity'],
+        requiredToolKinds: ['resolution', 'open'],
+        forbiddenTools: ['search_rules'],
+        forbiddenToolKinds: ['traversal'],
+        requiredRefs: ['card:frosthaven/items/gloomhavensecretariat:item/1'],
+        maxToolCalls: 3,
+      },
+      [
+        { name: 'resolve_entity', input: { query: 'item 1' } },
+        {
+          name: 'open_entity',
+          input: { ref: 'card:frosthaven/items/gloomhavensecretariat:item/1' },
+        },
+      ],
+    );
+
+    expect(result).toEqual({ pass: true, failures: [] });
+  });
+
+  it('matches required refs against normalized inputs and tool-result canonical refs', () => {
+    const result = scoreTrajectory(
+      {
+        requiredTools: ['resolve_entity', 'neighbors'],
+        requiredToolKinds: ['resolution', 'traversal'],
+        forbiddenTools: [],
+        forbiddenToolKinds: [],
+        requiredRefs: ['scenario:frosthaven/061', 'section:frosthaven/67.1'],
+        maxToolCalls: 2,
+      },
+      [
+        { name: 'resolve_entity', input: { query: 'scenario 61' } },
+        {
+          name: 'neighbors',
+          input: { ref: 'gloomhavensecretariat:scenario/61' },
+          canonicalRefs: ['section:67.1'],
+        },
+      ],
+    );
+
+    expect(result).toEqual({ pass: true, failures: [] });
+  });
+
+  it('reports missing requirements and forbidden calls', () => {
+    const result = scoreTrajectory(
+      {
+        requiredTools: ['neighbors'],
+        requiredToolKinds: ['traversal'],
+        forbiddenTools: ['search_rules'],
+        forbiddenToolKinds: ['search'],
+        requiredRefs: ['section:frosthaven/67.1'],
+        maxToolCalls: 1,
+      },
+      [
+        { name: 'search_rules', input: { query: 'scenario 61' } },
+        { name: 'open_entity', input: { ref: 'scenario:frosthaven/061' } },
+      ],
+    );
+
+    expect(result.pass).toBe(false);
+    expect(result.failures).toEqual([
+      'expected at most 1 tool call(s), saw 2',
+      'missing required tool: neighbors',
+      'used forbidden tool: search_rules',
+      'missing required tool kind: traversal',
+      'used forbidden tool kind: search',
+      'missing required ref: section:frosthaven/67.1',
+    ]);
+  });
+});

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -32,6 +32,12 @@ describe('askFrosthaven', () => {
     expect(mockAsk).toHaveBeenCalledWith('What is the loot action?');
   });
 
+  it('passes options through to service.ask()', async () => {
+    const options = { toolSurface: 'legacy' as const };
+    await askFrosthaven('What is the loot action?', options);
+    expect(mockAsk).toHaveBeenCalledWith('What is the loot action?', options);
+  });
+
   it('returns the answer from service.ask()', async () => {
     const result = await askFrosthaven('What is the loot action?');
     expect(result).toBe('Mocked answer from service');


### PR DESCRIPTION
## Summary
- add trajectory-only Frosthaven eval cases for tool-path quality
- add eval schema validation, stale Langfuse dataset checks, and trajectory scoring for tools, kinds, refs, and call budgets
- bump package version to 0.1.5 and document the eval additions

## QA
- npm run check
- node eval/run.ts --seed
- node eval/run.ts --id=traj-source-discovery --name=qa-sqr-120-post-sqr121-smoke
- full Langfuse eval run after seeding: 13/17 final-answer cases passed; trajectory improved from 3/12 to 8/12, with remaining behavior failures tracked in SQR-136 and SQR-137

Fixes SQR-120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trajectory-based evaluation for Frosthaven tool-paths: required/forbidden tools and tool kinds, required refs, call budgets, ref normalization and trajectory scoring.
  * Query options support for flexible calls.
  * Local and remote dataset schema validation before runs.

* **Tests**
  * Added dataset schema, trajectory scoring, and query-option tests with coverage and stale-remote detection.

* **Chores**
  * Version bumped to 0.1.5 and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->