### PR TITLE
SQR-133: Add eval performance and cost comparison harness

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -347,6 +347,32 @@ npm run eval -- --id=rule-poison
 Runs one specific eval case by ID (IDs are in `eval/dataset.json`). Useful for
 debugging a single failure without waiting for the full suite.
 
+**Run and compare a model matrix experiment:**
+
+```bash
+npm run eval -- --matrix --id=building-alchemist --name=sqr-133-before --local-report=/tmp/sqr-133-before.json
+npm run eval -- --matrix --id=building-alchemist --name=sqr-133-after --tool-loop-limit=4 --broad-search-synthesis-threshold=2 --local-report=/tmp/sqr-133-after.json
+npm run eval -- --compare-runs=/tmp/sqr-133-before.json,/tmp/sqr-133-after.json
+```
+
+Matrix reports include pass rate, score, latency, token use, estimated cost,
+tool-call count, retry count, timeout rate, loop iterations, Langfuse trace
+links, prompt/tool schema versions, and model knob values. The comparison
+command prints deltas by provider/model and rejects comparisons when prompt or
+tool schema versions differ; do not mix those runs, because a prompt or schema
+change changes more than model tuning.
+
+Tunable eval-only knobs:
+
+- `--max-output-tokens=`
+- `--reasoning-effort=`
+- `--timeout-ms=`
+- `--tool-loop-limit=`
+- `--broad-search-synthesis-threshold=`
+- `--anthropic-concurrency=` / `--openai-concurrency=`
+- `--retry-count=`
+- `--max-estimated-cost-usd=` with `--allow-estimated-cost`
+
 ## Pre-commit hooks
 
 Git hooks are installed automatically when you run `npm install`. Squire pins

--- a/eval/anthropic-runner.ts
+++ b/eval/anthropic-runner.ts
@@ -10,6 +10,7 @@ import {
 } from '../src/agent.ts';
 import type { EvalProviderConfig, EvalToolSurface } from './cli.ts';
 import { DATASET_NAME } from './dataset.ts';
+import { ANTHROPIC_TOOL_SCHEMA_VERSION } from './run-metadata.ts';
 import {
   writeEvalTrace,
   type EvalTraceScore,
@@ -17,8 +18,6 @@ import {
   type EvalTraceToolCall,
   type LangfuseTraceIngestionClient,
 } from './trace.ts';
-
-export const ANTHROPIC_TOOL_SCHEMA_VERSION = 'squire-anthropic-tools-v1' as const;
 
 export type AnthropicEvalFailureClass = 'access' | 'api' | 'timeout' | 'tool' | 'quality';
 

--- a/eval/anthropic-runner.ts
+++ b/eval/anthropic-runner.ts
@@ -205,6 +205,7 @@ async function writeSuccessTrace(
       reasoningEffort: options.providerConfig.reasoningEffort,
       timeoutMs: options.providerConfig.timeoutMs,
       toolLoopLimit: options.providerConfig.toolLoopLimit,
+      broadSearchSynthesisThreshold: options.providerConfig.broadSearchSynthesisThreshold,
     },
     inputQuestion: options.case.question,
     finalAnswer: result.answer,
@@ -280,6 +281,7 @@ async function writeFailureTrace(
       reasoningEffort: options.providerConfig.reasoningEffort,
       timeoutMs: options.providerConfig.timeoutMs,
       toolLoopLimit: options.providerConfig.toolLoopLimit,
+      broadSearchSynthesisThreshold: options.providerConfig.broadSearchSynthesisThreshold,
     },
     inputQuestion: options.case.question,
     finalAnswer: null,
@@ -321,6 +323,7 @@ export async function runAnthropicEvalCase(
       maxOutputTokens: options.providerConfig.maxOutputTokens,
       timeoutMs: options.providerConfig.timeoutMs,
       toolLoopLimit: options.providerConfig.toolLoopLimit,
+      broadSearchSynthesisThreshold: options.providerConfig.broadSearchSynthesisThreshold,
     });
     const endedAtDate = now();
     const endedAt = endedAtDate.toISOString();

--- a/eval/cli.ts
+++ b/eval/cli.ts
@@ -15,6 +15,7 @@ export interface EvalProviderConfig {
   maxOutputTokens: number | undefined;
   timeoutMs: number | undefined;
   toolLoopLimit: number | undefined;
+  broadSearchSynthesisThreshold?: number | undefined;
 }
 
 export interface EvalReplayCliOptions {
@@ -46,6 +47,12 @@ export interface EvalCliOptions {
   replay: EvalReplayCliOptions | undefined;
   matrixMode: boolean;
   matrixGuardrails: EvalMatrixGuardrails;
+  comparison: EvalRunComparisonCliOptions | undefined;
+}
+
+export interface EvalRunComparisonCliOptions {
+  beforeReportPath: string;
+  afterReportPath: string;
 }
 
 function valueFor(args: string[], prefix: string): string | undefined {
@@ -196,6 +203,23 @@ function optionalPositiveNumberFor(args: string[], prefix: string, fallback: num
   return parsed;
 }
 
+function comparisonOptionsFor(args: string[]): EvalRunComparisonCliOptions | undefined {
+  const raw = valueFor(args, '--compare-runs=');
+  if (!raw) return undefined;
+
+  const paths = raw
+    .split(',')
+    .map((path) => path.trim())
+    .filter(Boolean);
+  if (paths.length !== 2) {
+    throw new Error('Invalid --compare-runs: expected two comma-separated report paths.');
+  }
+  return {
+    beforeReportPath: paths[0],
+    afterReportPath: paths[1],
+  };
+}
+
 export function parseEvalArgs(
   args: string[],
   now = new Date(),
@@ -253,6 +277,12 @@ export function parseEvalArgs(
         env,
         'SQUIRE_EVAL_TOOL_LOOP_LIMIT',
       ),
+      broadSearchSynthesisThreshold: positiveIntegerFor(
+        args,
+        '--broad-search-synthesis-threshold=',
+        env,
+        'SQUIRE_EVAL_BROAD_SEARCH_SYNTHESIS_THRESHOLD',
+      ),
     },
     replay: replayOptionsFor(args, valueFor(args, '--id='), provider),
     matrixMode: args.includes('--matrix'),
@@ -267,5 +297,6 @@ export function parseEvalArgs(
         openai: optionalPositiveIntegerFor(args, '--openai-concurrency=', 1),
       },
     },
+    comparison: comparisonOptionsFor(args),
   };
 }

--- a/eval/cost-harness.ts
+++ b/eval/cost-harness.ts
@@ -1,0 +1,256 @@
+import { readFileSync } from 'node:fs';
+import type { EvalMatrixResult, EvalMatrixRow } from './matrix.ts';
+
+export interface EvalRunComparisonInput {
+  before: EvalMatrixResult;
+  after: EvalMatrixResult;
+}
+
+export interface EvalRunAggregate {
+  passRate: number;
+  averageScore: number | null;
+  averageLatencyMs: number | null;
+  totalTokens: number;
+  totalEstimatedCostUsd: number;
+  averageToolCallCount: number | null;
+  averageRetryCount: number;
+  timeoutRate: number;
+  averageLoopIterations: number | null;
+  failureBreakdown: Record<string, number>;
+}
+
+export interface EvalRunAggregateDelta {
+  passRate: number;
+  averageScore: number | null;
+  averageLatencyMs: number | null;
+  totalTokens: number;
+  totalEstimatedCostUsd: number;
+  averageToolCallCount: number | null;
+  averageRetryCount: number;
+  timeoutRate: number;
+  averageLoopIterations: number | null;
+}
+
+export interface EvalRunComparisonGroup {
+  provider: EvalMatrixRow['provider'];
+  model: EvalMatrixRow['model'];
+  casesCompared: number;
+  before: EvalRunAggregate;
+  after: EvalRunAggregate;
+  delta: EvalRunAggregateDelta;
+  diagnosis: string[];
+}
+
+export interface EvalRunComparison {
+  beforeRunLabel: string;
+  afterRunLabel: string;
+  groups: EvalRunComparisonGroup[];
+}
+
+function rowKey(row: EvalMatrixRow): string {
+  return `${row.caseId}:${row.provider}:${row.model}`;
+}
+
+function groupKey(row: EvalMatrixRow): string {
+  return `${row.provider}:${row.model}`;
+}
+
+function average(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function nullableDelta(after: number | null, before: number | null): number | null {
+  if (after === null || before === null) return null;
+  return after - before;
+}
+
+function numeric(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function aggregate(rows: EvalMatrixRow[]): EvalRunAggregate {
+  const failureBreakdown: Record<string, number> = {};
+  for (const row of rows) {
+    failureBreakdown[row.failureClass] = (failureBreakdown[row.failureClass] ?? 0) + 1;
+  }
+
+  return {
+    passRate: rows.filter((row) => row.pass === true).length / rows.length,
+    averageScore: average(rows.map((row) => row.score).filter(numeric)),
+    averageLatencyMs: average(rows.map((row) => row.latencyMs).filter(numeric)),
+    totalTokens: rows
+      .map((row) => row.tokenTotal)
+      .filter(numeric)
+      .reduce((sum, value) => sum + value, 0),
+    totalEstimatedCostUsd: rows
+      .map((row) => row.estimatedCostUsd)
+      .filter(numeric)
+      .reduce((sum, value) => sum + value, 0),
+    averageToolCallCount: average(rows.map((row) => row.toolCallCount).filter(numeric)),
+    averageRetryCount: rows.reduce((sum, row) => sum + row.retryCount, 0) / rows.length,
+    timeoutRate: rows.filter((row) => row.failureClass === 'timeout').length / rows.length,
+    averageLoopIterations: average(rows.map((row) => row.loopIterations).filter(numeric)),
+    failureBreakdown,
+  };
+}
+
+function delta(after: EvalRunAggregate, before: EvalRunAggregate): EvalRunAggregateDelta {
+  return {
+    passRate: after.passRate - before.passRate,
+    averageScore: nullableDelta(after.averageScore, before.averageScore),
+    averageLatencyMs: nullableDelta(after.averageLatencyMs, before.averageLatencyMs),
+    totalTokens: after.totalTokens - before.totalTokens,
+    totalEstimatedCostUsd: after.totalEstimatedCostUsd - before.totalEstimatedCostUsd,
+    averageToolCallCount: nullableDelta(after.averageToolCallCount, before.averageToolCallCount),
+    averageRetryCount: after.averageRetryCount - before.averageRetryCount,
+    timeoutRate: after.timeoutRate - before.timeoutRate,
+    averageLoopIterations: nullableDelta(after.averageLoopIterations, before.averageLoopIterations),
+  };
+}
+
+function increasedFailure(
+  before: EvalRunAggregate,
+  after: EvalRunAggregate,
+  failureClass: string,
+): boolean {
+  return (after.failureBreakdown[failureClass] ?? 0) > (before.failureBreakdown[failureClass] ?? 0);
+}
+
+function decreasedFailure(
+  before: EvalRunAggregate,
+  after: EvalRunAggregate,
+  failureClass: string,
+): boolean {
+  return (after.failureBreakdown[failureClass] ?? 0) < (before.failureBreakdown[failureClass] ?? 0);
+}
+
+function diagnose(before: EvalRunAggregate, after: EvalRunAggregate): string[] {
+  const reasons: string[] = [];
+  if (
+    after.passRate > before.passRate &&
+    (decreasedFailure(before, after, 'quality') ||
+      decreasedFailure(before, after, 'answer_quality'))
+  ) {
+    reasons.push('raw_answer_quality improved');
+  }
+  if (after.timeoutRate < before.timeoutRate) reasons.push('timeouts improved');
+  if (increasedFailure(before, after, 'timeout')) reasons.push('timeouts worsened');
+  if (increasedFailure(before, after, 'rate_limit'))
+    reasons.push('provider_rate_limiting worsened');
+  if (increasedFailure(before, after, 'cost_guardrail')) reasons.push('cost_guardrails worsened');
+  if (
+    increasedFailure(before, after, 'loop_limit') ||
+    increasedFailure(before, after, 'iteration_limit')
+  ) {
+    reasons.push('loop_budget worsened');
+  }
+  if (
+    increasedFailure(before, after, 'quality') ||
+    increasedFailure(before, after, 'answer_quality')
+  ) {
+    reasons.push('raw_answer_quality worsened');
+  }
+  if (after.passRate < before.passRate && reasons.length === 0) reasons.push('accuracy worsened');
+  if (reasons.length === 0) reasons.push('no obvious regression driver');
+  return reasons;
+}
+
+function assertCompatibleRows(before: EvalMatrixRow, after: EvalMatrixRow): void {
+  const mismatches = [
+    before.promptVersion !== after.promptVersion ? 'promptVersion' : undefined,
+    before.promptHash !== after.promptHash ? 'promptHash' : undefined,
+    before.toolSurface !== after.toolSurface ? 'toolSurface' : undefined,
+    before.toolSchemaVersion !== after.toolSchemaVersion ? 'toolSchemaVersion' : undefined,
+    before.toolSchemaHash !== after.toolSchemaHash ? 'toolSchemaHash' : undefined,
+  ].filter(Boolean);
+
+  if (mismatches.length > 0) {
+    throw new Error(
+      `Cannot compare ${before.runLabel} to ${after.runLabel}: incompatible ${mismatches.join(', ')} for ${before.caseId} ${before.provider}:${before.model}.`,
+    );
+  }
+}
+
+export function compareEvalRuns(input: EvalRunComparisonInput): EvalRunComparison {
+  const beforeRows = new Map(input.before.rows.map((row) => [rowKey(row), row]));
+  const pairs: Array<{ before: EvalMatrixRow; after: EvalMatrixRow }> = [];
+
+  for (const after of input.after.rows) {
+    const before = beforeRows.get(rowKey(after));
+    if (!before) continue;
+    assertCompatibleRows(before, after);
+    pairs.push({ before, after });
+  }
+
+  if (pairs.length === 0) {
+    throw new Error(
+      `Cannot compare ${input.before.runLabel} to ${input.after.runLabel}: no matching case/provider/model rows.`,
+    );
+  }
+
+  const grouped = new Map<string, Array<{ before: EvalMatrixRow; after: EvalMatrixRow }>>();
+  for (const pair of pairs) {
+    const key = groupKey(pair.after);
+    grouped.set(key, [...(grouped.get(key) ?? []), pair]);
+  }
+
+  return {
+    beforeRunLabel: input.before.runLabel,
+    afterRunLabel: input.after.runLabel,
+    groups: [...grouped.values()].map((pairsForGroup) => {
+      const before = aggregate(pairsForGroup.map((pair) => pair.before));
+      const after = aggregate(pairsForGroup.map((pair) => pair.after));
+      const first = pairsForGroup[0].after;
+      return {
+        provider: first.provider,
+        model: first.model,
+        casesCompared: pairsForGroup.length,
+        before,
+        after,
+        delta: delta(after, before),
+        diagnosis: diagnose(before, after),
+      };
+    }),
+  };
+}
+
+function formatNumber(value: number | null, digits = 3): string {
+  if (value === null) return '-';
+  return Number.isInteger(value) ? String(value) : value.toFixed(digits);
+}
+
+export function formatEvalRunComparison(comparison: EvalRunComparison): string {
+  const lines = [
+    `Eval run comparison: ${comparison.beforeRunLabel} -> ${comparison.afterRunLabel}`,
+    'model\tcases\tpass_delta\tlatency_delta_ms\ttoken_delta\tcost_delta_usd\tretry_delta\ttimeout_delta\tloop_delta\ttool_delta\tdiagnosis',
+  ];
+
+  for (const group of comparison.groups) {
+    lines.push(
+      [
+        `${group.provider}:${group.model}`,
+        group.casesCompared,
+        formatNumber(group.delta.passRate),
+        formatNumber(group.delta.averageLatencyMs),
+        group.delta.totalTokens,
+        formatNumber(group.delta.totalEstimatedCostUsd, 4),
+        formatNumber(group.delta.averageRetryCount),
+        formatNumber(group.delta.timeoutRate),
+        formatNumber(group.delta.averageLoopIterations),
+        formatNumber(group.delta.averageToolCallCount),
+        group.diagnosis.join('; '),
+      ].join('\t'),
+    );
+  }
+
+  return lines.join('\n');
+}
+
+export function readEvalMatrixReport(path: string): EvalMatrixResult {
+  const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+  if (!parsed || typeof parsed !== 'object' || !('runLabel' in parsed) || !('rows' in parsed)) {
+    throw new Error(`Invalid eval matrix report: ${path}`);
+  }
+  return parsed as EvalMatrixResult;
+}

--- a/eval/cost-harness.ts
+++ b/eval/cost-harness.ts
@@ -156,14 +156,34 @@ function diagnose(before: EvalRunAggregate, after: EvalRunAggregate): string[] {
   return reasons;
 }
 
+function stableStringify(value: unknown): string {
+  if (!value || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(',')}}`;
+}
+
 function assertCompatibleRows(before: EvalMatrixRow, after: EvalMatrixRow): void {
-  const mismatches = [
-    before.promptVersion !== after.promptVersion ? 'promptVersion' : undefined,
-    before.promptHash !== after.promptHash ? 'promptHash' : undefined,
-    before.toolSurface !== after.toolSurface ? 'toolSurface' : undefined,
-    before.toolSchemaVersion !== after.toolSchemaVersion ? 'toolSchemaVersion' : undefined,
-    before.toolSchemaHash !== after.toolSchemaHash ? 'toolSchemaHash' : undefined,
-  ].filter(Boolean);
+  const compatibilityFields = [
+    'promptVersion',
+    'promptHash',
+    'toolSurface',
+    'toolSchemaVersion',
+    'toolSchemaHash',
+    'modelSettings',
+    'runSettings',
+  ] as const satisfies readonly (keyof EvalMatrixRow)[];
+
+  const mismatches = compatibilityFields.flatMap((field) => {
+    const beforeValue = before[field];
+    const afterValue = after[field];
+    if (beforeValue === undefined || beforeValue === null) return [`missing ${field} before`];
+    if (afterValue === undefined || afterValue === null) return [`missing ${field} after`];
+    return stableStringify(beforeValue) === stableStringify(afterValue) ? [] : [field];
+  });
 
   if (mismatches.length > 0) {
     throw new Error(

--- a/eval/matrix-runtime.ts
+++ b/eval/matrix-runtime.ts
@@ -84,6 +84,7 @@ function outputFromTrace(
     toolCallCount: trace.toolCalls.length,
     loopIterations: scoreNamed(trace, 'loop_iterations') ?? 0,
     failureClass: failureClassFromTrace(trace),
+    modelSettings: trace.modelSettings,
   };
 }
 

--- a/eval/matrix.ts
+++ b/eval/matrix.ts
@@ -7,6 +7,13 @@ import type {
   EvalReasoningEffort,
   EvalToolSurface,
 } from './cli.ts';
+import {
+  evalMatrixRunSettingsFor,
+  evalModelSettingsFor,
+  evalRunCompatibilityFor,
+  type EvalMatrixRunSettings,
+  type EvalModelSettings,
+} from './run-metadata.ts';
 import type { EvalCase } from './schema.ts';
 
 export type EvalMatrixSelection = 'id' | 'category' | 'all';
@@ -39,6 +46,7 @@ export interface EvalMatrixRunnerOutput {
   toolCallCount: number;
   loopIterations: number;
   failureClass: string;
+  modelSettings?: EvalModelSettings;
 }
 
 export type EvalMatrixRunner = (input: EvalMatrixRunnerInput) => Promise<EvalMatrixRunnerOutput>;
@@ -64,6 +72,13 @@ export interface EvalMatrixRow {
   failureClass: string;
   traceId: string;
   traceUrl: string;
+  promptVersion: string;
+  promptHash: string;
+  toolSurface: EvalToolSurface;
+  toolSchemaVersion: string;
+  toolSchemaHash: string;
+  modelSettings: EvalModelSettings;
+  runSettings: EvalMatrixRunSettings;
   runUrl?: string;
   error?: string;
 }
@@ -258,7 +273,9 @@ function rowFromOutput(
   input: EvalMatrixRunnerInput,
   output: EvalMatrixRunnerOutput,
   retryCount: number,
+  guardrails: EvalMatrixGuardrails,
 ): EvalMatrixRow {
+  const compatibility = evalRunCompatibilityFor(input.providerConfig, input.toolSurface);
   return {
     runLabel: input.runLabel,
     caseId: input.evalCase.id,
@@ -280,6 +297,12 @@ function rowFromOutput(
     failureClass: output.failureClass,
     traceId: output.traceId,
     traceUrl: output.traceUrl,
+    ...compatibility,
+    modelSettings: {
+      ...evalModelSettingsFor(input.providerConfig),
+      ...(output.modelSettings ?? {}),
+    },
+    runSettings: evalMatrixRunSettingsFor(guardrails),
     runUrl: output.runUrl,
   };
 }
@@ -288,7 +311,9 @@ function rowFromError(
   input: EvalMatrixRunnerInput,
   error: unknown,
   retryCount: number,
+  guardrails: EvalMatrixGuardrails,
 ): EvalMatrixRow {
+  const compatibility = evalRunCompatibilityFor(input.providerConfig, input.toolSurface);
   return {
     runLabel: input.runLabel,
     caseId: input.evalCase.id,
@@ -310,6 +335,9 @@ function rowFromError(
     failureClass: failureClassForError(error),
     traceId: input.traceId,
     traceUrl: input.traceUrl,
+    ...compatibility,
+    modelSettings: evalModelSettingsFor(input.providerConfig),
+    runSettings: evalMatrixRunSettingsFor(guardrails),
     error: errorMessage(error),
   };
 }
@@ -321,11 +349,11 @@ async function runMatrixInput(
 ): Promise<EvalMatrixRow> {
   try {
     const result = await runWithRetries(input, runner, guardrails.retryCount);
-    return rowFromOutput(input, result.output, result.retryCount);
+    return rowFromOutput(input, result.output, result.retryCount, guardrails);
   } catch (error) {
     if (!guardrails.continueOnModelFailure) throw error;
     const retryCount = matrixRetryCountForError(error) ?? 0;
-    return rowFromError(input, error, retryCount);
+    return rowFromError(input, error, retryCount, guardrails);
   }
 }
 

--- a/eval/matrix.ts
+++ b/eval/matrix.ts
@@ -141,6 +141,7 @@ function withSharedKnobs(
     maxOutputTokens: shared.maxOutputTokens,
     timeoutMs: shared.timeoutMs,
     toolLoopLimit: shared.toolLoopLimit,
+    broadSearchSynthesisThreshold: shared.broadSearchSynthesisThreshold,
   };
 }
 

--- a/eval/openai-runner.ts
+++ b/eval/openai-runner.ts
@@ -88,6 +88,9 @@ interface OpenAiTranscriptTurn {
   error?: EvalTraceError;
 }
 
+const FORCE_SYNTHESIS_PROMPT =
+  'Use the retrieved rulebook context to answer now. Do not search again unless the existing tool results are empty or clearly unrelated.';
+
 export interface OpenAiResponsesEvalResult {
   ok: boolean;
   answer: string;
@@ -233,10 +236,12 @@ function sha256(value: string): string {
 
 function modelSettingsFor(config: EvalProviderConfig): Record<string, string | number | undefined> {
   return {
+    model: config.model,
     reasoningEffort: config.reasoningEffort,
     maxOutputTokens: config.maxOutputTokens,
     timeoutMs: config.timeoutMs,
     toolLoopLimit: config.toolLoopLimit,
+    broadSearchSynthesisThreshold: config.broadSearchSynthesisThreshold,
   };
 }
 
@@ -245,12 +250,13 @@ function createResponsesRequest(
   evalCase: EvalCase,
   providerConfig: EvalProviderConfig,
   toolSurface: EvalToolSurface,
+  allowTools: boolean,
 ): OpenAiResponsesCreateRequest {
   const request: OpenAiResponsesCreateRequest = {
     model: providerConfig.model,
     instructions: promptFor(toolSurface),
     input: [...input],
-    tools: renderOpenAiStrictToolSchemas(),
+    tools: allowTools ? renderOpenAiStrictToolSchemas() : [],
     store: false,
     parallel_tool_calls: false,
     include: ['reasoning.encrypted_content'],
@@ -263,6 +269,25 @@ function createResponsesRequest(
   if (providerConfig.reasoningEffort)
     request.reasoning = { effort: providerConfig.reasoningEffort };
   return request;
+}
+
+function isBroadRuleSearchTool(toolName: string, input: Record<string, unknown>): boolean {
+  if (toolName === 'search_rules') return true;
+  if (toolName !== 'search_knowledge') return false;
+
+  const scope = input.scope;
+  if (!Array.isArray(scope) || scope.length === 0) return false;
+  return scope.every((kind) => kind === 'rules_passage');
+}
+
+function isNonRuleSearchTool(toolName: string, input: Record<string, unknown>): boolean {
+  if (toolName === 'inspect_sources' || toolName === 'schema' || toolName === 'resolve_entity') {
+    return false;
+  }
+  if (toolName === 'open_entity' && typeof input.ref === 'string') {
+    return !input.ref.startsWith('rules:');
+  }
+  return !isBroadRuleSearchTool(toolName, input);
 }
 
 function functionCallItems(response: OpenAiResponsesResponse): Array<{
@@ -454,6 +479,9 @@ export async function runOpenAiResponsesEvalCase(
   const tokenUsage = { input: 0, output: 0, reasoning: 0, cached: 0, total: 0 };
   let resolvedModel: string = options.providerConfig.model;
   let iterations = 0;
+  let broadRuleSearches = 0;
+  let hasUsedNonRuleSearchTool = false;
+  let forceSynthesis = false;
 
   const buildTrace = (
     statusReason: string,
@@ -568,6 +596,7 @@ export async function runOpenAiResponsesEvalCase(
       options.evalCase,
       options.providerConfig,
       options.toolSurface,
+      !forceSynthesis,
     );
     requests.push(request);
     const turn: OpenAiTranscriptTurn = {
@@ -633,6 +662,12 @@ export async function runOpenAiResponsesEvalCase(
         return finish(false, '', failureClass, failureClass, message);
       }
 
+      if (isBroadRuleSearchTool(call.name, parsedArguments)) {
+        broadRuleSearches += 1;
+      } else if (isNonRuleSearchTool(call.name, parsedArguments)) {
+        hasUsedNonRuleSearchTool = true;
+      }
+
       const toolStartedAt = now().toISOString();
       let toolResult: ToolCallResult;
       let toolOk = true;
@@ -694,6 +729,19 @@ export async function runOpenAiResponsesEvalCase(
       };
       turn.functionCallOutputs.push(outputItem);
       input.push(outputItem);
+    }
+
+    if (
+      options.providerConfig.broadSearchSynthesisThreshold &&
+      broadRuleSearches >= options.providerConfig.broadSearchSynthesisThreshold &&
+      !hasUsedNonRuleSearchTool
+    ) {
+      forceSynthesis = true;
+      input.push({
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: FORCE_SYNTHESIS_PROMPT }],
+      });
     }
   }
 

--- a/eval/run-metadata.ts
+++ b/eval/run-metadata.ts
@@ -1,0 +1,81 @@
+import { createHash } from 'node:crypto';
+import {
+  AGENT_SYSTEM_PROMPT,
+  AGENT_TOOLS,
+  LEGACY_AGENT_SYSTEM_PROMPT,
+  LEGACY_AGENT_TOOLS,
+} from '../src/agent.ts';
+import type { EvalMatrixGuardrails, EvalProviderConfig, EvalToolSurface } from './cli.ts';
+import { OPENAI_TOOL_SCHEMA_VERSION, getOpenAiToolSchemaHash } from './openai-schema.ts';
+
+export const ANTHROPIC_TOOL_SCHEMA_VERSION = 'squire-anthropic-tools-v1' as const;
+
+export type EvalModelSettings = Record<string, string | number | boolean | null | undefined>;
+
+export interface EvalRunCompatibilityMetadata {
+  promptVersion: string;
+  promptHash: string;
+  toolSurface: EvalToolSurface;
+  toolSchemaVersion: string;
+  toolSchemaHash: string;
+}
+
+export interface EvalMatrixRunSettings {
+  retryCount: number;
+  maxEstimatedCostUsd: number;
+  providerConcurrency: Record<'anthropic' | 'openai', number>;
+}
+
+export function evalPromptVersionFor(toolSurface: EvalToolSurface): string {
+  return toolSurface === 'legacy' ? 'legacy-agent-v1' : 'redesigned-agent-v1';
+}
+
+export function evalPromptHashFor(toolSurface: EvalToolSurface): string {
+  const prompt = toolSurface === 'legacy' ? LEGACY_AGENT_SYSTEM_PROMPT : AGENT_SYSTEM_PROMPT;
+  return `sha256:${createHash('sha256').update(prompt).digest('hex')}`;
+}
+
+export function evalToolSchemaVersionFor(config: EvalProviderConfig): string {
+  return config.provider === 'openai' ? OPENAI_TOOL_SCHEMA_VERSION : ANTHROPIC_TOOL_SCHEMA_VERSION;
+}
+
+export function evalToolSchemaHashFor(
+  config: EvalProviderConfig,
+  toolSurface: EvalToolSurface,
+): string {
+  if (config.provider === 'openai') return getOpenAiToolSchemaHash();
+  const tools = toolSurface === 'legacy' ? LEGACY_AGENT_TOOLS : AGENT_TOOLS;
+  return `sha256:${createHash('sha256').update(JSON.stringify(tools)).digest('hex')}`;
+}
+
+export function evalModelSettingsFor(config: EvalProviderConfig): EvalModelSettings {
+  return {
+    model: config.model,
+    reasoningEffort: config.reasoningEffort,
+    maxOutputTokens: config.maxOutputTokens,
+    timeoutMs: config.timeoutMs,
+    toolLoopLimit: config.toolLoopLimit,
+    broadSearchSynthesisThreshold: config.broadSearchSynthesisThreshold,
+  };
+}
+
+export function evalRunCompatibilityFor(
+  config: EvalProviderConfig,
+  toolSurface: EvalToolSurface,
+): EvalRunCompatibilityMetadata {
+  return {
+    promptVersion: evalPromptVersionFor(toolSurface),
+    promptHash: evalPromptHashFor(toolSurface),
+    toolSurface,
+    toolSchemaVersion: evalToolSchemaVersionFor(config),
+    toolSchemaHash: evalToolSchemaHashFor(config, toolSurface),
+  };
+}
+
+export function evalMatrixRunSettingsFor(guardrails: EvalMatrixGuardrails): EvalMatrixRunSettings {
+  return {
+    retryCount: guardrails.retryCount,
+    maxEstimatedCostUsd: guardrails.maxEstimatedCostUsd,
+    providerConcurrency: guardrails.providerConcurrency,
+  };
+}

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -6,6 +6,7 @@ import {
   type EvalProviderConfig,
 } from './cli.ts';
 import { filterEvalCases, loadEvalCases, seedDataset } from './dataset.ts';
+import { compareEvalRuns, formatEvalRunComparison, readEvalMatrixReport } from './cost-harness.ts';
 import { evalCaseHasFinalAnswer } from './schema.ts';
 import { runFiltered, runOnDataset } from './experiments.ts';
 import { runLocalReport } from './local-report.ts';
@@ -32,6 +33,9 @@ function describeProviderConfig(config: EvalProviderConfig): string {
     config.maxOutputTokens ? `maxOutput=${config.maxOutputTokens}` : undefined,
     config.timeoutMs ? `timeoutMs=${config.timeoutMs}` : undefined,
     config.toolLoopLimit ? `toolLoopLimit=${config.toolLoopLimit}` : undefined,
+    config.broadSearchSynthesisThreshold
+      ? `broadSearchSynthesisThreshold=${config.broadSearchSynthesisThreshold}`
+      : undefined,
   ].filter(Boolean);
 
   return `${config.provider}:${config.model}${tuning.length > 0 ? ` (${tuning.join(', ')})` : ''}`;
@@ -50,6 +54,15 @@ function assertCurrentRunnerSupportsProviderConfig(config: EvalProviderConfig): 
 }
 
 export async function runEval(options: EvalCliOptions, env: NodeJS.ProcessEnv = process.env) {
+  if (options.comparison) {
+    const comparison = compareEvalRuns({
+      before: readEvalMatrixReport(options.comparison.beforeReportPath),
+      after: readEvalMatrixReport(options.comparison.afterReportPath),
+    });
+    console.log(formatEvalRunComparison(comparison));
+    return;
+  }
+
   if (options.replay) {
     const caseId = options.idFilter ?? options.replay.traceId;
     if (!caseId) throw new Error('Replay mode requires --id or --trace-id.');

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -436,6 +436,7 @@ export interface EvalAgentLoopOptions {
   maxOutputTokens?: number;
   timeoutMs?: number;
   toolLoopLimit?: number;
+  broadSearchSynthesisThreshold?: number;
 }
 
 const AGENT_MODEL = 'claude-sonnet-4-6' as const;
@@ -782,6 +783,7 @@ export async function runAgentLoopWithEvalConfig(
           maxOutputTokens: options.maxOutputTokens,
           timeoutMs: options.timeoutMs,
           toolLoopLimit: options.toolLoopLimit,
+          broadSearchSynthesisThreshold: options.broadSearchSynthesisThreshold,
         },
       );
       runSpan.setAttributes({
@@ -812,6 +814,7 @@ interface AgentLoopInternalConfig {
   maxOutputTokens?: number;
   timeoutMs?: number;
   toolLoopLimit?: number;
+  broadSearchSynthesisThreshold?: number;
 }
 
 async function runAgentLoopInternal(
@@ -825,6 +828,8 @@ async function runAgentLoopInternal(
   const truncatedHistory = history ? history.slice(-MAX_HISTORY_TURNS) : [];
   const model = config.model ?? AGENT_MODEL;
   const maxIterations = config.toolLoopLimit ?? MAX_AGENT_ITERATIONS;
+  const broadSearchSynthesisThreshold =
+    config.broadSearchSynthesisThreshold ?? MAX_RULE_SEARCHES_BEFORE_SYNTHESIS;
 
   const messages: MessageParam[] = [
     ...truncatedHistory.map((m: HistoryMessage) => ({
@@ -1038,7 +1043,7 @@ async function runAgentLoopInternal(
       // Simple factual rule lookups can drift into repeated broad searches.
       // After three rule-corpus searches, force synthesis from gathered context
       // without lowering the global loop budget needed by traversal questions.
-      if (broadRuleSearches >= MAX_RULE_SEARCHES_BEFORE_SYNTHESIS && !hasUsedNonRuleSearchTool) {
+      if (broadRuleSearches >= broadSearchSynthesisThreshold && !hasUsedNonRuleSearchTool) {
         forceSynthesis = true;
         messages.push({ role: 'user', content: FORCE_SYNTHESIS_PROMPT });
       }

--- a/test/eval-cli.test.ts
+++ b/test/eval-cli.test.ts
@@ -114,10 +114,11 @@ describe('parseEvalArgs', () => {
       maxOutputTokens: undefined,
       timeoutMs: undefined,
       toolLoopLimit: undefined,
+      broadSearchSynthesisThreshold: undefined,
     });
   });
 
-  it('parses provider, model, run label, timeout, max output, reasoning effort, and tool loop limit', () => {
+  it('parses provider, model, run label, timeout, max output, reasoning effort, tool loop limit, and synthesis threshold', () => {
     expect(
       parseEvalArgs([
         '--provider=openai',
@@ -127,6 +128,7 @@ describe('parseEvalArgs', () => {
         '--max-output-tokens=2048',
         '--reasoning-effort=low',
         '--tool-loop-limit=6',
+        '--broad-search-synthesis-threshold=2',
       ]).providerConfig,
     ).toEqual({
       provider: 'openai',
@@ -135,6 +137,14 @@ describe('parseEvalArgs', () => {
       maxOutputTokens: 2048,
       timeoutMs: 45000,
       toolLoopLimit: 6,
+      broadSearchSynthesisThreshold: 2,
+    });
+  });
+
+  it('parses local matrix report comparison inputs', () => {
+    expect(parseEvalArgs(['--compare-runs=/tmp/before.json,/tmp/after.json']).comparison).toEqual({
+      beforeReportPath: '/tmp/before.json',
+      afterReportPath: '/tmp/after.json',
     });
   });
 
@@ -170,6 +180,7 @@ describe('parseEvalArgs', () => {
         SQUIRE_EVAL_MAX_OUTPUT_TOKENS: '4096',
         SQUIRE_EVAL_REASONING_EFFORT: 'high',
         SQUIRE_EVAL_TOOL_LOOP_LIMIT: '8',
+        SQUIRE_EVAL_BROAD_SEARCH_SYNTHESIS_THRESHOLD: '2',
       }),
     ).toMatchObject({
       runName: 'env-run',
@@ -180,6 +191,7 @@ describe('parseEvalArgs', () => {
         maxOutputTokens: 4096,
         timeoutMs: 60000,
         toolLoopLimit: 8,
+        broadSearchSynthesisThreshold: 2,
       },
     });
   });
@@ -195,6 +207,7 @@ describe('parseEvalArgs', () => {
           '--max-output-tokens=128',
           '--reasoning-effort=none',
           '--tool-loop-limit=2',
+          '--broad-search-synthesis-threshold=4',
         ],
         new Date('2026-05-01T02:00:00Z'),
         {
@@ -205,6 +218,7 @@ describe('parseEvalArgs', () => {
           SQUIRE_EVAL_MAX_OUTPUT_TOKENS: '4096',
           SQUIRE_EVAL_REASONING_EFFORT: 'high',
           SQUIRE_EVAL_TOOL_LOOP_LIMIT: '8',
+          SQUIRE_EVAL_BROAD_SEARCH_SYNTHESIS_THRESHOLD: '3',
         },
       ),
     ).toMatchObject({
@@ -216,6 +230,7 @@ describe('parseEvalArgs', () => {
         maxOutputTokens: 128,
         timeoutMs: 1000,
         toolLoopLimit: 2,
+        broadSearchSynthesisThreshold: 4,
       },
     });
   });
@@ -251,6 +266,15 @@ describe('parseEvalArgs', () => {
     );
     expect(() => parseEvalArgs(['--tool-loop-limit=1.5'])).toThrow(
       /Invalid --tool-loop-limit: expected a positive integer/,
+    );
+    expect(() => parseEvalArgs(['--broad-search-synthesis-threshold=0'])).toThrow(
+      /Invalid --broad-search-synthesis-threshold: expected a positive integer/,
+    );
+  });
+
+  it('rejects invalid local report comparison inputs', () => {
+    expect(() => parseEvalArgs(['--compare-runs=/tmp/before.json'])).toThrow(
+      /Invalid --compare-runs: expected two comma-separated report paths/,
     );
   });
 

--- a/test/eval-cost-harness.test.ts
+++ b/test/eval-cost-harness.test.ts
@@ -251,4 +251,39 @@ describe('eval cost and performance harness', () => {
       /Cannot compare before to after.*promptHash.*toolSchemaVersion/s,
     );
   });
+
+  it('rejects comparisons with missing compatibility metadata', () => {
+    const input = comparisonInput();
+    const { modelSettings, ...legacyBeforeRow } = row({ runLabel: 'before' });
+    input.before.rows = [legacyBeforeRow as EvalMatrixRow];
+    input.after.rows = [row({ runLabel: 'after' })];
+    expect(modelSettings).toBeDefined();
+
+    expect(() => compareEvalRuns(input)).toThrow(
+      /Cannot compare before to after.*missing modelSettings before/s,
+    );
+  });
+
+  it('rejects comparisons when model or run settings differ', () => {
+    const input = comparisonInput();
+    input.before.rows = [row({ runLabel: 'before' })];
+    input.after.rows = [
+      row({
+        runLabel: 'after',
+        modelSettings: {
+          ...row({}).modelSettings,
+          broadSearchSynthesisThreshold: 3,
+        },
+        runSettings: {
+          retryCount: 0,
+          maxEstimatedCostUsd: 1,
+          providerConcurrency: { anthropic: 1, openai: 1 },
+        },
+      }),
+    ];
+
+    expect(() => compareEvalRuns(input)).toThrow(
+      /Cannot compare before to after.*modelSettings.*runSettings/s,
+    );
+  });
 });

--- a/test/eval-cost-harness.test.ts
+++ b/test/eval-cost-harness.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { EvalProviderConfig } from '../eval/cli.ts';
+import {
+  compareEvalRuns,
+  formatEvalRunComparison,
+  type EvalRunComparisonInput,
+} from '../eval/cost-harness.ts';
+import { runEvalMatrix, type EvalMatrixRow, type EvalMatrixRunner } from '../eval/matrix.ts';
+import type { EvalCase } from '../eval/schema.ts';
+
+const evalCase: EvalCase = {
+  id: 'building-alchemist',
+  category: 'card-data',
+  source: 'unit-test',
+  question: 'What does the Alchemist cost?',
+  finalAnswer: {
+    expected: 'The level 1 Alchemist starts built and has no build cost.',
+    grading: 'Mentions level 1 starts built.',
+  },
+};
+
+const modelConfig: EvalProviderConfig = {
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-6',
+  reasoningEffort: 'high',
+  maxOutputTokens: 2048,
+  timeoutMs: 45_000,
+  toolLoopLimit: 4,
+  broadSearchSynthesisThreshold: 2,
+};
+
+function row(overrides: Partial<EvalMatrixRow>): EvalMatrixRow {
+  return {
+    runLabel: 'before',
+    caseId: 'building-alchemist',
+    category: 'card-data',
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    ok: true,
+    answer: 'answer',
+    score: 0.4,
+    pass: false,
+    latencyMs: 1200,
+    tokenInput: 100,
+    tokenOutput: 50,
+    tokenTotal: 150,
+    estimatedCostUsd: 0.02,
+    toolCallCount: 4,
+    retryCount: 1,
+    loopIterations: 4,
+    failureClass: 'quality',
+    traceId: 'trace-before',
+    traceUrl: 'https://langfuse.test/trace-before',
+    promptVersion: 'redesigned-agent-v1',
+    promptHash: 'sha256:prompt',
+    toolSurface: 'redesigned',
+    toolSchemaVersion: 'squire-anthropic-tools-v1',
+    toolSchemaHash: 'sha256:tools',
+    modelSettings: {
+      model: 'claude-sonnet-4-6',
+      reasoningEffort: 'high',
+      maxOutputTokens: 2048,
+      timeoutMs: 45_000,
+      toolLoopLimit: 4,
+      broadSearchSynthesisThreshold: 2,
+    },
+    runSettings: {
+      retryCount: 1,
+      maxEstimatedCostUsd: 1,
+      providerConcurrency: { anthropic: 1, openai: 1 },
+    },
+    ...overrides,
+  };
+}
+
+function comparisonInput(): EvalRunComparisonInput {
+  return {
+    before: {
+      runLabel: 'before',
+      estimatedCostUsd: 0.02,
+      rows: [
+        row({ runLabel: 'before', score: 0.4, pass: false, failureClass: 'quality' }),
+        row({
+          runLabel: 'before',
+          caseId: 'rule-looting-definition',
+          score: null,
+          pass: false,
+          latencyMs: null,
+          tokenInput: null,
+          tokenOutput: null,
+          tokenTotal: null,
+          estimatedCostUsd: null,
+          toolCallCount: null,
+          loopIterations: null,
+          failureClass: 'timeout',
+          traceId: 'timeout-before',
+          traceUrl: 'https://langfuse.test/timeout-before',
+        }),
+      ],
+    },
+    after: {
+      runLabel: 'after',
+      estimatedCostUsd: 0.05,
+      rows: [
+        row({
+          runLabel: 'after',
+          score: 0.9,
+          pass: true,
+          latencyMs: 800,
+          tokenInput: 120,
+          tokenOutput: 80,
+          tokenTotal: 200,
+          estimatedCostUsd: 0.03,
+          toolCallCount: 2,
+          retryCount: 0,
+          loopIterations: 2,
+          failureClass: 'none',
+          traceId: 'trace-after',
+          traceUrl: 'https://langfuse.test/trace-after',
+        }),
+        row({
+          runLabel: 'after',
+          caseId: 'rule-looting-definition',
+          score: 0.8,
+          pass: true,
+          latencyMs: 900,
+          tokenInput: 110,
+          tokenOutput: 60,
+          tokenTotal: 170,
+          estimatedCostUsd: 0.02,
+          toolCallCount: 3,
+          retryCount: 0,
+          loopIterations: 3,
+          failureClass: 'none',
+          traceId: 'looting-after',
+          traceUrl: 'https://langfuse.test/looting-after',
+        }),
+      ],
+    },
+  };
+}
+
+describe('eval cost and performance harness', () => {
+  it('compares two named runs across accuracy, latency, token, cost, retry, timeout, loop, and tool deltas', () => {
+    const comparison = compareEvalRuns(comparisonInput());
+
+    expect(comparison.beforeRunLabel).toBe('before');
+    expect(comparison.afterRunLabel).toBe('after');
+    expect(comparison.groups).toEqual([
+      expect.objectContaining({
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-6',
+        casesCompared: 2,
+        before: expect.objectContaining({
+          passRate: 0,
+          timeoutRate: 0.5,
+          totalEstimatedCostUsd: 0.02,
+          averageRetryCount: 1,
+        }),
+        after: expect.objectContaining({
+          passRate: 1,
+          timeoutRate: 0,
+          totalEstimatedCostUsd: 0.05,
+          averageRetryCount: 0,
+        }),
+        delta: expect.objectContaining({
+          passRate: 1,
+          averageLatencyMs: -350,
+          totalTokens: 220,
+          averageRetryCount: -1,
+          timeoutRate: -0.5,
+          averageLoopIterations: -1.5,
+          averageToolCallCount: -1.5,
+        }),
+        diagnosis: expect.arrayContaining(['raw_answer_quality improved', 'timeouts improved']),
+      }),
+    ]);
+    expect(comparison.groups[0].delta.totalEstimatedCostUsd).toBeCloseTo(0.03);
+    expect(formatEvalRunComparison(comparison)).toContain('pass_delta');
+    expect(formatEvalRunComparison(comparison)).toContain('anthropic:claude-sonnet-4-6');
+  });
+
+  it('records model knobs and run guardrails on every matrix row', async () => {
+    const runner: EvalMatrixRunner = vi.fn(async ({ providerConfig, traceId }) => ({
+      ok: true,
+      answer: 'ok',
+      traceId,
+      traceUrl: `https://langfuse.test/project/default/traces/${traceId}`,
+      score: 1,
+      pass: true,
+      latencyMs: 500,
+      tokenUsage: { input: 10, output: 5, total: 15 },
+      estimatedCostUsd: 0.01,
+      toolCallCount: 1,
+      loopIterations: 2,
+      failureClass: 'none',
+      modelSettings: {
+        providerEcho: providerConfig.provider,
+      },
+    }));
+
+    const result = await runEvalMatrix({
+      cases: [evalCase],
+      runLabel: 'knob-capture',
+      toolSurface: 'redesigned',
+      selection: 'id',
+      modelConfigs: [modelConfig],
+      runner,
+      guardrails: {
+        allowFullDataset: false,
+        allowEstimatedCostOverride: true,
+        maxEstimatedCostUsd: 3,
+        retryCount: 2,
+        continueOnModelFailure: true,
+        providerConcurrency: { anthropic: 2, openai: 1 },
+      },
+      langfuseBaseUrl: 'https://langfuse.test',
+    });
+
+    expect(result.rows[0]).toMatchObject({
+      promptVersion: 'redesigned-agent-v1',
+      toolSurface: 'redesigned',
+      toolSchemaVersion: 'squire-anthropic-tools-v1',
+      modelSettings: {
+        model: 'claude-sonnet-4-6',
+        reasoningEffort: 'high',
+        maxOutputTokens: 2048,
+        timeoutMs: 45_000,
+        toolLoopLimit: 4,
+        broadSearchSynthesisThreshold: 2,
+        providerEcho: 'anthropic',
+      },
+      runSettings: {
+        retryCount: 2,
+        maxEstimatedCostUsd: 3,
+        providerConcurrency: { anthropic: 2, openai: 1 },
+      },
+    });
+  });
+
+  it('rejects incompatible comparisons when prompt or tool schema versions differ', () => {
+    const input = comparisonInput();
+    input.after.rows[0] = row({
+      runLabel: 'after',
+      promptHash: 'sha256:different-prompt',
+      toolSchemaVersion: 'squire-anthropic-tools-v2',
+    });
+
+    expect(() => compareEvalRuns(input)).toThrow(
+      /Cannot compare before to after.*promptHash.*toolSchemaVersion/s,
+    );
+  });
+});

--- a/test/eval-matrix.test.ts
+++ b/test/eval-matrix.test.ts
@@ -112,6 +112,7 @@ describe('eval matrix runner', () => {
         maxOutputTokens: 1024,
         timeoutMs: 30_000,
         toolLoopLimit: 4,
+        broadSearchSynthesisThreshold: 2,
       }),
     ).toEqual([
       expect.objectContaining({
@@ -119,18 +120,21 @@ describe('eval matrix runner', () => {
         model: 'claude-sonnet-4-6',
         reasoningEffort: undefined,
         maxOutputTokens: 1024,
+        broadSearchSynthesisThreshold: 2,
       }),
       expect.objectContaining({
         provider: 'anthropic',
         model: 'claude-opus-4-7',
         reasoningEffort: undefined,
         timeoutMs: 30_000,
+        broadSearchSynthesisThreshold: 2,
       }),
       expect.objectContaining({
         provider: 'openai',
         model: 'gpt-5.5',
         reasoningEffort: 'xhigh',
         toolLoopLimit: 4,
+        broadSearchSynthesisThreshold: 2,
       }),
     ]);
   });

--- a/test/eval-runner.test.ts
+++ b/test/eval-runner.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { parseEvalArgs } from '../eval/cli.ts';
@@ -6,6 +9,78 @@ import { runEval } from '../eval/runner.ts';
 describe('eval runner', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('prints a local before-after matrix comparison without running eval cases', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'squire-eval-compare-'));
+    const beforePath = join(dir, 'before.json');
+    const afterPath = join(dir, 'after.json');
+    const baseRow = {
+      runLabel: 'before',
+      caseId: 'building-alchemist',
+      category: 'card-data',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      ok: true,
+      answer: 'answer',
+      score: 0.4,
+      pass: false,
+      latencyMs: 1200,
+      tokenInput: 100,
+      tokenOutput: 50,
+      tokenTotal: 150,
+      estimatedCostUsd: 0.02,
+      toolCallCount: 4,
+      retryCount: 1,
+      loopIterations: 4,
+      failureClass: 'quality',
+      traceId: 'trace-before',
+      traceUrl: 'https://langfuse.test/trace-before',
+      promptVersion: 'redesigned-agent-v1',
+      promptHash: 'sha256:prompt',
+      toolSurface: 'redesigned',
+      toolSchemaVersion: 'squire-anthropic-tools-v1',
+      toolSchemaHash: 'sha256:tools',
+      modelSettings: { model: 'claude-sonnet-4-6' },
+      runSettings: {
+        retryCount: 1,
+        maxEstimatedCostUsd: 1,
+        providerConcurrency: { anthropic: 1, openai: 1 },
+      },
+    };
+    writeFileSync(
+      beforePath,
+      `${JSON.stringify({ runLabel: 'before', estimatedCostUsd: 0.02, rows: [baseRow] })}\n`,
+    );
+    writeFileSync(
+      afterPath,
+      `${JSON.stringify({
+        runLabel: 'after',
+        estimatedCostUsd: 0.03,
+        rows: [
+          {
+            ...baseRow,
+            runLabel: 'after',
+            pass: true,
+            score: 0.9,
+            latencyMs: 800,
+            estimatedCostUsd: 0.03,
+            failureClass: 'none',
+          },
+        ],
+      })}\n`,
+    );
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    try {
+      await runEval(parseEvalArgs([`--compare-runs=${beforePath},${afterPath}`]), {});
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('Eval run comparison: before -> after'),
+    );
   });
 
   it('honors estimated-cost guardrails for plain OpenAI Langfuse runs', async () => {


### PR DESCRIPTION
## Summary
- Adds a matrix-report comparison harness for accuracy, latency, token, cost, retry, timeout, loop, and tool-call deltas.
- Records prompt, tool schema, model, and run settings metadata so incompatible eval runs are rejected before comparison.
- Adds eval CLI knobs for run comparison and broad-search synthesis threshold tuning, with docs and regression coverage.

## Validation
- npm run check: 65 files, 1014 tests passed.
- Focused eval regression suite: 8 files, 112 tests passed during QA.
- CLI QA: valid compare run printed the delta table; incompatible promptHash and malformed --compare-runs failed with expected errors.
- Browser QA: /login and dev login to / loaded cleanly with no console errors. Live chat was not run because repo testing rules require explicit approval before live Anthropic calls.

## Pre-landing review
- Reviewed diff against origin/main for comparison safety, eval-only runtime changes, metadata compatibility checks, and production default behavior. No blocking findings.

Fixes SQR-133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New run-comparison flow to compare two eval reports and produce a tabular delta summary across metrics (pass rate, latency, tokens, cost, retries, failures).
  * CLI option to tune broad-search synthesis behavior, controlling when the agent forces synthesis during runs.
  * Eval matrix reports now include model settings and run configuration metadata for clearer traceability.

* **Documentation**
  * CONTRIBUTING updated with a matrix experiment workflow and documented eval tuning knobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->