### PR TITLE
test: cover SQR-136 scenario game-qualified fallback

### DIFF
--- a/docs/plans/sqr-136-redesigned-trajectory-fix-report.md
+++ b/docs/plans/sqr-136-redesigned-trajectory-fix-report.md
@@ -21,7 +21,7 @@ Those are tracked by SQR-137 rather than SQR-136.
 
 ## Root Causes
 
-The remaining trajectory failures had three causes:
+The previously observed trajectory failures had three causes:
 
 - `resolve_entity` returned legacy card source IDs and full record payloads. The
   model could answer from the resolution output or try to open an

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -271,6 +271,13 @@ describe('openEntity', () => {
     });
   });
 
+  it('does not open a default-game scenario for an explicit unsupported game ref', async () => {
+    await expect(openEntity('scenario:gloomhaven2/061')).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'not_found' },
+    });
+  });
+
   it('returns ambiguous for underspecified legacy refs', async () => {
     await expect(openEntity('61')).resolves.toMatchObject({
       ok: false,


### PR DESCRIPTION
## Summary

- Adds the CodeRabbit-requested symmetric scenario test for unsupported explicit game-qualified refs.
- Clarifies the SQR-136 report wording so the root causes refer to the previously observed trajectory failures.

## Verification

- `npm test -- test/tools.test.ts` passed: 51 tests.
- `git diff --check origin/main..HEAD` passed.
- The same diff also passed `npm run check` before being moved onto this fresh branch from updated `origin/main`.

Follow-up to SQR-136 and #289.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for unsupported game scenario error handling.

* **Documentation**
  * Updated planning documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->