### PR TITLE
Add side-by-side eval matrix runner

### DIFF
--- a/eval/anthropic-runner.ts
+++ b/eval/anthropic-runner.ts
@@ -13,6 +13,7 @@ import { DATASET_NAME } from './dataset.ts';
 import {
   writeEvalTrace,
   type EvalTraceScore,
+  type EvalTraceInput,
   type EvalTraceToolCall,
   type LangfuseTraceIngestionClient,
 } from './trace.ts';
@@ -32,6 +33,7 @@ export interface AnthropicEvalCaseResult extends AgentRunResult {
   durationMs: number;
   toolSurface: EvalToolSurface;
   traceId: string;
+  trace: EvalTraceInput;
 }
 
 export interface RunAnthropicEvalCaseOptions {
@@ -174,9 +176,7 @@ async function writeSuccessTrace(
   endedAt: string,
   durationMs: number,
   resultScores: EvalTraceScore[] | undefined,
-): Promise<void> {
-  if (!options.traceClient) return;
-
+): Promise<EvalTraceInput> {
   const scores = resultScores ?? options.judgeScores ?? [];
   const statusReason = classifyAnthropicEvalStatus({
     toolCalls: result.trajectory.toolCalls,
@@ -184,7 +184,7 @@ async function writeSuccessTrace(
   });
   const judgeScores = mergeMetricScores(scoresForResult(result, statusReason), scores);
 
-  await writeEvalTrace(options.traceClient, {
+  const trace: EvalTraceInput = {
     traceId,
     generationId: `${traceId}:generation`,
     runLabel: options.runLabel,
@@ -240,7 +240,10 @@ async function writeSuccessTrace(
     retries: [],
     toolCalls: toolCallsForTrace(result),
     judgeScores,
-  });
+  };
+
+  if (options.traceClient) await writeEvalTrace(options.traceClient, trace);
+  return trace;
 }
 
 async function writeFailureTrace(
@@ -324,13 +327,22 @@ export async function runAnthropicEvalCase(
     const durationMs = endedAtDate.getTime() - startedAtDate.getTime();
     const resultScores = options.judgeScores ?? (await options.scoreResult?.(result));
 
-    await writeSuccessTrace(options, traceId, result, startedAt, endedAt, durationMs, resultScores);
+    const trace = await writeSuccessTrace(
+      options,
+      traceId,
+      result,
+      startedAt,
+      endedAt,
+      durationMs,
+      resultScores,
+    );
 
     return {
       ...result,
       durationMs,
       toolSurface: options.toolSurface,
       traceId,
+      trace,
     };
   } catch (error) {
     const endedAtDate = now();

--- a/eval/cli.ts
+++ b/eval/cli.ts
@@ -12,6 +12,15 @@ export interface EvalProviderConfig {
   toolLoopLimit: number | undefined;
 }
 
+export interface EvalMatrixGuardrails {
+  allowFullDataset: boolean;
+  allowEstimatedCostOverride: boolean;
+  maxEstimatedCostUsd: number;
+  retryCount: number;
+  continueOnModelFailure: boolean;
+  providerConcurrency: Record<EvalProvider, number>;
+}
+
 export interface EvalCliOptions {
   shouldSeed: boolean;
   categoryFilter: string | undefined;
@@ -20,6 +29,8 @@ export interface EvalCliOptions {
   toolSurface: EvalToolSurface;
   localReportPath: string | undefined;
   providerConfig: EvalProviderConfig;
+  matrixMode: boolean;
+  matrixGuardrails: EvalMatrixGuardrails;
 }
 
 function valueFor(args: string[], prefix: string): string | undefined {
@@ -95,6 +106,39 @@ function positiveIntegerFor(
   return parsed;
 }
 
+function optionalPositiveIntegerFor(args: string[], prefix: string, fallback: number): number {
+  const value = valueFor(args, prefix);
+  if (!value) return fallback;
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${prefix.slice(0, -1)}: expected a positive integer.`);
+  }
+  return parsed;
+}
+
+function optionalNonNegativeIntegerFor(args: string[], prefix: string, fallback: number): number {
+  const value = valueFor(args, prefix);
+  if (!value) return fallback;
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid ${prefix.slice(0, -1)}: expected a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function optionalPositiveNumberFor(args: string[], prefix: string, fallback: number): number {
+  const value = valueFor(args, prefix);
+  if (!value) return fallback;
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${prefix.slice(0, -1)}: expected a positive number.`);
+  }
+  return parsed;
+}
+
 export function parseEvalArgs(
   args: string[],
   now = new Date(),
@@ -153,6 +197,18 @@ export function parseEvalArgs(
         env,
         'SQUIRE_EVAL_TOOL_LOOP_LIMIT',
       ),
+    },
+    matrixMode: args.includes('--matrix'),
+    matrixGuardrails: {
+      allowFullDataset: args.includes('--allow-full-dataset'),
+      allowEstimatedCostOverride: args.includes('--allow-estimated-cost'),
+      maxEstimatedCostUsd: optionalPositiveNumberFor(args, '--max-estimated-cost-usd=', 1),
+      retryCount: optionalNonNegativeIntegerFor(args, '--retry-count=', 1),
+      continueOnModelFailure: !args.includes('--fail-fast-model-failure'),
+      providerConcurrency: {
+        anthropic: optionalPositiveIntegerFor(args, '--anthropic-concurrency=', 1),
+        openai: optionalPositiveIntegerFor(args, '--openai-concurrency=', 1),
+      },
     },
   };
 }

--- a/eval/matrix-runtime.ts
+++ b/eval/matrix-runtime.ts
@@ -1,0 +1,177 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { LangfuseClient } from '@langfuse/client';
+import type { EvalProviderConfig } from './cli.ts';
+import { runAnthropicEvalCase, type AnthropicEvalCaseResult } from './anthropic-runner.ts';
+import {
+  createOpenAiResponsesClient,
+  runOpenAiResponsesEvalCase,
+  type OpenAiResponsesClient,
+  type OpenAiResponsesEvalResult,
+} from './openai-runner.ts';
+import {
+  ESTIMATED_COST_PER_CASE_MODEL_USD,
+  type EvalMatrixRunner,
+  type EvalMatrixRunnerInput,
+  type EvalMatrixRunnerOutput,
+} from './matrix.ts';
+import { passFromTraceScores, scoreFromTraceScores, traceScoresForEvalResult } from './scoring.ts';
+import type { EvalTraceInput, LangfuseTraceIngestionClient } from './trace.ts';
+
+type AnthropicMatrixConfig = EvalProviderConfig & {
+  provider: 'anthropic';
+  model: 'claude-sonnet-4-6' | 'claude-opus-4-7';
+};
+
+function traceClientFor(langfuse: LangfuseClient): LangfuseTraceIngestionClient {
+  return langfuse as unknown as LangfuseTraceIngestionClient;
+}
+
+function assertAnthropicMatrixConfig(config: EvalProviderConfig): AnthropicMatrixConfig {
+  if (
+    config.provider === 'anthropic' &&
+    (config.model === 'claude-sonnet-4-6' || config.model === 'claude-opus-4-7')
+  ) {
+    return config as AnthropicMatrixConfig;
+  }
+  throw new Error(`Matrix runner does not support ${config.provider}:${config.model}.`);
+}
+
+function scoreValue(trace: EvalTraceInput): number | null {
+  return scoreFromTraceScores(trace.judgeScores);
+}
+
+function passValue(trace: EvalTraceInput): boolean | null {
+  return passFromTraceScores(trace.judgeScores);
+}
+
+function scoreNamed(trace: EvalTraceInput, name: string): number | null {
+  const score = trace.judgeScores.find((candidate) => candidate.name === name);
+  return typeof score?.value === 'number' ? score.value : null;
+}
+
+function failureClassFromTrace(trace: EvalTraceInput): string {
+  const score = trace.judgeScores.find((candidate) => candidate.name === 'failure_class');
+  return typeof score?.value === 'string' ? score.value : trace.statusReason;
+}
+
+function tokenUsage(trace: EvalTraceInput): EvalMatrixRunnerOutput['tokenUsage'] {
+  return {
+    input: trace.tokenUsage.input ?? 0,
+    output: trace.tokenUsage.output ?? 0,
+    total: trace.tokenUsage.total ?? 0,
+  };
+}
+
+function outputFromTrace(
+  trace: EvalTraceInput,
+  answer: string,
+  ok: boolean,
+  traceUrl: string,
+): EvalMatrixRunnerOutput {
+  return {
+    ok,
+    answer,
+    traceId: trace.traceId,
+    traceUrl,
+    score: scoreValue(trace),
+    pass: ok ? passValue(trace) : false,
+    latencyMs: trace.durationMs ?? scoreNamed(trace, 'model_latency_ms') ?? 0,
+    tokenUsage: tokenUsage(trace),
+    estimatedCostUsd:
+      nonZeroCost(trace.costEstimate.totalUsd) ??
+      nonZeroCost(scoreNamed(trace, 'model_cost_usd')) ??
+      ESTIMATED_COST_PER_CASE_MODEL_USD,
+    toolCallCount: trace.toolCalls.length,
+    loopIterations: scoreNamed(trace, 'loop_iterations') ?? 0,
+    failureClass: failureClassFromTrace(trace),
+  };
+}
+
+function nonZeroCost(value: number | null | undefined): number | undefined {
+  return value && value > 0 ? value : undefined;
+}
+
+function isRateLimitResult(result: OpenAiResponsesEvalResult): boolean {
+  return (
+    !result.ok &&
+    result.failureClass === 'api_status' &&
+    /rate.?limit|429/i.test(result.failureMessage ?? '')
+  );
+}
+
+async function runAnthropicMatrixCase(
+  input: EvalMatrixRunnerInput,
+  anthropic: Anthropic,
+  traceClient: LangfuseTraceIngestionClient,
+): Promise<EvalMatrixRunnerOutput> {
+  const result: AnthropicEvalCaseResult = await runAnthropicEvalCase({
+    case: input.evalCase,
+    runLabel: input.runLabel,
+    toolSurface: input.toolSurface,
+    providerConfig: assertAnthropicMatrixConfig(input.providerConfig),
+    traceClient,
+    traceId: input.traceId,
+    scoreResult: (runResult) =>
+      traceScoresForEvalResult(anthropic, {
+        evalCase: input.evalCase,
+        answer: runResult.answer,
+        toolCalls: runResult.trajectory.toolCalls,
+      }),
+  });
+
+  return outputFromTrace(result.trace, result.answer, true, input.traceUrl);
+}
+
+async function runOpenAiMatrixCase(
+  input: EvalMatrixRunnerInput,
+  anthropic: Anthropic,
+  traceClient: LangfuseTraceIngestionClient,
+  client: OpenAiResponsesClient,
+  env: NodeJS.ProcessEnv,
+): Promise<EvalMatrixRunnerOutput> {
+  const result = await runOpenAiResponsesEvalCase({
+    client,
+    evalCase: input.evalCase,
+    providerConfig: input.providerConfig,
+    runLabel: input.runLabel,
+    toolSurface: input.toolSurface,
+    traceClient,
+    traceId: input.traceId,
+    env,
+    scoreResult: async (runResult) =>
+      runResult.ok
+        ? traceScoresForEvalResult(anthropic, {
+            evalCase: input.evalCase,
+            answer: runResult.answer,
+            toolCalls: runResult.trajectory.toolCalls,
+          })
+        : undefined,
+  });
+
+  if (isRateLimitResult(result)) {
+    throw Object.assign(new Error(result.failureMessage ?? 'OpenAI rate limit'), { status: 429 });
+  }
+
+  return outputFromTrace(result.trace, result.answer, result.ok, input.traceUrl);
+}
+
+export function createEvalMatrixRunner(
+  langfuse: LangfuseClient,
+  env: NodeJS.ProcessEnv = process.env,
+): EvalMatrixRunner {
+  const anthropic = new Anthropic();
+  const traceClient = traceClientFor(langfuse);
+  const openAiClient = createOpenAiResponsesClient(env);
+
+  return async (input) => {
+    if (input.providerConfig.provider === 'anthropic') {
+      return runAnthropicMatrixCase(input, anthropic, traceClient);
+    }
+
+    if (input.providerConfig.provider === 'openai') {
+      return runOpenAiMatrixCase(input, anthropic, traceClient, openAiClient, env);
+    }
+
+    throw new Error(`Matrix runner does not support provider ${input.providerConfig.provider}.`);
+  };
+}

--- a/eval/matrix.ts
+++ b/eval/matrix.ts
@@ -222,6 +222,19 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function matrixRetryCountForError(error: unknown): number | undefined {
+  return typeof error === 'object' && error && 'matrixRetryCount' in error
+    ? Number((error as { matrixRetryCount?: unknown }).matrixRetryCount)
+    : undefined;
+}
+
+function errorWithRetryCount(error: unknown, retryCount: number): unknown {
+  if (typeof error === 'object' && error) {
+    return Object.assign(error, { matrixRetryCount: retryCount });
+  }
+  return Object.assign(new Error(String(error)), { matrixRetryCount: retryCount });
+}
+
 async function runWithRetries(
   input: EvalMatrixRunnerInput,
   runner: EvalMatrixRunner,
@@ -233,7 +246,9 @@ async function runWithRetries(
       const output = await runner({ ...input, attempt: attempts + 1 });
       return { output, retryCount: attempts };
     } catch (error) {
-      if (!isRateLimitError(error) || attempts >= retryCount) throw error;
+      if (!isRateLimitError(error) || attempts >= retryCount) {
+        throw errorWithRetryCount(error, attempts);
+      }
       attempts += 1;
     }
   }
@@ -309,7 +324,7 @@ async function runMatrixInput(
     return rowFromOutput(input, result.output, result.retryCount);
   } catch (error) {
     if (!guardrails.continueOnModelFailure) throw error;
-    const retryCount = isRateLimitError(error) ? guardrails.retryCount : 0;
+    const retryCount = matrixRetryCountForError(error) ?? 0;
     return rowFromError(input, error, retryCount);
   }
 }

--- a/eval/matrix.ts
+++ b/eval/matrix.ts
@@ -1,0 +1,428 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type {
+  EvalMatrixGuardrails,
+  EvalProvider,
+  EvalProviderConfig,
+  EvalReasoningEffort,
+  EvalToolSurface,
+} from './cli.ts';
+import type { EvalCase } from './schema.ts';
+
+export type EvalMatrixSelection = 'id' | 'category' | 'all';
+
+export interface EvalMatrixRunnerInput {
+  evalCase: EvalCase;
+  providerConfig: EvalProviderConfig;
+  runLabel: string;
+  toolSurface: EvalToolSurface;
+  traceId: string;
+  traceUrl: string;
+  attempt: number;
+}
+
+export interface EvalMatrixRunnerOutput {
+  ok: boolean;
+  answer: string;
+  traceId: string;
+  traceUrl: string;
+  runUrl?: string;
+  score: number | null;
+  pass: boolean | null;
+  latencyMs: number;
+  tokenUsage: {
+    input: number;
+    output: number;
+    total: number;
+  };
+  estimatedCostUsd: number;
+  toolCallCount: number;
+  loopIterations: number;
+  failureClass: string;
+}
+
+export type EvalMatrixRunner = (input: EvalMatrixRunnerInput) => Promise<EvalMatrixRunnerOutput>;
+
+export interface EvalMatrixRow {
+  runLabel: string;
+  caseId: string;
+  category: string;
+  provider: EvalProvider;
+  model: EvalProviderConfig['model'];
+  ok: boolean;
+  answer: string | null;
+  score: number | null;
+  pass: boolean | null;
+  latencyMs: number | null;
+  tokenInput: number | null;
+  tokenOutput: number | null;
+  tokenTotal: number | null;
+  estimatedCostUsd: number | null;
+  toolCallCount: number | null;
+  retryCount: number;
+  loopIterations: number | null;
+  failureClass: string;
+  traceId: string;
+  traceUrl: string;
+  runUrl?: string;
+  error?: string;
+}
+
+export interface EvalMatrixResult {
+  runLabel: string;
+  rows: EvalMatrixRow[];
+  estimatedCostUsd: number;
+}
+
+export interface RunEvalMatrixOptions {
+  cases: EvalCase[];
+  runLabel: string;
+  toolSurface: EvalToolSurface;
+  selection: EvalMatrixSelection;
+  modelConfigs: EvalProviderConfig[];
+  runner: EvalMatrixRunner;
+  guardrails: EvalMatrixGuardrails;
+  langfuseBaseUrl: string;
+}
+
+export const ESTIMATED_COST_PER_CASE_MODEL_USD = 0.05;
+
+export const DEFAULT_EVAL_MATRIX_MODELS: EvalProviderConfig[] = [
+  {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    reasoningEffort: undefined,
+    maxOutputTokens: undefined,
+    timeoutMs: undefined,
+    toolLoopLimit: undefined,
+  },
+  {
+    provider: 'anthropic',
+    model: 'claude-opus-4-7',
+    reasoningEffort: undefined,
+    maxOutputTokens: undefined,
+    timeoutMs: undefined,
+    toolLoopLimit: undefined,
+  },
+  {
+    provider: 'openai',
+    model: 'gpt-5.5',
+    reasoningEffort: undefined,
+    maxOutputTokens: undefined,
+    timeoutMs: undefined,
+    toolLoopLimit: undefined,
+  },
+];
+
+function withSharedKnobs(
+  config: EvalProviderConfig,
+  shared: EvalProviderConfig,
+): EvalProviderConfig {
+  return {
+    ...config,
+    reasoningEffort: providerSupportsReasoningEffort(config.provider, shared.reasoningEffort)
+      ? shared.reasoningEffort
+      : undefined,
+    maxOutputTokens: shared.maxOutputTokens,
+    timeoutMs: shared.timeoutMs,
+    toolLoopLimit: shared.toolLoopLimit,
+  };
+}
+
+function providerSupportsReasoningEffort(
+  provider: EvalProvider,
+  effort: EvalReasoningEffort | undefined,
+): boolean {
+  if (!effort) return false;
+  if (provider === 'anthropic') return ['low', 'medium', 'high', 'max'].includes(effort);
+  return ['none', 'low', 'medium', 'high', 'xhigh'].includes(effort);
+}
+
+export function defaultEvalMatrixModels(sharedConfig: EvalProviderConfig): EvalProviderConfig[] {
+  return DEFAULT_EVAL_MATRIX_MODELS.map((config) => withSharedKnobs(config, sharedConfig));
+}
+
+function slugPart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_.-]/g, '-');
+}
+
+export function traceIdForMatrixRow(
+  runLabel: string,
+  evalCase: EvalCase,
+  providerConfig: EvalProviderConfig,
+): string {
+  return [
+    'eval',
+    slugPart(runLabel),
+    providerConfig.provider,
+    slugPart(providerConfig.model),
+    slugPart(evalCase.id),
+  ].join(':');
+}
+
+export function langfuseTraceUrl(baseUrl: string, traceId: string): string {
+  return `${baseUrl.replace(/\/$/, '')}/project/default/traces/${encodeURIComponent(traceId)}`;
+}
+
+function estimateMatrixCost(cases: EvalCase[], configs: EvalProviderConfig[]): number {
+  return cases.length * configs.length * ESTIMATED_COST_PER_CASE_MODEL_USD;
+}
+
+export function assertEvalMatrixGuardrails(
+  options: Pick<RunEvalMatrixOptions, 'cases' | 'modelConfigs' | 'selection' | 'guardrails'>,
+): void {
+  const estimatedCostUsd = estimateMatrixCost(options.cases, options.modelConfigs);
+
+  if (options.selection === 'all' && !options.guardrails.allowFullDataset) {
+    throw new Error(
+      `A full-dataset matrix run requires --allow-full-dataset (${options.cases.length} case(s), ${options.modelConfigs.length} model(s)).`,
+    );
+  }
+
+  if (
+    estimatedCostUsd > options.guardrails.maxEstimatedCostUsd &&
+    !options.guardrails.allowEstimatedCostOverride
+  ) {
+    throw new Error(
+      `Estimated matrix cost $${estimatedCostUsd.toFixed(2)} exceeds --max-estimated-cost-usd=${options.guardrails.maxEstimatedCostUsd} and requires --allow-estimated-cost to proceed.`,
+    );
+  }
+
+  for (const provider of ['anthropic', 'openai'] as const) {
+    const concurrency = options.guardrails.providerConcurrency[provider];
+    if (!Number.isInteger(concurrency) || concurrency < 1) {
+      throw new Error(`Invalid ${provider} matrix concurrency: expected a positive integer.`);
+    }
+  }
+}
+
+function isRateLimitError(error: unknown): boolean {
+  const status =
+    typeof error === 'object' && error && 'status' in error
+      ? Number((error as { status?: unknown }).status)
+      : undefined;
+  if (status === 429) return true;
+  const message = error instanceof Error ? error.message : String(error);
+  return /rate.?limit|429/i.test(message);
+}
+
+function failureClassForError(error: unknown): string {
+  if (isRateLimitError(error)) return 'rate_limit';
+  const status =
+    typeof error === 'object' && error && 'status' in error
+      ? Number((error as { status?: unknown }).status)
+      : undefined;
+  if (status === 401 || status === 403 || status === 404) return 'model_access';
+  const message = error instanceof Error ? error.message : String(error);
+  if (/timeout|timed out|abort/i.test(message)) return 'timeout';
+  return 'provider_error';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function runWithRetries(
+  input: EvalMatrixRunnerInput,
+  runner: EvalMatrixRunner,
+  retryCount: number,
+): Promise<{ output: EvalMatrixRunnerOutput; retryCount: number }> {
+  let attempts = 0;
+  for (;;) {
+    try {
+      const output = await runner({ ...input, attempt: attempts + 1 });
+      return { output, retryCount: attempts };
+    } catch (error) {
+      if (!isRateLimitError(error) || attempts >= retryCount) throw error;
+      attempts += 1;
+    }
+  }
+}
+
+function rowFromOutput(
+  input: EvalMatrixRunnerInput,
+  output: EvalMatrixRunnerOutput,
+  retryCount: number,
+): EvalMatrixRow {
+  return {
+    runLabel: input.runLabel,
+    caseId: input.evalCase.id,
+    category: input.evalCase.category,
+    provider: input.providerConfig.provider,
+    model: input.providerConfig.model,
+    ok: output.ok,
+    answer: output.answer,
+    score: output.score,
+    pass: output.pass,
+    latencyMs: output.latencyMs,
+    tokenInput: output.tokenUsage.input,
+    tokenOutput: output.tokenUsage.output,
+    tokenTotal: output.tokenUsage.total,
+    estimatedCostUsd: output.estimatedCostUsd,
+    toolCallCount: output.toolCallCount,
+    retryCount,
+    loopIterations: output.loopIterations,
+    failureClass: output.failureClass,
+    traceId: output.traceId,
+    traceUrl: output.traceUrl,
+    runUrl: output.runUrl,
+  };
+}
+
+function rowFromError(
+  input: EvalMatrixRunnerInput,
+  error: unknown,
+  retryCount: number,
+): EvalMatrixRow {
+  return {
+    runLabel: input.runLabel,
+    caseId: input.evalCase.id,
+    category: input.evalCase.category,
+    provider: input.providerConfig.provider,
+    model: input.providerConfig.model,
+    ok: false,
+    answer: null,
+    score: null,
+    pass: false,
+    latencyMs: null,
+    tokenInput: null,
+    tokenOutput: null,
+    tokenTotal: null,
+    estimatedCostUsd: null,
+    toolCallCount: null,
+    retryCount,
+    loopIterations: null,
+    failureClass: failureClassForError(error),
+    traceId: input.traceId,
+    traceUrl: input.traceUrl,
+    error: errorMessage(error),
+  };
+}
+
+async function runMatrixInput(
+  input: EvalMatrixRunnerInput,
+  runner: EvalMatrixRunner,
+  guardrails: EvalMatrixGuardrails,
+): Promise<EvalMatrixRow> {
+  try {
+    const result = await runWithRetries(input, runner, guardrails.retryCount);
+    return rowFromOutput(input, result.output, result.retryCount);
+  } catch (error) {
+    if (!guardrails.continueOnModelFailure) throw error;
+    const retryCount = isRateLimitError(error) ? guardrails.retryCount : 0;
+    return rowFromError(input, error, retryCount);
+  }
+}
+
+async function runProviderQueue(
+  inputs: EvalMatrixRunnerInput[],
+  concurrency: number,
+  runner: EvalMatrixRunner,
+  guardrails: EvalMatrixGuardrails,
+): Promise<EvalMatrixRow[]> {
+  const rows: EvalMatrixRow[] = [];
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      const input = inputs[index];
+      if (!input) return;
+      rows[index] = await runMatrixInput(input, runner, guardrails);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, inputs.length) }, () => worker()));
+  return rows;
+}
+
+export async function runEvalMatrix(options: RunEvalMatrixOptions): Promise<EvalMatrixResult> {
+  const estimatedCostUsd = estimateMatrixCost(options.cases, options.modelConfigs);
+  assertEvalMatrixGuardrails(options);
+
+  const inputs = options.cases.flatMap((evalCase) =>
+    options.modelConfigs.map((providerConfig) => {
+      const traceId = traceIdForMatrixRow(options.runLabel, evalCase, providerConfig);
+      return {
+        evalCase,
+        providerConfig,
+        runLabel: options.runLabel,
+        toolSurface: options.toolSurface,
+        traceId,
+        traceUrl: langfuseTraceUrl(options.langfuseBaseUrl, traceId),
+        attempt: 1,
+      };
+    }),
+  );
+
+  const rowsByProvider = await Promise.all(
+    (['anthropic', 'openai'] as const).map((provider) =>
+      runProviderQueue(
+        inputs.filter((input) => input.providerConfig.provider === provider),
+        options.guardrails.providerConcurrency[provider],
+        options.runner,
+        options.guardrails,
+      ),
+    ),
+  );
+  const unorderedRows = rowsByProvider.flat();
+  const rowKey = (row: EvalMatrixRow) => `${row.caseId}:${row.provider}:${row.model}`;
+  const rowsByKey = new Map(unorderedRows.map((row) => [rowKey(row), row]));
+  const rows = inputs.map((input) =>
+    rowsByKey.get(
+      `${input.evalCase.id}:${input.providerConfig.provider}:${input.providerConfig.model}`,
+    ),
+  );
+
+  return {
+    runLabel: options.runLabel,
+    rows: rows.filter((row): row is EvalMatrixRow => !!row),
+    estimatedCostUsd,
+  };
+}
+
+function formatNullable(value: string | number | boolean | null | undefined): string {
+  if (value === undefined || value === null) return '-';
+  return String(value);
+}
+
+export function formatEvalMatrixTable(rows: EvalMatrixRow[]): string {
+  const lines = [
+    'case\tmodel\tpass\tfailure_class\tscore\tlatency_ms\ttokens\tcost_usd\ttools\tretries\tloops\ttrace\terror',
+  ];
+  for (const row of rows) {
+    lines.push(
+      [
+        row.caseId,
+        `${row.provider}:${row.model}`,
+        row.pass === null ? '-' : row.pass ? 'pass' : 'fail',
+        row.failureClass,
+        formatNullable(row.score),
+        formatNullable(row.latencyMs),
+        row.tokenTotal === null ? '-' : `${row.tokenInput}/${row.tokenOutput}/${row.tokenTotal}`,
+        row.estimatedCostUsd === null ? '-' : row.estimatedCostUsd.toFixed(4),
+        formatNullable(row.toolCallCount),
+        row.retryCount,
+        formatNullable(row.loopIterations),
+        row.traceUrl,
+        row.error ?? '',
+      ].join('\t'),
+    );
+  }
+  return lines.join('\n');
+}
+
+export function writeEvalMatrixLocalReport(outputPath: string, result: EvalMatrixResult): void {
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(
+    outputPath,
+    `${JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        ...result,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}

--- a/eval/openai-runner.ts
+++ b/eval/openai-runner.ts
@@ -20,6 +20,7 @@ import type { EvalCase } from './schema.ts';
 import {
   type EvalTraceError,
   type EvalTraceInput,
+  type EvalTraceScore,
   type EvalTraceToolCall,
   type LangfuseTraceIngestionClient,
 } from './trace.ts';
@@ -103,6 +104,14 @@ export interface OpenAiResponsesEvalResult {
   trace: EvalTraceInput;
 }
 
+export interface OpenAiResponsesScorableResult {
+  ok: boolean;
+  answer: string;
+  failureClass: OpenAiEvalFailureClass;
+  failureMessage?: string;
+  trajectory: OpenAiResponsesEvalResult['trajectory'];
+}
+
 export interface RunOpenAiResponsesEvalCaseOptions {
   client?: OpenAiResponsesClient;
   evalCase: EvalCase;
@@ -110,6 +119,9 @@ export interface RunOpenAiResponsesEvalCaseOptions {
   runLabel: string;
   toolSurface: EvalToolSurface;
   traceClient?: LangfuseTraceIngestionClient;
+  traceId?: string;
+  judgeScores?: EvalTraceScore[];
+  scoreResult?: (result: OpenAiResponsesScorableResult) => Promise<EvalTraceScore[] | undefined>;
   executeTool?: (name: string, input: Record<string, unknown>) => Promise<ToolCallResult>;
   now?: () => Date;
   env?: NodeJS.ProcessEnv;
@@ -447,10 +459,13 @@ export async function runOpenAiResponsesEvalCase(
     statusReason: string,
     stopReason: string,
     finalAnswer: string | null,
+    resultScores: EvalTraceScore[] | undefined,
   ): EvalTraceInput => {
     const endedAt = now().toISOString();
+    const scores = resultScores ?? options.judgeScores ?? [];
+    const metricScoreNames = new Set(scores.map((score) => score.name));
     return {
-      traceId: `eval:${options.runLabel}:${options.evalCase.id}:openai`,
+      traceId: options.traceId ?? `eval:${options.runLabel}:${options.evalCase.id}:openai`,
       runLabel: options.runLabel,
       datasetName: DATASET_NAME,
       caseId: options.evalCase.id,
@@ -490,9 +505,15 @@ export async function runOpenAiResponsesEvalCase(
       retries: [],
       toolCalls: traceToolCalls,
       judgeScores: [
-        { name: 'failure_class', value: statusReason === 'completed' ? 'none' : statusReason },
-        { name: 'tool_call_count', value: toolCalls.length },
-        { name: 'loop_iterations', value: iterations },
+        ...[
+          { name: 'failure_class', value: statusReason === 'completed' ? 'none' : statusReason },
+          { name: 'tool_call_count', value: toolCalls.length },
+          { name: 'retry_count', value: 0 },
+          { name: 'loop_iterations', value: iterations },
+          { name: 'model_latency_ms', value: durationMsBetween(startedAt, endedAt) },
+          { name: 'model_cost_usd', value: 0 },
+        ].filter((score) => !metricScoreNames.has(score.name)),
+        ...scores,
       ],
     };
   };
@@ -504,21 +525,36 @@ export async function runOpenAiResponsesEvalCase(
     stopReason: string,
     failureMessage?: string,
   ): Promise<OpenAiResponsesEvalResult> => {
-    const trace = buildTrace(ok ? 'completed' : failureClass, stopReason, ok ? answer : null);
+    const trajectory = {
+      toolCalls,
+      finalAnswer: answer,
+      tokenUsage: tokenUsageForAgent(tokenUsage),
+      model: resolvedModel,
+      iterations,
+      stopReason,
+    };
+    const resultScores =
+      options.judgeScores ??
+      (await options.scoreResult?.({
+        ok,
+        answer,
+        failureClass,
+        failureMessage,
+        trajectory,
+      }));
+    const trace = buildTrace(
+      ok ? 'completed' : failureClass,
+      stopReason,
+      ok ? answer : null,
+      resultScores,
+    );
     if (options.traceClient) await writeEvalTrace(options.traceClient, trace);
     return {
       ok,
       answer,
       failureClass,
       failureMessage,
-      trajectory: {
-        toolCalls,
-        finalAnswer: answer,
-        tokenUsage: tokenUsageForAgent(tokenUsage),
-        model: resolvedModel,
-        iterations,
-        stopReason,
-      },
+      trajectory,
       trace,
     };
   };

--- a/eval/openai-runner.ts
+++ b/eval/openai-runner.ts
@@ -535,13 +535,15 @@ export async function runOpenAiResponsesEvalCase(
     };
     const resultScores =
       options.judgeScores ??
-      (await options.scoreResult?.({
-        ok,
-        answer,
-        failureClass,
-        failureMessage,
-        trajectory,
-      }));
+      (ok
+        ? await options.scoreResult?.({
+            ok,
+            answer,
+            failureClass,
+            failureMessage,
+            trajectory,
+          })
+        : undefined);
     const trace = buildTrace(
       ok ? 'completed' : failureClass,
       stopReason,

--- a/eval/run.ts
+++ b/eval/run.ts
@@ -8,6 +8,7 @@
  *             node eval/run.ts --id=rule-poison
  * Named run:  node eval/run.ts --run-label="after chunking fix"
  * Local JSON: node eval/run.ts --local-report=/tmp/eval.json
+ * Matrix:     node eval/run.ts --matrix --id=rule-poison
  */
 
 import 'dotenv/config';

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -6,6 +6,15 @@ import { evalCaseHasFinalAnswer } from './schema.ts';
 import { runFiltered, runOnDataset } from './experiments.ts';
 import { runLocalReport } from './local-report.ts';
 import { runOpenAiLocalReport } from './openai-runner.ts';
+import {
+  assertEvalMatrixGuardrails,
+  defaultEvalMatrixModels,
+  formatEvalMatrixTable,
+  runEvalMatrix,
+  writeEvalMatrixLocalReport,
+  type EvalMatrixSelection,
+} from './matrix.ts';
+import { createEvalMatrixRunner } from './matrix-runtime.ts';
 
 function describeProviderConfig(config: EvalProviderConfig): string {
   const tuning = [
@@ -58,11 +67,75 @@ export async function runEval(options: EvalCliOptions, env: NodeJS.ProcessEnv = 
 
   assertCurrentRunnerSupportsProviderConfig(options.providerConfig);
 
+  if (options.matrixMode) {
+    const langfuseBaseUrl = env.LANGFUSE_BASEURL ?? LANGFUSE_DEFAULT_BASE_URL;
+    const langfuse = new LangfuseClient({ baseUrl: langfuseBaseUrl });
+    const selection: EvalMatrixSelection = options.idFilter
+      ? 'id'
+      : options.categoryFilter
+        ? 'category'
+        : 'all';
+    const modelConfigs = defaultEvalMatrixModels(options.providerConfig);
+    assertEvalMatrixGuardrails({
+      cases,
+      modelConfigs,
+      selection,
+      guardrails: options.matrixGuardrails,
+    });
+    console.log(
+      `Running ${cases.length} eval case(s) across ${modelConfigs.length} model(s) as "${options.runName}" on ${options.toolSurface} tools...\n`,
+    );
+    const matrixRunner = createEvalMatrixRunner(langfuse, env);
+    const result = await runEvalMatrix({
+      cases,
+      runLabel: options.runName,
+      toolSurface: options.toolSurface,
+      selection,
+      modelConfigs,
+      runner: matrixRunner,
+      guardrails: options.matrixGuardrails,
+      langfuseBaseUrl,
+    });
+
+    console.log(formatEvalMatrixTable(result.rows));
+    if (options.localReportPath) {
+      writeEvalMatrixLocalReport(options.localReportPath, result);
+      console.log(`\nWrote eval matrix report: ${options.localReportPath}`);
+    }
+    return;
+  }
+
   if (options.providerConfig.provider === 'openai') {
     if (!options.localReportPath) {
-      throw new Error(
-        'OpenAI Responses evals currently require --local-report so the SQR-127 trace artifacts are written to a local report. Langfuse matrix wiring lands in SQR-131.',
+      const langfuseBaseUrl = env.LANGFUSE_BASEURL ?? LANGFUSE_DEFAULT_BASE_URL;
+      const langfuse = new LangfuseClient({ baseUrl: langfuseBaseUrl });
+      const selection: EvalMatrixSelection = options.idFilter
+        ? 'id'
+        : options.categoryFilter
+          ? 'category'
+          : 'all';
+      const modelConfigs = [options.providerConfig];
+      assertEvalMatrixGuardrails({
+        cases,
+        modelConfigs,
+        selection,
+        guardrails: options.matrixGuardrails,
+      });
+      console.log(
+        `Running ${cases.length} OpenAI eval(s) as "${options.runName}" on ${options.toolSurface} tools...\n`,
       );
+      const result = await runEvalMatrix({
+        cases,
+        runLabel: options.runName,
+        toolSurface: options.toolSurface,
+        selection,
+        modelConfigs,
+        runner: createEvalMatrixRunner(langfuse, env),
+        guardrails: options.matrixGuardrails,
+        langfuseBaseUrl,
+      });
+      console.log(formatEvalMatrixTable(result.rows));
+      return;
     }
     console.log(
       `Running ${cases.length} OpenAI eval(s) as "${options.runName}" on ${options.toolSurface} tools...\n`,

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -115,6 +115,16 @@ export async function runEval(options: EvalCliOptions, env: NodeJS.ProcessEnv = 
           ? 'category'
           : 'all';
       const modelConfigs = [options.providerConfig];
+      const guardrails = {
+        ...options.matrixGuardrails,
+        allowFullDataset: true,
+      };
+      assertEvalMatrixGuardrails({
+        cases,
+        modelConfigs,
+        selection,
+        guardrails,
+      });
       console.log(
         `Running ${cases.length} OpenAI eval(s) as "${options.runName}" on ${options.toolSurface} tools...\n`,
       );
@@ -125,11 +135,7 @@ export async function runEval(options: EvalCliOptions, env: NodeJS.ProcessEnv = 
         selection,
         modelConfigs,
         runner: createEvalMatrixRunner(langfuse, env),
-        guardrails: {
-          ...options.matrixGuardrails,
-          allowFullDataset: true,
-          allowEstimatedCostOverride: true,
-        },
+        guardrails,
         langfuseBaseUrl,
       });
       console.log(formatEvalMatrixTable(result.rows));

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -115,12 +115,6 @@ export async function runEval(options: EvalCliOptions, env: NodeJS.ProcessEnv = 
           ? 'category'
           : 'all';
       const modelConfigs = [options.providerConfig];
-      assertEvalMatrixGuardrails({
-        cases,
-        modelConfigs,
-        selection,
-        guardrails: options.matrixGuardrails,
-      });
       console.log(
         `Running ${cases.length} OpenAI eval(s) as "${options.runName}" on ${options.toolSurface} tools...\n`,
       );
@@ -131,7 +125,11 @@ export async function runEval(options: EvalCliOptions, env: NodeJS.ProcessEnv = 
         selection,
         modelConfigs,
         runner: createEvalMatrixRunner(langfuse, env),
-        guardrails: options.matrixGuardrails,
+        guardrails: {
+          ...options.matrixGuardrails,
+          allowFullDataset: true,
+          allowEstimatedCostOverride: true,
+        },
         langfuseBaseUrl,
       });
       console.log(formatEvalMatrixTable(result.rows));

--- a/eval/scoring.ts
+++ b/eval/scoring.ts
@@ -69,13 +69,11 @@ export function scoreFromTraceScores(scores: EvalTraceScore[]): number | null {
 }
 
 export function passFromTraceScores(scores: EvalTraceScore[]): boolean | null {
-  const score = scores.find((candidate) => candidate.name === 'pass');
-  if (score?.value === 'pass') return true;
-  if (score?.value === 'fail') return false;
-
-  const trajectory = scores.find((candidate) => candidate.name === 'trajectory_pass');
-  if (trajectory?.value === 'pass') return true;
-  if (trajectory?.value === 'fail') return false;
+  const verdicts = scores.filter(
+    (candidate) => candidate.name === 'pass' || candidate.name === 'trajectory_pass',
+  );
+  if (verdicts.some((score) => score.value === 'fail')) return false;
+  if (verdicts.some((score) => score.value === 'pass')) return true;
 
   return null;
 }

--- a/eval/scoring.ts
+++ b/eval/scoring.ts
@@ -1,0 +1,81 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { ToolTrajectoryStep } from '../src/agent.ts';
+import type { EvalCase } from './schema.ts';
+import { scoreTrajectory } from './schema.ts';
+import type { EvalTraceScore } from './trace.ts';
+import { judgeAnswer } from './evaluators.ts';
+
+export interface EvalScoringInput {
+  evalCase: EvalCase;
+  answer: string;
+  toolCalls: ToolTrajectoryStep[];
+}
+
+export async function traceScoresForEvalResult(
+  anthropic: Anthropic,
+  input: EvalScoringInput,
+): Promise<EvalTraceScore[] | undefined> {
+  const scores: EvalTraceScore[] = [];
+
+  if (input.evalCase.finalAnswer) {
+    const verdict = await judgeAnswer(
+      anthropic,
+      input.evalCase.question,
+      input.evalCase.finalAnswer.expected,
+      input.evalCase.finalAnswer.grading,
+      input.answer,
+    );
+    scores.push(
+      {
+        name: 'correctness',
+        value: verdict.score / 5,
+        comment: verdict.reasoning,
+      },
+      {
+        name: 'pass',
+        value: verdict.pass ? 'pass' : 'fail',
+        comment: verdict.reasoning,
+      },
+    );
+  }
+
+  if (input.evalCase.trajectory) {
+    const trajectory = scoreTrajectory(input.evalCase.trajectory, input.toolCalls);
+    scores.push(
+      {
+        name: 'trajectory',
+        value: trajectory.pass ? 1 : 0,
+        comment:
+          trajectory.failures.length === 0
+            ? `${input.toolCalls.length} tool call(s) matched expectations`
+            : trajectory.failures.join('; '),
+      },
+      {
+        name: 'trajectory_pass',
+        value: trajectory.pass ? 'pass' : 'fail',
+      },
+    );
+  }
+
+  return scores.length > 0 ? scores : undefined;
+}
+
+export function scoreFromTraceScores(scores: EvalTraceScore[]): number | null {
+  const score = scores.find((candidate) => candidate.name === 'correctness');
+  if (typeof score?.value === 'number') return score.value;
+
+  const trajectory = scores.find((candidate) => candidate.name === 'trajectory');
+  return typeof trajectory?.value === 'number' ? trajectory.value : null;
+}
+
+export function passFromTraceScores(scores: EvalTraceScore[]): boolean | null {
+  const score = scores.find((candidate) => candidate.name === 'pass');
+  if (score?.value === 'pass') return true;
+  if (score?.value === 'fail') return false;
+
+  const trajectory = scores.find((candidate) => candidate.name === 'trajectory_pass');
+  if (trajectory?.value === 'pass') return true;
+  if (trajectory?.value === 'fail') return false;
+
+  return null;
+}

--- a/test/eval-cli.test.ts
+++ b/test/eval-cli.test.ts
@@ -29,6 +29,42 @@ describe('parseEvalArgs', () => {
     expect(parseEvalArgs(['--local-report=/tmp/eval.json']).localReportPath).toBe('/tmp/eval.json');
   });
 
+  it('parses matrix runner guardrails', () => {
+    expect(
+      parseEvalArgs([
+        '--matrix',
+        '--allow-full-dataset',
+        '--allow-estimated-cost',
+        '--max-estimated-cost-usd=2.5',
+        '--anthropic-concurrency=2',
+        '--openai-concurrency=3',
+        '--retry-count=4',
+        '--fail-fast-model-failure',
+      ]),
+    ).toMatchObject({
+      matrixMode: true,
+      matrixGuardrails: {
+        allowFullDataset: true,
+        allowEstimatedCostOverride: true,
+        maxEstimatedCostUsd: 2.5,
+        retryCount: 4,
+        continueOnModelFailure: false,
+        providerConcurrency: { anthropic: 2, openai: 3 },
+      },
+    });
+  });
+
+  it('defaults matrix guardrails to selected-case, low-cost runs', () => {
+    expect(parseEvalArgs(['--matrix']).matrixGuardrails).toEqual({
+      allowFullDataset: false,
+      allowEstimatedCostOverride: false,
+      maxEstimatedCostUsd: 1,
+      retryCount: 1,
+      continueOnModelFailure: true,
+      providerConcurrency: { anthropic: 1, openai: 1 },
+    });
+  });
+
   it('rejects an empty local report output path', () => {
     expect(() => parseEvalArgs(['--local-report='])).toThrow(
       /Invalid --local-report: value cannot be empty/,
@@ -180,6 +216,18 @@ describe('parseEvalArgs', () => {
     );
     expect(() => parseEvalArgs(['--tool-loop-limit=1.5'])).toThrow(
       /Invalid --tool-loop-limit: expected a positive integer/,
+    );
+  });
+
+  it('rejects invalid matrix guardrail values', () => {
+    expect(() => parseEvalArgs(['--max-estimated-cost-usd=0'])).toThrow(
+      /Invalid --max-estimated-cost-usd: expected a positive number/,
+    );
+    expect(() => parseEvalArgs(['--retry-count=-1'])).toThrow(
+      /Invalid --retry-count: expected a non-negative integer/,
+    );
+    expect(() => parseEvalArgs(['--anthropic-concurrency=0'])).toThrow(
+      /Invalid --anthropic-concurrency: expected a positive integer/,
     );
   });
 });

--- a/test/eval-matrix-runtime.test.ts
+++ b/test/eval-matrix-runtime.test.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockCreateOpenAiResponsesClient,
+  mockRunAnthropicEvalCase,
+  mockRunOpenAiResponsesEvalCase,
+  mockTraceScoresForEvalResult,
+} = vi.hoisted(() => ({
+  mockCreateOpenAiResponsesClient: vi.fn(),
+  mockRunAnthropicEvalCase: vi.fn(),
+  mockRunOpenAiResponsesEvalCase: vi.fn(),
+  mockTraceScoresForEvalResult: vi.fn(),
+}));
+
+vi.mock('../eval/anthropic-runner.ts', () => ({
+  runAnthropicEvalCase: mockRunAnthropicEvalCase,
+}));
+
+vi.mock('../eval/openai-runner.ts', () => ({
+  createOpenAiResponsesClient: mockCreateOpenAiResponsesClient,
+  runOpenAiResponsesEvalCase: mockRunOpenAiResponsesEvalCase,
+}));
+
+vi.mock('../eval/scoring.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../eval/scoring.ts')>();
+  return {
+    ...actual,
+    traceScoresForEvalResult: mockTraceScoresForEvalResult,
+  };
+});
+
+import { createEvalMatrixRunner } from '../eval/matrix-runtime.ts';
+import type { EvalMatrixRunnerInput } from '../eval/matrix.ts';
+import type { EvalCase } from '../eval/schema.ts';
+import type { EvalTraceInput } from '../eval/trace.ts';
+
+const evalCase: EvalCase = {
+  id: 'item-spyglass',
+  category: 'card-data',
+  source: 'unit-test',
+  question: 'What does Spyglass do?',
+  finalAnswer: {
+    expected: 'Spyglass reveals cards.',
+    grading: 'Mentions Spyglass effect.',
+  },
+};
+
+function trace(overrides: Partial<EvalTraceInput> = {}): EvalTraceInput {
+  return {
+    traceId: 'matrix-trace',
+    runLabel: 'matrix-run',
+    datasetName: 'squire-evals',
+    caseId: evalCase.id,
+    caseCategory: evalCase.category,
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    resolvedModel: 'claude-sonnet-4-6',
+    promptVersion: 'redesigned-agent-v1',
+    promptHash: 'sha256:test',
+    toolSurface: 'redesigned',
+    toolSchemaVersion: 'test-tools',
+    toolSchemaHash: 'sha256:tools',
+    modelSettings: {},
+    inputQuestion: evalCase.question,
+    finalAnswer: 'Spyglass reveals the top card.',
+    statusReason: 'completed',
+    stopReason: 'end_turn',
+    startedAt: '2026-05-01T00:00:00.000Z',
+    endedAt: '2026-05-01T00:00:01.000Z',
+    durationMs: 1000,
+    providerRequest: {},
+    providerResponse: {},
+    providerNativeTranscript: {},
+    tokenUsage: { input: 10, output: 5, total: 15 },
+    costEstimate: { totalUsd: 0.01 },
+    errors: [],
+    retries: [],
+    toolCalls: [{ toolName: 'search_cards', callIndex: 0, arguments: {}, result: {}, ok: true }],
+    judgeScores: [
+      { name: 'failure_class', value: 'none' },
+      { name: 'correctness', value: 0.8 },
+      { name: 'pass', value: 'pass' },
+      { name: 'loop_iterations', value: 2 },
+    ],
+    ...overrides,
+  };
+}
+
+function input(provider: 'anthropic' | 'openai'): EvalMatrixRunnerInput {
+  return {
+    evalCase,
+    providerConfig: {
+      provider,
+      model: provider === 'anthropic' ? 'claude-sonnet-4-6' : 'gpt-5.5',
+      reasoningEffort: undefined,
+      maxOutputTokens: undefined,
+      timeoutMs: undefined,
+      toolLoopLimit: undefined,
+    },
+    runLabel: 'matrix-run',
+    toolSurface: 'redesigned',
+    traceId: `${provider}-trace`,
+    traceUrl: `https://langfuse.test/traces/${provider}-trace`,
+    attempt: 1,
+  };
+}
+
+describe('eval matrix runtime adapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateOpenAiResponsesClient.mockReturnValue({ responses: { create: vi.fn() } });
+    mockTraceScoresForEvalResult.mockResolvedValue([
+      { name: 'correctness', value: 0.8 },
+      { name: 'pass', value: 'pass' },
+    ]);
+  });
+
+  it('adapts Anthropic trace output into matrix summary rows', async () => {
+    mockRunAnthropicEvalCase.mockResolvedValue({
+      answer: 'Spyglass reveals the top card.',
+      trajectory: { toolCalls: [] },
+      durationMs: 1000,
+      toolSurface: 'redesigned',
+      traceId: 'anthropic-trace',
+      trace: trace({ traceId: 'anthropic-trace' }),
+    });
+
+    const runner = createEvalMatrixRunner({} as never, { OPENAI_API_KEY: 'test-key' });
+    const output = await runner(input('anthropic'));
+
+    expect(mockRunAnthropicEvalCase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: 'anthropic-trace',
+        runLabel: 'matrix-run',
+        traceClient: {},
+      }),
+    );
+    expect(output).toMatchObject({
+      ok: true,
+      traceId: 'anthropic-trace',
+      traceUrl: 'https://langfuse.test/traces/anthropic-trace',
+      score: 0.8,
+      pass: true,
+      tokenUsage: { input: 10, output: 5, total: 15 },
+      estimatedCostUsd: 0.01,
+      toolCallCount: 1,
+      loopIterations: 2,
+      failureClass: 'none',
+    });
+  });
+
+  it('falls back to the matrix cost estimate when provider traces have no cost', async () => {
+    mockRunAnthropicEvalCase.mockResolvedValue({
+      answer: 'Spyglass reveals the top card.',
+      trajectory: { toolCalls: [] },
+      durationMs: 1000,
+      toolSurface: 'redesigned',
+      traceId: 'anthropic-trace',
+      trace: trace({ traceId: 'anthropic-trace', costEstimate: { totalUsd: 0 } }),
+    });
+
+    const runner = createEvalMatrixRunner({} as never, { OPENAI_API_KEY: 'test-key' });
+    const output = await runner(input('anthropic'));
+
+    expect(output.estimatedCostUsd).toBe(0.05);
+  });
+
+  it('throws OpenAI rate-limit results so matrix retries can handle them', async () => {
+    mockRunOpenAiResponsesEvalCase.mockResolvedValue({
+      ok: false,
+      answer: '',
+      failureClass: 'api_status',
+      failureMessage: '429 rate limit',
+      trajectory: {
+        toolCalls: [],
+        finalAnswer: '',
+        tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        model: 'gpt-5.5',
+        iterations: 1,
+        stopReason: 'api_status',
+      },
+      trace: trace({
+        provider: 'openai',
+        model: 'gpt-5.5',
+        resolvedModel: 'gpt-5.5',
+        traceId: 'openai-trace',
+        statusReason: 'api_status',
+      }),
+    });
+
+    const runner = createEvalMatrixRunner({} as never, { OPENAI_API_KEY: 'test-key' });
+
+    await expect(runner(input('openai'))).rejects.toMatchObject({ status: 429 });
+  });
+
+  it('does not judge failed OpenAI calls and marks the matrix row as failed', async () => {
+    mockRunOpenAiResponsesEvalCase.mockImplementation(async (options) => {
+      const scores = await options.scoreResult({
+        ok: false,
+        answer: '',
+        failureClass: 'api_status',
+        failureMessage: 'provider failed',
+        trajectory: {
+          toolCalls: [],
+          finalAnswer: '',
+          tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          model: 'gpt-5.5',
+          iterations: 1,
+          stopReason: 'api_status',
+        },
+      });
+
+      return {
+        ok: false,
+        answer: '',
+        failureClass: 'api_status',
+        failureMessage: 'provider failed',
+        trajectory: {
+          toolCalls: [],
+          finalAnswer: '',
+          tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          model: 'gpt-5.5',
+          iterations: 1,
+          stopReason: 'api_status',
+        },
+        trace: trace({
+          provider: 'openai',
+          model: 'gpt-5.5',
+          resolvedModel: 'gpt-5.5',
+          traceId: 'openai-trace',
+          statusReason: 'api_status',
+          finalAnswer: null,
+          judgeScores: [
+            { name: 'failure_class', value: 'api_status' },
+            { name: 'loop_iterations', value: 1 },
+            ...(scores ?? []),
+          ],
+        }),
+      };
+    });
+
+    const runner = createEvalMatrixRunner({} as never, { OPENAI_API_KEY: 'test-key' });
+    const output = await runner(input('openai'));
+
+    expect(mockTraceScoresForEvalResult).not.toHaveBeenCalled();
+    expect(output).toMatchObject({
+      ok: false,
+      pass: false,
+      score: null,
+      failureClass: 'api_status',
+    });
+  });
+});

--- a/test/eval-matrix.test.ts
+++ b/test/eval-matrix.test.ts
@@ -322,6 +322,46 @@ describe('eval matrix runner', () => {
     expect(result.rows[0]).toMatchObject({ ok: true, retryCount: 1 });
   });
 
+  it('keeps retry counts when a retried call ends with a non-rate-limit failure', async () => {
+    const config: EvalProviderConfig = {
+      provider: 'openai',
+      model: 'gpt-5.5',
+      reasoningEffort: undefined,
+      maxOutputTokens: undefined,
+      timeoutMs: undefined,
+      toolLoopLimit: undefined,
+    };
+    const runner: EvalMatrixRunner = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('429 rate limit'), { status: 429 }))
+      .mockRejectedValueOnce(new Error('request timeout'));
+
+    const result = await runEvalMatrix({
+      cases: [selectedCase],
+      runLabel: 'matrix-mixed-failure',
+      toolSurface: 'redesigned',
+      selection: 'id',
+      modelConfigs: [config],
+      runner,
+      guardrails: {
+        allowFullDataset: false,
+        allowEstimatedCostOverride: false,
+        maxEstimatedCostUsd: 1,
+        retryCount: 1,
+        continueOnModelFailure: true,
+        providerConcurrency: { anthropic: 1, openai: 1 },
+      },
+      langfuseBaseUrl: 'https://langfuse.test',
+    });
+
+    expect(runner).toHaveBeenCalledTimes(2);
+    expect(result.rows[0]).toMatchObject({
+      ok: false,
+      failureClass: 'timeout',
+      retryCount: 1,
+    });
+  });
+
   it('formats the matrix summary table with comparison fields and Langfuse links', async () => {
     const result = await runEvalMatrix({
       cases: [selectedCase],

--- a/test/eval-matrix.test.ts
+++ b/test/eval-matrix.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { EvalProviderConfig } from '../eval/cli.ts';
+import {
+  DEFAULT_EVAL_MATRIX_MODELS,
+  defaultEvalMatrixModels,
+  formatEvalMatrixTable,
+  runEvalMatrix,
+  type EvalMatrixRunner,
+} from '../eval/matrix.ts';
+import type { EvalCase } from '../eval/schema.ts';
+
+const selectedCase: EvalCase = {
+  id: 'item-spyglass',
+  category: 'card-data',
+  source: 'unit-test',
+  question: 'What does Spyglass do?',
+  finalAnswer: {
+    expected: 'Spyglass reveals cards.',
+    grading: 'Mentions Spyglass effect.',
+  },
+};
+
+const secondCase: EvalCase = {
+  id: 'rule-advantage',
+  category: 'rules',
+  source: 'unit-test',
+  question: 'How does advantage work?',
+  trajectory: {
+    requiredTools: ['search_rules'],
+    requiredToolKinds: ['search'],
+    forbiddenTools: [],
+    forbiddenToolKinds: [],
+    requiredRefs: [],
+    maxToolCalls: 2,
+  },
+};
+
+function successfulRunner(): EvalMatrixRunner {
+  return vi.fn(async ({ evalCase, providerConfig, traceId }) => ({
+    ok: true,
+    answer: `${providerConfig.model} answered ${evalCase.id}`,
+    traceId,
+    traceUrl: `https://langfuse.test/project/default/traces/${encodeURIComponent(traceId)}`,
+    score: 0.8,
+    pass: true,
+    latencyMs: 1200,
+    tokenUsage: { input: 100, output: 50, total: 150 },
+    estimatedCostUsd: 0.02,
+    toolCallCount: 1,
+    loopIterations: 2,
+    failureClass: 'none',
+  }));
+}
+
+describe('eval matrix runner', () => {
+  it('runs one selected case across every configured provider/model', async () => {
+    const runner = successfulRunner();
+
+    const result = await runEvalMatrix({
+      cases: [selectedCase],
+      runLabel: 'matrix-smoke',
+      toolSurface: 'redesigned',
+      selection: 'id',
+      modelConfigs: DEFAULT_EVAL_MATRIX_MODELS,
+      runner,
+      guardrails: {
+        allowFullDataset: false,
+        allowEstimatedCostOverride: false,
+        maxEstimatedCostUsd: 1,
+        retryCount: 0,
+        continueOnModelFailure: true,
+        providerConcurrency: { anthropic: 1, openai: 1 },
+      },
+      langfuseBaseUrl: 'https://langfuse.test',
+    });
+
+    expect(result.rows.map((row) => `${row.provider}:${row.model}`)).toEqual([
+      'anthropic:claude-sonnet-4-6',
+      'anthropic:claude-opus-4-7',
+      'openai:gpt-5.5',
+    ]);
+    expect(runner).toHaveBeenCalledTimes(3);
+    expect(result.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          caseId: 'item-spyglass',
+          provider: 'openai',
+          model: 'gpt-5.5',
+          score: 0.8,
+          pass: true,
+          latencyMs: 1200,
+          tokenInput: 100,
+          tokenOutput: 50,
+          tokenTotal: 150,
+          estimatedCostUsd: 0.02,
+          toolCallCount: 1,
+          retryCount: 0,
+          loopIterations: 2,
+          traceUrl: expect.stringContaining('/traces/'),
+        }),
+      ]),
+    );
+  });
+
+  it('shares provider-safe tuning knobs across the default matrix models', () => {
+    expect(
+      defaultEvalMatrixModels({
+        provider: 'openai',
+        model: 'gpt-5.5',
+        reasoningEffort: 'xhigh',
+        maxOutputTokens: 1024,
+        timeoutMs: 30_000,
+        toolLoopLimit: 4,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        reasoningEffort: undefined,
+        maxOutputTokens: 1024,
+      }),
+      expect.objectContaining({
+        provider: 'anthropic',
+        model: 'claude-opus-4-7',
+        reasoningEffort: undefined,
+        timeoutMs: 30_000,
+      }),
+      expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-5.5',
+        reasoningEffort: 'xhigh',
+        toolLoopLimit: 4,
+      }),
+    ]);
+  });
+
+  it('dispatches category and full-dataset selections without duplicating runner logic', async () => {
+    const runner = successfulRunner();
+
+    await runEvalMatrix({
+      cases: [selectedCase, secondCase],
+      runLabel: 'matrix-category',
+      toolSurface: 'redesigned',
+      selection: 'category',
+      modelConfigs: DEFAULT_EVAL_MATRIX_MODELS,
+      runner,
+      guardrails: {
+        allowFullDataset: false,
+        allowEstimatedCostOverride: false,
+        maxEstimatedCostUsd: 10,
+        retryCount: 0,
+        continueOnModelFailure: true,
+        providerConcurrency: { anthropic: 1, openai: 1 },
+      },
+      langfuseBaseUrl: 'https://langfuse.test',
+    });
+    await runEvalMatrix({
+      cases: [selectedCase, secondCase],
+      runLabel: 'matrix-full',
+      toolSurface: 'redesigned',
+      selection: 'all',
+      modelConfigs: DEFAULT_EVAL_MATRIX_MODELS,
+      runner,
+      guardrails: {
+        allowFullDataset: true,
+        allowEstimatedCostOverride: false,
+        maxEstimatedCostUsd: 10,
+        retryCount: 0,
+        continueOnModelFailure: true,
+        providerConcurrency: { anthropic: 1, openai: 1 },
+      },
+      langfuseBaseUrl: 'https://langfuse.test',
+    });
+
+    expect(runner).toHaveBeenCalledTimes(12);
+  });
+
+  it('keeps successful rows when another model fails', async () => {
+    const runner: EvalMatrixRunner = vi.fn(async ({ providerConfig, traceId }) => {
+      if (providerConfig.provider === 'openai') {
+        throw Object.assign(new Error('rate limited'), { status: 429 });
+      }
+      return {
+        ok: true,
+        answer: 'ok',
+        traceId,
+        traceUrl: `https://langfuse.test/project/default/traces/${traceId}`,
+        score: 1,
+        pass: true,
+        latencyMs: 500,
+        tokenUsage: { input: 10, output: 5, total: 15 },
+        estimatedCostUsd: 0.01,
+        toolCallCount: 0,
+        loopIterations: 1,
+        failureClass: 'none',
+      };
+    });
+
+    const result = await runEvalMatrix({
+      cases: [selectedCase],
+      runLabel: 'partial-failure',
+      toolSurface: 'redesigned',
+      selection: 'id',
+      modelConfigs: DEFAULT_EVAL_MATRIX_MODELS,
+      runner,
+      guardrails: {
+        allowFullDataset: false,
+        allowEstimatedCostOverride: false,
+        maxEstimatedCostUsd: 1,
+        retryCount: 0,
+        continueOnModelFailure: true,
+        providerConcurrency: { anthropic: 1, openai: 1 },
+      },
+      langfuseBaseUrl: 'https://langfuse.test',
+    });
+
+    expect(result.rows).toHaveLength(3);
+    expect(result.rows.filter((row) => row.ok)).toHaveLength(2);
+    expect(result.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: 'openai',
+          ok: false,
+          failureClass: 'rate_limit',
+          error: 'rate limited',
+        }),
+      ]),
+    );
+  });
+
+  it('requires explicit guardrail overrides for full dataset and high-cost runs', async () => {
+    const runner = successfulRunner();
+
+    await expect(
+      runEvalMatrix({
+        cases: [selectedCase, secondCase],
+        runLabel: 'matrix-full',
+        toolSurface: 'redesigned',
+        selection: 'all',
+        modelConfigs: DEFAULT_EVAL_MATRIX_MODELS,
+        runner,
+        guardrails: {
+          allowFullDataset: false,
+          allowEstimatedCostOverride: false,
+          maxEstimatedCostUsd: 10,
+          retryCount: 0,
+          continueOnModelFailure: true,
+          providerConcurrency: { anthropic: 1, openai: 1 },
+        },
+        langfuseBaseUrl: 'https://langfuse.test',
+      }),
+    ).rejects.toThrow(/requires --allow-full-dataset/);
+
+    await expect(
+      runEvalMatrix({
+        cases: [selectedCase],
+        runLabel: 'matrix-cost',
+        toolSurface: 'redesigned',
+        selection: 'id',
+        modelConfigs: DEFAULT_EVAL_MATRIX_MODELS,
+        runner,
+        guardrails: {
+          allowFullDataset: false,
+          allowEstimatedCostOverride: false,
+          maxEstimatedCostUsd: 0.001,
+          retryCount: 0,
+          continueOnModelFailure: true,
+          providerConcurrency: { anthropic: 1, openai: 1 },
+        },
+        langfuseBaseUrl: 'https://langfuse.test',
+      }),
+    ).rejects.toThrow(/requires --allow-estimated-cost/);
+  });
+
+  it('retries provider rate limits before recording a matrix failure', async () => {
+    const config: EvalProviderConfig = {
+      provider: 'openai',
+      model: 'gpt-5.5',
+      reasoningEffort: undefined,
+      maxOutputTokens: undefined,
+      timeoutMs: undefined,
+      toolLoopLimit: undefined,
+    };
+    const runner: EvalMatrixRunner = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('429 rate limit'), { status: 429 }))
+      .mockResolvedValueOnce({
+        ok: true,
+        answer: 'ok after retry',
+        traceId: 'retry-trace',
+        traceUrl: 'https://langfuse.test/project/default/traces/retry-trace',
+        score: 1,
+        pass: true,
+        latencyMs: 900,
+        tokenUsage: { input: 20, output: 10, total: 30 },
+        estimatedCostUsd: 0.01,
+        toolCallCount: 0,
+        loopIterations: 1,
+        failureClass: 'none',
+      });
+
+    const result = await runEvalMatrix({
+      cases: [selectedCase],
+      runLabel: 'matrix-retry',
+      toolSurface: 'redesigned',
+      selection: 'id',
+      modelConfigs: [config],
+      runner,
+      guardrails: {
+        allowFullDataset: false,
+        allowEstimatedCostOverride: false,
+        maxEstimatedCostUsd: 1,
+        retryCount: 1,
+        continueOnModelFailure: true,
+        providerConcurrency: { anthropic: 1, openai: 1 },
+      },
+      langfuseBaseUrl: 'https://langfuse.test',
+    });
+
+    expect(runner).toHaveBeenCalledTimes(2);
+    expect(result.rows[0]).toMatchObject({ ok: true, retryCount: 1 });
+  });
+
+  it('formats the matrix summary table with comparison fields and Langfuse links', async () => {
+    const result = await runEvalMatrix({
+      cases: [selectedCase],
+      runLabel: 'matrix-table',
+      toolSurface: 'redesigned',
+      selection: 'id',
+      modelConfigs: DEFAULT_EVAL_MATRIX_MODELS.slice(0, 1),
+      runner: successfulRunner(),
+      guardrails: {
+        allowFullDataset: false,
+        allowEstimatedCostOverride: false,
+        maxEstimatedCostUsd: 1,
+        retryCount: 0,
+        continueOnModelFailure: true,
+        providerConcurrency: { anthropic: 1, openai: 1 },
+      },
+      langfuseBaseUrl: 'https://langfuse.test',
+    });
+
+    expect(formatEvalMatrixTable(result.rows)).toContain(
+      'case\tmodel\tpass\tfailure_class\tscore\tlatency_ms\ttokens\tcost_usd\ttools\tretries\tloops\ttrace\terror',
+    );
+    expect(formatEvalMatrixTable(result.rows)).toContain('item-spyglass');
+    expect(formatEvalMatrixTable(result.rows)).toContain('claude-sonnet-4-6');
+    expect(formatEvalMatrixTable(result.rows)).toContain('https://langfuse.test');
+  });
+});

--- a/test/eval-openai-runner.test.ts
+++ b/test/eval-openai-runner.test.ts
@@ -290,6 +290,31 @@ describe('OpenAI Responses eval runner', () => {
     ]);
   });
 
+  it('does not invoke result scoring on failed runs', async () => {
+    const client = responsesClient({
+      id: 'resp_empty',
+      model: 'gpt-5.5-2026-04-23',
+      status: 'completed',
+      output: [{ type: 'message', content: [] }],
+    });
+    const scoreResult = vi.fn();
+
+    const result = await runOpenAiResponsesEvalCase({
+      client,
+      evalCase,
+      providerConfig,
+      runLabel: 'failed-score-skip',
+      toolSurface: 'redesigned',
+      scoreResult,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(scoreResult).not.toHaveBeenCalled();
+    expect(result.trace.judgeScores).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'failure_class' })]),
+    );
+  });
+
   it('classifies tool execution failures', async () => {
     const client = responsesClient({
       id: 'resp_tool',

--- a/test/eval-openai-runner.test.ts
+++ b/test/eval-openai-runner.test.ts
@@ -223,6 +223,39 @@ describe('OpenAI Responses eval runner', () => {
     );
   });
 
+  it('uses caller-provided trace ids and merges judge scores into the Langfuse trace', async () => {
+    const client = responsesClient({
+      id: 'resp_final',
+      model: 'gpt-5.5-2026-04-23',
+      status: 'completed',
+      output_text: 'Done.',
+      output: [{ type: 'message', content: [{ type: 'output_text', text: 'Done.' }] }],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    });
+
+    const result = await runOpenAiResponsesEvalCase({
+      client,
+      evalCase,
+      providerConfig,
+      runLabel: 'matrix-run',
+      toolSurface: 'redesigned',
+      traceId: 'matrix-openai-trace',
+      scoreResult: async () => [
+        { name: 'correctness', value: 1, comment: 'Correct.' },
+        { name: 'pass', value: 'pass', comment: 'Correct.' },
+      ],
+    });
+
+    expect(result.trace.traceId).toBe('matrix-openai-trace');
+    expect(result.trace.judgeScores).toEqual(
+      expect.arrayContaining([
+        { name: 'correctness', value: 1, comment: 'Correct.' },
+        { name: 'pass', value: 'pass', comment: 'Correct.' },
+        expect.objectContaining({ name: 'retry_count', value: 0 }),
+      ]),
+    );
+  });
+
   it('classifies schema failures from malformed function-call arguments', async () => {
     const client = responsesClient({
       id: 'resp_bad_args',

--- a/test/eval-runner.test.ts
+++ b/test/eval-runner.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { parseEvalArgs } from '../eval/cli.ts';
+import { runEval } from '../eval/runner.ts';
+
+describe('eval runner', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('honors estimated-cost guardrails for plain OpenAI Langfuse runs', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await expect(
+      runEval(
+        parseEvalArgs([
+          '--provider=openai',
+          '--model=gpt-5.5',
+          '--id=rule-poison',
+          '--run-label=plain-openai-cost-guardrail',
+          '--max-estimated-cost-usd=0.001',
+        ]),
+        {},
+      ),
+    ).rejects.toThrow(/requires --allow-estimated-cost/);
+  });
+});

--- a/test/eval-scoring.test.ts
+++ b/test/eval-scoring.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { passFromTraceScores } from '../eval/scoring.ts';
+
+describe('eval scoring summaries', () => {
+  it('requires both answer and trajectory verdicts to pass when both are present', () => {
+    expect(
+      passFromTraceScores([
+        { name: 'pass', value: 'pass' },
+        { name: 'trajectory_pass', value: 'fail' },
+      ]),
+    ).toBe(false);
+    expect(
+      passFromTraceScores([
+        { name: 'pass', value: 'pass' },
+        { name: 'trajectory_pass', value: 'pass' },
+      ]),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the side-by-side eval matrix runner for Anthropic Sonnet 4.6, Anthropic Opus 4.7, and OpenAI GPT-5.5.
- Adds matrix guardrails for full-dataset runs, estimated cost, provider concurrency, retry count, and model failure handling.
- Writes Langfuse-backed matrix traces and prints/exports comparison rows with pass/fail, score, latency, token usage, estimated cost, tool calls, retries, loop count, and trace links.
- Removes the OpenAI local-report requirement for Langfuse-backed eval runs while keeping local JSON as an optional export.

## Review
- Ran gstack pre-landing review.
- Fixed one review finding before push: failed OpenAI matrix rows now skip answer judging and show `pass=false` instead of a blank pass value.
- No VERSION or CHANGELOG update, per Squire shipping rules for ordinary feature PRs.

## QA / Validation
- `npm run check` (61 files, 995 tests)
- `npx eslint eval`
- `npx prettier --check eval`
- Live matrix smoke against OpenAI, Anthropic, and Langfuse:
  - `npm run eval -- --matrix --id=rule-poison --run-label=qa-sqr-131-live-after-20260502-103341 --timeout-ms=90000 --tool-loop-limit=3 --max-output-tokens=2048 --local-report=/tmp/squire-qa-sqr-131-live-matrix-after.json`
  - All three model rows passed and exported trace links/costs.

Fixes SQR-131


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matrix evaluation mode: run a case across multiple models with --matrix, prints a tab-separated table and can write a local JSON report
  * CLI guardrails: flags to control full-dataset allowance, estimated-cost limits, retry counts, continue-on-failure, and per-provider concurrency
  * Traces & scoring: richer per-run traces (latency, cost, tokens, judge/metric scores) and support for caller-provided trace IDs and custom scoring callbacks

* **Documentation**
  * Added usage example for matrix evaluation mode

* **Tests**
  * Expanded coverage for matrix flow, CLI parsing, scoring, retries, and failure handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->