### PR TITLE
v0.1.6 feat: add SQR-122 retrieval decision report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.1.6] - 2026-04-29
+
+### Changed
+
+- Added the SQR-122 retrieval eval decision report comparing the legacy and redesigned tool surfaces on the same 29-case eval suite.
+- Kept Phase 1 production on the legacy prompt-routed tool surface while leaving the redesigned surface selectable for evals and follow-up work.
+- Added eval runner flags for selecting the tool surface and writing local JSON reports with per-case latency, token, tool-call, and scoring data.
+- Tightened the server CLI entrypoint guard so importing `src/server.ts` in tests cannot start the HTTP server as a side effect.
+
 ## [0.1.5] - 2026-04-28
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,6 +47,12 @@ Agents and LangSmith Deployment are explicitly deferred until after the Step 3
 eval report. See
 [ADR 0013 — Keep Phase 1 production on the current knowledge-agent path](adr/0013-phase-1-production-agent-baseline.md).
 
+The Step 3 eval report is checked in at
+[docs/plans/sqr-122-retrieval-eval-decision-report.md](plans/sqr-122-retrieval-eval-decision-report.md).
+Its decision is to keep Phase 1 production on the legacy prompt-routed tool
+surface and defer the redesigned self-describing tool surface until its
+final-answer regressions and remaining trajectory failures are fixed.
+
 The active baseline is:
 
 - Hono hosts the web UI, REST endpoints, and MCP endpoint in one server.

--- a/docs/plans/sqr-122-retrieval-eval-decision-report.md
+++ b/docs/plans/sqr-122-retrieval-eval-decision-report.md
@@ -1,0 +1,147 @@
+# SQR-122 Retrieval Eval Decision Report
+
+**Date:** 2026-04-29  
+**Decision:** Defer the redesigned tool surface and keep the legacy
+prompt-routed tool surface for Phase 1 production.
+
+## Recommendation
+
+Proceed to the deployment and production-readiness work that was gated by
+SQR-115, but ship Phase 1 on the legacy tool surface. Do not ship the redesigned
+self-describing tool surface as the production default yet.
+
+This report does not recommend a Deep Agents spike before production. The
+observed failures are mostly answer-quality, exact-open discipline, source-data,
+and invalid-ref behavior. Those should be fixed in the existing follow-up work
+before revisiting runtime migration.
+
+## Runs
+
+Both runs used the same checked-in `eval/dataset.json` suite:
+
+- 29 total cases
+- 18 final-answer cases
+- 12 trajectory cases
+- `traj-invalid-cross-game-ref` counts in both groups because it has both
+  final-answer and trajectory expectations
+
+Commands:
+
+```bash
+npm run eval -- --tool-surface=legacy --name=sqr-122-legacy --local-report=/tmp/sqr-122-legacy.json
+npm run eval -- --tool-surface=redesigned --name=sqr-122-redesigned --local-report=/tmp/sqr-122-redesigned.json
+```
+
+The local JSON report mode uses the same agent, judge prompt, final-answer
+scoring, and trajectory scorer as `eval/run.ts`. It also records per-case
+latency, token usage, tool-call count, tool names, source labels, canonical refs,
+and failure reasons.
+
+## Summary
+
+| Metric                                    |            Legacy surface |        Redesigned surface |
+| ----------------------------------------- | ------------------------: | ------------------------: |
+| Final-answer pass rate                    |               15/18 (83%) |               13/18 (72%) |
+| Average final-answer score                |                    4.28/5 |                    3.83/5 |
+| Trajectory pass rate                      |                      0/12 |                      8/12 |
+| Required canonical refs found             |                      8/13 |                     12/13 |
+| Forbidden-tool or forbidden-kind failures |                         2 |                         0 |
+| Tool-budget failures                      |                         1 |                         1 |
+| Average tool calls per case               |                      2.55 |                      3.21 |
+| Average latency per case                  |                    12.99s |                    14.45s |
+| Total latency                             |                   376.58s |                   418.97s |
+| Input tokens                              |                   563,757 |                   481,395 |
+| Output tokens                             |                    16,333 |                    17,654 |
+| Total tokens                              |                   580,090 |                   499,049 |
+| System prompt length                      | 2,565 chars (~642 tokens) | 1,424 chars (~356 tokens) |
+
+Dollar cost is not frozen in this repo because model prices are external. The
+raw token totals are included so current provider pricing can be applied later.
+On raw model tokens, the redesigned surface used 81,041 fewer total tokens
+(-14.0%) despite producing 1,321 more output tokens.
+
+## Final-Answer Results
+
+| Case                            |   Legacy | Redesigned | Notes                                                                                                          |
+| ------------------------------- | -------: | ---------: | -------------------------------------------------------------------------------------------------------------- |
+| `rule-long-rest-init`           | pass 5/5 |   pass 5/5 |                                                                                                                |
+| `rule-long-rest-steps`          | pass 5/5 |   pass 5/5 |                                                                                                                |
+| `rule-scenario-level`           | pass 5/5 |   pass 5/5 |                                                                                                                |
+| `rule-poison`                   | pass 5/5 |   pass 5/5 |                                                                                                                |
+| `rule-brittle`                  | pass 5/5 |   pass 5/5 |                                                                                                                |
+| `rule-advantage`                | pass 5/5 |   pass 5/5 |                                                                                                                |
+| `rule-small-items`              | pass 5/5 |   pass 5/5 |                                                                                                                |
+| `rule-looting-definition`       | pass 5/5 |   pass 5/5 |                                                                                                                |
+| `monster-vermling-scout`        | pass 5/5 |   fail 1/5 | Redesigned retrieved ability cards but not the monster stat record.                                            |
+| `monster-living-bones-immunity` | fail 1/5 |   fail 1/5 | Both surfaces answered that Living Bones have no immunities, contradicting the expected Poison/Wound immunity. |
+| `monster-flame-demon-elite`     | pass 5/5 |   pass 5/5 |                                                                                                                |
+| `building-alchemist`            | fail 1/5 |   fail 1/5 | Both surfaces failed to provide the expected level-1 build cost.                                               |
+| `item-spyglass`                 | pass 4/5 |   pass 4/5 |                                                                                                                |
+| `item-crude-boots`              | pass 4/5 |   pass 5/5 |                                                                                                                |
+| `scenario-61-unlock`            | fail 2/5 |   fail 1/5 | Legacy answered section 79.4 instead of 67.1; redesigned hit the iteration limit.                              |
+| `rule-wound`                    | pass 5/5 |   pass 5/5 |                                                                                                                |
+| `tool-free-assistant-game`      | pass 5/5 |   pass 5/5 |                                                                                                                |
+| `traj-invalid-cross-game-ref`   | pass 5/5 |   fail 1/5 | Redesigned failed the Gloomhaven 2 rejection expectation.                                                      |
+
+## Trajectory Results
+
+| Case                                  |         Legacy |     Redesigned | Redesigned failure reason                                                                                                   |
+| ------------------------------------- | -------------: | -------------: | --------------------------------------------------------------------------------------------------------------------------- |
+| `traj-source-discovery`               | fail (2 calls) |  pass (1 call) |                                                                                                                             |
+| `traj-scenario-conclusion-open`       | fail (3 calls) | pass (4 calls) |                                                                                                                             |
+| `traj-section-read-now-chain`         | fail (4 calls) | pass (4 calls) |                                                                                                                             |
+| `traj-exact-item-open`                | fail (3 calls) | fail (7 calls) | Expected at most 6 tool calls, saw 7.                                                                                       |
+| `traj-rule-brittle-citation`          |  fail (1 call) |  pass (1 call) |                                                                                                                             |
+| `traj-ambiguous-algox-archer`         | fail (3 calls) | fail (3 calls) | Missing required tool: `resolve_entity`; missing required tool kind: `resolution`.                                          |
+| `traj-scenario-neighbors`             | fail (7 calls) | pass (4 calls) |                                                                                                                             |
+| `traj-section-unlocks-scenario`       |  fail (1 call) | pass (2 calls) |                                                                                                                             |
+| `traj-scenario-conclusion-next-links` | fail (5 calls) | pass (5 calls) |                                                                                                                             |
+| `traj-rule-during-scenario`           | fail (3 calls) | pass (4 calls) |                                                                                                                             |
+| `traj-card-fuzzy-vs-exact`            | fail (5 calls) | fail (2 calls) | Missing required tool: `open_entity`; missing required tool kind: `open`.                                                   |
+| `traj-invalid-cross-game-ref`         | fail (2 calls) | fail (2 calls) | Missing required tool: `open_entity`; missing required tool kind: `open`; missing required ref: `section:gloomhaven2/67.1`. |
+
+## Failure Modes
+
+Legacy surface:
+
+- Better final-answer pass rate today.
+- Fails the redesigned trajectory suite because it cannot use the new
+  self-describing operations by design.
+- Uses forbidden or wasteful paths on two trajectory cases, including scenario
+  traversal when the scenario mention is incidental.
+- Uses the longer prompt and more total tokens.
+
+Redesigned surface:
+
+- Much better trajectory behavior: 8/12 pass, 12/13 required refs found, and no
+  forbidden-tool failures.
+- Worse final-answer quality: 13/18 versus legacy's 15/18.
+- Still misses exact-open behavior after resolution in card cases.
+- Fails the cross-game invalid-ref case in both final answer and trajectory.
+- Hits the iteration limit on `scenario-61-unlock`.
+- Is slower on this run despite lower token usage.
+
+## Decision Rationale
+
+The redesigned surface is a real improvement for tool-path shape, prompt length,
+and token volume. It is not ready to be the production default because the Phase
+1 user-facing final-answer score regressed and the remaining failures are
+load-bearing:
+
+- exact monster/card record lookup is inconsistent
+- cross-game ref handling can silently reuse the wrong game path
+- scenario unlock traversal can still stall
+- known source-data or fixture issues remain in the final-answer suite
+
+The legacy surface is not a good long-term retrieval contract, but it is the
+better Phase 1 production default because users experience the final answer, not
+the internal tool contract. SQR-136 and SQR-137 already track the redesigned
+trajectory and final-answer follow-up work.
+
+## Gate Outcome
+
+SQR-115 can be unblocked after this report lands. Deployment/readiness steps 4
+and 5 may proceed on the legacy production surface. The redesigned surface
+should remain selectable for evals and follow-up tickets, but it should not be
+the default production path until its final-answer pass rate is at least level
+with legacy and the remaining trajectory failures are fixed.

--- a/eval/cli.ts
+++ b/eval/cli.ts
@@ -11,7 +11,13 @@ export interface EvalCliOptions {
 
 function valueFor(args: string[], prefix: string): string | undefined {
   const arg = args.find((candidate) => candidate.startsWith(prefix));
-  return arg ? arg.slice(prefix.length) : undefined;
+  if (!arg) return undefined;
+
+  const value = arg.slice(prefix.length);
+  if (value.length === 0) {
+    throw new Error(`Invalid ${prefix.slice(0, -1)}: value cannot be empty.`);
+  }
+  return value;
 }
 
 export function parseEvalArgs(args: string[], now = new Date()): EvalCliOptions {

--- a/eval/cli.ts
+++ b/eval/cli.ts
@@ -1,0 +1,33 @@
+export type EvalToolSurface = 'redesigned' | 'legacy';
+
+export interface EvalCliOptions {
+  shouldSeed: boolean;
+  categoryFilter: string | undefined;
+  idFilter: string | undefined;
+  runName: string;
+  toolSurface: EvalToolSurface;
+  localReportPath: string | undefined;
+}
+
+function valueFor(args: string[], prefix: string): string | undefined {
+  const arg = args.find((candidate) => candidate.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : undefined;
+}
+
+export function parseEvalArgs(args: string[], now = new Date()): EvalCliOptions {
+  const surface = valueFor(args, '--tool-surface=') ?? 'redesigned';
+  if (surface !== 'redesigned' && surface !== 'legacy') {
+    throw new Error(`Invalid --tool-surface: ${surface}. Expected "redesigned" or "legacy".`);
+  }
+
+  const runName = valueFor(args, '--name=') ?? `eval-${now.toISOString().slice(0, 16)}-${surface}`;
+
+  return {
+    shouldSeed: args.includes('--seed'),
+    categoryFilter: valueFor(args, '--category='),
+    idFilter: valueFor(args, '--id='),
+    runName,
+    toolSurface: surface,
+    localReportPath: valueFor(args, '--local-report='),
+  };
+}

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -382,6 +382,8 @@ async function runLocalReport(
         id: c.id,
         category: c.category,
         source: c.source,
+        hasFinalAnswerExpectation: Boolean(c.finalAnswer),
+        hasTrajectoryExpectation: Boolean(c.trajectory),
         question: c.question,
         answer: output.answer,
         durationMs,
@@ -407,6 +409,8 @@ async function runLocalReport(
         id: c.id,
         category: c.category,
         source: c.source,
+        hasFinalAnswerExpectation: Boolean(c.finalAnswer),
+        hasTrajectoryExpectation: Boolean(c.trajectory),
         question: c.question,
         durationMs: Date.now() - startedAt,
         error: err instanceof Error ? err.message : String(err),
@@ -416,6 +420,8 @@ async function runLocalReport(
 
   const finalAnswerResults = results.filter((result) => result.finalAnswer);
   const trajectoryResults = results.filter((result) => result.trajectory);
+  const finalAnswerCases = results.filter((result) => result.hasFinalAnswerExpectation).length;
+  const trajectoryCases = results.filter((result) => result.hasTrajectoryExpectation).length;
   const totalDurationMs = results.reduce((sum, result) => sum + (result.durationMs ?? 0), 0);
   const totalToolCalls = results.reduce((sum, result) => sum + (result.toolCallCount ?? 0), 0);
   const promptLength = promptLengthFor(toolSurface);
@@ -429,15 +435,17 @@ async function runLocalReport(
     summary: {
       totalCases: results.length,
       erroredCases: results.filter((result) => result.error).length,
-      finalAnswerCases: finalAnswerResults.length,
-      finalAnswerPasses: finalAnswerResults.filter((result) => result.finalAnswer?.pass).length,
+      finalAnswerCases,
+      finalAnswerPasses: finalAnswerResults.filter((result) => result.finalAnswer?.pass === true)
+        .length,
       avgCorrectnessScore:
         finalAnswerResults.length === 0
           ? null
           : finalAnswerResults.reduce((sum, result) => sum + (result.finalAnswer?.score ?? 0), 0) /
             finalAnswerResults.length,
-      trajectoryCases: trajectoryResults.length,
-      trajectoryPasses: trajectoryResults.filter((result) => result.trajectory?.pass).length,
+      trajectoryCases,
+      trajectoryPasses: trajectoryResults.filter((result) => result.trajectory?.pass === true)
+        .length,
       avgToolCalls: results.length === 0 ? 0 : totalToolCalls / results.length,
       avgLatencyMs: results.length === 0 ? 0 : totalDurationMs / results.length,
       totalLatencyMs: totalDurationMs,

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -2,20 +2,24 @@
  * RAG pipeline evaluation runner using Langfuse datasets & experiments.
  *
  * First run:  node eval/run.ts --seed        # upload dataset to Langfuse
- * Run eval:   node eval/run.ts               # run all questions
+ * Run eval:   node eval/run.ts               # run all questions on redesigned tools
+ * Legacy:     node eval/run.ts --tool-surface=legacy
  * Filtered:   node eval/run.ts --category=rulebook
  *             node eval/run.ts --id=rule-poison
  * Named run:  node eval/run.ts --name="after chunking fix"
+ * Local JSON: node eval/run.ts --local-report=/tmp/eval.json
  */
 
 import 'dotenv/config';
 import { sdk, LANGFUSE_DEFAULT_BASE_URL } from '../src/instrumentation.ts';
-import { readFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import Anthropic from '@anthropic-ai/sdk';
 import { LangfuseClient } from '@langfuse/client';
 import { askFrosthavenWithTrajectory } from '../src/query.ts';
+import { AGENT_SYSTEM_PROMPT, LEGACY_AGENT_SYSTEM_PROMPT, type TokenUsage } from '../src/agent.ts';
+import { parseEvalArgs, type EvalToolSurface } from './cli.ts';
 import {
   EvalDatasetSchema,
   evalCaseHasFinalAnswer,
@@ -34,6 +38,8 @@ const DATASET_NAME = 'frosthaven-qa';
 interface EvalRunOutput {
   answer: string;
   trajectory: AgentRunResult['trajectory'];
+  durationMs?: number;
+  toolSurface?: EvalToolSurface;
 }
 
 const JUDGE_PROMPT = `You are an evaluation judge for a Frosthaven board game rules assistant.
@@ -254,7 +260,11 @@ function buildRunEvaluators() {
 
 // --- Run experiment ---
 
-async function runOnDataset(langfuse: LangfuseClient, runName: string): Promise<void> {
+async function runOnDataset(
+  langfuse: LangfuseClient,
+  runName: string,
+  toolSurface: EvalToolSurface,
+): Promise<void> {
   const anthropic = new Anthropic();
   const dataset = await langfuse.dataset.get(DATASET_NAME);
   console.log(`Dataset has ${dataset.items.length} items`);
@@ -267,7 +277,9 @@ async function runOnDataset(langfuse: LangfuseClient, runName: string): Promise<
       const question = (item.input as { question: string }).question;
       const meta = item.metadata as { id?: string } | undefined;
       process.stdout.write(`  ${meta?.id ?? '?'}... `);
-      return askFrosthavenWithTrajectory(question);
+      const startedAt = Date.now();
+      const result = await askFrosthavenWithTrajectory(question, { toolSurface });
+      return { ...result, durationMs: Date.now() - startedAt, toolSurface };
     },
     evaluators: buildEvaluators(anthropic),
     runEvaluators: buildRunEvaluators(),
@@ -283,6 +295,7 @@ async function runFiltered(
   langfuse: LangfuseClient,
   cases: EvalCase[],
   runName: string,
+  toolSurface: EvalToolSurface,
 ): Promise<void> {
   const anthropic = new Anthropic();
 
@@ -306,7 +319,9 @@ async function runFiltered(
       const question = (item.input as { question: string }).question;
       const meta = item.metadata as { id?: string } | undefined;
       process.stdout.write(`  ${meta?.id ?? '?'}... `);
-      return askFrosthavenWithTrajectory(question);
+      const startedAt = Date.now();
+      const result = await askFrosthavenWithTrajectory(question, { toolSurface });
+      return { ...result, durationMs: Date.now() - startedAt, toolSurface };
     },
     evaluators: buildEvaluators(anthropic),
     runEvaluators: buildRunEvaluators(),
@@ -315,15 +330,131 @@ async function runFiltered(
   console.log('\n' + (await result.format()));
 }
 
+function addTokenUsage(total: TokenUsage, next: TokenUsage): void {
+  total.inputTokens += next.inputTokens;
+  total.outputTokens += next.outputTokens;
+  total.totalTokens += next.totalTokens;
+}
+
+function promptLengthFor(toolSurface: EvalToolSurface): { chars: number; estimatedTokens: number } {
+  const prompt = toolSurface === 'legacy' ? LEGACY_AGENT_SYSTEM_PROMPT : AGENT_SYSTEM_PROMPT;
+  return { chars: prompt.length, estimatedTokens: Math.ceil(prompt.length / 4) };
+}
+
+async function runLocalReport(
+  cases: EvalCase[],
+  runName: string,
+  toolSurface: EvalToolSurface,
+  outputPath: string,
+): Promise<void> {
+  const anthropic = new Anthropic();
+  const results = [];
+  const totalTokenUsage: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
+  for (const c of cases) {
+    process.stdout.write(`  ${c.id}... `);
+    const startedAt = Date.now();
+    try {
+      const output = await askFrosthavenWithTrajectory(c.question, { toolSurface });
+      const durationMs = Date.now() - startedAt;
+      addTokenUsage(totalTokenUsage, output.trajectory.tokenUsage);
+
+      const finalAnswer = c.finalAnswer
+        ? await judgeAnswer(
+            anthropic,
+            c.question,
+            c.finalAnswer.expected,
+            c.finalAnswer.grading,
+            output.answer,
+          )
+        : null;
+      const trajectory = c.trajectory
+        ? scoreTrajectory(c.trajectory, output.trajectory.toolCalls)
+        : null;
+
+      const mark =
+        (finalAnswer ? finalAnswer.pass : true) && (trajectory ? trajectory.pass : true)
+          ? '\u2713'
+          : '\u2717';
+      console.log(mark);
+
+      results.push({
+        id: c.id,
+        category: c.category,
+        source: c.source,
+        question: c.question,
+        answer: output.answer,
+        durationMs,
+        finalAnswer,
+        trajectory,
+        toolCallCount: output.trajectory.toolCalls.length,
+        toolCalls: output.trajectory.toolCalls.map((call) => ({
+          name: call.name,
+          input: call.input,
+          ok: call.ok,
+          sourceLabels: call.sourceLabels,
+          canonicalRefs: call.canonicalRefs,
+          durationMs: call.durationMs,
+          error: call.error,
+        })),
+        tokenUsage: output.trajectory.tokenUsage,
+        iterations: output.trajectory.iterations,
+        stopReason: output.trajectory.stopReason,
+      });
+    } catch (err) {
+      console.log('\u2717');
+      results.push({
+        id: c.id,
+        category: c.category,
+        source: c.source,
+        question: c.question,
+        durationMs: Date.now() - startedAt,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const finalAnswerResults = results.filter((result) => result.finalAnswer);
+  const trajectoryResults = results.filter((result) => result.trajectory);
+  const totalDurationMs = results.reduce((sum, result) => sum + (result.durationMs ?? 0), 0);
+  const totalToolCalls = results.reduce((sum, result) => sum + (result.toolCallCount ?? 0), 0);
+  const promptLength = promptLengthFor(toolSurface);
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    runName,
+    toolSurface,
+    datasetName: DATASET_NAME,
+    promptLength,
+    summary: {
+      totalCases: results.length,
+      erroredCases: results.filter((result) => result.error).length,
+      finalAnswerCases: finalAnswerResults.length,
+      finalAnswerPasses: finalAnswerResults.filter((result) => result.finalAnswer?.pass).length,
+      avgCorrectnessScore:
+        finalAnswerResults.length === 0
+          ? null
+          : finalAnswerResults.reduce((sum, result) => sum + (result.finalAnswer?.score ?? 0), 0) /
+            finalAnswerResults.length,
+      trajectoryCases: trajectoryResults.length,
+      trajectoryPasses: trajectoryResults.filter((result) => result.trajectory?.pass).length,
+      avgToolCalls: results.length === 0 ? 0 : totalToolCalls / results.length,
+      avgLatencyMs: results.length === 0 ? 0 : totalDurationMs / results.length,
+      totalLatencyMs: totalDurationMs,
+      tokenUsage: totalTokenUsage,
+    },
+    results,
+  };
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(`\nWrote local eval report: ${outputPath}`);
+}
+
 // --- CLI ---
 
-const args = process.argv.slice(2);
-const shouldSeed = args.includes('--seed');
-const categoryFilter = args.find((a) => a.startsWith('--category='))?.split('=')[1];
-const idFilter = args.find((a) => a.startsWith('--id='))?.split('=')[1];
-const runName =
-  args.find((a) => a.startsWith('--name='))?.split('=')[1] ??
-  `eval-${new Date().toISOString().slice(0, 16)}`;
+const { shouldSeed, categoryFilter, idFilter, runName, toolSurface, localReportPath } =
+  parseEvalArgs(process.argv.slice(2));
 
 const allCases: EvalCase[] = EvalDatasetSchema.parse(
   JSON.parse(readFileSync(join(__dirname, 'dataset.json'), 'utf-8')),
@@ -346,18 +477,23 @@ if (shouldSeed) {
   );
 }
 
-const langfuse = new LangfuseClient({
-  baseUrl: process.env.LANGFUSE_BASEURL ?? LANGFUSE_DEFAULT_BASE_URL,
-});
-
-if (shouldSeed) {
-  await seedDataset(langfuse, allCases);
+if (localReportPath) {
+  console.log(`Running ${cases.length} local eval(s) as "${runName}" on ${toolSurface} tools...\n`);
+  await runLocalReport(cases, runName, toolSurface, localReportPath);
 } else {
-  console.log(`Running ${cases.length} eval(s) as "${runName}"...\n`);
-  if (isFiltered) {
-    await runFiltered(langfuse, cases, runName);
+  const langfuse = new LangfuseClient({
+    baseUrl: process.env.LANGFUSE_BASEURL ?? LANGFUSE_DEFAULT_BASE_URL,
+  });
+
+  if (shouldSeed) {
+    await seedDataset(langfuse, allCases);
   } else {
-    await runOnDataset(langfuse, runName);
+    console.log(`Running ${cases.length} eval(s) as "${runName}" on ${toolSurface} tools...\n`);
+    if (isFiltered) {
+      await runFiltered(langfuse, cases, runName, toolSurface);
+    } else {
+      await runOnDataset(langfuse, runName, toolSurface);
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
         "@hono/node-server": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "scripts": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -354,16 +354,10 @@ function selectedAgentSurface(surface: AgentToolSurface | undefined): {
   system: string;
   tools: readonly Tool[];
 } {
-  if (surface === 'legacy') {
-    return {
-      system: LEGACY_AGENT_SYSTEM_PROMPT,
-      tools: LEGACY_AGENT_TOOLS,
-    };
+  if (surface === 'redesigned') {
+    return { system: AGENT_SYSTEM_PROMPT, tools: AGENT_TOOLS };
   }
-  return {
-    system: AGENT_SYSTEM_PROMPT,
-    tools: AGENT_TOOLS,
-  };
+  return { system: LEGACY_AGENT_SYSTEM_PROMPT, tools: LEGACY_AGENT_TOOLS };
 }
 
 export interface ToolCallResult {

--- a/src/query.ts
+++ b/src/query.ts
@@ -20,9 +20,14 @@ export async function askFrosthaven(question: string, options?: AskOptions): Pro
   return options ? ask(question, options) : ask(question);
 }
 
-export async function askFrosthavenWithTrajectory(question: string): Promise<AgentRunResult> {
+export async function askFrosthavenWithTrajectory(
+  question: string,
+  options?: AskOptions,
+): Promise<AgentRunResult> {
   await initialize();
-  return runAgentLoopWithTrajectory(question);
+  return options
+    ? runAgentLoopWithTrajectory(question, options)
+    : runAgentLoopWithTrajectory(question);
 }
 
 // CLI entrypoint

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import 'dotenv/config';
 // before service.ts transitively loads db.ts, otherwise Postgres spans never
 // reach Langfuse in production. Same pattern as query.ts and eval/run.ts.
 import './instrumentation.ts';
+import { pathToFileURL } from 'node:url';
 import { Hono, type Context, type MiddlewareHandler } from 'hono';
 import { html } from 'hono/html';
 import { streamSSE } from 'hono/streaming';
@@ -1231,7 +1232,7 @@ async function listen(server: import('node:net').Server, port: number): Promise<
 }
 
 // CLI entrypoint
-if (process.argv[1]?.endsWith('server.ts')) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   startServer().catch((err: unknown) => {
     console.error('Failed to start server:', err);
     process.exit(1);

--- a/src/service.ts
+++ b/src/service.ts
@@ -516,8 +516,8 @@ export type EmitFn = (event: string, data: unknown) => Promise<void>;
 export interface AskOptions {
   history?: HistoryMessage[];
   /**
-   * Default uses the redesigned self-describing knowledge tools. `legacy`
-   * keeps the old tool surface selectable until eval parity closes Step 3.
+   * Phase 1 defaults to the legacy prompt-routed tools after the SQR-122 eval
+   * report. `redesigned` remains selectable for the follow-up retrieval work.
    */
   toolSurface?: 'redesigned' | 'legacy';
   /** Campaign UUID — reserved for future campaign context loading. */

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -209,18 +209,27 @@ describe('runAgentLoop', () => {
     expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
   });
 
-  it('passes tools to Claude API', async () => {
+  it('defaults to the legacy tool surface for Phase 1', async () => {
     mockMessagesCreate.mockResolvedValue(textResponse('Answer'));
     await runAgentLoop('test');
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: LEGACY_AGENT_TOOLS,
+        system: LEGACY_AGENT_SYSTEM_PROMPT,
+      }),
+    );
+  });
+
+  it('keeps the redesigned tools selectable for evals and follow-up work', async () => {
+    mockMessagesCreate.mockResolvedValue(textResponse('Answer'));
+    await runAgentLoop('test', { toolSurface: 'redesigned' });
+
     expect(mockMessagesCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: AGENT_TOOLS,
         system: AGENT_SYSTEM_PROMPT,
       }),
     );
-  });
-
-  it('uses only the redesigned tools by default', async () => {
     expect(AGENT_TOOLS.map((tool) => tool.name)).toEqual([
       'inspect_sources',
       'schema',
@@ -234,7 +243,7 @@ describe('runAgentLoop', () => {
     expect(AGENT_SYSTEM_PROMPT).not.toContain('follow_links');
   });
 
-  it('can select the legacy tool surface while evals are pending', async () => {
+  it('keeps the legacy tool list stable', async () => {
     mockMessagesCreate.mockResolvedValue(textResponse('Answer'));
     await runAgentLoop('test', { toolSurface: 'legacy' });
 
@@ -295,6 +304,7 @@ describe('runAgentLoop', () => {
 
     const result = await runAgentLoop(
       'show the full text of the section to read at the conclusion of scenario 61',
+      { toolSurface: 'redesigned' },
     );
 
     expect(result).toBe('Read section 67.1.');
@@ -320,7 +330,9 @@ describe('runAgentLoop', () => {
       )
       .mockResolvedValueOnce(textResponse('Loot rules and item results are grounded together.'));
 
-    const result = await runAgentLoop('How do loot rules interact with items?');
+    const result = await runAgentLoop('How do loot rules interact with items?', {
+      toolSurface: 'redesigned',
+    });
 
     expect(result).toBe('Loot rules and item results are grounded together.');
     expect(mockSearchKnowledge).toHaveBeenCalledWith('loot and item interactions', {
@@ -407,7 +419,9 @@ describe('runAgentLoop', () => {
       )
       .mockResolvedValueOnce(textResponse('Jump ignores terrain except in the last hex.'));
 
-    const result = await runAgentLoopWithTrajectory('What is Jump?');
+    const result = await runAgentLoopWithTrajectory('What is Jump?', {
+      toolSurface: 'redesigned',
+    });
 
     expect(result.answer).toBe('Jump ignores terrain except in the last hex.');
     expect(result.trajectory.toolCalls).toMatchObject([
@@ -1006,7 +1020,7 @@ describe('runAgentLoop with emit (streaming)', () => {
     mockMessagesStream.mockReturnValue(mockStream(msg, ['Hello ', 'world']));
     const emit = vi.fn().mockResolvedValue(undefined);
 
-    await runAgentLoop('test', { emit });
+    await runAgentLoop('test', { emit, toolSurface: 'redesigned' });
     expect(emit).toHaveBeenCalledWith('text', { delta: 'Hello ' });
     expect(emit).toHaveBeenCalledWith('text', { delta: 'world' });
   });

--- a/test/eval-cli.test.ts
+++ b/test/eval-cli.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseEvalArgs } from '../eval/cli.ts';
+
+describe('parseEvalArgs', () => {
+  it('defaults to the redesigned tool surface', () => {
+    expect(parseEvalArgs([]).toolSurface).toBe('redesigned');
+  });
+
+  it('accepts the legacy tool surface', () => {
+    expect(parseEvalArgs(['--tool-surface=legacy']).toolSurface).toBe('legacy');
+  });
+
+  it('rejects unknown tool surfaces', () => {
+    expect(() => parseEvalArgs(['--tool-surface=old'])).toThrow(/Invalid --tool-surface/);
+  });
+
+  it('parses the local report output path', () => {
+    expect(parseEvalArgs(['--local-report=/tmp/eval.json']).localReportPath).toBe('/tmp/eval.json');
+  });
+});

--- a/test/eval-cli.test.ts
+++ b/test/eval-cli.test.ts
@@ -15,7 +15,23 @@ describe('parseEvalArgs', () => {
     expect(() => parseEvalArgs(['--tool-surface=old'])).toThrow(/Invalid --tool-surface/);
   });
 
+  it('rejects an empty tool surface', () => {
+    expect(() => parseEvalArgs(['--tool-surface='])).toThrow(
+      /Invalid --tool-surface: value cannot be empty/,
+    );
+  });
+
+  it('rejects an empty run name', () => {
+    expect(() => parseEvalArgs(['--name='])).toThrow(/Invalid --name: value cannot be empty/);
+  });
+
   it('parses the local report output path', () => {
     expect(parseEvalArgs(['--local-report=/tmp/eval.json']).localReportPath).toBe('/tmp/eval.json');
+  });
+
+  it('rejects an empty local report output path', () => {
+    expect(() => parseEvalArgs(['--local-report='])).toThrow(
+      /Invalid --local-report: value cannot be empty/,
+    );
   });
 });

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -8,18 +8,37 @@ const { mockInitialize, mockAsk } = vi.hoisted(() => ({
   mockAsk: vi.fn(),
 }));
 
+const { mockRunAgentLoopWithTrajectory } = vi.hoisted(() => ({
+  mockRunAgentLoopWithTrajectory: vi.fn(),
+}));
+
 vi.mock('../src/service.ts', () => ({
   initialize: mockInitialize,
   ask: mockAsk,
 }));
 
-import { askFrosthaven } from '../src/query.ts';
+vi.mock('../src/agent.ts', () => ({
+  runAgentLoopWithTrajectory: mockRunAgentLoopWithTrajectory,
+}));
+
+import { askFrosthaven, askFrosthavenWithTrajectory } from '../src/query.ts';
 
 describe('askFrosthaven', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockInitialize.mockResolvedValue(undefined);
     mockAsk.mockResolvedValue('Mocked answer from service');
+    mockRunAgentLoopWithTrajectory.mockResolvedValue({
+      answer: 'Mocked trajectory answer',
+      trajectory: {
+        toolCalls: [],
+        finalAnswer: 'Mocked trajectory answer',
+        tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        model: 'test-model',
+        iterations: 1,
+        stopReason: 'end_turn',
+      },
+    });
   });
 
   it('initializes the service before asking', async () => {
@@ -52,5 +71,17 @@ describe('askFrosthaven', () => {
   it('propagates ask errors', async () => {
     mockAsk.mockRejectedValue(new Error('Claude API error'));
     await expect(askFrosthaven('test')).rejects.toThrow('Claude API error');
+  });
+
+  it('passes options through to trajectory runs', async () => {
+    const options = { toolSurface: 'legacy' as const };
+
+    await askFrosthavenWithTrajectory('What is the loot action?', options);
+
+    expect(mockInitialize).toHaveBeenCalled();
+    expect(mockRunAgentLoopWithTrajectory).toHaveBeenCalledWith(
+      'What is the loot action?',
+      options,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Adds the checked-in SQR-122 retrieval eval decision report comparing legacy and redesigned tool surfaces on the same 29-case suite.
- Keeps Phase 1 production on the legacy prompt-routed surface while leaving the redesigned surface selectable for evals and follow-up work.
- Adds eval runner support for `--tool-surface` and `--local-report` so future comparisons can record per-case latency, tokens, tool calls, refs, and scoring data.
- Tightens the `src/server.ts` CLI entrypoint guard so imports in tests cannot start the HTTP server as a side effect.

## Decision

Defer the redesigned self-describing tool surface for Phase 1. Deployment/readiness can proceed on the legacy production surface after this lands.

## Verification

- `npm run eval -- --tool-surface=legacy --name=sqr-122-legacy --local-report=/tmp/sqr-122-legacy.json`
- `npm run eval -- --tool-surface=redesigned --name=sqr-122-redesigned --local-report=/tmp/sqr-122-redesigned.json`
- `npm run check` — 54 test files, 916 tests

## Linear

Fixes SQR-122
Related to SQR-115


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Eval runner can target legacy or redesigned tool surfaces and produce detailed local per-case JSON reports (latency, tokens, tool-call data, scores).

* **Bug Fixes**
  * Server startup guard tightened to avoid starting the HTTP server during test imports.

* **Documentation**
  * Added SQR-122 decision report and updated architecture notes recording Phase 1 staying on the legacy tool surface.

* **Tests**
  * Added CLI and eval/run tests covering tool-surface selection and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->