### PR TITLE
feat(eval): add OpenAI Responses eval runner

### DIFF
--- a/docs/plans/sqr-129-openai-responses-runner.md
+++ b/docs/plans/sqr-129-openai-responses-runner.md
@@ -1,0 +1,66 @@
+# SQR-129 OpenAI Responses Eval Runner
+
+Generated on 2026-05-01 for SQR-129.
+
+## Scope
+
+SQR-129 adds an eval-only OpenAI Responses runner. It does not change
+production `/api/ask`, REST, MCP, web behavior, or Anthropic runner internals.
+
+The runner lives in `eval/openai-runner.ts` and consumes:
+
+- provider/model config from `eval/cli.ts` (`openai:gpt-5.5`)
+- strict function schemas from `eval/openai-schema.ts`
+- Squire tool execution through `executeOpenAiToolCall`
+- SQR-127 trace payloads through `eval/trace.ts`
+
+## Stateless Responses Loop
+
+The runner uses the manual stateless Responses flow verified in SQR-123:
+
+1. Send the user eval question, strict Squire tool schemas, `store: false`, and
+   `parallel_tool_calls: false`.
+2. Preserve every provider-native `response.output` item, including reasoning
+   and `function_call` items.
+3. Execute each `function_call` through the Squire OpenAI tool wrapper.
+4. Append the original provider-native output items plus
+   `function_call_output` items into the next request `input`.
+5. Repeat until the model returns a final message or the loop limit is reached.
+
+The runner never sends `previous_response_id`. This keeps eval behavior
+independent of hosted response retention and preserves all continuation state in
+the trace artifact.
+
+## Trace Shape
+
+Each run returns an `EvalTraceInput` object with:
+
+- provider request objects for every model turn
+- provider response objects for every model turn
+- provider-native transcript turns containing output items and function outputs
+- one tool span input per Squire tool call
+- one tool span output per Squire tool result
+- normalized failure class, stop reason, token usage, and loop count
+
+`runOpenAiResponsesEvalCase` can also write the trace through the SQR-127
+Langfuse ingestion client when one is provided. The local report path mirrors
+the same trace object for selected-case smoke runs.
+
+## Failure Classes
+
+OpenAI runner failures are normalized into:
+
+- `model_access` for missing API key, unavailable model, auth, or not-found
+  responses
+- `api_status` for non-access API errors and failed/cancelled Responses states
+- `schema` for malformed function-call arguments or unsafe argument shapes
+- `tool_execution` for Squire tool errors
+- `timeout` for aborted or timed-out provider calls
+- `answer_quality` for completed provider turns that contain no final text
+- `loop_limit` when the model keeps requesting tools until the configured limit
+
+## CLI Behavior
+
+OpenAI evals currently require `--local-report` so selected-case runs can write
+the complete trace artifact without depending on the future matrix runner. Full
+Langfuse matrix wiring remains owned by SQR-131.

--- a/eval/anthropic-runner.ts
+++ b/eval/anthropic-runner.ts
@@ -113,6 +113,17 @@ function scoresForResult(result: AgentRunResult, statusReason: string): EvalTrac
   ];
 }
 
+function mergeMetricScores(
+  metricScores: EvalTraceScore[],
+  judgeScores: EvalTraceScore[],
+): EvalTraceScore[] {
+  const judgeScoreNames = new Set(judgeScores.map((score) => score.name));
+  return [
+    ...metricScores.filter((metricScore) => !judgeScoreNames.has(metricScore.name)),
+    ...judgeScores,
+  ];
+}
+
 function totalModelLatencyMs(result: AgentRunResult): number {
   return result.trajectory.modelCalls.reduce((sum, call) => sum + call.durationMs, 0);
 }
@@ -171,7 +182,7 @@ async function writeSuccessTrace(
     toolCalls: result.trajectory.toolCalls,
     judgeScores: scores,
   });
-  const judgeScores = scores.length > 0 ? scores : scoresForResult(result, statusReason);
+  const judgeScores = mergeMetricScores(scoresForResult(result, statusReason), scores);
 
   await writeEvalTrace(options.traceClient, {
     traceId,

--- a/eval/openai-runner.ts
+++ b/eval/openai-runner.ts
@@ -1,0 +1,713 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import {
+  AGENT_SYSTEM_PROMPT,
+  LEGACY_AGENT_SYSTEM_PROMPT,
+  type ToolCallResult,
+} from '../src/agent.ts';
+import type { ToolTrajectoryStep, TokenUsage } from '../src/agent.ts';
+import type { EvalProviderConfig, EvalToolSurface } from './cli.ts';
+import { DATASET_NAME } from './dataset.ts';
+import {
+  OPENAI_TOOL_SCHEMA_VERSION,
+  executeOpenAiToolCall,
+  getOpenAiToolSchemaHash,
+  renderOpenAiStrictToolSchemas,
+  type OpenAiStrictFunctionTool,
+} from './openai-schema.ts';
+import type { EvalCase } from './schema.ts';
+import {
+  type EvalTraceError,
+  type EvalTraceInput,
+  type EvalTraceToolCall,
+  type LangfuseTraceIngestionClient,
+} from './trace.ts';
+import { TRACE_CONTRACT_VERSION } from './trace-contract.ts';
+import { writeEvalTrace } from './trace.ts';
+
+export type OpenAiEvalFailureClass =
+  | 'none'
+  | 'model_access'
+  | 'api_status'
+  | 'schema'
+  | 'tool_execution'
+  | 'timeout'
+  | 'answer_quality'
+  | 'loop_limit';
+
+type OpenAiResponseInputItem = Record<string, unknown>;
+type OpenAiResponseOutputItem = Record<string, unknown>;
+
+export interface OpenAiResponsesCreateRequest {
+  model: string;
+  instructions: string;
+  input: OpenAiResponseInputItem[];
+  tools: OpenAiStrictFunctionTool[];
+  store: false;
+  parallel_tool_calls: false;
+  include: string[];
+  max_output_tokens?: number;
+  reasoning?: { effort: string };
+  metadata?: Record<string, string>;
+}
+
+export interface OpenAiResponsesResponse {
+  id?: string;
+  model?: string;
+  status?: string;
+  output?: OpenAiResponseOutputItem[];
+  output_text?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+    input_tokens_details?: { cached_tokens?: number };
+    output_tokens_details?: { reasoning_tokens?: number };
+  };
+  error?: { message?: string; code?: string; type?: string };
+  incomplete_details?: { reason?: string };
+}
+
+export interface OpenAiResponsesClient {
+  responses: {
+    create: (
+      request: OpenAiResponsesCreateRequest,
+      options?: { signal?: AbortSignal },
+    ) => Promise<OpenAiResponsesResponse>;
+  };
+}
+
+interface OpenAiTranscriptTurn {
+  iteration: number;
+  request: OpenAiResponsesCreateRequest;
+  response: OpenAiResponsesResponse | null;
+  outputItems: OpenAiResponseOutputItem[];
+  functionCallOutputs: OpenAiResponseInputItem[];
+  error?: EvalTraceError;
+}
+
+export interface OpenAiResponsesEvalResult {
+  ok: boolean;
+  answer: string;
+  failureClass: OpenAiEvalFailureClass;
+  failureMessage?: string;
+  trajectory: {
+    toolCalls: ToolTrajectoryStep[];
+    finalAnswer: string;
+    tokenUsage: TokenUsage;
+    model: string;
+    iterations: number;
+    stopReason: string | null;
+  };
+  trace: EvalTraceInput;
+}
+
+export interface RunOpenAiResponsesEvalCaseOptions {
+  client?: OpenAiResponsesClient;
+  evalCase: EvalCase;
+  providerConfig: EvalProviderConfig;
+  runLabel: string;
+  toolSurface: EvalToolSurface;
+  traceClient?: LangfuseTraceIngestionClient;
+  executeTool?: (name: string, input: Record<string, unknown>) => Promise<ToolCallResult>;
+  now?: () => Date;
+  env?: NodeJS.ProcessEnv;
+}
+
+export class OpenAiEvalRunnerError extends Error {
+  failureClass: Exclude<OpenAiEvalFailureClass, 'none'>;
+  status: number | undefined;
+
+  constructor(
+    failureClass: Exclude<OpenAiEvalFailureClass, 'none'>,
+    message: string,
+    status?: number,
+  ) {
+    super(message);
+    this.name = 'OpenAiEvalRunnerError';
+    this.failureClass = failureClass;
+    this.status = status;
+  }
+}
+
+export function classifyOpenAiResponsesFailure(
+  error: unknown,
+): Exclude<OpenAiEvalFailureClass, 'none'> {
+  if (error instanceof OpenAiEvalRunnerError) return error.failureClass;
+
+  const candidate = error as { name?: unknown; status?: unknown; message?: unknown };
+  if (candidate?.name === 'AbortError') return 'timeout';
+
+  const message = typeof candidate?.message === 'string' ? candidate.message : '';
+  if (/timeout|timed out|aborted/i.test(message)) return 'timeout';
+
+  if (candidate && typeof candidate.status === 'number') {
+    if (candidate.status === 401 || candidate.status === 403 || candidate.status === 404) {
+      return 'model_access';
+    }
+    return 'api_status';
+  }
+
+  return 'api_status';
+}
+
+export function createOpenAiResponsesClient(
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImpl: typeof fetch = fetch,
+): OpenAiResponsesClient {
+  const apiKey = env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new OpenAiEvalRunnerError('model_access', 'OPENAI_API_KEY is required for OpenAI evals.');
+  }
+
+  return {
+    responses: {
+      create: async (request, options) => {
+        const response = await fetchImpl('https://api.openai.com/v1/responses', {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${apiKey}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify(request),
+          signal: options?.signal,
+        });
+        const text = await response.text();
+        const parsed = parseOpenAiResponseBody(text, response.status);
+        if (!response.ok) {
+          const message =
+            parsed.error?.message ?? `OpenAI Responses API returned ${response.status}.`;
+          throw new OpenAiEvalRunnerError(
+            classifyStatus(response.status),
+            message,
+            response.status,
+          );
+        }
+        return parsed;
+      },
+    },
+  };
+}
+
+function parseOpenAiResponseBody(text: string, status: number): OpenAiResponsesResponse {
+  if (!text) return {};
+  try {
+    return JSON.parse(text) as OpenAiResponsesResponse;
+  } catch {
+    throw new OpenAiEvalRunnerError(
+      'api_status',
+      `OpenAI Responses API returned non-JSON body with status ${status}.`,
+      status,
+    );
+  }
+}
+
+function classifyStatus(status: number): Exclude<OpenAiEvalFailureClass, 'none'> {
+  return status === 401 || status === 403 || status === 404 ? 'model_access' : 'api_status';
+}
+
+function promptFor(toolSurface: EvalToolSurface): string {
+  return toolSurface === 'legacy' ? LEGACY_AGENT_SYSTEM_PROMPT : AGENT_SYSTEM_PROMPT;
+}
+
+function promptVersionFor(toolSurface: EvalToolSurface): string {
+  return toolSurface === 'legacy' ? 'legacy-agent-v1' : 'redesigned-agent-v1';
+}
+
+function sha256(value: string): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+function modelSettingsFor(config: EvalProviderConfig): Record<string, string | number | undefined> {
+  return {
+    reasoningEffort: config.reasoningEffort,
+    maxOutputTokens: config.maxOutputTokens,
+    timeoutMs: config.timeoutMs,
+    toolLoopLimit: config.toolLoopLimit,
+  };
+}
+
+function createResponsesRequest(
+  input: OpenAiResponseInputItem[],
+  evalCase: EvalCase,
+  providerConfig: EvalProviderConfig,
+  toolSurface: EvalToolSurface,
+): OpenAiResponsesCreateRequest {
+  const request: OpenAiResponsesCreateRequest = {
+    model: providerConfig.model,
+    instructions: promptFor(toolSurface),
+    input: [...input],
+    tools: renderOpenAiStrictToolSchemas(),
+    store: false,
+    parallel_tool_calls: false,
+    include: ['reasoning.encrypted_content'],
+    metadata: {
+      dataset: DATASET_NAME,
+      caseId: evalCase.id,
+    },
+  };
+  if (providerConfig.maxOutputTokens) request.max_output_tokens = providerConfig.maxOutputTokens;
+  if (providerConfig.reasoningEffort)
+    request.reasoning = { effort: providerConfig.reasoningEffort };
+  return request;
+}
+
+function functionCallItems(response: OpenAiResponsesResponse): Array<{
+  id?: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+}> {
+  return (response.output ?? []).filter(
+    (
+      item,
+    ): item is {
+      id?: string;
+      call_id: string;
+      name: string;
+      arguments: string;
+    } => {
+      return (
+        item.type === 'function_call' &&
+        typeof item.call_id === 'string' &&
+        typeof item.name === 'string' &&
+        typeof item.arguments === 'string'
+      );
+    },
+  );
+}
+
+function parseFunctionArguments(item: {
+  name: string;
+  arguments: string;
+}): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = item.arguments ? JSON.parse(item.arguments) : {};
+  } catch (error) {
+    throw new OpenAiEvalRunnerError(
+      'schema',
+      `Invalid JSON arguments for ${item.name}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new OpenAiEvalRunnerError(
+      'schema',
+      `Invalid arguments for ${item.name}: expected a JSON object.`,
+    );
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function extractFinalAnswer(response: OpenAiResponsesResponse): string {
+  if (typeof response.output_text === 'string' && response.output_text.trim()) {
+    return response.output_text.trim();
+  }
+
+  const texts: string[] = [];
+  for (const item of response.output ?? []) {
+    if (item.type !== 'message' || !Array.isArray(item.content)) continue;
+    for (const content of item.content as Array<Record<string, unknown>>) {
+      if (
+        (content.type === 'output_text' || content.type === 'text') &&
+        typeof content.text === 'string' &&
+        content.text.trim()
+      ) {
+        texts.push(content.text.trim());
+      }
+    }
+  }
+  return texts.join('\n\n');
+}
+
+function addUsage(
+  total: {
+    input: number;
+    output: number;
+    reasoning: number;
+    cached: number;
+    total: number;
+  },
+  response: OpenAiResponsesResponse,
+): void {
+  const usage = response.usage;
+  if (!usage) return;
+  total.input += usage.input_tokens ?? 0;
+  total.output += usage.output_tokens ?? 0;
+  total.reasoning += usage.output_tokens_details?.reasoning_tokens ?? 0;
+  total.cached += usage.input_tokens_details?.cached_tokens ?? 0;
+  total.total += usage.total_tokens ?? (usage.input_tokens ?? 0) + (usage.output_tokens ?? 0);
+}
+
+function tokenUsageForAgent(total: { input: number; output: number; total: number }): TokenUsage {
+  return {
+    inputTokens: total.input,
+    outputTokens: total.output,
+    totalTokens: total.total,
+  };
+}
+
+function collectCanonicalRefs(value: unknown, refs = new Set<string>()): Set<string> {
+  if (!value || typeof value !== 'object') return refs;
+  if (Array.isArray(value)) {
+    for (const item of value) collectCanonicalRefs(item, refs);
+    return refs;
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    if ((key === 'ref' || key === 'sourceId') && typeof nested === 'string') {
+      refs.add(nested);
+    } else {
+      collectCanonicalRefs(nested, refs);
+    }
+  }
+  return refs;
+}
+
+function summarizeToolOutput(content: string): { summary: string; canonicalRefs: string[] } {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    const canonicalRefs = [...collectCanonicalRefs(parsed)];
+    if (Array.isArray(parsed)) {
+      return {
+        summary: `json array (${parsed.length} item${parsed.length === 1 ? '' : 's'})`,
+        canonicalRefs,
+      };
+    }
+    if (parsed && typeof parsed === 'object') {
+      return {
+        summary: `json object (${Object.keys(parsed).slice(0, 8).join(', ') || 'no keys'})`,
+        canonicalRefs,
+      };
+    }
+    return { summary: `json ${typeof parsed}`, canonicalRefs };
+  } catch {
+    return {
+      summary: content.length > 240 ? `${content.slice(0, 237)}...` : content,
+      canonicalRefs: [],
+    };
+  }
+}
+
+function errorTrace(
+  type: Exclude<OpenAiEvalFailureClass, 'none'>,
+  message: string,
+): EvalTraceError {
+  return { type, message, retryable: type === 'timeout' || type === 'api_status' };
+}
+
+function durationMsBetween(startIso: string, endIso: string): number {
+  return Math.max(0, new Date(endIso).getTime() - new Date(startIso).getTime());
+}
+
+async function createResponseWithTimeout(
+  client: OpenAiResponsesClient,
+  request: OpenAiResponsesCreateRequest,
+  timeoutMs: number | undefined,
+): Promise<OpenAiResponsesResponse> {
+  if (!timeoutMs) return client.responses.create(request);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await client.responses.create(request, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function runOpenAiResponsesEvalCase(
+  options: RunOpenAiResponsesEvalCaseOptions,
+): Promise<OpenAiResponsesEvalResult> {
+  const client = options.client ?? createOpenAiResponsesClient(options.env);
+  const executeTool = options.executeTool ?? executeOpenAiToolCall;
+  const now = options.now ?? (() => new Date());
+  const startedAt = now().toISOString();
+  const input: OpenAiResponseInputItem[] = [
+    {
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_text', text: options.evalCase.question }],
+    },
+  ];
+  const requests: OpenAiResponsesCreateRequest[] = [];
+  const responses: OpenAiResponsesResponse[] = [];
+  const transcriptTurns: OpenAiTranscriptTurn[] = [];
+  const toolCalls: ToolTrajectoryStep[] = [];
+  const traceToolCalls: EvalTraceToolCall[] = [];
+  const errors: EvalTraceError[] = [];
+  const tokenUsage = { input: 0, output: 0, reasoning: 0, cached: 0, total: 0 };
+  let resolvedModel: string = options.providerConfig.model;
+  let iterations = 0;
+
+  const buildTrace = (
+    statusReason: string,
+    stopReason: string,
+    finalAnswer: string | null,
+  ): EvalTraceInput => {
+    const endedAt = now().toISOString();
+    return {
+      traceId: `eval:${options.runLabel}:${options.evalCase.id}:openai`,
+      runLabel: options.runLabel,
+      datasetName: DATASET_NAME,
+      caseId: options.evalCase.id,
+      caseCategory: options.evalCase.category,
+      provider: 'openai',
+      model: options.providerConfig.model,
+      resolvedModel,
+      promptVersion: promptVersionFor(options.toolSurface),
+      promptHash: sha256(promptFor(options.toolSurface)),
+      toolSurface: options.toolSurface,
+      toolSchemaVersion: OPENAI_TOOL_SCHEMA_VERSION,
+      toolSchemaHash: getOpenAiToolSchemaHash(),
+      modelSettings: modelSettingsFor(options.providerConfig),
+      inputQuestion: options.evalCase.question,
+      finalAnswer,
+      statusReason,
+      stopReason,
+      startedAt,
+      endedAt,
+      durationMs: durationMsBetween(startedAt, endedAt),
+      providerRequest: requests,
+      providerResponse: responses,
+      providerNativeTranscript: {
+        contractVersion: TRACE_CONTRACT_VERSION,
+        mode: 'stateless-responses',
+        usesPreviousResponseId: false,
+        turns: transcriptTurns,
+      },
+      tokenUsage,
+      costEstimate: {
+        promptUsd: 0,
+        completionUsd: 0,
+        reasoningUsd: 0,
+        totalUsd: 0,
+      },
+      errors,
+      retries: [],
+      toolCalls: traceToolCalls,
+      judgeScores: [
+        { name: 'failure_class', value: statusReason },
+        { name: 'tool_call_count', value: toolCalls.length },
+        { name: 'loop_iterations', value: iterations },
+      ],
+    };
+  };
+
+  const finish = async (
+    ok: boolean,
+    answer: string,
+    failureClass: OpenAiEvalFailureClass,
+    stopReason: string,
+    failureMessage?: string,
+  ): Promise<OpenAiResponsesEvalResult> => {
+    const trace = buildTrace(ok ? 'completed' : failureClass, stopReason, ok ? answer : null);
+    if (options.traceClient) await writeEvalTrace(options.traceClient, trace);
+    return {
+      ok,
+      answer,
+      failureClass,
+      failureMessage,
+      trajectory: {
+        toolCalls,
+        finalAnswer: answer,
+        tokenUsage: tokenUsageForAgent(tokenUsage),
+        model: resolvedModel,
+        iterations,
+        stopReason,
+      },
+      trace,
+    };
+  };
+
+  for (let i = 0; i < (options.providerConfig.toolLoopLimit ?? 10); i++) {
+    iterations = i + 1;
+    const request = createResponsesRequest(
+      input,
+      options.evalCase,
+      options.providerConfig,
+      options.toolSurface,
+    );
+    requests.push(request);
+    const turn: OpenAiTranscriptTurn = {
+      iteration: iterations,
+      request,
+      response: null,
+      outputItems: [],
+      functionCallOutputs: [],
+    };
+    transcriptTurns.push(turn);
+
+    let response: OpenAiResponsesResponse;
+    try {
+      response = await createResponseWithTimeout(client, request, options.providerConfig.timeoutMs);
+    } catch (error) {
+      const failureClass = classifyOpenAiResponsesFailure(error);
+      const message = error instanceof Error ? error.message : String(error);
+      const traceError = errorTrace(failureClass, message);
+      errors.push(traceError);
+      turn.error = traceError;
+      return finish(false, '', failureClass, failureClass, message);
+    }
+
+    responses.push(response);
+    turn.response = response;
+    turn.outputItems = response.output ?? [];
+    input.push(...turn.outputItems);
+    if (response.model) resolvedModel = response.model;
+    addUsage(tokenUsage, response);
+
+    if (response.status === 'failed' || response.status === 'cancelled') {
+      const message =
+        response.error?.message ??
+        response.incomplete_details?.reason ??
+        `OpenAI response ${response.status}`;
+      const traceError = errorTrace('api_status', message);
+      errors.push(traceError);
+      turn.error = traceError;
+      return finish(false, '', 'api_status', response.status, message);
+    }
+
+    const calls = functionCallItems(response);
+    if (calls.length === 0) {
+      const answer = extractFinalAnswer(response);
+      if (!answer) {
+        const message = 'OpenAI response completed with an empty final answer.';
+        errors.push(errorTrace('answer_quality', message));
+        return finish(false, '', 'answer_quality', 'empty_final_answer', message);
+      }
+      return finish(true, answer, 'none', response.status ?? 'completed');
+    }
+
+    for (const call of calls) {
+      let parsedArguments: Record<string, unknown>;
+      try {
+        parsedArguments = parseFunctionArguments(call);
+      } catch (error) {
+        const failureClass = classifyOpenAiResponsesFailure(error);
+        const message = error instanceof Error ? error.message : String(error);
+        const traceError = errorTrace(failureClass, message);
+        errors.push(traceError);
+        turn.error = traceError;
+        return finish(false, '', failureClass, failureClass, message);
+      }
+
+      const toolStartedAt = now().toISOString();
+      let toolResult: ToolCallResult;
+      let toolOk = true;
+      let toolError: EvalTraceError | undefined;
+      try {
+        toolResult = await executeTool(call.name, parsedArguments);
+      } catch (error) {
+        toolOk = false;
+        const message = error instanceof Error ? error.message : String(error);
+        toolError = errorTrace('tool_execution', message);
+        toolResult = { content: `Tool error: ${message}` };
+      }
+      const toolEndedAt = now().toISOString();
+      const toolDurationMs = durationMsBetween(toolStartedAt, toolEndedAt);
+      const summary = summarizeToolOutput(toolResult.content);
+
+      toolCalls.push({
+        iteration: iterations,
+        id: call.id ?? call.call_id,
+        name: call.name,
+        input: parsedArguments,
+        ok: toolOk,
+        outputSummary: summary.summary,
+        sourceLabels: toolResult.sourceBooks ?? [],
+        canonicalRefs: summary.canonicalRefs,
+        ...(toolError ? { error: toolError.message } : {}),
+        startedAt: toolStartedAt,
+        endedAt: toolEndedAt,
+        durationMs: toolDurationMs,
+      });
+      traceToolCalls.push({
+        id: `eval:${options.runLabel}:${options.evalCase.id}:tool:${traceToolCalls.length}`,
+        toolName: call.name,
+        toolCallId: call.id,
+        providerToolCallId: call.call_id,
+        callIndex: traceToolCalls.length,
+        arguments: parsedArguments,
+        result: toolResult.content,
+        ok: toolOk,
+        startedAt: toolStartedAt,
+        endedAt: toolEndedAt,
+        durationMs: toolDurationMs,
+        sourceLabels: toolResult.sourceBooks ?? [],
+        canonicalRefs: summary.canonicalRefs,
+        errors: toolError ? [toolError] : [],
+        retries: [],
+      });
+
+      if (toolError) {
+        errors.push(toolError);
+        turn.error = toolError;
+        return finish(false, '', 'tool_execution', 'tool_execution', toolError.message);
+      }
+
+      const outputItem = {
+        type: 'function_call_output',
+        call_id: call.call_id,
+        output: toolResult.content,
+      };
+      turn.functionCallOutputs.push(outputItem);
+      input.push(outputItem);
+    }
+  }
+
+  const message = `OpenAI Responses loop reached ${options.providerConfig.toolLoopLimit ?? 10} iteration(s) without a final answer.`;
+  errors.push(errorTrace('loop_limit', message));
+  return finish(false, '', 'loop_limit', 'loop_limit', message);
+}
+
+export async function runOpenAiLocalReport(
+  cases: EvalCase[],
+  runLabel: string,
+  providerConfig: EvalProviderConfig,
+  toolSurface: EvalToolSurface,
+  outputPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const client = createOpenAiResponsesClient(env);
+  const results = [];
+  for (const evalCase of cases) {
+    process.stdout.write(`  ${evalCase.id}... `);
+    const result = await runOpenAiResponsesEvalCase({
+      client,
+      evalCase,
+      providerConfig,
+      runLabel,
+      toolSurface,
+      env,
+    });
+    console.log(result.ok ? '\u2713' : '\u2717');
+    results.push({
+      id: evalCase.id,
+      category: evalCase.category,
+      question: evalCase.question,
+      answer: result.answer,
+      ok: result.ok,
+      failureClass: result.failureClass,
+      failureMessage: result.failureMessage,
+      trajectory: result.trajectory,
+      trace: result.trace,
+    });
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    runLabel,
+    provider: 'openai',
+    model: providerConfig.model,
+    datasetName: DATASET_NAME,
+    results,
+  };
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(`\nWrote OpenAI eval report: ${outputPath}`);
+}

--- a/eval/openai-runner.ts
+++ b/eval/openai-runner.ts
@@ -490,7 +490,7 @@ export async function runOpenAiResponsesEvalCase(
       retries: [],
       toolCalls: traceToolCalls,
       judgeScores: [
-        { name: 'failure_class', value: statusReason },
+        { name: 'failure_class', value: statusReason === 'completed' ? 'none' : statusReason },
         { name: 'tool_call_count', value: toolCalls.length },
         { name: 'loop_iterations', value: iterations },
       ],

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -5,6 +5,7 @@ import { filterEvalCases, loadEvalCases, seedDataset } from './dataset.ts';
 import { evalCaseHasFinalAnswer } from './schema.ts';
 import { runFiltered, runOnDataset } from './experiments.ts';
 import { runLocalReport } from './local-report.ts';
+import { runOpenAiLocalReport } from './openai-runner.ts';
 
 function describeProviderConfig(config: EvalProviderConfig): string {
   const tuning = [
@@ -18,6 +19,8 @@ function describeProviderConfig(config: EvalProviderConfig): string {
 }
 
 function assertCurrentRunnerSupportsProviderConfig(config: EvalProviderConfig): void {
+  if (config.provider === 'openai') return;
+
   const usesDefaultModel = config.provider === 'anthropic' && config.model === 'claude-sonnet-4-6';
   const hasFutureRunnerTuning =
     config.reasoningEffort || config.maxOutputTokens || config.timeoutMs || config.toolLoopLimit;
@@ -59,6 +62,26 @@ export async function runEval(options: EvalCliOptions, env: NodeJS.ProcessEnv = 
   }
 
   assertCurrentRunnerSupportsProviderConfig(options.providerConfig);
+
+  if (options.providerConfig.provider === 'openai') {
+    if (!options.localReportPath) {
+      throw new Error(
+        'OpenAI Responses evals currently require --local-report so the SQR-127 trace artifacts are written to a local report. Langfuse matrix wiring lands in SQR-131.',
+      );
+    }
+    console.log(
+      `Running ${cases.length} OpenAI eval(s) as "${options.runName}" on ${options.toolSurface} tools...\n`,
+    );
+    await runOpenAiLocalReport(
+      cases,
+      options.runName,
+      options.providerConfig,
+      options.toolSurface,
+      options.localReportPath,
+      env,
+    );
+    return;
+  }
 
   if (options.localReportPath) {
     console.log(

--- a/eval/trace.ts
+++ b/eval/trace.ts
@@ -177,6 +177,14 @@ function generationIdFor(input: EvalTraceInput): string {
   return input.generationId ?? `${input.traceId}:generation`;
 }
 
+function scoreIdFor(input: EvalTraceInput, score: EvalTraceScore): string {
+  return `${input.traceId}:score:${score.name}`;
+}
+
+function scoreDataTypeFor(score: EvalTraceScore): string {
+  return typeof score.value === 'number' ? 'NUMERIC' : 'CATEGORICAL';
+}
+
 function timestampFor(input: EvalTraceInput): string {
   return input.startedAt;
 }
@@ -273,15 +281,18 @@ export function buildEvalTraceIngestionBatch(input: EvalTraceInput): EvalTraceIn
     });
   });
 
-  const scoreEvents = input.judgeScores.map((score) =>
-    event('score-create', `${input.traceId}:score:${score.name}`, timestamp, {
+  const scoreEvents = input.judgeScores.map((score) => {
+    const scoreId = scoreIdFor(input, score);
+    return event('score-create', `${scoreId}:score-create`, timestamp, {
+      id: scoreId,
       traceId: input.traceId,
       name: score.name,
       value: score.value,
+      dataType: scoreDataTypeFor(score),
       comment: score.comment,
       metadata: redactTracePayload(score.metadata ?? {}),
-    }),
-  );
+    });
+  });
 
   return {
     batch: [traceEvent, generationEvent, ...toolEvents, ...scoreEvents],
@@ -295,5 +306,12 @@ export async function writeEvalTrace(
   client: LangfuseTraceIngestionClient,
   input: EvalTraceInput,
 ): Promise<void> {
-  await client.api.ingestion.batch(buildEvalTraceIngestionBatch(input));
+  const response = await client.api.ingestion.batch(buildEvalTraceIngestionBatch(input));
+  const errors =
+    response && typeof response === 'object' && 'errors' in response
+      ? (response.errors as unknown)
+      : undefined;
+  if (Array.isArray(errors) && errors.length > 0) {
+    throw new Error(`Langfuse trace ingestion failed: ${JSON.stringify(errors)}`);
+  }
 }

--- a/test/eval-anthropic-runner.test.ts
+++ b/test/eval-anthropic-runner.test.ts
@@ -240,6 +240,12 @@ describe('SQR-128 Anthropic eval runner', () => {
         traceId: 'trace-quality',
         statusReason: 'quality',
         judgeScores: [
+          { name: 'failure_class', value: 'quality' },
+          { name: 'tool_call_count', value: 1 },
+          { name: 'retry_count', value: 0 },
+          { name: 'loop_iterations', value: 2 },
+          { name: 'model_latency_ms', value: 1500 },
+          { name: 'model_cost_usd', value: 0 },
           { name: 'correctness', value: 0.4, comment: 'Missing upgrade distinction.' },
           { name: 'pass', value: 'fail', comment: 'Expected upgrade cost distinction.' },
         ],

--- a/test/eval-openai-runner.test.ts
+++ b/test/eval-openai-runner.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { EvalProviderConfig } from '../eval/cli.ts';
+import {
+  OpenAiEvalRunnerError,
+  classifyOpenAiResponsesFailure,
+  createOpenAiResponsesClient,
+  runOpenAiResponsesEvalCase,
+  type OpenAiResponsesClient,
+} from '../eval/openai-runner.ts';
+import type { EvalCase } from '../eval/schema.ts';
+import { TRACE_CONTRACT_VERSION } from '../eval/trace-contract.ts';
+
+const providerConfig: EvalProviderConfig = {
+  provider: 'openai',
+  model: 'gpt-5.5',
+  reasoningEffort: 'low',
+  maxOutputTokens: 1024,
+  timeoutMs: 30_000,
+  toolLoopLimit: 4,
+};
+
+const evalCase: EvalCase = {
+  id: 'item-spyglass',
+  category: 'card-data',
+  source: 'unit-test',
+  question: 'What does Spyglass do?',
+  finalAnswer: {
+    expected: 'Spyglass reveals cards.',
+    grading: 'Mentions Spyglass effect.',
+  },
+};
+
+function responsesClient(...responses: unknown[]): OpenAiResponsesClient {
+  const create = vi.fn();
+  for (const response of responses) {
+    create.mockResolvedValueOnce(response);
+  }
+  return { responses: { create } };
+}
+
+describe('OpenAI Responses eval runner', () => {
+  it('runs a manual stateless Responses tool loop without previous_response_id', async () => {
+    const reasoningItem = {
+      type: 'reasoning',
+      id: 'rs_1',
+      encrypted_content: 'opaque-reasoning',
+    };
+    const toolCallItem = {
+      type: 'function_call',
+      id: 'fc_1',
+      call_id: 'call_1',
+      name: 'search_cards',
+      arguments: '{"query":"Spyglass","topK":null}',
+    };
+    const client = responsesClient(
+      {
+        id: 'resp_1',
+        model: 'gpt-5.5-2026-04-23',
+        status: 'completed',
+        output: [reasoningItem, toolCallItem],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      },
+      {
+        id: 'resp_2',
+        model: 'gpt-5.5-2026-04-23',
+        status: 'completed',
+        output: [
+          {
+            type: 'message',
+            id: 'msg_1',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Spyglass reveals the top card.' }],
+          },
+        ],
+        output_text: 'Spyglass reveals the top card.',
+        usage: {
+          input_tokens: 20,
+          output_tokens: 8,
+          total_tokens: 28,
+          output_tokens_details: { reasoning_tokens: 2 },
+        },
+      },
+    );
+    const executeTool = vi.fn().mockResolvedValue({
+      content: '[{"name":"Spyglass","effect":"Reveal the top card."}]',
+      sourceBooks: ['Items'],
+    });
+
+    const result = await runOpenAiResponsesEvalCase({
+      client,
+      evalCase,
+      providerConfig,
+      runLabel: 'unit-openai',
+      toolSurface: 'redesigned',
+      executeTool,
+      now: () => new Date('2026-05-01T00:00:00.000Z'),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.answer).toBe('Spyglass reveals the top card.');
+    expect(result.failureClass).toBe('none');
+    expect(executeTool).toHaveBeenCalledWith('search_cards', { query: 'Spyglass', topK: null });
+
+    const create = vi.mocked(client.responses.create);
+    expect(create).toHaveBeenCalledTimes(2);
+
+    const firstRequest = create.mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+    expect(firstRequest).toMatchObject({
+      model: 'gpt-5.5',
+      store: false,
+      parallel_tool_calls: false,
+      max_output_tokens: 1024,
+      reasoning: { effort: 'low' },
+    });
+    expect(firstRequest).not.toHaveProperty('previous_response_id');
+    expect(firstRequest.tools).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'search_cards', strict: true })]),
+    );
+
+    const secondRequest = create.mock.calls[1]?.[0] as { input: unknown[] };
+    expect(secondRequest).not.toHaveProperty('previous_response_id');
+    expect(secondRequest.input).toEqual(
+      expect.arrayContaining([
+        reasoningItem,
+        toolCallItem,
+        {
+          type: 'function_call_output',
+          call_id: 'call_1',
+          output: '[{"name":"Spyglass","effect":"Reveal the top card."}]',
+        },
+      ]),
+    );
+
+    expect(result.trajectory.toolCalls).toEqual([
+      expect.objectContaining({
+        iteration: 1,
+        id: 'fc_1',
+        name: 'search_cards',
+        ok: true,
+        sourceLabels: ['Items'],
+      }),
+    ]);
+    expect(result.trace).toMatchObject({
+      runLabel: 'unit-openai',
+      provider: 'openai',
+      model: 'gpt-5.5',
+      resolvedModel: 'gpt-5.5-2026-04-23',
+      caseId: 'item-spyglass',
+      caseCategory: 'card-data',
+      toolSurface: 'redesigned',
+      statusReason: 'completed',
+      stopReason: 'completed',
+      finalAnswer: 'Spyglass reveals the top card.',
+      tokenUsage: {
+        input: 30,
+        output: 13,
+        reasoning: 2,
+        total: 43,
+      },
+      toolCalls: [
+        expect.objectContaining({
+          toolName: 'search_cards',
+          providerToolCallId: 'call_1',
+          arguments: { query: 'Spyglass', topK: null },
+          result: '[{"name":"Spyglass","effect":"Reveal the top card."}]',
+        }),
+      ],
+      errors: [],
+    });
+    expect(result.trace.providerNativeTranscript).toMatchObject({
+      contractVersion: TRACE_CONTRACT_VERSION,
+      turns: [
+        expect.objectContaining({
+          response: expect.objectContaining({ id: 'resp_1' }),
+          outputItems: [reasoningItem, toolCallItem],
+          functionCallOutputs: [
+            {
+              type: 'function_call_output',
+              call_id: 'call_1',
+              output: '[{"name":"Spyglass","effect":"Reveal the top card."}]',
+            },
+          ],
+        }),
+        expect.objectContaining({
+          response: expect.objectContaining({ id: 'resp_2' }),
+        }),
+      ],
+    });
+  });
+
+  it('writes SQR-127 trace artifacts when a trace client is provided', async () => {
+    const client = responsesClient({
+      id: 'resp_final',
+      model: 'gpt-5.5-2026-04-23',
+      status: 'completed',
+      output_text: 'Done.',
+      output: [{ type: 'message', content: [{ type: 'output_text', text: 'Done.' }] }],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    });
+    const batch = vi.fn();
+
+    await runOpenAiResponsesEvalCase({
+      client,
+      evalCase,
+      providerConfig,
+      runLabel: 'trace-run',
+      toolSurface: 'redesigned',
+      traceClient: { api: { ingestion: { batch } } },
+    });
+
+    expect(batch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { contractVersion: TRACE_CONTRACT_VERSION },
+        batch: expect.arrayContaining([
+          expect.objectContaining({ type: 'trace-create' }),
+          expect.objectContaining({ type: 'generation-create' }),
+        ]),
+      }),
+    );
+  });
+
+  it('classifies schema failures from malformed function-call arguments', async () => {
+    const client = responsesClient({
+      id: 'resp_bad_args',
+      model: 'gpt-5.5-2026-04-23',
+      status: 'completed',
+      output: [
+        {
+          type: 'function_call',
+          id: 'fc_bad',
+          call_id: 'call_bad',
+          name: 'search_cards',
+          arguments: '{"query":',
+        },
+      ],
+    });
+
+    const result = await runOpenAiResponsesEvalCase({
+      client,
+      evalCase,
+      providerConfig,
+      runLabel: 'schema-failure',
+      toolSurface: 'redesigned',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failureClass).toBe('schema');
+    expect(result.trace.errors).toEqual([
+      expect.objectContaining({
+        type: 'schema',
+        message: expect.stringContaining('Invalid JSON arguments'),
+      }),
+    ]);
+  });
+
+  it('classifies tool execution failures', async () => {
+    const client = responsesClient({
+      id: 'resp_tool',
+      model: 'gpt-5.5-2026-04-23',
+      status: 'completed',
+      output: [
+        {
+          type: 'function_call',
+          id: 'fc_tool',
+          call_id: 'call_tool',
+          name: 'search_cards',
+          arguments: '{"query":"Spyglass"}',
+        },
+      ],
+    });
+
+    const result = await runOpenAiResponsesEvalCase({
+      client,
+      evalCase,
+      providerConfig,
+      runLabel: 'tool-failure',
+      toolSurface: 'redesigned',
+      executeTool: vi.fn().mockRejectedValue(new Error('tool exploded')),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failureClass).toBe('tool_execution');
+    expect(result.trace.toolCalls).toEqual([
+      expect.objectContaining({
+        ok: false,
+        errors: [expect.objectContaining({ type: 'tool_execution', message: 'tool exploded' })],
+      }),
+    ]);
+  });
+
+  it('classifies answer-quality failures when the model returns no text', async () => {
+    const client = responsesClient({
+      id: 'resp_empty',
+      model: 'gpt-5.5-2026-04-23',
+      status: 'completed',
+      output: [{ type: 'message', content: [] }],
+    });
+
+    const result = await runOpenAiResponsesEvalCase({
+      client,
+      evalCase,
+      providerConfig,
+      runLabel: 'empty-answer',
+      toolSurface: 'redesigned',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failureClass).toBe('answer_quality');
+    expect(result.trace.errors).toEqual([
+      expect.objectContaining({
+        type: 'answer_quality',
+        message: expect.stringContaining('empty final answer'),
+      }),
+    ]);
+  });
+
+  it('classifies model access, API status, and timeout failures', () => {
+    expect(classifyOpenAiResponsesFailure({ status: 401, message: 'missing model' })).toBe(
+      'model_access',
+    );
+    expect(classifyOpenAiResponsesFailure({ status: 429, message: 'rate limited' })).toBe(
+      'api_status',
+    );
+    expect(classifyOpenAiResponsesFailure(new DOMException('aborted', 'AbortError'))).toBe(
+      'timeout',
+    );
+    expect(classifyOpenAiResponsesFailure(new OpenAiEvalRunnerError('schema', 'bad schema'))).toBe(
+      'schema',
+    );
+  });
+
+  it('classifies non-JSON OpenAI API responses as API status failures', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('bad gateway', { status: 502 }));
+    const client = createOpenAiResponsesClient(
+      { OPENAI_API_KEY: 'test-key' } as NodeJS.ProcessEnv,
+      fetchImpl as typeof fetch,
+    );
+
+    await expect(
+      client.responses.create({
+        model: 'gpt-5.5',
+        instructions: 'Answer the question.',
+        input: [],
+        tools: [],
+        store: false,
+        parallel_tool_calls: false,
+        include: [],
+      }),
+    ).rejects.toMatchObject({
+      failureClass: 'api_status',
+      status: 502,
+      message: 'OpenAI Responses API returned non-JSON body with status 502.',
+    });
+  });
+});

--- a/test/eval-openai-runner.test.ts
+++ b/test/eval-openai-runner.test.ts
@@ -168,6 +168,9 @@ describe('OpenAI Responses eval runner', () => {
       ],
       errors: [],
     });
+    expect(result.trace.judgeScores).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'failure_class', value: 'none' })]),
+    );
     expect(result.trace.providerNativeTranscript).toMatchObject({
       contractVersion: TRACE_CONTRACT_VERSION,
       turns: [

--- a/test/eval-trace.test.ts
+++ b/test/eval-trace.test.ts
@@ -238,22 +238,35 @@ describe('SQR-127 eval trace writer', () => {
 
     expect(scores).toEqual([
       expect.objectContaining({
+        id: 'trace-case-1:score:correctness:score-create',
         body: expect.objectContaining({
+          id: 'trace-case-1:score:correctness',
           traceId: 'trace-case-1',
           name: 'correctness',
           value: 1,
+          dataType: 'NUMERIC',
           comment: 'Expected detail present.',
           metadata: { playerId: '[REDACTED]' },
         }),
       }),
       expect.objectContaining({
-        body: expect.objectContaining({ traceId: 'trace-case-1', name: 'pass', value: 'pass' }),
+        id: 'trace-case-1:score:pass:score-create',
+        body: expect.objectContaining({
+          id: 'trace-case-1:score:pass',
+          traceId: 'trace-case-1',
+          name: 'pass',
+          value: 'pass',
+          dataType: 'CATEGORICAL',
+        }),
       }),
       expect.objectContaining({
+        id: 'trace-case-1:score:tool_call_count:score-create',
         body: expect.objectContaining({
+          id: 'trace-case-1:score:tool_call_count',
           traceId: 'trace-case-1',
           name: 'tool_call_count',
           value: 1,
+          dataType: 'NUMERIC',
         }),
       }),
     ]);
@@ -325,5 +338,22 @@ describe('SQR-127 eval trace writer', () => {
     expect(JSON.stringify(batches[0])).not.toContain('sk-tool-secret');
     expect(JSON.stringify(batches[0])).not.toContain('session-secret');
     expect(JSON.stringify(batches[0])).not.toContain('player@example.test');
+  });
+
+  it('fails when Langfuse accepts a batch with per-event ingestion errors', async () => {
+    const client: LangfuseTraceIngestionClient = {
+      api: {
+        ingestion: {
+          batch: async () => ({
+            successes: [],
+            errors: [{ id: 'score-event', status: 400, message: 'invalid score' }],
+          }),
+        },
+      },
+    };
+
+    await expect(writeEvalTrace(client, baseTrace)).rejects.toThrow(
+      'Langfuse trace ingestion failed',
+    );
   });
 });


### PR DESCRIPTION
## Summary
Adds the eval-only OpenAI Responses runner for SQR-129.

- Adds a stateless OpenAI Responses loop with `store: false`, no `previous_response_id`, strict Squire tool schemas, native transcript preservation, and normalized failure classes.
- Wires OpenAI selected-case evals into `npm run eval` behind `--local-report`, leaving full Langfuse matrix execution to SQR-131.
- Writes SQR-127 trace artifacts for OpenAI runs and fixes Langfuse score ingestion so scores are queryable by stable IDs and explicit data types.
- Keeps Anthropic metric scores when judge scores are present, folding in the CodeRabbit nit from PR #300.
- Documents the SQR-129 runner shape in `docs/plans/sqr-129-openai-responses-runner.md`.

Fixes SQR-129

## Test Coverage
OpenAI runner coverage includes:

- stateless Responses tool loop with native output replay and no `previous_response_id`
- trace writing through the SQR-127 ingestion contract
- malformed function-call argument classification
- tool execution failure classification
- empty-final-answer classification
- API status, model access, timeout, and non-JSON provider body handling

Anthropic coverage was extended for preserving metric scores alongside explicit judge scores.

## Pre-Landing Review
Pre-Landing Review: No issues found.

Scope Check: CLEAN
Intent: Add the SQR-129 OpenAI Responses eval runner and preserve trace/debug evidence.
Delivered: OpenAI eval runner, local-report CLI path, Langfuse score readback fix, Anthropic metric-score preservation, and focused tests/docs.

## Design Review
No frontend files changed — design review skipped.

## Eval Results
Live exploratory QA completed before shipping:

- OpenAI selected-case run passed for `item-spyglass`.
- Langfuse ingestion/readback was verified after the score-ID fix.
- Sanity trace readback confirmed model generation, provider payloads, native transcript, tool spans, and three queryable scores.

## Plan Completion
Plan: `docs/plans/sqr-129-openai-responses-runner.md`

- [x] Add eval-only OpenAI Responses runner.
- [x] Use stateless manual Responses loop without `previous_response_id`.
- [x] Preserve provider-native output items and function outputs in trace artifacts.
- [x] Normalize failure classes.
- [x] Require `--local-report` for OpenAI selected-case runs until SQR-131.

## Verification Results
- [x] `npm run check` passed: typecheck, ESLint, Stylelint, markdownlint, Prettier check, and Vitest.
- [x] Vitest passed: 59 files, 980 tests.
- [x] Focused OpenAI runner tests passed.
- [x] Focused Anthropic runner tests passed.
- [x] Focused trace tests passed.

## TODOS
No `TODOS.md` items completed in this PR.

## Test plan
- [x] `npm run check`
- [x] Live OpenAI selected-case smoke
- [x] Live Langfuse trace and score readback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI Responses evaluation runner with tool-enabled, iterative responses handling and local-report mode.
  * Enhanced score merging to combine baseline metrics with judge-produced scores.
  * Implemented failure classification for eval errors and richer trace metadata (data types, score IDs).

* **Documentation**
  * Added planning document describing the OpenAI Responses runner behavior and trace format; CLI requires --local-report for selected-case smoke runs.

* **Tests**
  * Added comprehensive tests for OpenAI runner, trace ingestion, and failure classifications; strengthened score-event assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->