### PR TITLE
v0.1.7 fix: improve redesigned trajectory routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.7] - 2026-04-29
+
+### Fixed
+
+- Improved redesigned retrieval trajectory behavior so the checked-in trajectory suite passes 12/12 without regressing final-answer coverage.
+- Made `resolve_entity` return concise, canonical, openable refs while keeping full record payloads behind `open_entity`.
+- Fixed game-qualified scenario and section opens so unsupported game refs do not fall back to Frosthaven data.
+
 ## [0.1.6] - 2026-04-29
 
 ### Changed

--- a/docs/plans/sqr-136-redesigned-trajectory-fix-report.md
+++ b/docs/plans/sqr-136-redesigned-trajectory-fix-report.md
@@ -1,0 +1,81 @@
+# SQR-136 Redesigned Trajectory Fix Report
+
+**Date:** 2026-04-29
+
+## Outcome
+
+The redesigned tool surface now passes the checked-in trajectory suite:
+
+| Run                          | Final-answer pass rate | Average final-answer score | Trajectory pass rate |
+| ---------------------------- | ---------------------: | -------------------------: | -------------------: |
+| SQR-122 redesigned baseline  |                  13/18 |                     3.83/5 |                 8/12 |
+| SQR-136 final redesigned run |                  15/18 |                     4.33/5 |                12/12 |
+
+Final-answer failures that remain after this work are:
+
+- `monster-living-bones-immunity`
+- `building-alchemist`
+- `scenario-61-unlock`
+
+Those are tracked by SQR-137 rather than SQR-136.
+
+## Root Causes
+
+The remaining trajectory failures had three causes:
+
+- `resolve_entity` returned legacy card source IDs and full record payloads. The
+  model could answer from the resolution output or try to open an
+  underspecified legacy source ID instead of opening a canonical card ref.
+- `open_entity` accepted `section:gloomhaven2/67.1` but stripped the game
+  qualifier before lookup, so a foreign-game ref could accidentally open
+  Frosthaven data.
+- The redesigned prompt did not strongly distinguish traversal from opening.
+  For relationship questions, the model sometimes used links embedded in
+  `open_entity` output instead of calling `neighbors`, and it sometimes opened a
+  known canonical ref without first resolving when the user explicitly asked it
+  to resolve.
+
+## Fixes
+
+- `resolve_entity` now returns canonical card refs such as
+  `card:frosthaven/items/gloomhavensecretariat:item/1`.
+- `resolve_entity` now stays concise: candidates provide refs, titles, source
+  labels, confidence, and match reason, but not full record data. Exact record
+  payloads come from `open_entity`.
+- `open_entity` now respects explicit game-qualified scenario and section refs
+  during lookup.
+- The redesigned agent prompt now preserves explicit game qualifiers in
+  canonical refs and routes scenario/section relationship questions through
+  `neighbors`.
+
+## Verification
+
+Commands:
+
+```bash
+npm test -- test/tools.test.ts
+npm run eval -- --tool-surface=redesigned --category=trajectory --name=sqr-136-redesigned-trajectory-after --local-report=/tmp/sqr-136-redesigned-trajectory-after.json
+npm run eval -- --tool-surface=redesigned --name=sqr-136-redesigned-final --local-report=/tmp/sqr-136-redesigned-final.json
+```
+
+Final local report summary:
+
+```json
+{
+  "totalCases": 29,
+  "erroredCases": 0,
+  "finalAnswerCases": 18,
+  "finalAnswerPasses": 15,
+  "avgCorrectnessScore": 4.333333333333333,
+  "trajectoryCases": 12,
+  "trajectoryPasses": 12,
+  "avgToolCalls": 3.103448275862069,
+  "avgLatencyMs": 12938.862068965518,
+  "totalLatencyMs": 375227,
+  "tokenUsage": {
+    "inputTokens": 439947,
+    "outputTokens": 16522,
+    "totalTokens": 456469
+  }
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
         "@hono/node-server": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "scripts": {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -64,7 +64,9 @@ Grounding rules:
 - Treat tool results as the source of truth. Do not invent rules, stats, item numbers, section text, or scenario outcomes.
 - If the available data does not answer the question, say what is missing instead of guessing.
 - Resolve natural user language to refs when exact records are needed, then open or traverse those refs.
-- Follow explicit links between records when the answer depends on connected scenario or section text.
+- If the user asks you to resolve something, call resolve_entity before opening or answering.
+- When the user gives an explicit game qualifier, preserve it in canonical refs such as section:gloomhaven2/67.1; never invent URI forms like gloomhaven2://section/67.1.
+- Use neighbors for scenario/section traversal questions, including conclusions, read-now links, unlocks, next links, and related records. Open entities for record text after traversal identifies the target.
 
 Citations and answer shape:
 - Cite the book, section, scenario, or card source when the tool result provides one.
@@ -159,7 +161,7 @@ export const AGENT_TOOLS = [
   {
     name: 'open_entity',
     description:
-      'Open one exact Squire entity by canonical ref: rules passage, scenario, section, or card.',
+      'Open one exact Squire entity by canonical ref: rules:<game>/<source>#chunk=N, scenario:<game>/<id>, section:<game>/<id>, or card:<game>/<type>/<sourceId>. Use this to validate unavailable game-qualified refs instead of inventing URI forms.',
     input_schema: {
       type: 'object',
       properties: {
@@ -188,7 +190,8 @@ export const AGENT_TOOLS = [
   },
   {
     name: 'neighbors',
-    description: 'Traverse known outgoing relationships from a scenario or section ref.',
+    description:
+      'Traverse known outgoing relationships from a scenario or section ref. Prefer this for conclusions, read-now links, unlocks, next links, and related scenario/section questions.',
     input_schema: {
       type: 'object',
       properties: {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -471,11 +471,10 @@ async function resolveCards(
       candidates.push({
         entity: {
           kind: 'card',
-          ref: sourceId,
+          ref: canonicalCardRef(type, sourceId, game),
           title,
           source: `source:${game}/cards`,
           sourceLabel: 'GHS Card Data',
-          data: { ...record, cardType: type },
         },
         confidence: cardMatchConfidence(query, record, type),
         matchReason: cardMatchReason(query, record, type),
@@ -493,11 +492,10 @@ async function resolveCards(
       candidates.push({
         entity: {
           kind: 'card',
-          ref: sourceId,
+          ref: canonicalCardRef(record._type, sourceId, game),
           title: displayTitleForCard(stripped, record._type),
           source: `source:${game}/cards`,
           sourceLabel: 'GHS Card Data',
-          data: { ...stripped, cardType: record._type },
         },
         confidence: 0.68,
         matchReason: 'Card text match',
@@ -541,6 +539,15 @@ function scenarioStorageRef(ref: string): string {
 
 function sectionStorageRef(ref: string): string {
   return ref.replace(/^section:[^/]+\//, '');
+}
+
+function gameQualifiedRef(
+  ref: string,
+  prefix: 'scenario' | 'section',
+  fallbackGame = DEFAULT_GAME,
+): { game: string; ref: string } {
+  const match = ref.match(new RegExp(`^${prefix}:([^/]+)/(.+)$`));
+  return match ? { game: match[1], ref: match[2] } : { game: fallbackGame, ref };
 }
 
 function canonicalSectionRef(ref: string, game = DEFAULT_GAME): string {
@@ -863,7 +870,6 @@ export async function resolveEntity(
           title: scenario.name,
           source: `source:${game}/scenario-section-books`,
           sourceLabel: formatRetrievalSourceLabel(scenario.sourcePdf ?? 'fh-scenario-book.pdf'),
-          data: scenario,
         },
         confidence,
         matchReason: confidence === 0.99 ? 'Exact scenario number' : 'Scenario name match',
@@ -883,7 +889,6 @@ export async function resolveEntity(
             title: `Section ${section.ref}`,
             source: `source:${game}/scenario-section-books`,
             sourceLabel: formatRetrievalSourceLabel(section.sourcePdf),
-            data: section,
           },
           confidence: 0.99,
           matchReason: 'Exact section ref',
@@ -903,7 +908,6 @@ export async function resolveEntity(
             title: type,
             source: `source:${game}/cards`,
             sourceLabel: 'GHS Card Data',
-            data: { cardType: type },
           },
           confidence: 0.95,
           matchReason: 'Exact card type',
@@ -1020,16 +1024,19 @@ export async function openEntity(ref: string, opts?: ToolOpts): Promise<Knowledg
   }
 
   if (ref.startsWith('scenario:') || ref.startsWith('gloomhavensecretariat:scenario/')) {
+    const parsed = gameQualifiedRef(ref, 'scenario', game);
     const scenario = await getScenario(
-      ref.startsWith('scenario:') ? ref : canonicalScenarioRef(ref, game),
+      ref.startsWith('scenario:')
+        ? canonicalScenarioRef(parsed.ref, parsed.game)
+        : canonicalScenarioRef(ref, parsed.game),
       {
-        game,
+        game: parsed.game,
       },
     );
     if (!scenario) {
       return { ok: false, error: { code: 'not_found', message: `Scenario not found: ${ref}` } };
     }
-    const entity = summarizeScenario(scenario, game);
+    const entity = summarizeScenario(scenario, parsed.game);
     return {
       ok: true,
       entity: {
@@ -1047,18 +1054,19 @@ export async function openEntity(ref: string, opts?: ToolOpts): Promise<Knowledg
           metadata: scenario.metadata,
         },
       },
-      citations: citationForScenario(scenario, game),
-      links: await linksFor('scenario', scenario.ref, { game }),
+      citations: citationForScenario(scenario, parsed.game),
+      links: await linksFor('scenario', scenario.ref, { game: parsed.game }),
       related: [],
     };
   }
 
   if (ref.startsWith('section:') || /^\d+\.\d+$/.test(ref)) {
-    const section = await getSection(ref, { game });
+    const parsed = gameQualifiedRef(ref, 'section', game);
+    const section = await getSection(parsed.ref, { game: parsed.game });
     if (!section) {
       return { ok: false, error: { code: 'not_found', message: `Section not found: ${ref}` } };
     }
-    const entity = summarizeSection(section, game);
+    const entity = summarizeSection(section, parsed.game);
     return {
       ok: true,
       entity: {
@@ -1072,8 +1080,8 @@ export async function openEntity(ref: string, opts?: ToolOpts): Promise<Knowledg
           metadata: section.metadata,
         },
       },
-      citations: citationForSection(section, game),
-      links: await linksFor('section', section.ref, { game }),
+      citations: citationForSection(section, parsed.game),
+      links: await linksFor('section', section.ref, { game: parsed.game }),
       related: [],
     };
   }

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -264,6 +264,13 @@ describe('openEntity', () => {
     });
   });
 
+  it('does not open a default-game section for an explicit unsupported game ref', async () => {
+    await expect(openEntity('section:gloomhaven2/67.1')).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'not_found' },
+    });
+  });
+
   it('returns ambiguous for underspecified legacy refs', async () => {
     await expect(openEntity('61')).resolves.toMatchObject({
       ok: false,
@@ -591,21 +598,29 @@ describe('knowledge discovery tools', () => {
         confidence: expect.any(Number),
         entity: expect.objectContaining({
           kind: 'card',
-          ref: 'gloomhavensecretariat:item/1',
+          ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
           title: 'Spyglass',
-          data: expect.objectContaining({ cardType: 'items' }),
         }),
       }),
     );
+    expect(item.candidates[0].entity).not.toHaveProperty('data');
+    await expect(openEntity(item.candidates[0].entity.ref)).resolves.toMatchObject({
+      ok: true,
+      entity: expect.objectContaining({
+        kind: 'card',
+        ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+      }),
+    });
 
     const monster = await resolveEntity('Living Bones', { kinds: ['monster'] });
     expect(monster.candidates[0].entity).toEqual(
       expect.objectContaining({
         kind: 'card',
+        ref: expect.stringMatching(/^card:frosthaven\/monster-stats\//),
         title: 'Living Bones',
-        data: expect.objectContaining({ cardType: 'monster-stats' }),
       }),
     );
+    expect(monster.candidates[0].entity).not.toHaveProperty('data');
 
     const ability = await resolveEntity('Blinkblade level 4 cards', {
       kinds: ['character-ability'],
@@ -615,15 +630,12 @@ describe('knowledge discovery tools', () => {
         expect.objectContaining({
           entity: expect.objectContaining({
             kind: 'card',
-            data: expect.objectContaining({
-              cardType: 'character-abilities',
-              characterClass: 'Blinkblade',
-              level: 4,
-            }),
+            ref: expect.stringMatching(/^card:frosthaven\/character-abilities\//),
           }),
         }),
       ]),
     );
+    expect(ability.candidates[0].entity).not.toHaveProperty('data');
   });
 
   it('resolveEntity validates kind filters against the discovery registry', async () => {


### PR DESCRIPTION
## Summary

- Fixes SQR-136 redesigned trajectory routing by making `resolve_entity` return concise, canonical, openable refs.
- Preserves explicit game-qualified scenario and section refs in `open_entity` so unsupported game refs do not fall back to Frosthaven data.
- Tightens redesigned prompt/tool guidance for resolve-first and scenario/section traversal paths.
- Adds regression coverage and the SQR-136 fix report.

## Review

- No blocking findings in the pre-landing review.
- Checked SQL/data safety, LLM tool trust boundary, prompt/tool routing, ref normalization, and game-qualified fallback behavior.

## Verification

- `npm test -- test/tools.test.ts` passed: 50 tests.
- `npm run eval -- --tool-surface=redesigned --category=trajectory --name=sqr-136-redesigned-trajectory-after --local-report=/tmp/sqr-136-redesigned-trajectory-after.json` passed: 12/12 trajectory.
- `npm run eval -- --tool-surface=redesigned --name=sqr-136-redesigned-final --local-report=/tmp/sqr-136-redesigned-final.json` passed with final-answer 15/18 and trajectory 12/12.
- `npm run check` passed: typecheck, eslint, stylelint, markdownlint, prettier check, and 920 tests.
- `git diff --check` passed.

## Eval Delta

- SQR-122 redesigned baseline: final-answer 13/18, trajectory 8/12, average final-answer score 3.83/5.
- SQR-136 final redesigned run: final-answer 15/18, trajectory 12/12, average final-answer score 4.33/5.
- Remaining final-answer failures are tracked by SQR-137: `monster-living-bones-immunity`, `building-alchemist`, and `scenario-61-unlock`.

Fixes SQR-136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.1.7

* **Bug Fixes**
  * Enhanced entity reference resolution for improved accuracy and clarity
  * Corrected handling of game-qualified scenario and section references
  * Fixed trajectory validation to pass all test requirements

* **Documentation**
  * Added comprehensive performance metrics and test results documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->