### PR TITLE
chore: remove accidental SQR-136 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## [0.1.7] - 2026-04-29
-
-### Fixed
-
-- Improved redesigned retrieval trajectory behavior so the checked-in trajectory suite passes 12/12 without regressing final-answer coverage.
-- Made `resolve_entity` return concise, canonical, openable refs while keeping full record payloads behind `open_entity`.
-- Fixed game-qualified scenario and section opens so unsupported game refs do not fall back to Frosthaven data.
-
 ## [0.1.6] - 2026-04-29
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.7",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.7",
+      "version": "0.1.6",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
         "@hono/node-server": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.7",
+  "version": "0.1.6",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Removes the accidental SQR-136 `CHANGELOG.md` entry.
- Reverts the accidental package version bump from `0.1.7` back to `0.1.6`.

This follows `docs/agent/shipping.md`: ordinary feature-branch PRs should not bump versions or edit `CHANGELOG.md` unless the user explicitly asks for a release/version cut.

## Verification

- `git diff --check`
- `npm run lint:md`
- `npm run format:check`
- `npm test -- test/tools.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Version rolled back to 0.1.6 from 0.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->