### PR TITLE
docs(eval): remove local env path from capability matrix

### DIFF
--- a/docs/plans/sqr-123-model-capability-matrix.md
+++ b/docs/plans/sqr-123-model-capability-matrix.md
@@ -16,10 +16,11 @@ and `SQR-126`.
 
 ## Probe Inputs
 
-- Anthropic credentials were loaded from `/Users/bcm/Projects/maz/squire/.env`.
-- OpenAI credentials were loaded from `/Users/bcm/Projects/maz/squire/.env`.
-- Langfuse credentials are present in `/Users/bcm/Projects/maz/squire/.env`, but
-  this issue only verifies provider model access.
+- Anthropic credentials were loaded from the local `.env` file used for this
+  run.
+- OpenAI credentials were loaded from the local `.env` file used for this run.
+- Langfuse credentials were present in the local `.env` file used for this run,
+  but this issue only verifies provider model access.
 
 No secrets or raw API keys are recorded here.
 


### PR DESCRIPTION
## Summary

- Replace developer-local absolute `.env` paths in the SQR-123 capability matrix with generic local `.env` wording.
- Leave the verified provider capability findings unchanged.

## Validation

- `docker compose up -d`
- `npm run db:migrate`
- `npm run db:migrate:test`
- `npm run check` (55 files, 951 tests)

Fixes SQR-139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to use generic credential location descriptions instead of hard-coded paths, improving clarity and security of probe input examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->