### PR TITLE
feat(eval): add Langfuse trace writer

### DIFF
--- a/eval/trace.ts
+++ b/eval/trace.ts
@@ -1,0 +1,299 @@
+import { TRACE_CONTRACT_VERSION, TRACE_REDACTION_DENYLIST } from './trace-contract.ts';
+
+export const TRACE_REDACTION_PLACEHOLDER = '[REDACTED]' as const;
+
+type JsonPrimitive = string | number | boolean | null;
+
+type TraceEventType = 'trace-create' | 'generation-create' | 'span-create' | 'score-create';
+
+interface LangfuseEvent<Body extends Record<string, unknown>> {
+  type: TraceEventType;
+  id: string;
+  timestamp: string;
+  body: Body;
+}
+
+export interface EvalTraceIngestionBatch {
+  batch: LangfuseEvent<Record<string, unknown>>[];
+  metadata: {
+    contractVersion: typeof TRACE_CONTRACT_VERSION;
+  };
+}
+
+export interface LangfuseTraceIngestionClient {
+  api: {
+    ingestion: {
+      batch: (payload: EvalTraceIngestionBatch) => unknown;
+    };
+  };
+}
+
+export interface EvalTraceScore {
+  name: string;
+  value: number | string;
+  comment?: string;
+  metadata?: unknown;
+}
+
+export interface EvalTraceError {
+  type: string;
+  message: string;
+  retryable?: boolean;
+  metadata?: unknown;
+}
+
+export interface EvalTraceRetry {
+  operation: string;
+  attempt: number;
+  reason: string;
+  delayMs?: number;
+  final: boolean;
+  errorType?: string;
+  errorMessage?: string;
+}
+
+export interface EvalTraceToolCall {
+  id?: string;
+  toolName: string;
+  toolCallId?: string;
+  providerToolCallId?: string;
+  callIndex: number;
+  arguments: unknown;
+  result: unknown;
+  ok: boolean;
+  startedAt?: string;
+  endedAt?: string;
+  durationMs?: number;
+  sourceLabels?: string[];
+  canonicalRefs?: string[];
+  errors?: EvalTraceError[];
+  retries?: EvalTraceRetry[];
+}
+
+export interface EvalTraceInput {
+  traceId: string;
+  generationId?: string;
+  runLabel: string;
+  datasetName: string;
+  caseId: string;
+  caseCategory: string;
+  provider: 'anthropic' | 'openai';
+  model: string;
+  resolvedModel: string;
+  promptVersion: string;
+  promptHash: string;
+  toolSurface: string;
+  toolSchemaVersion: string;
+  toolSchemaHash: string;
+  modelSettings: Record<string, JsonPrimitive | undefined>;
+  inputQuestion: string;
+  finalAnswer: string | null;
+  statusReason: string;
+  stopReason: string;
+  startedAt: string;
+  endedAt?: string;
+  durationMs?: number;
+  completionStartedAt?: string;
+  providerRequest: unknown;
+  providerResponse: unknown;
+  providerNativeTranscript: unknown;
+  tokenUsage: Record<string, number>;
+  costEstimate: Record<string, number>;
+  errors: EvalTraceError[];
+  retries: EvalTraceRetry[];
+  toolCalls: EvalTraceToolCall[];
+  judgeScores: EvalTraceScore[];
+}
+
+const REDACTED_KEY_NAMES = new Set(
+  TRACE_REDACTION_DENYLIST.map((name) => normalizedRedactionKey(name)),
+);
+
+const SECRET_STRING_PATTERNS = [
+  /\bbearer\s+[a-z0-9._~+/=-]{8,}\b/i,
+  /\b(?:sk|pk|ak|api)[-_]?(?:live|test|proj)?[-_][a-z0-9._-]{20,}\b/i,
+  /\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|session)=["']?[^"'\s;]+/i,
+];
+
+function normalizedRedactionKey(key: string): string {
+  return key.replace(/[^a-z0-9]/gi, '').toLowerCase();
+}
+
+function shouldRedactKey(key: string): boolean {
+  return REDACTED_KEY_NAMES.has(normalizedRedactionKey(key));
+}
+
+function shouldRedactString(value: string): boolean {
+  return SECRET_STRING_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+export function redactTracePayload<T>(payload: T): T {
+  return redactValue(payload) as T;
+}
+
+function redactValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return shouldRedactString(value) ? TRACE_REDACTION_PLACEHOLDER : value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    if (value instanceof Date) return value.toISOString();
+
+    const redacted: Record<string, unknown> = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      if (nestedValue === undefined) continue;
+      redacted[key] = shouldRedactKey(key) ? TRACE_REDACTION_PLACEHOLDER : redactValue(nestedValue);
+    }
+    return redacted;
+  }
+
+  return value;
+}
+
+function requiredTraceMetadata(input: EvalTraceInput): Record<string, unknown> {
+  return {
+    contractVersion: TRACE_CONTRACT_VERSION,
+    provider: input.provider,
+    model: input.model,
+    resolvedModel: input.resolvedModel,
+    runLabel: input.runLabel,
+    datasetName: input.datasetName,
+    caseId: input.caseId,
+    caseCategory: input.caseCategory,
+    promptVersion: input.promptVersion,
+    promptHash: input.promptHash,
+    toolSurface: input.toolSurface,
+    toolSchemaVersion: input.toolSchemaVersion,
+    toolSchemaHash: input.toolSchemaHash,
+    statusReason: input.statusReason,
+  };
+}
+
+function generationIdFor(input: EvalTraceInput): string {
+  return input.generationId ?? `${input.traceId}:generation`;
+}
+
+function timestampFor(input: EvalTraceInput): string {
+  return input.startedAt;
+}
+
+function event(
+  type: TraceEventType,
+  id: string,
+  timestamp: string,
+  body: Record<string, unknown>,
+): LangfuseEvent<Record<string, unknown>> {
+  return { type, id, timestamp, body };
+}
+
+export function buildEvalTraceIngestionBatch(input: EvalTraceInput): EvalTraceIngestionBatch {
+  const generationId = generationIdFor(input);
+  const timestamp = timestampFor(input);
+  const traceMetadata = requiredTraceMetadata(input);
+
+  const traceEvent = event('trace-create', `${input.traceId}:trace-create`, timestamp, {
+    id: input.traceId,
+    timestamp: input.startedAt,
+    name: 'eval.case',
+    input: redactTracePayload({ question: input.inputQuestion }),
+    output: redactTracePayload({
+      finalAnswer: input.finalAnswer,
+      statusReason: input.statusReason,
+    }),
+    metadata: redactTracePayload(traceMetadata),
+    tags: ['eval', input.provider, input.model, input.runLabel],
+  });
+
+  const generationEvent = event(
+    'generation-create',
+    `${generationId}:generation-create`,
+    timestamp,
+    {
+      id: generationId,
+      traceId: input.traceId,
+      name: 'eval.model_call',
+      startTime: input.startedAt,
+      endTime: input.endedAt,
+      completionStartTime: input.completionStartedAt,
+      model: input.model,
+      input: redactTracePayload({ request: input.providerRequest }),
+      output: redactTracePayload({
+        finalAnswer: input.finalAnswer,
+        response: input.providerResponse,
+      }),
+      modelParameters: redactTracePayload(input.modelSettings),
+      usageDetails: redactTracePayload(input.tokenUsage),
+      costDetails: redactTracePayload(input.costEstimate),
+      metadata: redactTracePayload({
+        provider: input.provider,
+        resolvedModel: input.resolvedModel,
+        stopReason: input.stopReason,
+        statusReason: input.statusReason,
+        providerNativeTranscript: input.providerNativeTranscript,
+        errors: input.errors,
+        retries: input.retries,
+        timings: {
+          startedAt: input.startedAt,
+          endedAt: input.endedAt,
+          durationMs: input.durationMs,
+        },
+      }),
+    },
+  );
+
+  const toolEvents = input.toolCalls.map((toolCall) => {
+    const spanId = toolCall.id ?? `${input.traceId}:tool:${toolCall.callIndex}`;
+    return event('span-create', `${spanId}:span-create`, toolCall.startedAt ?? timestamp, {
+      id: spanId,
+      traceId: input.traceId,
+      parentObservationId: generationId,
+      name: `eval.tool_call.${toolCall.toolName}`,
+      startTime: toolCall.startedAt,
+      endTime: toolCall.endedAt,
+      input: redactTracePayload(toolCall.arguments),
+      output: redactTracePayload(toolCall.result),
+      metadata: redactTracePayload({
+        toolName: toolCall.toolName,
+        toolCallId: toolCall.toolCallId,
+        providerToolCallId: toolCall.providerToolCallId,
+        callIndex: toolCall.callIndex,
+        ok: toolCall.ok,
+        durationMs: toolCall.durationMs,
+        startedAt: toolCall.startedAt,
+        endedAt: toolCall.endedAt,
+        sourceLabels: toolCall.sourceLabels ?? [],
+        canonicalRefs: toolCall.canonicalRefs ?? [],
+        errors: toolCall.errors ?? [],
+        retries: toolCall.retries ?? [],
+      }),
+    });
+  });
+
+  const scoreEvents = input.judgeScores.map((score) =>
+    event('score-create', `${input.traceId}:score:${score.name}`, timestamp, {
+      traceId: input.traceId,
+      name: score.name,
+      value: score.value,
+      comment: score.comment,
+      metadata: redactTracePayload(score.metadata ?? {}),
+    }),
+  );
+
+  return {
+    batch: [traceEvent, generationEvent, ...toolEvents, ...scoreEvents],
+    metadata: {
+      contractVersion: TRACE_CONTRACT_VERSION,
+    },
+  };
+}
+
+export async function writeEvalTrace(
+  client: LangfuseTraceIngestionClient,
+  input: EvalTraceInput,
+): Promise<void> {
+  await client.api.ingestion.batch(buildEvalTraceIngestionBatch(input));
+}

--- a/test/eval-trace.test.ts
+++ b/test/eval-trace.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from 'vitest';
+
+import { DATASET_NAME } from '../eval/dataset.ts';
+import { OPENAI_TOOL_SCHEMA_VERSION, getOpenAiToolSchemaHash } from '../eval/openai-schema.ts';
+import {
+  buildEvalTraceIngestionBatch,
+  redactTracePayload,
+  writeEvalTrace,
+  type EvalTraceInput,
+  type LangfuseTraceIngestionClient,
+} from '../eval/trace.ts';
+import { TRACE_CONTRACT_VERSION } from '../eval/trace-contract.ts';
+
+const baseTrace: EvalTraceInput = {
+  traceId: 'trace-case-1',
+  generationId: 'generation-case-1',
+  runLabel: 'sqr-127-test-run',
+  datasetName: DATASET_NAME,
+  caseId: 'case-1',
+  caseCategory: 'buildings',
+  provider: 'openai',
+  model: 'gpt-5.5',
+  resolvedModel: 'gpt-5.5-2026-04-23',
+  promptVersion: 'redesigned-agent-v1',
+  promptHash: 'sha256:prompt',
+  toolSurface: 'redesigned',
+  toolSchemaVersion: OPENAI_TOOL_SCHEMA_VERSION,
+  toolSchemaHash: getOpenAiToolSchemaHash(),
+  modelSettings: {
+    temperature: 0,
+    maxOutputTokens: 1024,
+    reasoningEffort: 'medium',
+    timeoutMs: 30000,
+    toolLoopLimit: 4,
+  },
+  inputQuestion: 'What does the level 1 Alchemist unlock?',
+  finalAnswer: 'It can brew 2-herb potions.',
+  statusReason: 'completed',
+  stopReason: 'end_turn',
+  startedAt: '2026-05-01T00:00:00.000Z',
+  endedAt: '2026-05-01T00:00:02.500Z',
+  durationMs: 2500,
+  providerRequest: {
+    input: 'question',
+    authorization: 'Bearer sk-live-secret',
+  },
+  providerResponse: {
+    id: 'resp_123',
+    output: [{ type: 'message', content: 'It can brew 2-herb potions.' }],
+  },
+  providerNativeTranscript: {
+    output: [
+      { type: 'message', id: 'msg_1' },
+      { type: 'function_call', id: 'call_1', arguments: { apiKey: 'sk-tool-secret' } },
+    ],
+  },
+  tokenUsage: {
+    input: 120,
+    output: 45,
+    reasoning: 10,
+    cached: 5,
+    total: 175,
+  },
+  costEstimate: {
+    promptUsd: 0.0012,
+    completionUsd: 0.0009,
+    reasoningUsd: 0.0002,
+    totalUsd: 0.0023,
+  },
+  errors: [
+    {
+      type: 'provider',
+      message: 'first response timed out',
+      retryable: true,
+    },
+  ],
+  retries: [
+    {
+      operation: 'model',
+      attempt: 1,
+      reason: 'timeout',
+      delayMs: 250,
+      final: false,
+    },
+  ],
+  toolCalls: [
+    {
+      id: 'tool-span-1',
+      toolName: 'searchCards',
+      toolCallId: 'tool-call-1',
+      providerToolCallId: 'call_1',
+      callIndex: 0,
+      arguments: {
+        query: 'Alchemist',
+        sessionId: 'session-secret',
+      },
+      result: {
+        items: [{ name: 'Alchemist', userEmail: 'player@example.test' }],
+      },
+      ok: true,
+      startedAt: '2026-05-01T00:00:01.000Z',
+      endedAt: '2026-05-01T00:00:01.125Z',
+      durationMs: 125,
+      sourceLabels: ['Building 35'],
+      canonicalRefs: ['building:35'],
+      errors: [],
+      retries: [],
+    },
+  ],
+  judgeScores: [
+    {
+      name: 'correctness',
+      value: 1,
+      comment: 'Expected detail present.',
+      metadata: { playerId: 'player-1' },
+    },
+    { name: 'pass', value: 'pass' },
+    { name: 'tool_call_count', value: 1 },
+  ],
+};
+
+describe('SQR-127 eval trace writer', () => {
+  it('builds Langfuse trace, generation, tool-span, and score events with required metadata', () => {
+    const batch = buildEvalTraceIngestionBatch(baseTrace);
+
+    expect(batch.metadata).toEqual({ contractVersion: TRACE_CONTRACT_VERSION });
+    expect(batch.batch.map((event) => event.type)).toEqual([
+      'trace-create',
+      'generation-create',
+      'span-create',
+      'score-create',
+      'score-create',
+      'score-create',
+    ]);
+
+    const [trace, generation, toolSpan, ...scores] = batch.batch;
+
+    expect(trace.body).toMatchObject({
+      id: 'trace-case-1',
+      name: 'eval.case',
+      input: { question: 'What does the level 1 Alchemist unlock?' },
+      output: { finalAnswer: 'It can brew 2-herb potions.', statusReason: 'completed' },
+      metadata: {
+        contractVersion: TRACE_CONTRACT_VERSION,
+        provider: 'openai',
+        model: 'gpt-5.5',
+        resolvedModel: 'gpt-5.5-2026-04-23',
+        runLabel: 'sqr-127-test-run',
+        datasetName: DATASET_NAME,
+        caseId: 'case-1',
+        caseCategory: 'buildings',
+        promptVersion: 'redesigned-agent-v1',
+        promptHash: 'sha256:prompt',
+        toolSurface: 'redesigned',
+        toolSchemaVersion: OPENAI_TOOL_SCHEMA_VERSION,
+        toolSchemaHash: getOpenAiToolSchemaHash(),
+        statusReason: 'completed',
+      },
+    });
+
+    expect(generation.body).toMatchObject({
+      id: 'generation-case-1',
+      traceId: 'trace-case-1',
+      name: 'eval.model_call',
+      model: 'gpt-5.5',
+      input: {
+        request: {
+          input: 'question',
+          authorization: '[REDACTED]',
+        },
+      },
+      output: {
+        finalAnswer: 'It can brew 2-herb potions.',
+        response: {
+          id: 'resp_123',
+        },
+      },
+      modelParameters: baseTrace.modelSettings,
+      usageDetails: {
+        input: 120,
+        output: 45,
+        reasoning: 10,
+        cached: 5,
+        total: 175,
+      },
+      costDetails: {
+        promptUsd: 0.0012,
+        completionUsd: 0.0009,
+        reasoningUsd: 0.0002,
+        totalUsd: 0.0023,
+      },
+      metadata: {
+        provider: 'openai',
+        resolvedModel: 'gpt-5.5-2026-04-23',
+        stopReason: 'end_turn',
+        statusReason: 'completed',
+        providerNativeTranscript: {
+          output: [
+            { type: 'message', id: 'msg_1' },
+            { type: 'function_call', id: 'call_1', arguments: { apiKey: '[REDACTED]' } },
+          ],
+        },
+        errors: baseTrace.errors,
+        retries: baseTrace.retries,
+        timings: {
+          startedAt: '2026-05-01T00:00:00.000Z',
+          endedAt: '2026-05-01T00:00:02.500Z',
+          durationMs: 2500,
+        },
+      },
+    });
+
+    expect(toolSpan.body).toMatchObject({
+      id: 'tool-span-1',
+      traceId: 'trace-case-1',
+      parentObservationId: 'generation-case-1',
+      name: 'eval.tool_call.searchCards',
+      input: {
+        query: 'Alchemist',
+        sessionId: '[REDACTED]',
+      },
+      output: {
+        items: [{ name: 'Alchemist', userEmail: '[REDACTED]' }],
+      },
+      metadata: {
+        toolName: 'searchCards',
+        toolCallId: 'tool-call-1',
+        providerToolCallId: 'call_1',
+        callIndex: 0,
+        ok: true,
+        durationMs: 125,
+        sourceLabels: ['Building 35'],
+        canonicalRefs: ['building:35'],
+        errors: [],
+        retries: [],
+      },
+    });
+
+    expect(scores).toEqual([
+      expect.objectContaining({
+        body: expect.objectContaining({
+          traceId: 'trace-case-1',
+          name: 'correctness',
+          value: 1,
+          comment: 'Expected detail present.',
+          metadata: { playerId: '[REDACTED]' },
+        }),
+      }),
+      expect.objectContaining({
+        body: expect.objectContaining({ traceId: 'trace-case-1', name: 'pass', value: 'pass' }),
+      }),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          traceId: 'trace-case-1',
+          name: 'tool_call_count',
+          value: 1,
+        }),
+      }),
+    ]);
+  });
+
+  it('redacts API keys, bearer tokens, cookies, sessions, and future user/campaign state', () => {
+    const redacted = redactTracePayload({
+      apiKey: 'sk-test-secret',
+      authorization: 'Bearer live-token',
+      nested: {
+        Cookie: 'squire_session=abc123',
+        set_cookie: 'session=abc123',
+        session: 'session-value',
+        csrf: 'csrf-token',
+        oauth: 'oauth-token',
+        accessToken: 'access-token',
+        refresh_token: 'refresh-token',
+        userId: 'user-1',
+        userEmail: 'player@example.test',
+        campaignId: 'campaign-1',
+        character_id: 'character-1',
+        playerId: 'player-1',
+      },
+      values: [
+        'Bearer another-token',
+        'sk-live-abcdefghijklmnopqrstuvwxyz1234567890',
+        'ordinary rules text',
+      ],
+    });
+
+    expect(redacted).toEqual({
+      apiKey: '[REDACTED]',
+      authorization: '[REDACTED]',
+      nested: {
+        Cookie: '[REDACTED]',
+        set_cookie: '[REDACTED]',
+        session: '[REDACTED]',
+        csrf: '[REDACTED]',
+        oauth: '[REDACTED]',
+        accessToken: '[REDACTED]',
+        refresh_token: '[REDACTED]',
+        userId: '[REDACTED]',
+        userEmail: '[REDACTED]',
+        campaignId: '[REDACTED]',
+        character_id: '[REDACTED]',
+        playerId: '[REDACTED]',
+      },
+      values: ['[REDACTED]', '[REDACTED]', 'ordinary rules text'],
+    });
+  });
+
+  it('sends only redacted Langfuse-bound events through the ingestion API', async () => {
+    const batches: unknown[] = [];
+    const client: LangfuseTraceIngestionClient = {
+      api: {
+        ingestion: {
+          batch: async (payload) => {
+            batches.push(payload);
+            return { successes: [], errors: [] };
+          },
+        },
+      },
+    };
+
+    await writeEvalTrace(client, baseTrace);
+
+    expect(batches).toHaveLength(1);
+    expect(JSON.stringify(batches[0])).not.toContain('sk-live-secret');
+    expect(JSON.stringify(batches[0])).not.toContain('sk-tool-secret');
+    expect(JSON.stringify(batches[0])).not.toContain('session-secret');
+    expect(JSON.stringify(batches[0])).not.toContain('player@example.test');
+  });
+});


### PR DESCRIPTION
## Summary

- Add a provider-neutral eval trace writer that builds Langfuse trace, generation, tool span, and score ingestion events from the SQR-125 contract.
- Add shared trace redaction for Langfuse-bound payloads, including nested provider transcript data, tool args/results, retry/error metadata, and score metadata.
- Cover the emitted trace shape and redaction behavior in `test/eval-trace.test.ts`.

## Scope

- No Anthropic/OpenAI provider runner behavior is added here.
- No production app conversation history changes.
- No `CHANGELOG.md` or `VERSION` edits.

## Validation

- `npm run check` (57 files, 966 tests)

Fixes SQR-127


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added eval trace ingestion with automatic redaction of sensitive data (API keys, tokens, user identifiers).
  * Enabled integration with trace monitoring for evaluation tracking.

* **Tests**
  * Added comprehensive test coverage for trace ingestion construction and security redaction mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->