### PR TITLE
fix(eval): correct SQR-137 final-answer fixtures

### DIFF
--- a/data/extracted/buildings.json
+++ b/data/extracted/buildings.json
@@ -4,6 +4,7 @@
     "name": "Mining Camp",
     "level": 1,
     "buildCost": {
+      "prosperity": 1,
       "gold": 10,
       "lumber": 4,
       "metal": 2,
@@ -18,7 +19,8 @@
     "name": "Mining Camp",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 3,
+      "gold": 0,
       "lumber": 6,
       "metal": 3,
       "hide": 2
@@ -32,7 +34,8 @@
     "name": "Mining Camp",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 5,
+      "gold": 0,
       "lumber": 8,
       "metal": 5,
       "hide": 2
@@ -46,7 +49,8 @@
     "name": "Mining Camp",
     "level": 4,
     "buildCost": {
-      "gold": null,
+      "prosperity": 7,
+      "gold": 0,
       "lumber": 10,
       "metal": 6,
       "hide": 3
@@ -60,6 +64,7 @@
     "name": "Hunting Lodge",
     "level": 1,
     "buildCost": {
+      "prosperity": 1,
       "gold": 10,
       "lumber": 4,
       "metal": 1,
@@ -74,7 +79,8 @@
     "name": "Hunting Lodge",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 3,
+      "gold": 0,
       "lumber": 6,
       "metal": 2,
       "hide": 3
@@ -88,7 +94,8 @@
     "name": "Hunting Lodge",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 5,
+      "gold": 0,
       "lumber": 8,
       "metal": 2,
       "hide": 5
@@ -102,7 +109,8 @@
     "name": "Hunting Lodge",
     "level": 4,
     "buildCost": {
-      "gold": null,
+      "prosperity": 7,
+      "gold": 0,
       "lumber": 10,
       "metal": 3,
       "hide": 6
@@ -116,6 +124,7 @@
     "name": "Logging Camp",
     "level": 1,
     "buildCost": {
+      "prosperity": 1,
       "gold": 10,
       "lumber": 2,
       "metal": 3,
@@ -130,7 +139,8 @@
     "name": "Logging Camp",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 3,
+      "gold": 0,
       "lumber": 4,
       "metal": 5,
       "hide": 2
@@ -144,7 +154,8 @@
     "name": "Logging Camp",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 5,
+      "gold": 0,
       "lumber": 6,
       "metal": 6,
       "hide": 3
@@ -158,7 +169,8 @@
     "name": "Logging Camp",
     "level": 4,
     "buildCost": {
-      "gold": null,
+      "prosperity": 7,
+      "gold": 0,
       "lumber": 8,
       "metal": 8,
       "hide": 3
@@ -172,6 +184,7 @@
     "name": "Inn",
     "level": 1,
     "buildCost": {
+      "prosperity": 2,
       "gold": 10,
       "lumber": 4,
       "metal": 4,
@@ -186,7 +199,8 @@
     "name": "Inn",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 4,
+      "gold": 0,
       "lumber": 5,
       "metal": 5,
       "hide": 5
@@ -200,7 +214,8 @@
     "name": "Inn",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 5,
+      "gold": 0,
       "lumber": 6,
       "metal": 6,
       "hide": 6
@@ -214,10 +229,11 @@
     "name": "Garden",
     "level": 1,
     "buildCost": {
+      "prosperity": 1,
       "gold": 10,
       "lumber": 3,
-      "metal": null,
-      "hide": null
+      "metal": 0,
+      "hide": 0
     },
     "effect": "Plant herbs, rotate this card 180°, then stop - Gain 1 herb from each planted plot, then rotate this card 180° then stop",
     "notes": null,
@@ -228,7 +244,8 @@
     "name": "Garden",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 2,
+      "gold": 0,
       "lumber": 4,
       "metal": 2,
       "hide": 2
@@ -242,7 +259,8 @@
     "name": "Garden",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 5,
+      "gold": 0,
       "lumber": 3,
       "metal": 3,
       "hide": 3
@@ -256,7 +274,8 @@
     "name": "Garden",
     "level": 4,
     "buildCost": {
-      "gold": null,
+      "prosperity": 7,
+      "gold": 0,
       "lumber": 6,
       "metal": 3,
       "hide": 3
@@ -270,10 +289,11 @@
     "name": "Craftsman",
     "level": 1,
     "buildCost": {
-      "gold": null,
-      "lumber": null,
-      "metal": null,
-      "hide": null
+      "prosperity": 0,
+      "gold": 0,
+      "lumber": 0,
+      "metal": 0,
+      "hide": 0
     },
     "effect": "Lose 1 collective Hide",
     "notes": null,
@@ -284,7 +304,8 @@
     "name": "Craftsman",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 1,
+      "gold": 0,
       "lumber": 2,
       "metal": 2,
       "hide": 1
@@ -298,7 +319,8 @@
     "name": "Craftsman",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 2,
+      "gold": 0,
       "lumber": 3,
       "metal": 2,
       "hide": 2
@@ -312,7 +334,8 @@
     "name": "Craftsman",
     "level": 4,
     "buildCost": {
-      "gold": null,
+      "prosperity": 3,
+      "gold": 0,
       "lumber": 4,
       "metal": 3,
       "hide": 2
@@ -326,7 +349,8 @@
     "name": "Craftsman",
     "level": 5,
     "buildCost": {
-      "gold": null,
+      "prosperity": 4,
+      "gold": 0,
       "lumber": 5,
       "metal": 3,
       "hide": 3
@@ -340,7 +364,8 @@
     "name": "Craftsman",
     "level": 6,
     "buildCost": {
-      "gold": null,
+      "prosperity": 5,
+      "gold": 0,
       "lumber": 6,
       "metal": 4,
       "hide": 3
@@ -354,7 +379,8 @@
     "name": "Craftsman",
     "level": 7,
     "buildCost": {
-      "gold": null,
+      "prosperity": 6,
+      "gold": 0,
       "lumber": 7,
       "metal": 4,
       "hide": 4
@@ -368,7 +394,8 @@
     "name": "Craftsman",
     "level": 8,
     "buildCost": {
-      "gold": null,
+      "prosperity": 7,
+      "gold": 0,
       "lumber": 8,
       "metal": 5,
       "hide": 3
@@ -382,7 +409,8 @@
     "name": "Craftsman",
     "level": 9,
     "buildCost": {
-      "gold": null,
+      "prosperity": 8,
+      "gold": 0,
       "lumber": 9,
       "metal": 5,
       "hide": 5
@@ -396,10 +424,11 @@
     "name": "Alchemist",
     "level": 1,
     "buildCost": {
-      "gold": null,
-      "lumber": null,
-      "metal": null,
-      "hide": null
+      "prosperity": 0,
+      "gold": 0,
+      "lumber": 0,
+      "metal": 0,
+      "hide": 0
     },
     "effect": "Characters cannot use potions",
     "notes": null,
@@ -410,7 +439,8 @@
     "name": "Alchemist",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 1,
+      "gold": 0,
       "lumber": 2,
       "metal": 2,
       "hide": 1
@@ -424,7 +454,8 @@
     "name": "Alchemist",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 4,
+      "gold": 0,
       "lumber": 4,
       "metal": 4,
       "hide": 2
@@ -438,6 +469,7 @@
     "name": "Trading Post",
     "level": 1,
     "buildCost": {
+      "prosperity": 2,
       "gold": 10,
       "lumber": 2,
       "metal": 2,
@@ -452,7 +484,8 @@
     "name": "Trading Post",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 3,
+      "gold": 0,
       "lumber": 3,
       "metal": 3,
       "hide": 2
@@ -466,7 +499,8 @@
     "name": "Trading Post",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 5,
+      "gold": 0,
       "lumber": 4,
       "metal": 3,
       "hide": 3
@@ -480,7 +514,8 @@
     "name": "Trading Post",
     "level": 4,
     "buildCost": {
-      "gold": null,
+      "prosperity": 7,
+      "gold": 0,
       "lumber": 5,
       "metal": 4,
       "hide": 4
@@ -494,6 +529,7 @@
     "name": "Jeweler",
     "level": 1,
     "buildCost": {
+      "prosperity": 4,
       "gold": 10,
       "lumber": 3,
       "metal": 2,
@@ -508,7 +544,8 @@
     "name": "Jeweler",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 6,
+      "gold": 0,
       "lumber": 3,
       "metal": 6,
       "hide": 3
@@ -522,7 +559,8 @@
     "name": "Jeweler",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 8,
+      "gold": 0,
       "lumber": 2,
       "metal": 10,
       "hide": 3
@@ -536,6 +574,7 @@
     "name": "Temple of the Great Oak",
     "level": 1,
     "buildCost": {
+      "prosperity": 1,
       "gold": 10,
       "lumber": 4,
       "metal": 2,
@@ -550,7 +589,8 @@
     "name": "Temple of the Great Oak",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 4,
+      "gold": 0,
       "lumber": 3,
       "metal": 6,
       "hide": 3
@@ -564,7 +604,8 @@
     "name": "Temple of the Great Oak",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 7,
+      "gold": 0,
       "lumber": 4,
       "metal": 10,
       "hide": 4
@@ -578,10 +619,11 @@
     "name": "Enhancer",
     "level": 1,
     "buildCost": {
+      "prosperity": 1,
       "gold": 10,
       "lumber": 3,
       "metal": 4,
-      "hide": null
+      "hide": 0
     },
     "effect": "",
     "notes": null,
@@ -592,10 +634,11 @@
     "name": "Enhancer",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 3,
+      "gold": 0,
       "lumber": 4,
       "metal": 5,
-      "hide": null
+      "hide": 0
     },
     "effect": "Reduce all enhancement costs by 10 gold",
     "notes": null,
@@ -606,7 +649,8 @@
     "name": "Enhancer",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 5,
+      "gold": 0,
       "lumber": 4,
       "metal": 4,
       "hide": 4
@@ -620,7 +664,8 @@
     "name": "Enhancer",
     "level": 4,
     "buildCost": {
-      "gold": null,
+      "prosperity": 7,
+      "gold": 0,
       "lumber": 5,
       "metal": 6,
       "hide": 6
@@ -634,6 +679,7 @@
     "name": "Metal Depot",
     "level": 1,
     "buildCost": {
+      "prosperity": 3,
       "gold": 10,
       "lumber": 2,
       "metal": 6,
@@ -648,7 +694,8 @@
     "name": "Metal Depot",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 7,
+      "gold": 0,
       "lumber": 5,
       "metal": 5,
       "hide": 5
@@ -662,6 +709,7 @@
     "name": "Lumber Depot",
     "level": 1,
     "buildCost": {
+      "prosperity": 3,
       "gold": 10,
       "lumber": 6,
       "metal": 2,
@@ -676,7 +724,8 @@
     "name": "Lumber Depot",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 7,
+      "gold": 0,
       "lumber": 5,
       "metal": 5,
       "hide": 5
@@ -690,6 +739,7 @@
     "name": "Hide Depot",
     "level": 1,
     "buildCost": {
+      "prosperity": 3,
       "gold": 10,
       "lumber": 2,
       "metal": 2,
@@ -704,7 +754,8 @@
     "name": "Hide Depot",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 7,
+      "gold": 0,
       "lumber": 5,
       "metal": 5,
       "hide": 5
@@ -718,6 +769,7 @@
     "name": "Tavern",
     "level": 1,
     "buildCost": {
+      "prosperity": 2,
       "gold": 10,
       "lumber": 2,
       "metal": 2,
@@ -732,7 +784,8 @@
     "name": "Tavern",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 4,
+      "gold": 0,
       "lumber": 4,
       "metal": 3,
       "hide": 2
@@ -746,7 +799,8 @@
     "name": "Tavern",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 6,
+      "gold": 0,
       "lumber": 6,
       "metal": 4,
       "hide": 2
@@ -760,6 +814,7 @@
     "name": "Hall of Revelry",
     "level": 1,
     "buildCost": {
+      "prosperity": 5,
       "gold": 10,
       "lumber": 6,
       "metal": 6,
@@ -774,6 +829,7 @@
     "name": "Hall of Revelry",
     "level": 2,
     "buildCost": {
+      "prosperity": null,
       "gold": null,
       "lumber": null,
       "metal": null,
@@ -788,10 +844,11 @@
     "name": "Library",
     "level": 1,
     "buildCost": {
+      "prosperity": 2,
       "gold": 10,
       "lumber": 3,
       "metal": 2,
-      "hide": null
+      "hide": 0
     },
     "effect": "Lose 1 inspiration",
     "notes": null,
@@ -802,7 +859,8 @@
     "name": "Library",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 4,
+      "gold": 0,
       "lumber": 4,
       "metal": 4,
       "hide": 1
@@ -816,7 +874,8 @@
     "name": "Library",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 6,
+      "gold": 0,
       "lumber": 2,
       "metal": 5,
       "hide": 5
@@ -830,10 +889,11 @@
     "name": "Workshop",
     "level": 1,
     "buildCost": {
-      "gold": null,
-      "lumber": null,
-      "metal": null,
-      "hide": null
+      "prosperity": 0,
+      "gold": 0,
+      "lumber": 0,
+      "metal": 0,
+      "hide": 0
     },
     "effect": "Lose 1 collective Lumber",
     "notes": null,
@@ -844,6 +904,7 @@
     "name": "Carpenter",
     "level": 1,
     "buildCost": {
+      "prosperity": 2,
       "gold": 10,
       "lumber": 4,
       "metal": 3,
@@ -858,7 +919,8 @@
     "name": "Carpenter",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 5,
+      "gold": 0,
       "lumber": 6,
       "metal": 5,
       "hide": 4
@@ -872,6 +934,7 @@
     "name": "Stables",
     "level": 1,
     "buildCost": {
+      "prosperity": 2,
       "gold": 10,
       "lumber": 6,
       "metal": 2,
@@ -886,7 +949,8 @@
     "name": "Stables",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 4,
+      "gold": 0,
       "lumber": 4,
       "metal": 5,
       "hide": 5
@@ -900,7 +964,8 @@
     "name": "Stables",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 6,
+      "gold": 0,
       "lumber": 6,
       "metal": 7,
       "hide": 6
@@ -914,7 +979,8 @@
     "name": "Stables",
     "level": 4,
     "buildCost": {
-      "gold": null,
+      "prosperity": 8,
+      "gold": 0,
       "lumber": 8,
       "metal": 8,
       "hide": 8
@@ -928,6 +994,7 @@
     "name": "Town Hall",
     "level": 1,
     "buildCost": {
+      "prosperity": 2,
       "gold": 10,
       "lumber": 2,
       "metal": 2,
@@ -942,7 +1009,8 @@
     "name": "Town Hall",
     "level": 2,
     "buildCost": {
-      "gold": null,
+      "prosperity": 4,
+      "gold": 0,
       "lumber": 3,
       "metal": 3,
       "hide": 3
@@ -956,7 +1024,8 @@
     "name": "Town Hall",
     "level": 3,
     "buildCost": {
-      "gold": null,
+      "prosperity": 6,
+      "gold": 0,
       "lumber": 4,
       "metal": 5,
       "hide": 4
@@ -970,10 +1039,11 @@
     "name": "Barracks",
     "level": 1,
     "buildCost": {
-      "gold": null,
-      "lumber": null,
-      "metal": null,
-      "hide": null
+      "prosperity": 0,
+      "gold": 0,
+      "lumber": 0,
+      "metal": 0,
+      "hide": 0
     },
     "effect": "Collectively train up to 1 soldier for 3 gold and 1 material resource Capacity: 4 Effect: advantage and -5 Attack",
     "notes": null,
@@ -984,6 +1054,7 @@
     "name": "Barracks",
     "level": 2,
     "buildCost": {
+      "prosperity": null,
       "gold": null,
       "lumber": null,
       "metal": null,
@@ -998,6 +1069,7 @@
     "name": "Barracks",
     "level": 3,
     "buildCost": {
+      "prosperity": null,
       "gold": null,
       "lumber": null,
       "metal": null,
@@ -1012,6 +1084,7 @@
     "name": "Barracks",
     "level": 4,
     "buildCost": {
+      "prosperity": null,
       "gold": null,
       "lumber": null,
       "metal": null,
@@ -1026,10 +1099,11 @@
     "name": "Wall J",
     "level": 1,
     "buildCost": {
+      "prosperity": 1,
       "gold": 10,
       "lumber": 4,
-      "metal": null,
-      "hide": null
+      "metal": 0,
+      "hide": 0
     },
     "effect": "+5 Defense",
     "notes": null,
@@ -1040,6 +1114,7 @@
     "name": "Wall K",
     "level": 1,
     "buildCost": {
+      "prosperity": 2,
       "gold": 10,
       "lumber": 3,
       "metal": 2,
@@ -1054,6 +1129,7 @@
     "name": "Wall L",
     "level": 1,
     "buildCost": {
+      "prosperity": 3,
       "gold": 10,
       "lumber": 5,
       "metal": 2,
@@ -1068,6 +1144,7 @@
     "name": "Wall M",
     "level": 1,
     "buildCost": {
+      "prosperity": 4,
       "gold": 10,
       "lumber": 4,
       "metal": 3,
@@ -1082,6 +1159,7 @@
     "name": "Wall N",
     "level": 1,
     "buildCost": {
+      "prosperity": 6,
       "gold": 10,
       "lumber": 6,
       "metal": 3,

--- a/docs/plans/sqr-137-final-answer-eval-triage-report.md
+++ b/docs/plans/sqr-137-final-answer-eval-triage-report.md
@@ -1,0 +1,52 @@
+# SQR-137 Final-Answer Eval Triage Report
+
+**Date:** 2026-04-29
+
+## Outcome
+
+The SQR-137 triage found two fixture errors, one traversal gap, and one
+building-source-data gap:
+
+| Case                            | Root cause                                                                                                                                                          | Fix                                                                                                                                                                                                              |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `monster-living-bones-immunity` | Fixture expected Poison/Wound immunity, but both checked-in Living Bones monster-stat records have empty `immunities` arrays.                                       | Updated expected answer and grading to require no condition immunities.                                                                                                                                          |
+| `building-alchemist`            | The fixture conflated the Alchemist level 1 upgrade cost with its initial build cost, and the importer converted known zero costs into null.                        | Updated the fixture to require no initial build cost, preserved zero-valued building costs, added prosperity to building cost data, and kept the level 1 upgrade cost grounded on the level 2 build-cost record. |
+| `scenario-61-unlock`            | Fixture expected section 67.1, which is the scenario conclusion link. The checked-in unlock link for scenario 61 is incoming from section 79.4.                     | Updated expected answer and grading to section 79.4, added incoming scenario unlock traversal, and nudged the agent to open traversal targets instead of searching after `neighbors` succeeds.                   |
+| `rule-looting-definition`       | This case was already green after SQR-122/SQR-136, but full runs could still spend the whole loop on repeated redesigned rule searches after opening rule passages. | Extended the repeated-rule-search synthesis guard to redesigned `search_knowledge` and rule-passage `open_entity` calls.                                                                                         |
+
+I also adjusted `traj-section-read-now-chain`: the question asks where the chain ends, so `neighbors` is the required traversal behavior; requiring `open_entity` was overstrict and caused tool-path variance.
+
+## Verification
+
+Commands:
+
+```bash
+GHS_DATA_DIR=$HOME/data/ghs npm exec tsx -- src/import-buildings.ts
+npm run seed:cards
+npm test -- test/agent.test.ts test/eval-dataset.test.ts test/tools.test.ts
+npm test -- test/import-buildings.test.ts test/extracted-data.test.ts test/eval-dataset.test.ts test/tools.test.ts
+npm run eval -- --tool-surface=redesigned --id=monster-living-bones-immunity --name=sqr-137-living-bones-final --local-report=/tmp/sqr-137-living-bones-final.json
+npm run eval -- --tool-surface=redesigned --id=building-alchemist --name=sqr-137-building-zero-cost-manual-guard --local-report=/tmp/sqr-137-building-zero-cost-manual-guard.json
+npm run eval -- --tool-surface=redesigned --id=scenario-61-unlock --name=sqr-137-scenario-61-final --local-report=/tmp/sqr-137-scenario-61-final.json
+npm run eval -- --tool-surface=redesigned --id=rule-looting-definition --name=sqr-137-looting-final --local-report=/tmp/sqr-137-looting-final.json
+npm run eval -- --tool-surface=redesigned --category=trajectory --name=sqr-137-trajectory-final --local-report=/tmp/sqr-137-trajectory-final.json
+```
+
+Final targeted summaries:
+
+```json
+{
+  "livingBones": { "finalAnswerPasses": 1, "avgCorrectnessScore": 5 },
+  "buildingAlchemist": { "finalAnswerPasses": 1, "avgCorrectnessScore": 4 },
+  "scenario61Unlock": { "finalAnswerPasses": 1, "avgCorrectnessScore": 5 },
+  "lootingDefinition": { "finalAnswerPasses": 1, "avgCorrectnessScore": 5 },
+  "trajectory": { "trajectoryPasses": 12, "trajectoryCases": 12 }
+}
+```
+
+## Data Operations
+
+The checked-in building extract was regenerated from local GHS data. Existing
+Postgres databases need `npm run seed:cards` after this change is deployed so
+the `card_buildings` rows pick up the regenerated `buildCost` JSON. This is not
+a schema migration; `build_cost` is already `jsonb`.

--- a/eval/dataset.json
+++ b/eval/dataset.json
@@ -94,8 +94,8 @@
     "category": "monster-stats",
     "question": "What conditions are Living Bones immune to in Frosthaven?",
     "finalAnswer": {
-      "expected": "Poison and wound.",
-      "grading": "Must mention both poison and wound immunity."
+      "expected": "Living Bones have no condition immunities in the checked-in Frosthaven monster stat data.",
+      "grading": "Must state that Living Bones have no condition immunities, or that the immunities list is empty. Must not claim poison or wound immunity."
     },
     "source": "data/extracted/monster-stats.json"
   },
@@ -114,8 +114,8 @@
     "category": "buildings",
     "question": "What does the Alchemist building cost to build at level 1 in Frosthaven?",
     "finalAnswer": {
-      "expected": "1 gold, 2 lumber, 2 metal, 1 hide.",
-      "grading": "Must mention the four resources: 1 gold, 2 lumber, 2 metal, 1 hide."
+      "expected": "The Alchemist starts the campaign already built at level 1, so it has no initial build cost. Its level 1 upgrade cost is 1 prosperity, 2 lumber, 2 metal, and 1 hide.",
+      "grading": "Must say the level 1 Alchemist has no initial build cost. Must not present 1 prosperity, 2 lumber, 2 metal, and 1 hide as the initial build cost; those are the upgrade cost shown on the level 1 building card."
     },
     "source": "data/extracted/buildings.json"
   },
@@ -144,8 +144,8 @@
     "category": "scenarios",
     "question": "What section text unlocks scenario 61 (Life and Death) in Frosthaven?",
     "finalAnswer": {
-      "expected": "Section 67.1 links to Life and Death (scenario 61). The section involves escaping shadows with Moonshard.",
-      "grading": "Must reference section 67 or the narrative context that leads to scenario 61. Mentioning 'Life and Death' as the scenario name is a bonus."
+      "expected": "Section 79.4 unlocks Life and Death (scenario 61). It is the Crain/star iron section whose rewards include New Scenario: Life and Death.",
+      "grading": "Must reference section 79.4 and the Crain/star iron context or the New Scenario: Life and Death reward."
     },
     "source": "fh-section-book-62-81.pdf"
   },
@@ -201,8 +201,8 @@
     "category": "trajectory",
     "question": "Starting from section 103.1, follow the next two read-now links and tell me where I end up.",
     "trajectory": {
-      "requiredTools": ["open_entity", "neighbors"],
-      "requiredToolKinds": ["open", "traversal"],
+      "requiredTools": ["neighbors"],
+      "requiredToolKinds": ["traversal"],
       "forbiddenTools": ["search_rules"],
       "requiredRefs": ["section:frosthaven/103.1"],
       "maxToolCalls": 7

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -70,7 +70,7 @@ Grounding rules:
 - For scenario/section relationship questions, resolve the named scenario or section first, then open or traverse the canonical ref.
 - For named card-data records such as items, monsters, buildings, events, battle goals, personal quests, and character mats, resolve the record first and then open the exact ref.
 - When an exact record has null or empty fields, state that the field is not available in the checked-in data. Do not recommend physical components, community knowledge, memory, or likely values as a substitute for missing tool data.
-- For building records, a cost object whose resources are all 0 means a known no-cost record, not missing data. Phrase this as "no listed cost" or "no initial build cost" rather than guessing why it is free.
+- For building records, treat a cost object as known no-cost only when every numeric cost field is 0, including prosperity when present. If resources are 0 but prosperity is non-zero, say there is no resource cost but there is still a prosperity requirement.
 - If the user asks you to resolve something, call resolve_entity before opening or answering.
 - When the user gives an explicit game qualifier, preserve it in canonical refs such as section:gloomhaven2/67.1; never invent URI forms like gloomhaven2://section/67.1.
 - Use neighbors for scenario/section traversal questions, including conclusions, read-now links, unlocks, next links, and related records. Open entities for record text after traversal identifies the target.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -53,6 +53,9 @@ const MAX_HISTORY_TURNS = 20;
 const FORCE_SYNTHESIS_PROMPT =
   'Use the retrieved rulebook context to answer now. Do not search again unless the existing tool results are empty or clearly unrelated.';
 
+const NEIGHBORS_TARGET_PROMPT =
+  'If this neighbors result completes the requested traversal, use it as the traversal answer. If the question asks for section text, call open_entity on the returned section ref now; otherwise answer from the neighbors result. Do not search for another path unless neighbors returned no relevant target.';
+
 const ANSWER_FORMATTING_PROMPT = `Formatting:
 - Use *italics* only for named Frosthaven game terms — mechanics, abilities, conditions, status effects, keyword phrases (e.g., *Muddle*, *Shield 1*, *Retaliate*, *Loot 2*, *Move 3*). The UI renders these as a highlighted rule-term chip, so emphasizing prose words like *not* or *however* turns ordinary stress into a false rule citation. Use **bold** for general emphasis instead.
 - Use > blockquotes when you reproduce literal rulebook text. Don't wrap quoted sentences in italics.`;
@@ -64,9 +67,17 @@ Grounding rules:
 - Treat tool results as the source of truth. Do not invent rules, stats, item numbers, section text, or scenario outcomes.
 - If the available data does not answer the question, say what is missing instead of guessing.
 - Resolve natural user language to refs when exact records are needed, then open or traverse those refs.
+- For scenario/section relationship questions, resolve the named scenario or section first, then open or traverse the canonical ref.
+- For named card-data records such as items, monsters, buildings, events, battle goals, personal quests, and character mats, resolve the record first and then open the exact ref.
+- When an exact record has null or empty fields, state that the field is not available in the checked-in data. Do not recommend physical components, community knowledge, memory, or likely values as a substitute for missing tool data.
+- For building records, a cost object whose resources are all 0 means a known no-cost record, not missing data. Phrase this as "no listed cost" or "no initial build cost" rather than guessing why it is free.
 - If the user asks you to resolve something, call resolve_entity before opening or answering.
 - When the user gives an explicit game qualifier, preserve it in canonical refs such as section:gloomhaven2/67.1; never invent URI forms like gloomhaven2://section/67.1.
 - Use neighbors for scenario/section traversal questions, including conclusions, read-now links, unlocks, next links, and related records. Open entities for record text after traversal identifies the target.
+- When neighbors returns the requested unlock, conclusion, read-now, next, or related target, open that target if text is needed, then answer. Do not search for a second path unless neighbors returns no relevant target.
+- For multi-hop traversal questions, open the starting record, then call neighbors for each hop; do not rely on open_entity links alone.
+- For direct "related records" questions, a neighbors result is enough unless the user asks for full text from each neighbor.
+- When comparing exact records with fuzzy search matches, open the exact requested record and use search result summaries for fuzzy/contextual matches. Do not open every fuzzy match unless the user asks for full details.
 
 Citations and answer shape:
 - Cite the book, section, scenario, or card source when the tool result provides one.
@@ -137,7 +148,7 @@ export const AGENT_TOOLS = [
   {
     name: 'resolve_entity',
     description:
-      'Resolve natural references like "scenario 61", "section 90.2", "Spyglass", or "Blinkblade level 4 cards" to ranked opener-ready entity refs.',
+      'Resolve natural references like "scenario 61", "section 90.2", "Spyglass", "Alchemist building", or "Blinkblade level 4 cards" to ranked opener-ready entity refs.',
     input_schema: {
       type: 'object',
       properties: {
@@ -161,7 +172,7 @@ export const AGENT_TOOLS = [
   {
     name: 'open_entity',
     description:
-      'Open one exact Squire entity by canonical ref: rules:<game>/<source>#chunk=N, scenario:<game>/<id>, section:<game>/<id>, or card:<game>/<type>/<sourceId>. Use this to validate unavailable game-qualified refs instead of inventing URI forms.',
+      'Open one exact Squire entity by canonical ref: rules:<game>/<source>#chunk=N, scenario:<game>/<id>, section:<game>/<id>, or card:<game>/<type>/<sourceId>. Do not use this as the only step for traversal questions; call neighbors to follow links. Use this to validate unavailable game-qualified refs instead of inventing URI forms.',
     input_schema: {
       type: 'object',
       properties: {
@@ -191,7 +202,7 @@ export const AGENT_TOOLS = [
   {
     name: 'neighbors',
     description:
-      'Traverse known outgoing relationships from a scenario or section ref. Prefer this for conclusions, read-now links, unlocks, next links, and related scenario/section questions.',
+      'Traverse known relationships from a scenario or section ref, including incoming section links and unlocks for a scenario. Use this even when open_entity shows links; it is the traversal tool for conclusions, read-now links, unlocks, next links, and related scenario/section questions.',
     input_schema: {
       type: 'object',
       properties: {
@@ -485,6 +496,23 @@ const DISCOVERY_ONLY_TOOL_NAMES = new Set<AgentToolName>([
   'schema',
   'resolve_entity',
 ]);
+
+function isBroadRuleSearchTool(toolName: string, input: Record<string, unknown>): boolean {
+  if (toolName === 'search_rules') return true;
+  if (toolName !== 'search_knowledge') return false;
+
+  const scope = input.scope;
+  if (!Array.isArray(scope) || scope.length === 0) return true;
+  return scope.every((kind) => kind === 'rules_passage');
+}
+
+function isNonRuleSearchTool(toolName: string, input: Record<string, unknown>): boolean {
+  if (DISCOVERY_ONLY_TOOL_NAMES.has(toolName as AgentToolName)) return false;
+  if (toolName === 'open_entity' && typeof input.ref === 'string') {
+    return !input.ref.startsWith('rules:');
+  }
+  return !isBroadRuleSearchTool(toolName, input);
+}
 
 /**
  * Execute a single tool call and return the result content plus any per-result
@@ -794,12 +822,17 @@ async function runAgentLoopInternal(
       messages.push({ role: 'assistant', content: response.content });
 
       const toolResults: ContentBlockParam[] = [];
+      let sawNeighborsTool = false;
       for (const block of response.content) {
         if (block.type === 'tool_use') {
-          if (block.name === 'search_rules') {
+          const input = block.input as Record<string, unknown>;
+          if (isBroadRuleSearchTool(block.name, input)) {
             broadRuleSearches += 1;
-          } else if (!DISCOVERY_ONLY_TOOL_NAMES.has(block.name as AgentToolName)) {
+          } else if (isNonRuleSearchTool(block.name, input)) {
             hasUsedNonRuleSearchTool = true;
+          }
+          if (block.name === 'neighbors') {
+            sawNeighborsTool = true;
           }
 
           if (emit) {
@@ -885,6 +918,9 @@ async function runAgentLoopInternal(
       }
 
       messages.push({ role: 'user', content: toolResults });
+      if (sawNeighborsTool) {
+        messages.push({ role: 'user', content: NEIGHBORS_TARGET_PROMPT });
+      }
       // Simple factual rule lookups can drift into repeated broad searches.
       // After three rule-corpus searches, force synthesis from gathered context
       // without lowering the global loop budget needed by traversal questions.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -502,8 +502,8 @@ function isBroadRuleSearchTool(toolName: string, input: Record<string, unknown>)
   if (toolName !== 'search_knowledge') return false;
 
   const scope = input.scope;
-  if (!Array.isArray(scope) || scope.length === 0) return true;
-  return scope.every((kind) => kind === 'rules_passage');
+  if (!Array.isArray(scope) || scope.length === 0) return false;
+  return scope.length > 0 && scope.every((kind) => kind === 'rules_passage');
 }
 
 function isNonRuleSearchTool(toolName: string, input: Record<string, unknown>): boolean {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -469,6 +469,18 @@ function summarizeToolOutput(content: string): { summary: string; canonicalRefs:
   }
 }
 
+function hasUsefulNeighborsResult(result: ToolCallResult): boolean {
+  try {
+    const parsed = JSON.parse(result.content) as {
+      ok?: unknown;
+      neighbors?: unknown;
+    };
+    return parsed.ok === true && Array.isArray(parsed.neighbors) && parsed.neighbors.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 function sourceLabelsFromResult(value: unknown): string[] {
   const seen = new Set<string>();
   const labels: string[] = [];
@@ -822,7 +834,7 @@ async function runAgentLoopInternal(
       messages.push({ role: 'assistant', content: response.content });
 
       const toolResults: ContentBlockParam[] = [];
-      let sawNeighborsTool = false;
+      let sawNeighborsWithTargets = false;
       for (const block of response.content) {
         if (block.type === 'tool_use') {
           const input = block.input as Record<string, unknown>;
@@ -830,9 +842,6 @@ async function runAgentLoopInternal(
             broadRuleSearches += 1;
           } else if (isNonRuleSearchTool(block.name, input)) {
             hasUsedNonRuleSearchTool = true;
-          }
-          if (block.name === 'neighbors') {
-            sawNeighborsTool = true;
           }
 
           if (emit) {
@@ -899,6 +908,9 @@ async function runAgentLoopInternal(
             endedAt: new Date(toolEndedAtMs).toISOString(),
             durationMs: toolEndedAtMs - toolStartedAtMs,
           });
+          if (block.name === 'neighbors' && !isError && hasUsefulNeighborsResult(toolResult)) {
+            sawNeighborsWithTargets = true;
+          }
 
           if (emit) {
             await emit('tool_result', {
@@ -918,7 +930,7 @@ async function runAgentLoopInternal(
       }
 
       messages.push({ role: 'user', content: toolResults });
-      if (sawNeighborsTool) {
+      if (sawNeighborsWithTargets) {
         messages.push({ role: 'user', content: NEIGHBORS_TARGET_PROMPT });
       }
       // Simple factual rule lookups can drift into repeated broad searches.

--- a/src/db/schema/cards.ts
+++ b/src/db/schema/cards.ts
@@ -265,7 +265,7 @@ export const cardBuildings = pgTable(
     buildingNumber: text('building_number'),
     name: text('name').notNull(),
     level: integer('level').notNull(),
-    buildCost: jsonb('build_cost').notNull(), // { gold, lumber, metal, hide }
+    buildCost: jsonb('build_cost').notNull(), // { prosperity, gold, lumber, metal, hide }
     effect: text('effect').notNull(),
     notes: text('notes'),
     searchVector: tsvector('search_vector').generatedAlwaysAs(SV_MARKER),

--- a/src/extracted-data.ts
+++ b/src/extracted-data.ts
@@ -396,11 +396,13 @@ function recordToText(record: ExtractedRecord): string {
     const costEntries = buildCost
       ? Object.entries(buildCost).filter(([, v]) => v !== null && v !== 0)
       : [];
-    const knownCosts = buildCost ? Object.values(buildCost).filter((v) => v !== null) : [];
+    const values = buildCost ? Object.values(buildCost) : [];
+    const knownCosts = values.filter((v): v is number => v !== null);
+    const hasUnknownCosts = values.some((v) => v === null);
     const cost = buildCost
       ? costEntries.length > 0
         ? costEntries.map(([k, v]) => `${v} ${k}`).join(', ')
-        : knownCosts.length > 0 && knownCosts.every((v) => v === 0)
+        : !hasUnknownCosts && knownCosts.length > 0 && knownCosts.every((v) => v === 0)
           ? 'no cost'
           : 'unknown'
       : 'unknown';

--- a/src/extracted-data.ts
+++ b/src/extracted-data.ts
@@ -393,11 +393,16 @@ function recordToText(record: ExtractedRecord): string {
   if (t === 'buildings') {
     const r = record as ExtractedRecord;
     const buildCost = r.buildCost as Record<string, number | null> | undefined;
+    const costEntries = buildCost
+      ? Object.entries(buildCost).filter(([, v]) => v !== null && v !== 0)
+      : [];
+    const knownCosts = buildCost ? Object.values(buildCost).filter((v) => v !== null) : [];
     const cost = buildCost
-      ? Object.entries(buildCost)
-          .filter(([, v]) => v)
-          .map(([k, v]) => `${v} ${k}`)
-          .join(', ')
+      ? costEntries.length > 0
+        ? costEntries.map(([k, v]) => `${v} ${k}`).join(', ')
+        : knownCosts.length > 0 && knownCosts.every((v) => v === 0)
+          ? 'no cost'
+          : 'unknown'
       : 'unknown';
     return `Building #${r.buildingNumber} — ${r.name} Level ${r.level}. Cost: ${cost}. Effect: ${r.effect}. ${(r.notes as string) || ''}`.trim();
   }

--- a/src/import-buildings.ts
+++ b/src/import-buildings.ts
@@ -41,10 +41,11 @@ export interface GhsBuilding {
     gold: number;
   };
   upgrades: Array<{
-    prosperity: number;
-    lumber: number;
-    metal: number;
-    hide: number;
+    prosperity?: number;
+    lumber?: number;
+    metal?: number;
+    hide?: number;
+    manual?: number;
   }>;
   repair: number[];
   rebuild: Array<{ lumber: number; metal: number; hide: number }>;
@@ -61,6 +62,7 @@ interface ExtractedBuilding {
   name: string;
   level: number;
   buildCost: {
+    prosperity: number | null;
     gold: number | null;
     lumber: number | null;
     metal: number | null;
@@ -73,9 +75,31 @@ interface ExtractedBuilding {
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
-/** Convert a number to null if it's zero or undefined (zero means "no cost"). */
-function zeroToNull(n: number | undefined): number | null {
-  return n === 0 || n === undefined ? null : n;
+type GhsCostMap = Partial<Record<'prosperity' | 'gold' | 'lumber' | 'metal' | 'hide', number>>;
+
+/** GHS omits some zero-valued cost keys, so normalize absent cost fields to 0. */
+function costOrZero(n: number | undefined): number {
+  return n ?? 0;
+}
+
+function knownCostMap(cost: GhsCostMap) {
+  return {
+    prosperity: costOrZero(cost.prosperity),
+    gold: costOrZero(cost.gold),
+    lumber: costOrZero(cost.lumber),
+    metal: costOrZero(cost.metal),
+    hide: costOrZero(cost.hide),
+  };
+}
+
+function unknownCostMap() {
+  return {
+    prosperity: null,
+    gold: null,
+    lumber: null,
+    metal: null,
+    hide: null,
+  };
 }
 
 /**
@@ -120,20 +144,10 @@ export function convertBuilding(ghs: GhsBuilding, labels: LabelData): ExtractedB
     // Level 1 uses initial build costs; level 2+ uses upgrades[level-2]
     let buildCost: ExtractedBuilding['buildCost'];
     if (level === 1) {
-      buildCost = {
-        gold: zeroToNull(ghs.costs.gold),
-        lumber: zeroToNull(ghs.costs.lumber),
-        metal: zeroToNull(ghs.costs.metal),
-        hide: zeroToNull(ghs.costs.hide),
-      };
+      buildCost = knownCostMap(ghs.costs);
     } else {
       const upgrade = ghs.upgrades[level - 2];
-      buildCost = {
-        gold: upgrade ? zeroToNull((upgrade as Record<string, number>).gold) : null,
-        lumber: upgrade ? zeroToNull(upgrade.lumber) : null,
-        metal: upgrade ? zeroToNull(upgrade.metal) : null,
-        hide: upgrade ? zeroToNull(upgrade.hide) : null,
-      };
+      buildCost = upgrade && !upgrade.manual ? knownCostMap(upgrade) : unknownCostMap();
     }
 
     results.push({

--- a/src/scenario-section-data.ts
+++ b/src/scenario-section-data.ts
@@ -261,6 +261,37 @@ export async function followReferences(
   return rows.rows;
 }
 
+export async function findIncomingReferences(
+  toKind: BookRecordKind,
+  toRef: string,
+  referenceType?: BookReferenceType,
+  opts: LoadOpts = {},
+): Promise<BookReference[]> {
+  const { db } = getDb();
+  const game = opts.game ?? 'frosthaven';
+  const referenceTypeClause = referenceType ? sql`AND link_type = ${referenceType}` : sql``;
+
+  const rows = await db.execute<BookReference>(sql`
+    SELECT
+      from_kind AS "fromKind",
+      from_ref AS "fromRef",
+      to_kind AS "toKind",
+      to_ref AS "toRef",
+      link_type AS "linkType",
+      raw_label AS "rawLabel",
+      raw_context AS "rawContext",
+      sequence
+    FROM ${bookReferences}
+    WHERE game = ${game}
+      AND to_kind = ${toKind}
+      AND to_ref = ${toRef}
+      ${referenceTypeClause}
+    ORDER BY sequence, from_ref
+  `);
+
+  return rows.rows;
+}
+
 export async function getScenarioSectionBooksBootstrapStatus(
   opts: LoadOpts = {},
 ): Promise<ScenarioSectionBooksBootstrapStatus> {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -170,12 +170,13 @@ export const BuildingSchema = z.object({
   level: z.number().int().describe('Building level'),
   buildCost: z
     .object({
+      prosperity: nullableInt,
       gold: nullableInt,
       lumber: nullableInt,
       metal: nullableInt,
       hide: nullableInt,
     })
-    .describe('Resource costs, null for resources not required'),
+    .describe('Resource costs, with 0 for resources not required and null only if unknown'),
   effect: z.string().describe('Full effect/ability text at this level'),
   notes: nullableStr.describe('Any other relevant text, or null'),
 });

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -16,6 +16,7 @@ import {
   getSection as loadSection,
   searchSections as loadSections,
   followReferences as loadReferences,
+  findIncomingReferences as loadIncomingReferences,
 } from './scenario-section-data.ts';
 import {
   BOOK_REFERENCE_TYPES,
@@ -267,6 +268,16 @@ const CARD_KIND_ALIASES: Record<string, CardType[]> = {
   abilities: ['character-abilities'],
   'character-ability': ['character-abilities'],
   'character-abilities': ['character-abilities'],
+  building: ['buildings'],
+  buildings: ['buildings'],
+  event: ['events'],
+  events: ['events'],
+  'battle-goal': ['battle-goals'],
+  'battle-goals': ['battle-goals'],
+  'personal-quest': ['personal-quests'],
+  'personal-quests': ['personal-quests'],
+  'character-mat': ['character-mats'],
+  'character-mats': ['character-mats'],
 };
 
 const KIND_ALIASES: Record<string, KnowledgeKind> = {
@@ -984,6 +995,17 @@ export async function followLinks(
   return loadReferences(fromKind, normalizedRef, linkType, opts);
 }
 
+export async function incomingLinks(
+  toKind: BookRecordKind,
+  toRef: string,
+  linkType?: BookReferenceType,
+  opts?: ToolOpts,
+): Promise<ReferenceResult[]> {
+  const normalizedRef =
+    toKind === 'scenario' ? scenarioStorageRef(toRef) : sectionStorageRef(toRef);
+  return loadIncomingReferences(toKind, normalizedRef, linkType, opts);
+}
+
 export async function openEntity(ref: string, opts?: ToolOpts): Promise<KnowledgeOpenResult> {
   const game = opts?.game ?? DEFAULT_GAME;
 
@@ -1262,12 +1284,32 @@ export async function neighbors(
     return { ok: false, error: { code: 'not_found', message: `No neighbors for ref: ${ref}` } };
   }
 
-  const links = await followLinks(kind, storageRef, relation, { game });
+  let links = await followLinks(kind, storageRef, relation, { game });
+  if (kind === 'scenario') {
+    const incoming = await incomingLinks(kind, storageRef, relation, { game });
+    const seen = new Set(
+      links.map(
+        (link) => `${link.linkType}:${link.fromKind}:${link.fromRef}:${link.toKind}:${link.toRef}`,
+      ),
+    );
+    links = [
+      ...links,
+      ...incoming.filter((link) => {
+        const key = `${link.linkType}:${link.fromKind}:${link.fromRef}:${link.toKind}:${link.toRef}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      }),
+    ];
+  }
   const limit = Math.min(Math.max(options.limit ?? 20, 1), 50);
   const mapped = await Promise.all(
     links.slice(0, limit).map(async (link) => ({
       relation: link.linkType,
-      target: await targetSummary(link.toKind, link.toRef, game),
+      target:
+        link.fromKind === kind && link.fromRef === storageRef
+          ? await targetSummary(link.toKind, link.toRef, game)
+          : await targetSummary(link.fromKind, link.fromRef, game),
       reason: link.rawLabel ?? link.rawContext ?? undefined,
     })),
   );

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -324,6 +324,28 @@ describe('runAgentLoop', () => {
     });
   });
 
+  it('does not add the neighbors target prompt for empty neighbor results', async () => {
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('neighbors', {
+          ref: 'scenario:frosthaven/061',
+          relation: 'unlock',
+        }),
+      )
+      .mockResolvedValueOnce(textResponse('I could not find an unlock from that scenario.'));
+
+    const result = await runAgentLoop('what does scenario 61 unlock?', {
+      toolSurface: 'redesigned',
+    });
+
+    expect(result).toBe('I could not find an unlock from that scenario.');
+    expect(mockMessagesCreate.mock.calls[1][0].messages).not.toContainEqual({
+      role: 'user',
+      content:
+        'If this neighbors result completes the requested traversal, use it as the traversal answer. If the question asks for section text, call open_entity on the returned section ref now; otherwise answer from the neighbors result. Do not search for another path unless neighbors returned no relevant target.',
+    });
+  });
+
   it('uses the redesigned broad search tool for mixed rules and cards discovery', async () => {
     mockMessagesCreate
       .mockResolvedValueOnce(

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -317,6 +317,11 @@ describe('runAgentLoop', () => {
       limit: 20,
     });
     expect(mockOpenEntity).toHaveBeenCalledWith('section:frosthaven/67.1');
+    expect(mockMessagesCreate.mock.calls[2][0].messages).toContainEqual({
+      role: 'user',
+      content:
+        'If this neighbors result completes the requested traversal, use it as the traversal answer. If the question asks for section text, call open_entity on the returned section ref now; otherwise answer from the neighbors result. Do not search for another path unless neighbors returned no relevant target.',
+    });
   });
 
   it('uses the redesigned broad search tool for mixed rules and cards discovery', async () => {
@@ -671,6 +676,77 @@ describe('runAgentLoop', () => {
       content:
         'Use the retrieved rulebook context to answer now. Do not search again unless the existing tool results are empty or clearly unrelated.',
     });
+  });
+
+  it('forces synthesis after three repeated redesigned rule-only searches', async () => {
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'looting rules',
+          scope: ['rules_passage'],
+        }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'loot ability end-of-turn looting money tokens treasure tiles',
+          scope: ['rules_passage'],
+        }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'end-of-turn looting character loot token own hex',
+          scope: ['rules_passage'],
+        }),
+      )
+      .mockResolvedValueOnce(textResponse('Looting means picking up loot tokens.'));
+
+    const result = await runAgentLoop('What is looting?', { toolSurface: 'redesigned' });
+
+    expect(result).toBe('Looting means picking up loot tokens.');
+    expect(mockSearchKnowledge).toHaveBeenCalledTimes(3);
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(4);
+    expect(mockMessagesCreate.mock.calls[3][0]).not.toHaveProperty('tools');
+    expect(mockMessagesCreate.mock.calls[3][0].messages.at(-1)).toEqual({
+      role: 'user',
+      content:
+        'Use the retrieved rulebook context to answer now. Do not search again unless the existing tool results are empty or clearly unrelated.',
+    });
+  });
+
+  it('still forces synthesis after opening rule passages between redesigned searches', async () => {
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'looting rules',
+          scope: ['rules_passage'],
+        }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse('open_entity', {
+          ref: 'rules:frosthaven/fh-rule-book.pdf#chunk=111',
+        }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'end-of-turn looting character loot token own hex',
+          scope: ['rules_passage'],
+        }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'loot deck money tokens treasure tiles',
+          scope: ['rules_passage'],
+        }),
+      )
+      .mockResolvedValueOnce(textResponse('Looting means picking up loot tokens.'));
+
+    const result = await runAgentLoop('What is looting?', { toolSurface: 'redesigned' });
+
+    expect(result).toBe('Looting means picking up loot tokens.');
+    expect(mockSearchKnowledge).toHaveBeenCalledTimes(3);
+    expect(mockOpenEntity).toHaveBeenCalledWith('rules:frosthaven/fh-rule-book.pdf#chunk=111');
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(5);
+    expect(mockMessagesCreate.mock.calls[4][0]).not.toHaveProperty('tools');
   });
 
   it('keeps discovery-only tools out of repeated rule search synthesis guard', async () => {

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -713,6 +713,41 @@ describe('runAgentLoop', () => {
     });
   });
 
+  it('does not force synthesis after unscoped redesigned knowledge searches', async () => {
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'Alchemist building',
+        }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'Alchemist level 1',
+        }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'Alchemist upgrade cost',
+        }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse('open_entity', {
+          ref: 'card:frosthaven/buildings/gloomhavensecretariat:building/35/L1',
+        }),
+      )
+      .mockResolvedValueOnce(textResponse('The Alchemist has no listed build cost.'));
+
+    const result = await runAgentLoop('What does Alchemist cost?', { toolSurface: 'redesigned' });
+
+    expect(result).toBe('The Alchemist has no listed build cost.');
+    expect(mockSearchKnowledge).toHaveBeenCalledTimes(3);
+    expect(mockOpenEntity).toHaveBeenCalledWith(
+      'card:frosthaven/buildings/gloomhavensecretariat:building/35/L1',
+    );
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(5);
+    expect(mockMessagesCreate.mock.calls[3][0]).toHaveProperty('tools');
+  });
+
   it('still forces synthesis after opening rule passages between redesigned searches', async () => {
     mockMessagesCreate
       .mockResolvedValueOnce(

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -238,6 +238,9 @@ describe('runAgentLoop', () => {
       'search_knowledge',
       'neighbors',
     ]);
+    expect(AGENT_SYSTEM_PROMPT).toContain(
+      'known no-cost only when every numeric cost field is 0, including prosperity when present',
+    );
     expect(AGENT_SYSTEM_PROMPT).not.toContain('search_rules');
     expect(AGENT_SYSTEM_PROMPT).not.toContain('find_scenario');
     expect(AGENT_SYSTEM_PROMPT).not.toContain('follow_links');

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -33,6 +33,35 @@ describe('eval dataset', () => {
     expect(evalCase?.trajectory?.requiredRefs).toContain('section:gloomhaven2/67.1');
   });
 
+  it('treats read-now chain traversal as a neighbors requirement', () => {
+    const cases = EvalDatasetSchema.parse(dataset);
+    const evalCase = cases.find((candidate) => candidate.id === 'traj-section-read-now-chain');
+
+    expect(evalCase?.trajectory?.requiredTools).toContain('neighbors');
+    expect(evalCase?.trajectory?.requiredToolKinds).toContain('traversal');
+    expect(evalCase?.trajectory?.requiredTools).not.toContain('open_entity');
+  });
+
+  it('keeps SQR-137 final-answer expectations aligned with checked-in data', () => {
+    const cases = EvalDatasetSchema.parse(dataset);
+    const byId = new Map(cases.map((evalCase) => [evalCase.id, evalCase]));
+
+    expect(byId.get('monster-living-bones-immunity')?.finalAnswer).toMatchObject({
+      expected: expect.stringMatching(/no condition immunit/i),
+      grading: expect.stringMatching(/must not claim poison or wound immunity/i),
+    });
+
+    expect(byId.get('building-alchemist')?.finalAnswer).toMatchObject({
+      expected: expect.stringMatching(/no initial build cost/i),
+      grading: expect.stringMatching(/upgrade cost/i),
+    });
+
+    expect(byId.get('scenario-61-unlock')?.finalAnswer).toMatchObject({
+      expected: expect.stringMatching(/Section 79\.4/i),
+      grading: expect.stringMatching(/Crain|star iron/i),
+    });
+  });
+
   it('defines flexible tool-path expectations for trajectory cases', () => {
     const cases = EvalDatasetSchema.parse(dataset).filter(evalCaseHasTrajectory);
 

--- a/test/extracted-data.test.ts
+++ b/test/extracted-data.test.ts
@@ -388,15 +388,33 @@ describe('formatExtracted', () => {
         buildingNumber: '05',
         name: 'Mining Camp',
         level: 1,
-        buildCost: { gold: 20, lumber: 5, metal: null, hide: null },
+        buildCost: { prosperity: 1, gold: 20, lumber: 5, metal: 0, hide: 0 },
         effect: 'Gain 2 metal each week',
         notes: null,
       },
     ]);
     expect(text).toContain('Mining Camp');
+    expect(text).toContain('1 prosperity');
     expect(text).toContain('20 gold');
     expect(text).toContain('5 lumber');
+    expect(text).not.toContain('0 metal');
     expect(text).toContain('Gain 2 metal');
+  });
+
+  it('formats known zero building costs as no cost', () => {
+    const text = formatExtracted([
+      {
+        _type: 'buildings',
+        buildingNumber: '35',
+        name: 'Alchemist',
+        level: 1,
+        buildCost: { prosperity: 0, gold: 0, lumber: 0, metal: 0, hide: 0 },
+        effect: 'Characters cannot use potions',
+        notes: null,
+      },
+    ]);
+    expect(text).toContain('Alchemist');
+    expect(text).toContain('Cost: no cost');
   });
 
   it('formats monster abilities with initiative', () => {

--- a/test/extracted-data.test.ts
+++ b/test/extracted-data.test.ts
@@ -417,6 +417,23 @@ describe('formatExtracted', () => {
     expect(text).toContain('Cost: no cost');
   });
 
+  it('formats mixed unknown and zero building costs as unknown', () => {
+    const text = formatExtracted([
+      {
+        _type: 'buildings',
+        buildingNumber: '98',
+        name: 'Barracks',
+        level: 2,
+        buildCost: { prosperity: null, gold: 0, lumber: 0, metal: 0, hide: 0 },
+        effect: 'Train soldiers',
+        notes: null,
+      },
+    ]);
+    expect(text).toContain('Barracks');
+    expect(text).toContain('Cost: unknown');
+    expect(text).not.toContain('Cost: no cost');
+  });
+
   it('formats monster abilities with initiative', () => {
     const text = formatExtracted([
       {

--- a/test/import-buildings.test.ts
+++ b/test/import-buildings.test.ts
@@ -65,6 +65,7 @@ describe('convertBuilding', () => {
   it('uses initial costs for level 1', () => {
     const results = convertBuilding(miningCamp, labels);
     expect(results[0].buildCost).toEqual({
+      prosperity: 1,
       gold: 10,
       lumber: 4,
       metal: 2,
@@ -75,7 +76,8 @@ describe('convertBuilding', () => {
   it('uses upgrade costs for levels 2+', () => {
     const results = convertBuilding(miningCamp, labels);
     expect(results[1].buildCost).toEqual({
-      gold: null,
+      prosperity: 3,
+      gold: 0,
       lumber: 6,
       metal: 3,
       hide: 2,
@@ -123,13 +125,13 @@ describe('convertBuilding', () => {
     expect(results[0].sourceId).toBe('gloomhavensecretariat:building/wall-j/L1');
   });
 
-  it('treats zero-valued resources as null', () => {
+  it('normalizes missing cost fields to zero', () => {
     const results = convertBuilding(miningCamp, labels);
-    // Upgrade costs have no gold field → null
-    expect(results[1].buildCost.gold).toBeNull();
+    // Upgrade costs in GHS omit gold when it is not required.
+    expect(results[1].buildCost.gold).toBe(0);
   });
 
-  it('handles buildings with effectWrecked instead of effectNormal', () => {
+  it('handles already-built buildings with explicit zero level 1 build costs', () => {
     const wreckedLabels = {
       buildings: {
         craftsman: {
@@ -169,6 +171,20 @@ describe('convertBuilding', () => {
     expect(results[0].level).toBe(1);
     // Effect text is resolved
     expect(results[0].effect).toBe('Lose 1 collective Hide');
+    expect(results[0].buildCost).toEqual({
+      prosperity: 0,
+      gold: 0,
+      lumber: 0,
+      metal: 0,
+      hide: 0,
+    });
+    expect(results[1].buildCost).toEqual({
+      prosperity: 1,
+      gold: 0,
+      lumber: 2,
+      metal: 2,
+      hide: 1,
+    });
   });
 
   it('handles buildings with no effect arrays (zero levels)', () => {
@@ -242,7 +258,7 @@ describe('convertBuilding', () => {
     expect(results[0].effect).toBe('Train soldiers Capacity: 4');
   });
 
-  it('converts zero costs to null', () => {
+  it('preserves known zero costs', () => {
     const zeroLabels = {
       buildings: {
         free: {
@@ -265,6 +281,46 @@ describe('convertBuilding', () => {
 
     const results = convertBuilding(free, zeroLabels);
     expect(results[0].buildCost).toEqual({
+      prosperity: 0,
+      gold: 0,
+      lumber: 0,
+      metal: 0,
+      hide: 0,
+    });
+  });
+
+  it('keeps manual upgrade costs unknown', () => {
+    const barracksLabels = {
+      buildings: {
+        barracks: {
+          '': 'Barracks',
+          '1': 'Train soldiers',
+          '2': 'Train more soldiers',
+        },
+      },
+    };
+
+    const barracks: GhsBuilding = {
+      id: '98',
+      name: 'barracks',
+      costs: { prosperity: 0, lumber: 0, metal: 0, hide: 0, gold: 0 },
+      upgrades: [{ prosperity: 0, lumber: 0, metal: 0, hide: 0, manual: 1 }],
+      repair: [2],
+      rebuild: [{ lumber: 0, metal: 0, hide: 0 }],
+      effectNormal: ['%data.buildings.barracks.1%', '%data.buildings.barracks.2%'],
+      rewards: [{}, {}],
+    };
+
+    const results = convertBuilding(barracks, barracksLabels);
+    expect(results[0].buildCost).toEqual({
+      prosperity: 0,
+      gold: 0,
+      lumber: 0,
+      metal: 0,
+      hide: 0,
+    });
+    expect(results[1].buildCost).toEqual({
+      prosperity: null,
       gold: null,
       lumber: null,
       metal: null,

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -645,6 +645,55 @@ describe('knowledge discovery tools', () => {
     expect(ability.candidates[0].entity).not.toHaveProperty('data');
   });
 
+  it('resolveEntity accepts building aliases and returns openable building refs', async () => {
+    const result = await resolveEntity('Alchemist building level 1', {
+      kinds: ['building'],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.candidates[0]).toEqual(
+      expect.objectContaining({
+        entity: expect.objectContaining({
+          kind: 'card',
+          ref: 'card:frosthaven/buildings/gloomhavensecretariat:building/35/L1',
+          title: 'Alchemist',
+        }),
+      }),
+    );
+    await expect(openEntity(result.candidates[0].entity.ref)).resolves.toMatchObject({
+      ok: true,
+      entity: expect.objectContaining({
+        data: expect.objectContaining({
+          level: 1,
+          buildCost: {
+            prosperity: 0,
+            gold: 0,
+            lumber: 0,
+            metal: 0,
+            hide: 0,
+          },
+        }),
+      }),
+    });
+    await expect(
+      openEntity('card:frosthaven/buildings/gloomhavensecretariat:building/35/L2'),
+    ).resolves.toMatchObject({
+      ok: true,
+      entity: expect.objectContaining({
+        data: expect.objectContaining({
+          level: 2,
+          buildCost: {
+            prosperity: 1,
+            gold: 0,
+            lumber: 2,
+            metal: 2,
+            hide: 1,
+          },
+        }),
+      }),
+    });
+  });
+
   it('resolveEntity validates kind filters against the discovery registry', async () => {
     await expect(resolveEntity('Spyglass', { kinds: ['nonsense'] })).resolves.toEqual({
       ok: false,
@@ -812,6 +861,56 @@ describe('scenario/section book tools', () => {
         linkType: 'unlock',
       }),
     ]);
+  });
+
+  it('resolves incoming unlock links for a scenario through neighbors', async () => {
+    const result = await neighbors('scenario:frosthaven/061', { relation: 'unlock' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+
+    expect(result.neighbors).toEqual([
+      expect.objectContaining({
+        relation: 'unlock',
+        target: expect.objectContaining({
+          kind: 'section',
+          ref: 'section:frosthaven/79.4',
+        }),
+      }),
+    ]);
+  });
+
+  it('includes incoming section links when listing scenario neighbors', async () => {
+    const result = await neighbors('scenario:frosthaven/061');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+
+    expect(result.neighbors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          relation: 'section_link',
+          target: expect.objectContaining({
+            kind: 'section',
+            ref: 'section:frosthaven/105.1',
+          }),
+        }),
+        expect.objectContaining({
+          relation: 'section_link',
+          target: expect.objectContaining({
+            kind: 'section',
+            ref: 'section:frosthaven/82.2',
+          }),
+        }),
+        expect.objectContaining({
+          relation: 'section_link',
+          target: expect.objectContaining({
+            kind: 'section',
+            ref: 'section:frosthaven/97.3',
+          }),
+        }),
+      ]),
+    );
   });
 
   it('keeps scenario-box links whose section refs are OCR-spaced around the dot', async () => {


### PR DESCRIPTION
## Summary

- correct SQR-137 eval expectations for Living Bones immunities, Alchemist build cost, scenario 61 unlocks, and read-now traversal
- preserve building `prosperity` costs and known zero costs in the extracted building data, while leaving manual upgrade costs unknown
- add incoming scenario unlock traversal and agent guardrails for exact card opens, repeated rule searches, and successful neighbor traversals

## Data note

This PR changes checked-in card extract data. Existing Postgres databases need to be reseeded after deploy so `card_buildings.build_cost` picks up the new JSON:

```bash
npm run seed:cards
```

No schema migration is needed; `build_cost` is already `jsonb`.

## Validation

- `GHS_DATA_DIR=$HOME/data/ghs npm exec tsx -- src/import-buildings.ts`
- `npm run seed:cards`
- `npm run check`
- `npm run eval -- --tool-surface=redesigned --id=monster-living-bones-immunity --name=sqr-137-living-bones-final --local-report=/tmp/sqr-137-living-bones-final.json`
- `npm run eval -- --tool-surface=redesigned --id=building-alchemist --name=sqr-137-building-zero-cost-manual-guard --local-report=/tmp/sqr-137-building-zero-cost-manual-guard.json`
- `npm run eval -- --tool-surface=redesigned --id=scenario-61-unlock --name=sqr-137-scenario-61-final --local-report=/tmp/sqr-137-scenario-61-final.json`
- `npm run eval -- --tool-surface=redesigned --id=rule-looting-definition --name=sqr-137-looting-final --local-report=/tmp/sqr-137-looting-final.json`
- `npm run eval -- --tool-surface=redesigned --category=trajectory --name=sqr-137-trajectory-final --local-report=/tmp/sqr-137-trajectory-final.json`

Fixes SQR-137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incoming-reference lookup for richer scenario/section traversal
  * Building costs now include prosperity as a recognized resource
  * Improved handling of manual/unknown upgrade costs

* **Bug Fixes**
  * Clearer cost rendering: distinguishes "no cost" vs "unknown"
  * Stronger neighbor-based traversal and traversal-result guidance
  * Updated dataset final-answer expectations to match revised sources

* **Documentation**
  * Added SQR-137 final-answer triage report summarizing fixes and checks

* **Tests**
  * Expanded tests for traversal, synthesis guards, and cost-formatting behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->