### PR TITLE
feat(eval): add Anthropic model runner traces

### DIFF
--- a/eval/anthropic-runner.ts
+++ b/eval/anthropic-runner.ts
@@ -1,0 +1,331 @@
+import { createHash } from 'node:crypto';
+import {
+  AGENT_SYSTEM_PROMPT,
+  AGENT_TOOLS,
+  LEGACY_AGENT_SYSTEM_PROMPT,
+  LEGACY_AGENT_TOOLS,
+  runAgentLoopWithEvalConfig,
+  type AgentRunResult,
+  type AnthropicEvalModel,
+} from '../src/agent.ts';
+import type { EvalProviderConfig, EvalToolSurface } from './cli.ts';
+import { DATASET_NAME } from './dataset.ts';
+import {
+  writeEvalTrace,
+  type EvalTraceScore,
+  type EvalTraceToolCall,
+  type LangfuseTraceIngestionClient,
+} from './trace.ts';
+
+export const ANTHROPIC_TOOL_SCHEMA_VERSION = 'squire-anthropic-tools-v1' as const;
+
+export type AnthropicEvalFailureClass = 'access' | 'api' | 'timeout' | 'tool' | 'quality';
+
+interface AnthropicEvalCase {
+  id: string;
+  category: string;
+  source?: string;
+  question: string;
+}
+
+export interface AnthropicEvalCaseResult extends AgentRunResult {
+  durationMs: number;
+  toolSurface: EvalToolSurface;
+  traceId: string;
+}
+
+export interface RunAnthropicEvalCaseOptions {
+  case: AnthropicEvalCase;
+  runLabel: string;
+  toolSurface: EvalToolSurface;
+  providerConfig: EvalProviderConfig & {
+    provider: 'anthropic';
+    model: AnthropicEvalModel;
+  };
+  traceClient?: LangfuseTraceIngestionClient;
+  traceId?: string;
+  judgeScores?: EvalTraceScore[];
+  scoreResult?: (result: AgentRunResult) => Promise<EvalTraceScore[] | undefined>;
+  now?: () => Date;
+}
+
+interface StatusClassificationInput {
+  toolCalls: Array<{ ok: boolean; error?: string }>;
+  judgeScores: Array<{ name: string; value: number | string }>;
+}
+
+export function classifyAnthropicEvalFailure(error: unknown): AnthropicEvalFailureClass {
+  const status =
+    typeof error === 'object' && error && 'status' in error
+      ? Number((error as { status?: unknown }).status)
+      : undefined;
+  if (status === 401 || status === 403) return 'access';
+
+  const message = error instanceof Error ? error.message : String(error);
+  if (/timeout|timed out|abort/i.test(message)) return 'timeout';
+  if (/tool/i.test(message)) return 'tool';
+  return 'api';
+}
+
+export function classifyAnthropicEvalStatus(input: StatusClassificationInput): string {
+  if (input.toolCalls.some((call) => !call.ok)) return 'tool';
+  if (input.judgeScores.some((score) => score.name === 'pass' && score.value === 'fail')) {
+    return 'quality';
+  }
+  return 'completed';
+}
+
+function promptVersionFor(toolSurface: EvalToolSurface): string {
+  return toolSurface === 'legacy' ? 'legacy-agent-v1' : 'redesigned-agent-v1';
+}
+
+function promptHashFor(toolSurface: EvalToolSurface): string {
+  const prompt = toolSurface === 'legacy' ? LEGACY_AGENT_SYSTEM_PROMPT : AGENT_SYSTEM_PROMPT;
+  return `sha256:${createHash('sha256').update(prompt).digest('hex')}`;
+}
+
+function toolSchemaHashFor(toolSurface: EvalToolSurface): string {
+  const tools = toolSurface === 'legacy' ? LEGACY_AGENT_TOOLS : AGENT_TOOLS;
+  return createHash('sha256').update(JSON.stringify(tools)).digest('hex');
+}
+
+function traceIdFor(options: RunAnthropicEvalCaseOptions): string {
+  if (options.traceId) return options.traceId;
+  return [
+    'eval',
+    options.runLabel,
+    options.providerConfig.provider,
+    options.providerConfig.model,
+    options.case.id,
+  ]
+    .join(':')
+    .replace(/[^a-zA-Z0-9:_.-]/g, '-');
+}
+
+function scoresForResult(result: AgentRunResult, statusReason: string): EvalTraceScore[] {
+  return [
+    { name: 'failure_class', value: statusReason === 'completed' ? 'none' : statusReason },
+    { name: 'tool_call_count', value: result.trajectory.toolCalls.length },
+    { name: 'retry_count', value: 0 },
+    { name: 'loop_iterations', value: result.trajectory.iterations },
+    { name: 'model_latency_ms', value: totalModelLatencyMs(result) },
+    { name: 'model_cost_usd', value: 0 },
+  ];
+}
+
+function totalModelLatencyMs(result: AgentRunResult): number {
+  return result.trajectory.modelCalls.reduce((sum, call) => sum + call.durationMs, 0);
+}
+
+function toolCallsForTrace(result: AgentRunResult): EvalTraceToolCall[] {
+  return result.trajectory.toolCalls.map((call, index) => ({
+    id: `${call.id}:span`,
+    toolName: call.name,
+    toolCallId: call.id,
+    providerToolCallId: call.id,
+    callIndex: index,
+    arguments: call.input,
+    result: {
+      outputSummary: call.outputSummary,
+    },
+    ok: call.ok,
+    startedAt: call.startedAt,
+    endedAt: call.endedAt,
+    durationMs: call.durationMs,
+    sourceLabels: call.sourceLabels,
+    canonicalRefs: call.canonicalRefs,
+    errors: call.error
+      ? [
+          {
+            type: 'tool',
+            message: call.error,
+            retryable: false,
+          },
+        ]
+      : [],
+    retries: [],
+  }));
+}
+
+function tokenUsageForTrace(result: AgentRunResult): Record<string, number> {
+  return {
+    input: result.trajectory.tokenUsage.inputTokens,
+    output: result.trajectory.tokenUsage.outputTokens,
+    total: result.trajectory.tokenUsage.totalTokens,
+  };
+}
+
+async function writeSuccessTrace(
+  options: RunAnthropicEvalCaseOptions,
+  traceId: string,
+  result: AgentRunResult,
+  startedAt: string,
+  endedAt: string,
+  durationMs: number,
+  resultScores: EvalTraceScore[] | undefined,
+): Promise<void> {
+  if (!options.traceClient) return;
+
+  const scores = resultScores ?? options.judgeScores ?? [];
+  const statusReason = classifyAnthropicEvalStatus({
+    toolCalls: result.trajectory.toolCalls,
+    judgeScores: scores,
+  });
+  const judgeScores = scores.length > 0 ? scores : scoresForResult(result, statusReason);
+
+  await writeEvalTrace(options.traceClient, {
+    traceId,
+    generationId: `${traceId}:generation`,
+    runLabel: options.runLabel,
+    datasetName: DATASET_NAME,
+    caseId: options.case.id,
+    caseCategory: options.case.category,
+    provider: 'anthropic',
+    model: options.providerConfig.model,
+    resolvedModel: result.trajectory.model,
+    promptVersion: promptVersionFor(options.toolSurface),
+    promptHash: promptHashFor(options.toolSurface),
+    toolSurface: options.toolSurface,
+    toolSchemaVersion: ANTHROPIC_TOOL_SCHEMA_VERSION,
+    toolSchemaHash: toolSchemaHashFor(options.toolSurface),
+    modelSettings: {
+      model: options.providerConfig.model,
+      maxOutputTokens: options.providerConfig.maxOutputTokens,
+      reasoningEffort: options.providerConfig.reasoningEffort,
+      timeoutMs: options.providerConfig.timeoutMs,
+      toolLoopLimit: options.providerConfig.toolLoopLimit,
+    },
+    inputQuestion: options.case.question,
+    finalAnswer: result.answer,
+    statusReason,
+    stopReason: result.trajectory.stopReason ?? 'unknown',
+    startedAt,
+    endedAt,
+    durationMs,
+    providerRequest: {
+      question: options.case.question,
+      toolSurface: options.toolSurface,
+      model: options.providerConfig.model,
+    },
+    providerResponse: {
+      finalAnswer: result.answer,
+      stopReason: result.trajectory.stopReason,
+      iterations: result.trajectory.iterations,
+    },
+    providerNativeTranscript: {
+      modelCalls: result.trajectory.modelCalls,
+    },
+    tokenUsage: tokenUsageForTrace(result),
+    costEstimate: {
+      totalUsd: 0,
+    },
+    errors: result.trajectory.toolCalls
+      .filter((call) => call.error)
+      .map((call) => ({
+        type: 'tool',
+        message: call.error ?? 'Tool execution failed',
+        retryable: false,
+      })),
+    retries: [],
+    toolCalls: toolCallsForTrace(result),
+    judgeScores,
+  });
+}
+
+async function writeFailureTrace(
+  options: RunAnthropicEvalCaseOptions,
+  traceId: string,
+  error: unknown,
+  startedAt: string,
+  endedAt: string,
+  durationMs: number,
+): Promise<void> {
+  if (!options.traceClient) return;
+
+  const statusReason = classifyAnthropicEvalFailure(error);
+  const message = error instanceof Error ? error.message : String(error);
+
+  await writeEvalTrace(options.traceClient, {
+    traceId,
+    generationId: `${traceId}:generation`,
+    runLabel: options.runLabel,
+    datasetName: DATASET_NAME,
+    caseId: options.case.id,
+    caseCategory: options.case.category,
+    provider: 'anthropic',
+    model: options.providerConfig.model,
+    resolvedModel: options.providerConfig.model,
+    promptVersion: promptVersionFor(options.toolSurface),
+    promptHash: promptHashFor(options.toolSurface),
+    toolSurface: options.toolSurface,
+    toolSchemaVersion: ANTHROPIC_TOOL_SCHEMA_VERSION,
+    toolSchemaHash: toolSchemaHashFor(options.toolSurface),
+    modelSettings: {
+      model: options.providerConfig.model,
+      maxOutputTokens: options.providerConfig.maxOutputTokens,
+      reasoningEffort: options.providerConfig.reasoningEffort,
+      timeoutMs: options.providerConfig.timeoutMs,
+      toolLoopLimit: options.providerConfig.toolLoopLimit,
+    },
+    inputQuestion: options.case.question,
+    finalAnswer: null,
+    statusReason,
+    stopReason: 'error',
+    startedAt,
+    endedAt,
+    durationMs,
+    providerRequest: {
+      question: options.case.question,
+      toolSurface: options.toolSurface,
+      model: options.providerConfig.model,
+    },
+    providerResponse: null,
+    providerNativeTranscript: {
+      modelCalls: [],
+    },
+    tokenUsage: { input: 0, output: 0, total: 0 },
+    costEstimate: { totalUsd: 0 },
+    errors: [{ type: statusReason, message, retryable: statusReason === 'timeout' }],
+    retries: [],
+    toolCalls: [],
+    judgeScores: [{ name: 'failure_class', value: statusReason }],
+  });
+}
+
+export async function runAnthropicEvalCase(
+  options: RunAnthropicEvalCaseOptions,
+): Promise<AnthropicEvalCaseResult> {
+  const now = options.now ?? (() => new Date());
+  const startedAtDate = now();
+  const startedAt = startedAtDate.toISOString();
+  const traceId = traceIdFor(options);
+
+  try {
+    const result = await runAgentLoopWithEvalConfig(options.case.question, {
+      toolSurface: options.toolSurface,
+      anthropicModel: options.providerConfig.model,
+      maxOutputTokens: options.providerConfig.maxOutputTokens,
+      timeoutMs: options.providerConfig.timeoutMs,
+      toolLoopLimit: options.providerConfig.toolLoopLimit,
+    });
+    const endedAtDate = now();
+    const endedAt = endedAtDate.toISOString();
+    const durationMs = endedAtDate.getTime() - startedAtDate.getTime();
+    const resultScores = options.judgeScores ?? (await options.scoreResult?.(result));
+
+    await writeSuccessTrace(options, traceId, result, startedAt, endedAt, durationMs, resultScores);
+
+    return {
+      ...result,
+      durationMs,
+      toolSurface: options.toolSurface,
+      traceId,
+    };
+  } catch (error) {
+    const endedAtDate = now();
+    const endedAt = endedAtDate.toISOString();
+    const durationMs = endedAtDate.getTime() - startedAtDate.getTime();
+    await writeFailureTrace(options, traceId, error, startedAt, endedAt, durationMs);
+    throw error;
+  }
+}

--- a/eval/experiments.ts
+++ b/eval/experiments.ts
@@ -1,18 +1,86 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { LangfuseClient } from '@langfuse/client';
-import { askFrosthavenWithTrajectory } from '../src/query.ts';
-import type { EvalToolSurface } from './cli.ts';
+import type { EvalProviderConfig, EvalToolSurface } from './cli.ts';
+import { runAnthropicEvalCase, type AnthropicEvalCaseResult } from './anthropic-runner.ts';
 import { DATASET_NAME } from './dataset.ts';
-import { buildEvaluators, buildRunEvaluators } from './evaluators.ts';
+import { buildEvaluators, buildRunEvaluators, judgeAnswer } from './evaluators.ts';
 import { validateRemoteDatasetShape, type EvalCase } from './schema.ts';
+import type { AgentRunResult } from '../src/agent.ts';
+import type { LangfuseTraceIngestionClient } from './trace.ts';
+
+type AnthropicEvalProviderConfig = EvalProviderConfig & {
+  provider: 'anthropic';
+  model: 'claude-sonnet-4-6' | 'claude-opus-4-7';
+};
+
+function assertAnthropicProviderConfig(
+  providerConfig: EvalProviderConfig,
+): AnthropicEvalProviderConfig {
+  if (
+    providerConfig.provider === 'anthropic' &&
+    (providerConfig.model === 'claude-sonnet-4-6' || providerConfig.model === 'claude-opus-4-7')
+  ) {
+    return providerConfig as AnthropicEvalProviderConfig;
+  }
+  throw new Error(`Provider runner is not implemented yet for ${providerConfig.provider}.`);
+}
+
+function traceClientFor(langfuse: LangfuseClient): LangfuseTraceIngestionClient {
+  return langfuse as unknown as LangfuseTraceIngestionClient;
+}
+
+function datasetItemCase(item: {
+  input?: unknown;
+  metadata?: unknown;
+}): Pick<EvalCase, 'id' | 'category' | 'source' | 'question'> {
+  const input = item.input as { question?: string } | undefined;
+  const metadata = item.metadata as { id?: string; category?: string; source?: string } | undefined;
+  return {
+    id: metadata?.id ?? 'unknown-case',
+    category: metadata?.category ?? 'unknown',
+    source: metadata?.source ?? 'langfuse',
+    question: input?.question ?? '',
+  };
+}
+
+async function traceScoresForCase(
+  anthropic: Anthropic,
+  evalCase: Pick<EvalCase, 'question' | 'finalAnswer'>,
+  result: AgentRunResult,
+) {
+  if (!evalCase.finalAnswer) return undefined;
+
+  const verdict = await judgeAnswer(
+    anthropic,
+    evalCase.question,
+    evalCase.finalAnswer.expected,
+    evalCase.finalAnswer.grading,
+    result.answer,
+  );
+
+  return [
+    {
+      name: 'correctness',
+      value: verdict.score / 5,
+      comment: verdict.reasoning,
+    },
+    {
+      name: 'pass',
+      value: verdict.pass ? 'pass' : 'fail',
+      comment: verdict.reasoning,
+    },
+  ];
+}
 
 export async function runOnDataset(
   langfuse: LangfuseClient,
   runName: string,
   toolSurface: EvalToolSurface,
   expectedCaseCount: number,
+  providerConfig: EvalProviderConfig,
 ): Promise<void> {
   const anthropic = new Anthropic();
+  const anthropicConfig = assertAnthropicProviderConfig(providerConfig);
   const dataset = await langfuse.dataset.get(DATASET_NAME);
   console.log(`Dataset has ${dataset.items.length} items`);
   validateRemoteDatasetShape(dataset.items, expectedCaseCount, DATASET_NAME);
@@ -21,12 +89,23 @@ export async function runOnDataset(
     name: runName,
     maxConcurrency: 1,
     task: async (item) => {
-      const question = (item.input as { question: string }).question;
       const meta = item.metadata as { id?: string } | undefined;
+      const evalCase = datasetItemCase(item);
+      const expected = item.expectedOutput as Pick<EvalCase, 'finalAnswer'> | undefined;
       process.stdout.write(`  ${meta?.id ?? '?'}... `);
-      const startedAt = Date.now();
-      const result = await askFrosthavenWithTrajectory(question, { toolSurface });
-      return { ...result, durationMs: Date.now() - startedAt, toolSurface };
+      return runAnthropicEvalCase({
+        case: evalCase,
+        runLabel: runName,
+        toolSurface,
+        providerConfig: anthropicConfig,
+        traceClient: traceClientFor(langfuse),
+        scoreResult: (result) =>
+          traceScoresForCase(
+            anthropic,
+            { ...evalCase, finalAnswer: expected?.finalAnswer },
+            result,
+          ),
+      });
     },
     evaluators: buildEvaluators(anthropic),
     runEvaluators: buildRunEvaluators(),
@@ -43,8 +122,10 @@ export async function runFiltered(
   cases: EvalCase[],
   runName: string,
   toolSurface: EvalToolSurface,
+  providerConfig: EvalProviderConfig,
 ): Promise<void> {
   const anthropic = new Anthropic();
+  const anthropicConfig = assertAnthropicProviderConfig(providerConfig);
 
   const data = cases.map((c) => ({
     input: { question: c.question },
@@ -63,12 +144,23 @@ export async function runFiltered(
     data,
     maxConcurrency: 1,
     task: async (item) => {
-      const question = (item.input as { question: string }).question;
       const meta = item.metadata as { id?: string } | undefined;
+      const evalCase = datasetItemCase(item) as EvalCase;
+      const expected = item.expectedOutput as Pick<EvalCase, 'finalAnswer'> | undefined;
       process.stdout.write(`  ${meta?.id ?? '?'}... `);
-      const startedAt = Date.now();
-      const result = await askFrosthavenWithTrajectory(question, { toolSurface });
-      return { ...result, durationMs: Date.now() - startedAt, toolSurface };
+      return runAnthropicEvalCase({
+        case: evalCase,
+        runLabel: runName,
+        toolSurface,
+        providerConfig: anthropicConfig,
+        traceClient: traceClientFor(langfuse),
+        scoreResult: (result) =>
+          traceScoresForCase(
+            anthropic,
+            { ...evalCase, finalAnswer: expected?.finalAnswer },
+            result,
+          ),
+      }) satisfies Promise<AnthropicEvalCaseResult>;
     },
     evaluators: buildEvaluators(anthropic),
     runEvaluators: buildRunEvaluators(),

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -18,16 +18,12 @@ function describeProviderConfig(config: EvalProviderConfig): string {
 }
 
 function assertCurrentRunnerSupportsProviderConfig(config: EvalProviderConfig): void {
-  const usesDefaultModel = config.provider === 'anthropic' && config.model === 'claude-sonnet-4-6';
-  const hasFutureRunnerTuning =
-    config.reasoningEffort || config.maxOutputTokens || config.timeoutMs || config.toolLoopLimit;
-  if (usesDefaultModel && !hasFutureRunnerTuning) return;
+  if (config.provider === 'anthropic') return;
 
   throw new Error(
     [
       `Eval provider config parsed as ${describeProviderConfig(config)}, but the provider runner is not implemented yet.`,
-      'This SQR-124 contract only defines eval-only config and module boundaries.',
-      'Use the existing default anthropic:claude-sonnet-4-6 runner until SQR-128/SQR-129 add provider-specific loops.',
+      'SQR-128 adds the Anthropic eval runner; SQR-129 still owns OpenAI runner support.',
     ].join(' '),
   );
 }
@@ -76,8 +72,20 @@ export async function runEval(options: EvalCliOptions, env: NodeJS.ProcessEnv = 
     `Running ${cases.length} eval(s) as "${options.runName}" on ${options.toolSurface} tools...\n`,
   );
   if (isFiltered) {
-    await runFiltered(langfuse, cases, options.runName, options.toolSurface);
+    await runFiltered(
+      langfuse,
+      cases,
+      options.runName,
+      options.toolSurface,
+      options.providerConfig,
+    );
   } else {
-    await runOnDataset(langfuse, options.runName, options.toolSurface, allCases.length);
+    await runOnDataset(
+      langfuse,
+      options.runName,
+      options.toolSurface,
+      allCases.length,
+      options.providerConfig,
+    );
   }
 }

--- a/eval/trace.ts
+++ b/eval/trace.ts
@@ -275,6 +275,7 @@ export function buildEvalTraceIngestionBatch(input: EvalTraceInput): EvalTraceIn
 
   const scoreEvents = input.judgeScores.map((score) =>
     event('score-create', `${input.traceId}:score:${score.name}`, timestamp, {
+      id: `${input.traceId}:score:${score.name}`,
       traceId: input.traceId,
       name: score.name,
       value: score.value,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -362,7 +362,7 @@ export const ALL_AGENT_TOOLS = [...AGENT_TOOLS, ...LEGACY_AGENT_TOOLS] as const;
 /** Union of every selectable tool name. Keeps dependent maps honest. */
 export type AgentToolName = (typeof ALL_AGENT_TOOLS)[number]['name'];
 
-type AgentToolSurface = 'redesigned' | 'legacy';
+export type AgentToolSurface = 'redesigned' | 'legacy';
 
 function selectedAgentSurface(surface: AgentToolSurface | undefined): {
   system: string;
@@ -386,6 +386,8 @@ export interface TokenUsage {
   totalTokens: number;
 }
 
+export type AnthropicEvalModel = 'claude-sonnet-4-6' | 'claude-opus-4-7';
+
 export interface ToolTrajectoryStep {
   iteration: number;
   id: string;
@@ -401,8 +403,21 @@ export interface ToolTrajectoryStep {
   durationMs: number;
 }
 
+export interface ModelTrajectoryStep {
+  iteration: number;
+  model: string;
+  stopReason: StopReason | null;
+  inputTokens: number;
+  outputTokens: number;
+  content: unknown;
+  startedAt: string;
+  endedAt: string;
+  durationMs: number;
+}
+
 export interface AgentRunTrajectory {
   toolCalls: ToolTrajectoryStep[];
+  modelCalls: ModelTrajectoryStep[];
   finalAnswer: string;
   tokenUsage: TokenUsage;
   model: string;
@@ -413,6 +428,14 @@ export interface AgentRunTrajectory {
 export interface AgentRunResult {
   answer: string;
   trajectory: AgentRunTrajectory;
+}
+
+export interface EvalAgentLoopOptions {
+  toolSurface?: AgentToolSurface;
+  anthropicModel: AnthropicEvalModel;
+  maxOutputTokens?: number;
+  timeoutMs?: number;
+  toolLoopLimit?: number;
 }
 
 const AGENT_MODEL = 'claude-sonnet-4-6' as const;
@@ -661,13 +684,19 @@ export async function executeToolCall(
 async function callClaude(
   messages: MessageParam[],
   emit?: EmitFn,
-  opts: { allowTools?: boolean; toolSurface?: AgentToolSurface } = {},
+  opts: {
+    allowTools?: boolean;
+    toolSurface?: AgentToolSurface;
+    model?: string;
+    maxOutputTokens?: number;
+    timeoutMs?: number;
+  } = {},
 ): Promise<Message> {
   const allowTools = opts.allowTools ?? true;
   const surface = selectedAgentSurface(opts.toolSurface);
   const params = {
-    model: AGENT_MODEL,
-    max_tokens: 4096,
+    model: opts.model ?? AGENT_MODEL,
+    max_tokens: opts.maxOutputTokens ?? 4096,
     system: surface.system,
     messages,
   };
@@ -682,11 +711,16 @@ async function callClaude(
       }
     : params;
 
+  const requestOptions = opts.timeoutMs ? { timeout: opts.timeoutMs } : undefined;
+
   if (!emit) {
+    if (requestOptions) return client.messages.create(paramsWithTools, requestOptions);
     return client.messages.create(paramsWithTools);
   }
 
-  const stream = client.messages.stream(paramsWithTools);
+  const stream = requestOptions
+    ? client.messages.stream(paramsWithTools, requestOptions)
+    : client.messages.stream(paramsWithTools);
   stream.on('text', (delta) => {
     void emit('text', { delta });
   });
@@ -734,14 +768,63 @@ export async function runAgentLoopWithTrajectory(
   });
 }
 
+export async function runAgentLoopWithEvalConfig(
+  question: string,
+  options: EvalAgentLoopOptions,
+): Promise<AgentRunResult> {
+  return tracer.startActiveSpan('squire.agent.eval.run', async (runSpan) => {
+    try {
+      const result = await runAgentLoopInternal(
+        question,
+        { toolSurface: options.toolSurface },
+        {
+          model: options.anthropicModel,
+          maxOutputTokens: options.maxOutputTokens,
+          timeoutMs: options.timeoutMs,
+          toolLoopLimit: options.toolLoopLimit,
+        },
+      );
+      runSpan.setAttributes({
+        'squire.agent.model': result.trajectory.model,
+        'squire.agent.iterations': result.trajectory.iterations,
+        'squire.agent.tool_call_count': result.trajectory.toolCalls.length,
+        'squire.agent.stop_reason': result.trajectory.stopReason ?? 'unknown',
+        'squire.agent.input_tokens': result.trajectory.tokenUsage.inputTokens,
+        'squire.agent.output_tokens': result.trajectory.tokenUsage.outputTokens,
+        'squire.agent.eval': true,
+      });
+      return result;
+    } catch (err) {
+      runSpan.recordException(err as Error);
+      runSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    } finally {
+      runSpan.end();
+    }
+  });
+}
+
+interface AgentLoopInternalConfig {
+  model?: string;
+  maxOutputTokens?: number;
+  timeoutMs?: number;
+  toolLoopLimit?: number;
+}
+
 async function runAgentLoopInternal(
   question: string,
   options?: AskOptions,
+  config: AgentLoopInternalConfig = {},
 ): Promise<AgentRunResult> {
   const history = options?.history;
   const emit = options?.emit;
   const toolSurface = options?.toolSurface;
   const truncatedHistory = history ? history.slice(-MAX_HISTORY_TURNS) : [];
+  const model = config.model ?? AGENT_MODEL;
+  const maxIterations = config.toolLoopLimit ?? MAX_AGENT_ITERATIONS;
 
   const messages: MessageParam[] = [
     ...truncatedHistory.map((m: HistoryMessage) => ({
@@ -756,11 +839,14 @@ async function runAgentLoopInternal(
   let hasUsedNonRuleSearchTool = false;
   let forceSynthesis = false;
   const toolCalls: ToolTrajectoryStep[] = [];
+  const modelCalls: ModelTrajectoryStep[] = [];
   const tokenUsage: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
   let iterations = 0;
 
-  for (let i = 0; i < MAX_AGENT_ITERATIONS; i++) {
+  for (let i = 0; i < maxIterations; i++) {
     iterations = i + 1;
+    const modelStartedAtMs = Date.now();
+    const modelStartedAt = new Date(modelStartedAtMs).toISOString();
     const response = await tracer.startActiveSpan('squire.agent.iteration', async (span) => {
       try {
         span.setAttributes({
@@ -771,6 +857,9 @@ async function runAgentLoopInternal(
         const message = await callClaude(messages, emit, {
           allowTools: !forceSynthesis,
           toolSurface,
+          model,
+          maxOutputTokens: config.maxOutputTokens,
+          timeoutMs: config.timeoutMs,
         });
         span.setAttributes({
           'squire.agent.stop_reason': message.stop_reason ?? 'unknown',
@@ -788,6 +877,18 @@ async function runAgentLoopInternal(
       } finally {
         span.end();
       }
+    });
+    const modelEndedAtMs = Date.now();
+    modelCalls.push({
+      iteration: i + 1,
+      model,
+      stopReason: response.stop_reason,
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+      content: response.content,
+      startedAt: modelStartedAt,
+      endedAt: new Date(modelEndedAtMs).toISOString(),
+      durationMs: modelEndedAtMs - modelStartedAtMs,
     });
     addUsage(tokenUsage, response);
     const hasToolUse = response.content.some((block) => block.type === 'tool_use');
@@ -813,9 +914,10 @@ async function runAgentLoopInternal(
         answer: lastTextContent,
         trajectory: {
           toolCalls,
+          modelCalls,
           finalAnswer: lastTextContent,
           tokenUsage,
-          model: AGENT_MODEL,
+          model,
           iterations,
           stopReason: response.stop_reason,
         },
@@ -950,9 +1052,10 @@ async function runAgentLoopInternal(
       answer,
       trajectory: {
         toolCalls,
+        modelCalls,
         finalAnswer: answer,
         tokenUsage,
-        model: AGENT_MODEL,
+        model,
         iterations,
         stopReason: response.stop_reason,
       },
@@ -967,9 +1070,10 @@ async function runAgentLoopInternal(
     answer,
     trajectory: {
       toolCalls,
+      modelCalls,
       finalAnswer: answer,
       tokenUsage,
-      model: AGENT_MODEL,
+      model,
       iterations,
       stopReason: 'iteration_limit',
     },

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -64,6 +64,7 @@ vi.mock('../src/tools.ts', () => ({
 
 import {
   runAgentLoop,
+  runAgentLoopWithEvalConfig,
   runAgentLoopWithTrajectory,
   executeToolCall,
   AGENT_TOOLS,
@@ -267,6 +268,28 @@ describe('runAgentLoop', () => {
       'get_section',
       'follow_links',
     ]);
+  });
+
+  it('uses eval-only Anthropic model config without changing the tool loop', async () => {
+    mockMessagesCreate.mockResolvedValue(textResponse('Answer'));
+
+    await runAgentLoopWithEvalConfig('test', {
+      toolSurface: 'redesigned',
+      anthropicModel: 'claude-opus-4-7',
+      maxOutputTokens: 2048,
+      timeoutMs: 30000,
+      toolLoopLimit: 4,
+    });
+
+    expect(mockMessagesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-opus-4-7',
+        max_tokens: 2048,
+        tools: AGENT_TOOLS,
+        system: AGENT_SYSTEM_PROMPT,
+      }),
+      { timeout: 30000 },
+    );
   });
 
   it('uses the redesigned traversal tools for an exact scenario conclusion lookup', async () => {

--- a/test/eval-anthropic-runner.test.ts
+++ b/test/eval-anthropic-runner.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRunAgentLoopWithEvalConfig, mockWriteEvalTrace } = vi.hoisted(() => ({
+  mockRunAgentLoopWithEvalConfig: vi.fn(),
+  mockWriteEvalTrace: vi.fn(),
+}));
+
+vi.mock('../src/agent.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/agent.ts')>();
+  return {
+    ...actual,
+    runAgentLoopWithEvalConfig: mockRunAgentLoopWithEvalConfig,
+  };
+});
+
+vi.mock('../eval/trace.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../eval/trace.ts')>();
+  return {
+    ...actual,
+    writeEvalTrace: mockWriteEvalTrace,
+  };
+});
+
+import type { AskOptions } from '../src/service.ts';
+import {
+  classifyAnthropicEvalFailure,
+  classifyAnthropicEvalStatus,
+  runAnthropicEvalCase,
+} from '../eval/anthropic-runner.ts';
+import type { LangfuseTraceIngestionClient } from '../eval/trace.ts';
+
+const traceClient: LangfuseTraceIngestionClient = {
+  api: {
+    ingestion: {
+      batch: vi.fn(),
+    },
+  },
+};
+
+const baseCase = {
+  id: 'building-alchemist',
+  category: 'buildings',
+  source: 'dataset',
+  question: 'What does the level 1 Alchemist unlock?',
+};
+
+function successfulAgentResult(model: 'claude-sonnet-4-6' | 'claude-opus-4-7') {
+  return {
+    answer: 'It can brew 2-herb potions.',
+    trajectory: {
+      toolCalls: [
+        {
+          iteration: 1,
+          id: 'toolu_1',
+          name: 'open_entity',
+          input: { ref: 'building:35' },
+          ok: true,
+          outputSummary: 'json object (name, level, effect)',
+          sourceLabels: ['Building 35'],
+          canonicalRefs: ['building:35'],
+          startedAt: '2026-05-01T00:00:01.000Z',
+          endedAt: '2026-05-01T00:00:01.125Z',
+          durationMs: 125,
+        },
+      ],
+      modelCalls: [
+        {
+          iteration: 1,
+          model,
+          stopReason: 'tool_use',
+          inputTokens: 100,
+          outputTokens: 50,
+          content: [{ type: 'tool_use', id: 'toolu_1', name: 'open_entity' }],
+          startedAt: '2026-05-01T00:00:00.000Z',
+          endedAt: '2026-05-01T00:00:00.500Z',
+          durationMs: 500,
+        },
+        {
+          iteration: 2,
+          model,
+          stopReason: 'end_turn',
+          inputTokens: 150,
+          outputTokens: 75,
+          content: [{ type: 'text', text: 'It can brew 2-herb potions.' }],
+          startedAt: '2026-05-01T00:00:01.500Z',
+          endedAt: '2026-05-01T00:00:02.500Z',
+          durationMs: 1000,
+        },
+      ],
+      finalAnswer: 'It can brew 2-herb potions.',
+      tokenUsage: { inputTokens: 250, outputTokens: 125, totalTokens: 375 },
+      model,
+      iterations: 2,
+      stopReason: 'end_turn',
+    },
+  };
+}
+
+describe('SQR-128 Anthropic eval runner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs Sonnet and Opus through the same eval-only Claude loop with only model config changed', async () => {
+    mockRunAgentLoopWithEvalConfig
+      .mockResolvedValueOnce(successfulAgentResult('claude-sonnet-4-6'))
+      .mockResolvedValueOnce(successfulAgentResult('claude-opus-4-7'));
+    mockWriteEvalTrace.mockResolvedValue(undefined);
+
+    await runAnthropicEvalCase({
+      case: baseCase,
+      runLabel: 'matrix-smoke',
+      toolSurface: 'redesigned',
+      providerConfig: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        reasoningEffort: undefined,
+        maxOutputTokens: 2048,
+        timeoutMs: 30000,
+        toolLoopLimit: 6,
+      },
+      traceClient,
+    });
+    await runAnthropicEvalCase({
+      case: baseCase,
+      runLabel: 'matrix-smoke',
+      toolSurface: 'redesigned',
+      providerConfig: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-7',
+        reasoningEffort: undefined,
+        maxOutputTokens: 2048,
+        timeoutMs: 30000,
+        toolLoopLimit: 6,
+      },
+      traceClient,
+    });
+
+    expect(mockRunAgentLoopWithEvalConfig).toHaveBeenNthCalledWith(1, baseCase.question, {
+      toolSurface: 'redesigned',
+      anthropicModel: 'claude-sonnet-4-6',
+      maxOutputTokens: 2048,
+      timeoutMs: 30000,
+      toolLoopLimit: 6,
+    });
+    expect(mockRunAgentLoopWithEvalConfig).toHaveBeenNthCalledWith(2, baseCase.question, {
+      toolSurface: 'redesigned',
+      anthropicModel: 'claude-opus-4-7',
+      maxOutputTokens: 2048,
+      timeoutMs: 30000,
+      toolLoopLimit: 6,
+    });
+  });
+
+  it('writes SQR-127 trace payloads with Anthropic model settings and provider-native turns', async () => {
+    mockRunAgentLoopWithEvalConfig.mockResolvedValueOnce(successfulAgentResult('claude-opus-4-7'));
+    mockWriteEvalTrace.mockResolvedValue(undefined);
+
+    await runAnthropicEvalCase({
+      case: baseCase,
+      runLabel: 'opus-smoke',
+      toolSurface: 'legacy',
+      providerConfig: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-7',
+        reasoningEffort: 'high',
+        maxOutputTokens: 4096,
+        timeoutMs: 45000,
+        toolLoopLimit: 4,
+      },
+      traceClient,
+      traceId: 'trace-opus',
+    });
+
+    expect(mockWriteEvalTrace).toHaveBeenCalledWith(
+      traceClient,
+      expect.objectContaining({
+        traceId: 'trace-opus',
+        runLabel: 'opus-smoke',
+        caseId: 'building-alchemist',
+        caseCategory: 'buildings',
+        provider: 'anthropic',
+        model: 'claude-opus-4-7',
+        resolvedModel: 'claude-opus-4-7',
+        promptVersion: 'legacy-agent-v1',
+        toolSurface: 'legacy',
+        toolSchemaVersion: 'squire-anthropic-tools-v1',
+        modelSettings: {
+          model: 'claude-opus-4-7',
+          maxOutputTokens: 4096,
+          reasoningEffort: 'high',
+          timeoutMs: 45000,
+          toolLoopLimit: 4,
+        },
+        stopReason: 'end_turn',
+        statusReason: 'completed',
+        tokenUsage: { input: 250, output: 125, total: 375 },
+        providerNativeTranscript: {
+          modelCalls: successfulAgentResult('claude-opus-4-7').trajectory.modelCalls,
+        },
+        toolCalls: [
+          expect.objectContaining({
+            toolName: 'open_entity',
+            providerToolCallId: 'toolu_1',
+            arguments: { ref: 'building:35' },
+            result: { outputSummary: 'json object (name, level, effect)' },
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('marks answer-quality failures when result scoring returns a failed pass score', async () => {
+    mockRunAgentLoopWithEvalConfig.mockResolvedValueOnce(successfulAgentResult('claude-opus-4-7'));
+    mockWriteEvalTrace.mockResolvedValue(undefined);
+
+    await runAnthropicEvalCase({
+      case: baseCase,
+      runLabel: 'quality-smoke',
+      toolSurface: 'redesigned',
+      providerConfig: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-7',
+        reasoningEffort: undefined,
+        maxOutputTokens: 4096,
+        timeoutMs: 45000,
+        toolLoopLimit: 4,
+      },
+      traceClient,
+      traceId: 'trace-quality',
+      scoreResult: async () => [
+        { name: 'correctness', value: 0.4, comment: 'Missing upgrade distinction.' },
+        { name: 'pass', value: 'fail', comment: 'Expected upgrade cost distinction.' },
+      ],
+    });
+
+    expect(mockWriteEvalTrace).toHaveBeenCalledWith(
+      traceClient,
+      expect.objectContaining({
+        traceId: 'trace-quality',
+        statusReason: 'quality',
+        judgeScores: [
+          { name: 'correctness', value: 0.4, comment: 'Missing upgrade distinction.' },
+          { name: 'pass', value: 'fail', comment: 'Expected upgrade cost distinction.' },
+        ],
+      }),
+    );
+  });
+
+  it('keeps production AskOptions free of provider and model selection fields', () => {
+    const invalidProductionOptions: AskOptions = {
+      // @ts-expect-error Provider/model selection is intentionally eval-only.
+      provider: 'anthropic',
+      model: 'claude-opus-4-7',
+    };
+    const productionOptionsKeys = Object.keys({
+      history: [],
+      toolSurface: 'legacy',
+      campaignId: 'campaign',
+      userId: 'user',
+      emit: async () => {},
+    } satisfies AskOptions);
+
+    expect(productionOptionsKeys).not.toContain('provider');
+    expect(productionOptionsKeys).not.toContain('model');
+    expect(productionOptionsKeys).not.toContain('anthropicModel');
+    expect(invalidProductionOptions).toHaveProperty('provider', 'anthropic');
+  });
+
+  it('classifies Anthropic access, timeout, tool, and quality failures', () => {
+    expect(classifyAnthropicEvalFailure({ status: 401, message: 'Unauthorized' })).toBe('access');
+    expect(classifyAnthropicEvalFailure(new Error('request timeout after 30000ms'))).toBe(
+      'timeout',
+    );
+    expect(
+      classifyAnthropicEvalStatus({
+        toolCalls: [{ ok: false, error: 'Tool error: database unavailable' }],
+        judgeScores: [],
+      }),
+    ).toBe('tool');
+    expect(
+      classifyAnthropicEvalStatus({
+        toolCalls: [],
+        judgeScores: [{ name: 'pass', value: 'fail' }],
+      }),
+    ).toBe('quality');
+  });
+});

--- a/test/eval-trace.test.ts
+++ b/test/eval-trace.test.ts
@@ -239,6 +239,7 @@ describe('SQR-127 eval trace writer', () => {
     expect(scores).toEqual([
       expect.objectContaining({
         body: expect.objectContaining({
+          id: 'trace-case-1:score:correctness',
           traceId: 'trace-case-1',
           name: 'correctness',
           value: 1,
@@ -247,10 +248,16 @@ describe('SQR-127 eval trace writer', () => {
         }),
       }),
       expect.objectContaining({
-        body: expect.objectContaining({ traceId: 'trace-case-1', name: 'pass', value: 'pass' }),
+        body: expect.objectContaining({
+          id: 'trace-case-1:score:pass',
+          traceId: 'trace-case-1',
+          name: 'pass',
+          value: 'pass',
+        }),
       }),
       expect.objectContaining({
         body: expect.objectContaining({
+          id: 'trace-case-1:score:tool_call_count',
           traceId: 'trace-case-1',
           name: 'tool_call_count',
           value: 1,


### PR DESCRIPTION
## Summary

- Adds an eval-only Anthropic runner for `claude-sonnet-4-6` and `claude-opus-4-7` using the existing Squire Claude tool loop.
- Threads eval-only model, timeout, output-token, and tool-loop settings without adding provider/model selection to production `AskOptions`.
- Emits SQR-127 Langfuse traces with model-call transcripts, stop reasons, token usage, model settings, tool spans, and trace-level quality/failure scores.
- Keeps OpenAI runner behavior out of scope for SQR-129.

## Review

Pre-landing gstack review found one integration gap: answer-quality failures were classified in code but not reflected on the trace because Langfuse experiment judging ran after the task trace was written. Fixed by letting the Anthropic runner score the result before writing the trace, and by adding the missing Langfuse score body id required for score ingestion.

No remaining pre-landing review findings.

## Verification

- `npm run check` passed: 58 files, 972 tests.
- Focused tests covered Sonnet/Opus model override, production `AskOptions` isolation, trace shape, score ingestion ids, timeout wiring, and failure classification.
- Live Anthropic + Langfuse QA:
  - Sonnet run passed `building-alchemist` at 4/5: https://us.cloud.langfuse.com/project/cmn1deprv071ead07hellcosn/traces/eval:sqr-128-live-sonnet-scorefix-20260501T141037Z:anthropic:claude-sonnet-4-6:building-alchemist
  - Opus run failed answer quality at 2/5 and the trace now records `statusReason=quality` with failed `pass`/`correctness` scores: https://us.cloud.langfuse.com/project/cmn1deprv071ead07hellcosn/traces/eval:sqr-128-live-opus-qualityfix-20260501T142649Z:anthropic:claude-opus-4-7:building-alchemist

Fixes SQR-128


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for running evaluations using Anthropic's Claude models with configurable token limits and timeouts.
  * Introduced provider-aware evaluation execution for flexible model selection.
  * Enhanced evaluation trace reporting with improved metadata and scoring information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->