### PR TITLE
SQR-120 Improve remote eval dataset diagnostics

### DIFF
--- a/eval/schema.ts
+++ b/eval/schema.ts
@@ -112,12 +112,23 @@ export function validateRemoteDatasetShape(
     );
   }
 
-  const staleItems = remoteItems.filter(
-    (item) => !RemoteExpectedOutputSchema.safeParse(item.expectedOutput).success,
-  );
-  if (staleItems.length > 0) {
+  const invalidItems: Array<{ index: number; issues: string[] }> = [];
+  remoteItems.forEach((item, index) => {
+    const result = RemoteExpectedOutputSchema.safeParse(item.expectedOutput);
+    if (!result.success) {
+      invalidItems.push({
+        index,
+        issues: result.error.issues.map((issue) => issue.message),
+      });
+    }
+  });
+  if (invalidItems.length > 0) {
+    const sample = invalidItems
+      .slice(0, 3)
+      .map((item) => `item ${item.index}: ${item.issues[0] ?? 'invalid expectedOutput'}`)
+      .join('; ');
     throw new Error(
-      `Remote Langfuse dataset "${datasetName}" still uses the old expected-output shape for ${staleItems.length} item(s). Run \`node eval/run.ts --seed\` before running the full dataset.`,
+      `Remote Langfuse dataset "${datasetName}" has ${invalidItems.length} invalid expectedOutput item(s). Sample: ${sample}. Run \`node eval/run.ts --seed\` before running the full dataset.`,
     );
   }
 }

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -57,7 +57,7 @@ describe('eval dataset', () => {
         2,
         'frosthaven-qa',
       ),
-    ).toThrow(/old expected-output shape/);
+    ).toThrow(/invalid expectedOutput/);
   });
 
   it('rejects remote Langfuse datasets with a stale item count', () => {
@@ -80,6 +80,6 @@ describe('eval dataset', () => {
         2,
         'frosthaven-qa',
       ),
-    ).toThrow(/old expected-output shape/);
+    ).toThrow(/invalid expectedOutput/);
   });
 });


### PR DESCRIPTION
## Summary
- follow-up to #286 for the CodeRabbit nitpick
- include a small sample of Zod issue messages when remote Langfuse expectedOutput validation fails
- update eval dataset tests to assert the clearer diagnostic path

## QA
- npm test -- test/eval-dataset.test.ts
- npm run check

Refs SQR-120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error messages for remote datasets to display specific invalid items and provide clearer guidance for resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->