### PR TITLE
SQR-134: Expand eval model matrix decision report

### DIFF
--- a/docs/plans/sqr-134-expanded-full-matrix-report.json
+++ b/docs/plans/sqr-134-expanded-full-matrix-report.json
@@ -1,0 +1,7924 @@
+{
+  "generatedAt": "2026-05-02T22:21:27.718Z",
+  "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+  "rows": [
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-init",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "A *long rest* has an initiative value of **99**.\n\n> \"Any character long resting has an initiative of 99.\"\n*(Frosthaven Rulebook, Ordering of Initiative)*\n\nThis means a long-resting character acts **last** in the turn order for that round (since initiative is ordered from lowest to highest). The long rest is declared during the Card Selection step instead of playing two ability cards, and the character then performs their rest on that initiative 99 — losing one card of their choice from their discard pile, optionally healing 2 (self), and optionally recovering all spent items.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7130,
+      "tokenInput": 8135,
+      "tokenOutput": 215,
+      "tokenTotal": 8350,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:rule-long-rest-init",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-long-rest-init",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-init",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "A long rest is performed on **initiative 99**.\n\n> \"During the Card Selection step, a character may declare a long rest. This constitutes their entire turn for the round, instead of playing two cards, and it is performed on initiative 99.\"\n\n— Frosthaven Rulebook, p. 38 (Resting)",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5280,
+      "tokenInput": 10902,
+      "tokenOutput": 202,
+      "tokenTotal": 11104,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:rule-long-rest-init",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Arule-long-rest-init",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-init",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "According to the Frosthaven Rulebook, the initiative value of a long rest is **99**.\n\n> During the Card Selection step, a character may declare a long rest. This constitutes their entire turn for the round, instead of playing two cards, and it is performed on initiative 99.\n\nWhen you declare a long rest, you don't play any cards—your long rest action happens on initiative 99, and you always act at that point in the round.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 2592,
+      "tokenInput": 6736,
+      "tokenOutput": 160,
+      "tokenTotal": 6896,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:rule-long-rest-init",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Arule-long-rest-init",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-init",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "A *long rest* has initiative **99** in Frosthaven.\n\n> “Any character long resting has an initiative of 99.”  \n— Frosthaven Rulebook, initiative order / resting rules",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8064,
+      "tokenInput": 27861,
+      "tokenOutput": 136,
+      "tokenTotal": 27997,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:rule-long-rest-init",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Arule-long-rest-init",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-init",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "A *long rest* is performed at initiative **99**.  \nSource: Frosthaven *Rulebook*, “Resting” section.\n\n> “During the Card Selection step, a character may declare a long rest… it is performed on initiative 99.”",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9444,
+      "tokenInput": 39794,
+      "tokenOutput": 155,
+      "tokenTotal": 39949,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:rule-long-rest-init",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Arule-long-rest-init",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-init",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "A *long rest* has initiative value **99**. The rulebook says: “Any character long resting has an initiative of 99.”",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 3242,
+      "tokenInput": 15184,
+      "tokenOutput": 60,
+      "tokenTotal": 15244,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:rule-long-rest-init",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Arule-long-rest-init",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-init",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In *Frosthaven*, a *long rest* is performed on initiative **99**. (Rulebook: *Resting* / *Sticker 7 — ITEM USAGE*)",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5728,
+      "tokenInput": 26811,
+      "tokenOutput": 106,
+      "tokenTotal": 26917,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:rule-long-rest-init",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Arule-long-rest-init",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-steps",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "The first result has everything needed. Here are the long rest rules straight from the Frosthaven Rulebook:\n\n---\n\n## Long Rest Steps\n\nA long rest is **declared during the Card Selection step** (instead of playing two cards). It counts as the character's **entire turn for the round** and is performed on **initiative 99**.\n\nWhen a character long rests, they follow these steps **in order**:\n\n1. **Lose one card of their choice** from their discard pile, then return all remaining cards in the discard pile to their hand. *(Mandatory)*\n\n2. **Perform *Heal* 2, Self.** *(Optional)*\n\n3. **Recover all spent items.** Items can even be used during the **same turn** in which they are recovered. *(Optional)*\n\n---\n\nA few key reminders:\n- A long rest can only be performed if the character has **at least two cards** in their discard pile (so there is still a card to return to hand after losing one).\n- Unlike a short rest, **you choose which card to lose** — there is no random element.\n- Because the long rest happens on initiative 99, it will almost always occur **last** in the round.\n\n*(Source: Frosthaven Rulebook)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10787,
+      "tokenInput": 8287,
+      "tokenOutput": 367,
+      "tokenTotal": 8654,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:rule-long-rest-steps",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-long-rest-steps",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-steps",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here are the steps for a long rest in Frosthaven, per the Rulebook (p. 18 / Resting section):\n\nA long rest is **declared during the Card Selection step**, **constitutes your entire turn** for the round (instead of playing two cards), and is performed on **initiative 99**. The character then performs these steps:\n\n1. **Lose one card of their choice** from their discard pile and return the remaining cards to their hand *(mandatory)*.\n2. Perform **\"*Heal 2*, self\"** *(optional)*.\n3. **Recover all of their spent items** *(optional)*. Items can be used during the same turn in which they are recovered.\n\nNote: like a short rest, a long rest can only be performed if the character has at least two cards in their discard pile.\n\nSource: Frosthaven Rulebook, \"Resting\" section.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10042,
+      "tokenInput": 11061,
+      "tokenOutput": 390,
+      "tokenTotal": 11451,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:rule-long-rest-steps",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Arule-long-rest-steps",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-steps",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Perfect! I found the rules for a long rest. According to the Frosthaven Rulebook, when a character declares a long rest during the Card Selection step, they follow these steps:\n\n1. **Lose one card of their choice from their discard pile and return the remaining cards to their hand** (mandatory).\n\n2. **Perform *Heal 2, self*** (optional).\n\n3. **Recover all of their spent items** (optional). Items can be used during the same turn in which they are recovered.\n\nAdditionally, note that a long rest constitutes the character's entire turn for the round instead of playing two cards, and it is performed on initiative 99. A character may only declare a long rest if they have at least two cards in their discard pile.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4054,
+      "tokenInput": 8658,
+      "tokenOutput": 265,
+      "tokenTotal": 8923,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:rule-long-rest-steps",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Arule-long-rest-steps",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-steps",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "When a character takes a **long rest** in Frosthaven:\n\n1. **Declare the long rest during Card Selection** instead of playing two cards.\n2. The long rest is the character’s **entire turn** for the round.\n3. The character acts at **initiative 99**.\n4. On that turn, they perform these steps:\n   - **Mandatory:** Lose one card of their choice from their discard pile, then return the remaining discarded cards to their hand.\n   - **Optional:** Perform *Heal 2, self*.\n   - **Optional:** Recover all of their spent items. Items recovered this way can be used during that same turn.\n\nA long rest can only be performed if the character has at least **two cards in their discard pile**.\n\n> “When a character long rests, they follow these steps: Lose one card of their choice from their discard pile and return the remaining cards to their hand (mandatory). Perform ‘Heal 2, self’ (optional). Recover all of their spent items (optional).”  \n> — Frosthaven Rulebook, Resting section",
+      "score": 0.6,
+      "pass": false,
+      "latencyMs": 10222,
+      "tokenInput": 15344,
+      "tokenOutput": 284,
+      "tokenTotal": 15628,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:rule-long-rest-steps",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Arule-long-rest-steps",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-steps",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "When a character takes a long rest in Frosthaven, they do it during **Card Selection**, and it becomes their entire turn for the round at initiative **99**.\n\nThe steps are:\n\n1. **Lose one card of your choice from your discard pile** and return the rest of your discard pile to your hand.  \n   - This part is **mandatory**.\n2. **Perform *Heal 2, self***.  \n   - This is **optional**.\n3. **Recover all spent items**.  \n   - This is **optional**.\n   - Recovered items **can be used during that same turn**.\n\nAlso, a character can only rest if they have **at least two cards in their discard pile**.\n\nSource: Rulebook, “Resting” (fh-rule-book.pdf).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7816,
+      "tokenInput": 15445,
+      "tokenOutput": 214,
+      "tokenTotal": 15659,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:rule-long-rest-steps",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Arule-long-rest-steps",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-steps",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "When a character takes a **long rest**, they do this on *initiative 99* and it counts as their entire turn for the round. The steps are:\n\n1. **Lose one card of their choice** from their discard pile and return the remaining cards to their hand.  \n2. **Perform “Heal 2, self”** *(optional)*.  \n3. **Recover all spent items** *(optional)*. Items can be used during the same turn they are recovered.\n\nSource: *Frosthaven Rulebook*, “Resting” / *Long rest*.",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 6069,
+      "tokenInput": 15552,
+      "tokenOutput": 150,
+      "tokenTotal": 15702,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:rule-long-rest-steps",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Arule-long-rest-steps",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-long-rest-steps",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "When a character declares a *long rest*, they do the following steps (this happens on initiative 99 as part of *Card Selection*):\n\n1. **Lose 1 card of their choice from their discard pile** and **return the remaining cards to their hand** (**mandatory**).\n2. **Optionally perform “Heal 2, self.”**\n3. **Optionally recover all of their spent items.** (Items can then be used during the same turn.)",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8090,
+      "tokenInput": 27113,
+      "tokenOutput": 166,
+      "tokenTotal": 27279,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:rule-long-rest-steps",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Arule-long-rest-steps",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-scenario-level",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "The relevant rule is found clearly in the Rulebook. Here's the answer:\n\n---\n\n## Recommended Scenario Level\n\n> At recommended difficulty, the scenario level is equal to the **average level of the characters divided by 2 (rounded up).**\n\n**Example:** If all characters are level 2, the average (2) ÷ 2 = 1, so the scenario is still **level 1**. A character would need to reach **level 3** before the scenario level would potentially increase to 2.\n\n---\n\n### Key Points\n\n- **You can override it.** At the start of any scenario, you may freely set the scenario level to any number from **0–7**, regardless of the recommendation.\n  - **Decrease it** if your party is struggling.\n  - **Increase it** if you want a greater challenge as your party grows stronger.\n\n- **What scenario level affects** (per the chart in the Rulebook):\n\n| Scenario Level | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |\n|---|---|---|---|---|---|---|---|---|\n| Monster Level | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |\n| Gold Conversion | 2 | 2 | 3 | 3 | 4 | 4 | 5 | 6 |\n| Trap Damage | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |\n| Hazardous Terrain | 1 | 2 | 2 | 2 | 3 | 3 | 3 | 4 |\n| Bonus Experience | 4 | 6 | 8 | 10 | 12 | 14 | 16 | 18 |\n\n*(Source: Frosthaven Rulebook)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8682,
+      "tokenInput": 7305,
+      "tokenOutput": 547,
+      "tokenTotal": 7852,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:rule-scenario-level",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-scenario-level",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-scenario-level",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "At recommended difficulty, the **scenario level equals the average level of the characters divided by 2, rounded up** (Rulebook).\n\nFor example, if every character is level 2, the average (2) divided by 2 is 1, so the scenario is still level 1. The scenario level only starts to climb once a character reaches level 3.\n\nA few notes from the same passage:\n- This formula determines the **recommended** difficulty, but at the start of any scenario you can set the scenario level to **any number from 0–7**.\n- Lowering it can help a struggling party; raising it keeps things challenging as the party grows stronger.\n- Scenario level then drives monster level, gold conversion, trap damage, hazardous terrain damage, and bonus experience per the difficulty chart.\n\nSource: Frosthaven Rulebook (chunk 68).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8805,
+      "tokenInput": 9941,
+      "tokenOutput": 372,
+      "tokenTotal": 10313,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:rule-scenario-level",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Arule-scenario-level",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-scenario-level",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "According to the **Rulebook**, the recommended scenario level is calculated as follows:\n\n> At recommended difficulty, the scenario level is equal to the average level of the characters divided by 2 (rounded up).\n\n**Example:** If all characters are level 2, the average level (2) divided by 2 equals 1, so the scenario is level 1. Only once a character reaches level 3 would the scenario level potentially increase.\n\nIt's important to note that while this calculation determines the recommended difficulty, you can set the scenario level to any number from 0–7 at the start of any scenario. Decreasing the scenario level can help if your party is struggling, while increasing it can keep the game challenging as your party grows stronger.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 3820,
+      "tokenInput": 6103,
+      "tokenOutput": 220,
+      "tokenTotal": 6323,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:rule-scenario-level",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Arule-scenario-level",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-scenario-level",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "In Frosthaven, the **recommended scenario level** is:\n\n**Average character level ÷ 2, rounded up.**\n\nRulebook quote:\n\n> “At recommended difficulty, the scenario level is equal to the average level of the characters divided by 2 (rounded up).”  \n> — Frosthaven Rulebook, Scenario Level\n\nExample:\n- Party levels: 2, 2, 3, 3\n- Average level: 10 ÷ 4 = 2.5\n- Divide by 2: 1.25\n- Round up: **scenario level 2**\n\nYou can also choose to set the scenario level anywhere from **0–7** at the start of a scenario if you want to adjust difficulty.\n\nSolo-mode variant: calculate differently by adding 1 to the average level before dividing by 2 and rounding up.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 12933,
+      "tokenInput": 27355,
+      "tokenOutput": 385,
+      "tokenTotal": 27740,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:rule-scenario-level",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Arule-scenario-level",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-scenario-level",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "In Frosthaven, the **recommended scenario level** is:\n\n> Average character level ÷ 2, rounded up.\n\nSo the steps are:\n\n1. Add all characters’ levels together.\n2. Divide by the number of characters to get the average level.\n3. Divide that average by 2.\n4. Round up.\n\nExample:\n- Four level 2 characters:\n  - Average level = 2\n  - 2 ÷ 2 = 1\n  - Recommended scenario level = **1**\n\nThe rulebook also notes that the scenario level can still be set to **any value from 0–7** if you want to lower or raise the difficulty.  \nSource: Frosthaven Rulebook, *Scenario Level* / quick reference.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5921,
+      "tokenInput": 15382,
+      "tokenOutput": 195,
+      "tokenTotal": 15577,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:rule-scenario-level",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Arule-scenario-level",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-scenario-level",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "In Frosthaven, the **recommended scenario level** is calculated as:\n\n**Average character level ÷ 2, rounded up**\n\nSo if your party’s average character level is:\n- 1 or 2 → scenario level 1\n- 3 or 4 → scenario level 2\n- 5 or 6 → scenario level 3\n\nThe rulebook also says this is only the **recommended difficulty**; when starting a scenario, you may set the scenario level to **any number from 0–7**.  \n\nSource: **Rulebook, SCENARIO LEVEL** (p. 16)",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5396,
+      "tokenInput": 27001,
+      "tokenOutput": 201,
+      "tokenTotal": 27202,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:rule-scenario-level",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Arule-scenario-level",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-scenario-level",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In *Frosthaven*, the **recommended scenario level** at a given time is calculated as:\n\n- **Take the average level of all characters in your party.**\n- **Divide that average by 2.**\n- **Round up** to get the scenario’s recommended level.\n\nSo, for example, if all characters are level 2, the average level is 2; 2 ÷ 2 = 1, so the recommended scenario level is **1**. The scenario level would only potentially increase once a character reaches level 3. (Rulebook text: *“At recommended difficulty, the scenario level is equal to the average level of the characters divided by 2 (rounded up).”*)",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4921,
+      "tokenInput": 15649,
+      "tokenOutput": 185,
+      "tokenTotal": 15834,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:rule-scenario-level",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Arule-scenario-level",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-poison",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's what the Frosthaven Rulebook says about *Poison*:\n\n> **Poison:** All attacks targeting the figure gain \"+1 Attack.\" Poison is removed when the figure is healed but, unlike *Wound*/*Brittle*/*Bane*, poison prevents the heal from increasing the figure's current hit point value.\n\n**In summary:**\n\n- Any enemy attacking a *Poisoned* figure gets **+1 to their attack value** — this makes the condition dangerous whether it's on a character or a monster.\n- *Poison* is removed by a *Heal* effect, **but** the heal does **not** restore any hit points as long as *Poison* is present. The heal only serves to cleanse the condition.\n- Unlike *Wound*, *Poison* does not deal ongoing damage each turn — it purely amplifies incoming attacks.\n\n*(Source: Frosthaven Rulebook, Negative Conditions section)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 12143,
+      "tokenInput": 27641,
+      "tokenOutput": 534,
+      "tokenTotal": 28175,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:rule-poison",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-poison",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-poison",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Found it in the negative conditions section of the Rulebook.\n\n## Poison\n\n> All attacks targeting the figure gain \"+1 ⚔\". Poison is removed when the figure is healed but, unlike wound/brittle/bane, poison prevents the heal from increasing the figure's current hit point value.\n\nKey points:\n- While *Poisoned*, every attack against the figure deals **+1 damage**.\n- *Poison* is cleared by any heal — but that heal only removes the condition; it does **not** restore any hit points.\n- Like other conditions, you can't have multiple stacks of *Poison*; reapplying it just refreshes the duration. A figure also won't gain *Poison* if they're immune or if the triggering attack killed/exhausted them.\n\nSource: Frosthaven Rulebook, Negative Conditions (p. 30).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8113,
+      "tokenInput": 10574,
+      "tokenOutput": 378,
+      "tokenTotal": 10952,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:rule-poison",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Arule-poison",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-poison",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Perfect! I found the definition. According to the Frosthaven Rulebook:\n\n**Poison** is a negative condition with these effects:\n\n> All attacks targeting the figure gain \"+1 *Attack*.\" Poison is removed when the figure is healed but, unlike wound/brittle/bane, poison prevents the heal from increasing the figure's current hit point value.\n\nIn other words:\n- Enemies attacking a poisoned figure deal +1 additional damage per attack\n- *Poison* is removed when the figure receives healing, **but** the healing doesn't actually restore any hit points—it only removes the condition\n- If the figure gains *Poison* again, the condition's duration resets",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4996,
+      "tokenInput": 16620,
+      "tokenOutput": 332,
+      "tokenTotal": 16952,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:rule-poison",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Arule-poison",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-poison",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "In Frosthaven, *Poison* does two things:\n\n> “All attacks targeting the figure gain ‘+1 [Attack].’”  \n> “Poison is removed when the figure is healed but … poison prevents the heal from increasing the figure’s current hit point value.”  \n> — Frosthaven Rulebook, Negative Conditions\n\nSo at the table:\n\n- A *Poisoned* figure takes **+1 damage from each attack targeting it**.\n- The next *Heal* removes *Poison*.\n- If *Poison* is present, that *Heal* **does not restore any HP**.\n- A single *Heal* can remove any combination of *Wound*, *Brittle*, *Bane*, and *Poison*, but if *Poison* is among them, the HP increase is still prevented.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 20662,
+      "tokenInput": 108431,
+      "tokenOutput": 536,
+      "tokenTotal": 108967,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 7,
+      "retryCount": 0,
+      "loopIterations": 8,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:rule-poison",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Arule-poison",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-poison",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "In Frosthaven, *Poison* means:\n\n> “All attacks targeting the figure gain ‘+1 Attack.’ Poison is removed when the figure is healed but, unlike wound/brittle/bane, poison prevents the heal from increasing the figure’s current hit point value.”  \n> — Rulebook, negative conditions\n\nAlso, the *Heal* rules clarify:\n\n> “A single heal can remove any combination of wound, brittle, bane, and poison from a figure. However, if poison is present, the hit point increase is prevented.”  \n> — Rulebook, *Heal*\n\nSo at the table:\n\n- A poisoned figure takes **+1 damage from attacks** against it.\n- If that figure is healed, the heal **removes the poison**.\n- But that same heal **does not restore HP** if *Poison* was present.\n\nSource: Frosthaven Rulebook, negative conditions and *Heal* entries.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8940,
+      "tokenInput": 26294,
+      "tokenOutput": 280,
+      "tokenTotal": 26574,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:rule-poison",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Arule-poison",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-poison",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "*Poison* makes **all attacks targeting that figure gain +1 Attack**. It is removed when the figure is healed, but unlike *Wound*, *Brittle*, or *Bane*, the poison **prevents the heal from increasing current hit points**. \n\nSource: Frosthaven Rulebook, **Negative Conditions**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 3850,
+      "tokenInput": 14617,
+      "tokenOutput": 100,
+      "tokenTotal": 14717,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:rule-poison",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Arule-poison",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-poison",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "I checked the Frosthaven rules text available in the knowledge base, but it **does not contain a rules passage that defines the *Poison* condition** (e.g., the standard “*Poison* does X” description).\n\nIf you can tell me one of the following, I can try again more precisely:\n- what *Poison* is showing up on (an item, scenario rule, monster ability, or a specific card name), or\n- a screenshot / exact wording from the card/ability that applies *Poison*, or\n- which edition/content you’re using (Frosthaven base game vs an expansion / campaign box), if applicable.\n\nOnce I can match the *Poison* reference you’re using to its source, I can pull the exact definition.",
+      "score": 0.2,
+      "pass": false,
+      "latencyMs": 11013,
+      "tokenInput": 79081,
+      "tokenOutput": 329,
+      "tokenTotal": 79410,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:rule-poison",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Arule-poison",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-brittle",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here is the full rule for *Brittle* from the Frosthaven Rulebook:\n\n> **Brittle:** The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and *Brittle* is then removed. *Brittle* is also removed if the figure is healed.\n\n*(Rulebook, Negative Conditions)*\n\n---\n\n**Key points to remember:**\n\n- *Brittle* is a **negative condition** that can affect both characters and monsters.\n- It causes the **next instance of damage** to be **doubled** — then the condition is removed.\n- It is removed in **two ways**:\n  1. After the next damage is applied (doubled).\n  2. If the figure is **healed** at any point (even before taking damage).\n- The doubling happens *before* other damage interactions like *Ward* (which halves damage). For example, if a figure has both *Brittle* and *Ward*, the damage is first doubled (*Brittle*), then halved (*Ward*), resulting in the original amount.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8399,
+      "tokenInput": 8154,
+      "tokenOutput": 328,
+      "tokenTotal": 8482,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:rule-brittle",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-brittle",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-brittle",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Per the Frosthaven Rulebook (negative conditions):\n\n> *Brittle*: The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.\n\nA couple of clarifications from the rulebook's damage section:\n- *Brittle* is applied **before** damage negation. When a character would suffer damage, *ward* and *brittle* are resolved first to determine the final amount, and only then can the character negate that damage with an ability or by losing cards.\n- Healing removes *brittle* even if the figure is at full HP (just like *wound* and *poison*).\n\nSo in short: *brittle* makes the next instance of damage hit for double, then it's gone — unless you cleanse it with a heal first.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9228,
+      "tokenInput": 11000,
+      "tokenOutput": 362,
+      "tokenTotal": 11362,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:rule-brittle",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Arule-brittle",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-brittle",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "According to the Frosthaven Rulebook, **Brittle** is a negative condition that works as follows:\n\n> The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.\n\nIn short: *Brittle* causes the next damage a figure takes to be doubled, then the condition is removed. It can also be removed early if the figure receives any healing.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 2939,
+      "tokenInput": 7720,
+      "tokenOutput": 168,
+      "tokenTotal": 7888,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:rule-brittle",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Arule-brittle",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-brittle",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "In Frosthaven, *Brittle* makes the next damage the figure suffers hit twice as hard:\n\n> “The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.”  \n> — Frosthaven Rulebook, Negative Conditions\n\nA few practical notes:\n- It applies to **damage from any source**, not just attacks.\n- It is removed after it doubles that damage.\n- A *Heal* also removes *Brittle*.\n- If a figure has both *Ward* and *Brittle*, they cancel each other out and both are removed.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8595,
+      "tokenInput": 29371,
+      "tokenOutput": 240,
+      "tokenTotal": 29611,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:rule-brittle",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Arule-brittle",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-brittle",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "In Frosthaven, *Brittle* means:\n\n> “The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.”\n\nSo in play:\n- the **next damage source is doubled**\n- then *Brittle* is **removed**\n- if the figure is **healed before taking damage**, *Brittle* is removed without doubling anything\n\nSource: Rulebook, negative conditions (Rulebook chunk 99).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7304,
+      "tokenInput": 29506,
+      "tokenOutput": 181,
+      "tokenTotal": 29687,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:rule-brittle",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Arule-brittle",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-brittle",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "*Brittle* means:\n\n> The next time the figure would suffer damage from any source, they instead suffer **double that amount of damage**, and *Brittle* is then removed. *Brittle* is also removed if the figure is healed.\n\nSource: Frosthaven rulebook, negative conditions.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5578,
+      "tokenInput": 14979,
+      "tokenOutput": 100,
+      "tokenTotal": 15079,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:rule-brittle",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Arule-brittle",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-brittle",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In *Frosthaven*, the *Brittle* condition works like this:\n\n> **Brittle:** The next time the figure would suffer damage from any source, they instead suffer **double** that amount of damage, and **Brittle is then removed**. **Brittle is also removed if the figure is healed.**  \n*(Rulebook, Negative Conditions / sticker 5)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10474,
+      "tokenInput": 71961,
+      "tokenOutput": 237,
+      "tokenTotal": 72198,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:rule-brittle",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Arule-brittle",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-advantage",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here is a full breakdown of how *Advantage* works with attack modifier cards in Frosthaven, straight from the Rulebook (chunk 95–96):\n\n---\n\n## Advantage — Core Rule\n\n> With advantage, the attacker draws two modifiers and uses one of them. A monster always uses the better one, but **a character may use either one.**\n\nWith *Disadvantage*, the attacker draws two modifiers and **always uses the worse one.**\n\n---\n\n## Rolling Modifiers with Advantage/Disadvantage\n\nThings get more complex when *rolling modifiers* (cards with a rolling icon) show up:\n\n1. **If the first draw is a rolling modifier**, keep drawing one at a time until you hit a non-rolling modifier. Then draw **one more** card, ignoring any rolling icon on it.\n2. You now compare the **last two non-rolling modifiers**:\n   - **With *Advantage*:** Use all the initial rolling modifiers **plus whichever of the last two you choose.**\n   - **With *Disadvantage*:** Ignore all initial rolling modifiers and use whichever of the last two is **worse.**\n\n3. **If the first draw is not a rolling modifier but the second draw is**, the rolling icon on the second card is **ignored** (it does not chain further draws).\n\n---\n\n## Ambiguity (Non-Numeric Effects)\n\n> When there is ambiguity about which modifier is worse, the attacker must use the one drawn first.\n\nThis applies when comparing non-numeric effects like elemental infusions or negative conditions — these are treated as having a **positive but undefined value.**\n\n---\n\n## Multiple Advantage/Disadvantage\n\n> An attack cannot gain multiple instances of advantage or disadvantage. If an attack has both advantage and disadvantage, it is considered to have neither.\n\n---\n\n## Automatic Disadvantage\n\n> Any ranged attack on an adjacent enemy automatically gains *Disadvantage*.\n\n---\n\n### Quick Summary\n\n| Situation | Result |\n|---|---|\n| *Advantage*, no rolling | Draw 2, pick the better (or either, for characters) |\n| *Advantage*, first card rolling | Keep drawing until non-rolling, draw 1 more; use rolling chain + pick better of last 2 |\n| *Disadvantage*, no rolling | Draw 2, use the worse |\n| *Disadvantage*, first card(s) rolling | Keep drawing until non-rolling, draw 1 more; discard rolling chain, use worse of last 2 |\n| Both *Advantage* and *Disadvantage* | Neither applies — draw normally |\n\n*(Rulebook, p. 25 / chunk 95–96)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 16716,
+      "tokenInput": 8366,
+      "tokenOutput": 687,
+      "tokenTotal": 9053,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:rule-advantage",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-advantage",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-advantage",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here's how *advantage* works with attack modifier cards in Frosthaven:\n\n**Basic rule:** When an attack has *advantage*, the attacker draws **two** modifier cards and uses **one** of them.\n- A **monster** always uses the better of the two.\n- A **character** may choose either one.\n\nWith *disadvantage*, the attacker draws two and must use the worse one.\n\n**Rolling modifiers complicate things.** If the first draw is a *rolling* modifier, you keep drawing one at a time until you get a non-rolling modifier, then draw **one more** modifier (its rolling icon, if any, is ignored). Then:\n- With *advantage*: you apply all the initial rolling modifiers, and choose whichever of the last two (non-rolling) modifiers you prefer.\n- With *disadvantage*: you ignore all the initial rolling modifiers, and use whichever of the last two is worse.\n\nIf the first draw is non-rolling but the second draw is rolling, the rolling icon on that second card is still ignored.\n\n**Ambiguity:** When it's unclear which modifier is \"worse\" (e.g., comparing elemental infusions or negative conditions), the attacker must use the one drawn first. Any non-numeric effect counts as a positive but undefined value.\n\n**Stacking:** An attack can't gain multiple instances of *advantage* or *disadvantage*. If an attack has both, they cancel out and it has neither.\n\nAlso worth noting: any ranged attack against an **adjacent** enemy automatically gains *disadvantage*.\n\nSource: Frosthaven Rulebook, \"Advantage and Disadvantage\" (p. 26, rulebook chunks 95–96).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 12718,
+      "tokenInput": 11223,
+      "tokenOutput": 660,
+      "tokenTotal": 11883,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:rule-advantage",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Arule-advantage",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-advantage",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Based on the Frosthaven Rulebook, here's how **advantage** works with attack modifier cards:\n\n## Basic Advantage Mechanic\n\nWhen an attack gains **advantage**, the attacker draws **two modifiers instead of one** and uses one of them:\n- **Monsters always use the better modifier**\n- **Characters may use either modifier** (they have a choice)\n\n## Advantage with Rolling Modifiers\n\nIf the first draw is a *rolling modifier* (a modifier card with a rolling icon), things work differently:\n\n1. The attacker draws additional modifiers **one at a time** until a non-rolling modifier is drawn\n2. They then draw **one more modifier** and ignore any rolling icon on it\n3. The first non-rolling modifier and the one after it are compared\n4. With advantage, the attacker uses **all the initial rolling modifiers plus whichever of the last two modifiers they choose**\n\nSpecial case: If the first draw is not a rolling modifier but the second draw is, the rolling icon on the second modifier is still ignored.\n\n## Ambiguity and Cancellation\n\n- When comparing modifiers with ambiguous non-numeric effects (like elemental infusions or negative conditions), the attacker must use the modifier **drawn first**\n- **An attack cannot have both advantage and disadvantage** — if it somehow gains both, it is considered to have neither\n\nThe Rulebook includes visual examples (Examples 1–4) showing how these rules apply in practice with different modifier combinations.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6087,
+      "tokenInput": 8364,
+      "tokenOutput": 413,
+      "tokenTotal": 8777,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:rule-advantage",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Arule-advantage",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-advantage",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "In Frosthaven, *advantage* changes how you draw *attack modifier cards* for **that attack target**:\n\n> “With advantage, the attacker draws two modifiers and uses one of them. A monster always uses the better one, but a character may use either one.”  \n> — Rulebook, *Advantage and Disadvantage*\n\nKey details:\n\n- Draw separately for each target of an attack. Each target gets its own modifier draw.  \n- With *advantage*, draw 2 modifiers:\n  - If the attacker is a **character**, they may choose either card.\n  - If the attacker is a **monster**, it uses the better card.\n- If the **first** card drawn is a *rolling modifier*:\n  1. Keep drawing until you draw a non-rolling modifier.\n  2. Then draw one more modifier.\n  3. Compare the first non-rolling modifier and that final modifier.\n  4. With *advantage*, use all the initial rolling modifiers plus whichever of the last two modifiers you choose.\n- If the **second** card is rolling but the first was not, ignore the rolling icon on the second card.\n- Multiple sources of *advantage* do not stack.\n- If an attack has both *advantage* and *disadvantage*, it has neither.\n\nAttack modifier cards can include numeric modifiers, added effects, and rolling icons; rolling modifiers normally keep drawing until a non-rolling modifier is drawn.  \n\nCited: Rulebook passages on *Attack Modifier Cards* and *Advantage and Disadvantage*.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 19543,
+      "tokenInput": 73394,
+      "tokenOutput": 668,
+      "tokenTotal": 74062,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:rule-advantage",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Arule-advantage",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-advantage",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "In Frosthaven, *advantage* means you draw **two attack modifiers and use one of them**. For monsters, they always use the better one; for characters, **you may choose either one**. With *disadvantage*, you draw two and **must use the worse one**. If an attack has both, they cancel and you have neither.  \nSource: Rulebook, Advantage and Disadvantage.\n\nThe key rolling-card interaction is:\n\n> If the first draw with advantage or disadvantage is a rolling modifier, the attacker draws additional modifiers, one at a time, until a non-rolling modifier is drawn. They then draw one more modifier and ignore any rolling icon on it.\n\nSo in practice:\n\n- **Normal draw:** keep drawing rolling cards until you hit a non-rolling card.\n- **With advantage/disadvantage:**\n  - If the **first card is non-rolling**, draw one more card and compare those two.\n  - If the **first card is rolling**, keep drawing until you get the **first non-rolling** card, then draw **one more** card. Compare the **last two non-rolling results**; the rolling icon on that extra card is ignored.\n\nOutcome:\n- With *advantage*: use all the initial rolling modifiers, plus **whichever of the last two modifiers you choose**.\n- With *disadvantage*: **ignore all initial rolling modifiers**, and use **whichever of the last two is worse**.\n\nTie/ambiguity rule:\n- If it’s unclear which card is worse because of non-numeric effects, **use the one drawn first**.  \nSource: Frosthaven Rulebook, “Advantage and Disadvantage” (Rulebook passage 96 / chunk 95), plus example passage 97 / chunk 96.\n\nShort example:\n- You attack with *advantage*.\n- Draw 1: rolling *+1*\n- Draw 2: non-rolling *+0*\n- Draw 3: non-rolling *+2*\n\nYou keep the rolling *+1*, then choose between *+0* and *+2*, so you’d usually use **rolling +1 and +2**.\n\nIf you want, I can also explain how this differs from Gloomhaven’s old advantage/disadvantage handling.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 12920,
+      "tokenInput": 26773,
+      "tokenOutput": 547,
+      "tokenTotal": 27320,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:rule-advantage",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Arule-advantage",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-advantage",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "With *advantage*, you draw **two attack modifier cards** and use the **better** one; with *disadvantage*, you draw two and use the **worse** one. A monster always uses the better one, while a character may choose either one when they have advantage. If the attack has both, it has neither.  \n\nImportant wrinkle: if the first drawn card is a *rolling modifier*, keep drawing until you get a non-rolling card, then draw one more card and ignore the rolling icon on that last card. Compare the **last two non-rolling modifiers**; with advantage you keep the better one, with disadvantage the worse one. If there’s ambiguity, use the **first drawn** card.  \n\nSource: *Frosthaven Rulebook*, “ADVANTAGE AND DISADVANTAGE” (Sticker 5).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6306,
+      "tokenInput": 27727,
+      "tokenOutput": 245,
+      "tokenTotal": 27972,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:rule-advantage",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Arule-advantage",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-advantage",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In *Frosthaven*, if an attack gains *advantage*, you **draw two attack modifier cards** for that attack and **use one of them** (the attacker chooses; a monster uses the better one). If *disadvantage* is involved too, the attack effectively has **neither** advantage nor disadvantage.\n\n### How the two modifier cards are used\n- With *advantage*: draw **two**, then **choose one to apply** to the attack.\n- With *disadvantage*: draw **two**, then you **must use the worse** one.\n\n### Rolling modifier special case\nIf the **first** draw (with advantage/disadvantage) is a *rolling* modifier:\n1. Keep drawing **additional modifiers one at a time** until a **non-rolling** modifier is drawn.\n2. Then draw **one more modifier**.\n3. Compare **the first non-rolling modifier and the one after it**:\n   - *Advantage*: use the one you choose (but compare per the rule’s “rolling icon” handling).\n   - *Disadvantage*: use whichever of those two is worse.\n\nIf the first draw is **not** rolling but the **second** draw is rolling, the rolling icon on the **second** modifier is **ignored**.\n\n### When advantage happens (timing note)\nYour attack modifier cards are drawn when resolving an **attack ability**, with one card drawn **per individual target** of that attack ability.\n\n**Source:** Rulebook, *Advantage and Disadvantage* and *Attack Modifier Cards* sections.",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 6599,
+      "tokenInput": 15510,
+      "tokenOutput": 364,
+      "tokenTotal": 15874,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:rule-advantage",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Arule-advantage",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-small-items",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "The rulebook's **Item Limits** section (Rulebook, chunk 118–119) gives the answer:\n\n> A character can bring … a number of **[Small/I]** items up to **half their level (rounded up)**.\n\nSo the limit for *Small* (*I*) items scales with the character's level:\n\n| Character Level | Small Items Allowed |\n|:-:|:-:|\n| 1 | 1 |\n| 2 | 1 |\n| 3 | 2 |\n| 4 | 2 |\n| 5 | 3 |\n| 6 | 3 |\n| 7 | 4 |\n| 8 | 4 |\n| 9 | 5 |\n\nFor reference, the full item limits per character are:\n- **1** Head (*E*) item\n- **1** Body (*B*) item\n- **1** Feet (*L*) item\n- **Up to 2** One-Hand (*H*) items **or 1** Two-Hand (*h*) item\n- *Small* (*I*) items equal to **half their level, rounded up**",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10052,
+      "tokenInput": 20470,
+      "tokenOutput": 499,
+      "tokenTotal": 20969,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:rule-small-items",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-small-items",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-small-items",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "A character can bring **small items up to half their level, rounded up**, into a scenario.\n\nSo that's:\n- Levels 1–2: 1 small item\n- Levels 3–4: 2 small items\n- Levels 5–6: 3 small items\n- Levels 7–8: 4 small items\n- Level 9: 5 small items\n\nThis is in addition to the other equipment slots: one Head, one Body, one Feet, and either two One Hand items or one Two Hands item.\n\nSource: Frosthaven Rulebook, \"Item Limits\" (p. 35).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6511,
+      "tokenInput": 8170,
+      "tokenOutput": 267,
+      "tokenTotal": 8437,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:rule-small-items",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Arule-small-items",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-small-items",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Perfect! Based on the Frosthaven Rulebook, a character can bring **a number of *Small* items (I type) equal to up to half their level, rounded up**.\n\n> Each character can bring one E item, one B item, one L item, up to two H items -or- one h item, and a number of I items up to half their level (rounded up).\n\n**Rulebook**, Item Limits section.\n\nSo the exact number varies by character level:\n- **Level 1**: 1 *Small* item (½ rounded up)\n- **Level 2–3**: 1 *Small* item (1–1.5 rounded up)\n- **Level 4–5**: 2 *Small* items (2–2.5 rounded up)\n- **Level 6**: 3 *Small* items (3)",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6367,
+      "tokenInput": 24253,
+      "tokenOutput": 457,
+      "tokenTotal": 24710,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:rule-small-items",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Arule-small-items",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-small-items",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "A character can bring **small items equal to half their level, rounded up** into a scenario — i.e. **⌈level ÷ 2⌉**. (Frosthaven Rulebook, Items / Item Types)\n\nExamples:\n\n| Character level | Small items allowed |\n|---:|---:|\n| 1–2 | 1 |\n| 3–4 | 2 |\n| 5–6 | 3 |\n| 7–8 | 4 |\n| 9 | 5 |\n\nThey may **own** more items than they bring, but can’t own more than one copy of the same item.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 13753,
+      "tokenInput": 39852,
+      "tokenOutput": 391,
+      "tokenTotal": 40243,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:rule-small-items",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Arule-small-items",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-small-items",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "A character can bring a number of *small items* equal to **half their level, rounded up**. So:\n\n- Level 1–2: **1** small item\n- Level 3–4: **2**\n- Level 5–6: **3**\n- Level 7–8: **4**\n- Level 9: **5**\n\nFrom the Frosthaven Rulebook, item limits:  \n> “Each character can bring one [head] item, one [body] item, one [legs] item, up to two [one-hand] items -or- one [two-hand] item, and a number of [small item] items equal to half their level, rounded up.”\n\nSource: **Frosthaven Rulebook, Item Limits**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7811,
+      "tokenInput": 25666,
+      "tokenOutput": 230,
+      "tokenTotal": 25896,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:rule-small-items",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Arule-small-items",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-small-items",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "A character can bring **up to 1 *Small* item** into a Frosthaven scenario.\n\nMore generally, the rulebook says each character can bring:\n- 1 *Head* item\n- 1 *Body* item\n- 1 *Legs* item\n- up to 2 *Hand* items **or** 1 *Two Hands* item\n- **1 *Small* item**\n- a number of *Item* items up to half their level, rounded up\n\nSource: Frosthaven rulebook, item limits section.",
+      "score": 0.4,
+      "pass": false,
+      "latencyMs": 6293,
+      "tokenInput": 26221,
+      "tokenOutput": 193,
+      "tokenTotal": 26414,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:rule-small-items",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Arule-small-items",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-small-items",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In Frosthaven, each character can bring the following *types* of items into a scenario:\n\n- **1** *E* item  \n- **1** *B* item  \n- **1** *L* item  \n- **Up to 2** *H* items **OR** **1** *h* item  \n- **A number of *I* items** up to **half their level (rounded up)**  \n\n(These limits are listed under *Item Limits* in the Rulebook.)",
+      "score": 0.4,
+      "pass": false,
+      "latencyMs": 6939,
+      "tokenInput": 26223,
+      "tokenOutput": 202,
+      "tokenTotal": 26425,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:rule-small-items",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Arule-small-items",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-looting-definition",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's a full breakdown of **Looting** based on the Frosthaven Rulebook:\n\n---\n\n## The *Loot* Ability\n\n> \"*Loot X* is an ability that allows a figure to loot all loot tokens and treasure tiles within range X, including any in their current hex. This ability is unaffected by the presence of figures or overlay tiles. If there are no loot tokens or treasure tiles within the specified range, the ability cannot be performed.\"\n\n*(Rulebook, p. ~37)*\n\n---\n\n## Looting Loot Tokens\n\nWhen a **loot token** is looted, it is removed from the map. Then:\n\n- **If a monster loots it:** Nothing else happens.\n- **If a character loots it:** They draw one card from the **loot deck** (unless it's empty).\n  - If the card provides a **random item**, the character draws from the random item deck and can use it for the rest of the scenario (even above item limits). If the random item deck is empty, it counts as a money card with 3 coins.\n  - If the card provides **money or resources**, the character does **not** gain them until the **end of the scenario**.\n\n---\n\n## Looting Treasure Tiles\n\nWhen a **treasure tile** is looted, it is removed from the map. **Monsters cannot loot treasure tiles.**\n\n- If it is a **numbered treasure**, look it up in the Treasure Index and apply the effect.\n- Only the looting character gains the reward — **unless** it is a random item blueprint or random scenario unlock (those are shared).\n- If a character gains an item they cannot keep, they must **give it to another character or sell it immediately**.\n\n---\n\n## Key Reminders\n\n- **Monsters and summons do not perform end-of-turn looting.** *(Rulebook, Appendix C)*\n- Money and resources from loot cards are only collected **at the end of the scenario**, not immediately.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 16499,
+      "tokenInput": 30875,
+      "tokenOutput": 805,
+      "tokenTotal": 31680,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:rule-looting-definition",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-looting-definition",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-looting-definition",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "I have enough from the rulebook to give a solid answer.\n\n# Looting\n\nLooting is how figures pick up loot tokens and treasure tiles from the map.\n\n**The *Loot X* ability** (Rulebook, p. ~62):\n\n> \"*Loot X* is an ability that allows a figure to loot all loot tokens and treasure tiles within range X, including any in their current hex.\"\n\nKey rules:\n\n- *Loot X* is **unaffected by the presence of figures or overlay tiles**. If there are no loot tokens or treasure tiles within range, the ability cannot be performed.\n- When a **loot token** is looted, it's removed from the map.\n  - If a **monster** loots it, nothing else happens.\n  - If a **character** loots it, they draw one card from the loot deck (unless it's empty).\n    - If the loot card provides a **random item**, the character checks off a random-item slot in the scenario's loot table, draws from the random item deck, and adds it to their pool — usable for the rest of the scenario, even above the normal item limit. (If the random item deck is empty, the card is treated as a money card with 3 coins.)\n    - If the loot card provides **money or resources**, the character doesn't actually gain them until the **end of the scenario**.\n- When a **treasure tile** is looted, it's removed from the map. Monsters cannot loot treasure tiles. If it's a numbered treasure, look up the number in the Treasure Index and apply the effect.\n- Only the looting character gains the reward, unless it's a random item blueprint or random scenario (those are shared with the party).\n- If a character gains an item they aren't allowed to have, they must give it to another character or sell it immediately.\n\n**End-of-turn looting** (Rulebook, Appendix C):\nAt the end of their turn, a character automatically loots their own hex (a free *Loot 0*, essentially). **Monsters and summons do not perform end-of-turn looting.**\n\nSources: Frosthaven Rulebook, \"Loot\" section (chunks 110–111) and Appendix C (chunk 221).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 22839,
+      "tokenInput": 32052,
+      "tokenOutput": 1087,
+      "tokenTotal": 33139,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:rule-looting-definition",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Arule-looting-definition",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-looting-definition",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Based on the Frosthaven Rulebook, **looting** is a core mechanic that works as follows:\n\n## *Loot* Ability\n\n\"*Loot X*\" is an ability that allows a figure to loot all loot tokens and treasure tiles within range X, including any in their current hex. This ability is unaffected by the presence of figures or overlay tiles. If there are no loot tokens or treasure tiles within the specified range, the ability cannot be performed.\n\n## What Happens When You Loot\n\n**For monsters:** When a loot token is looted by a monster, it is simply removed from the map and nothing else happens.\n\n**For characters:** \n- **Loot tokens:** When a character loots a loot token, it is removed from the map and they draw one card from the loot deck (unless empty). If the card provides a random item, they gain it immediately. If it provides money or resources, they don't gain them until the end of the scenario.\n\n- **Treasure tiles:** When a character loots a numbered treasure tile, it is removed from the map. They then reference the treasure's number in the Treasure Index and apply the effect. Only the looting character gains the reward, unless it is a random item blueprint or random scenario. If a character gains an item they cannot gain for any reason, they must give it to another character or sell it immediately.\n\n**Important note:** Monsters cannot loot treasure tiles.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9941,
+      "tokenInput": 31435,
+      "tokenOutput": 719,
+      "tokenTotal": 32154,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:rule-looting-definition",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Arule-looting-definition",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-looting-definition",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "In Frosthaven, **looting** means picking up loot tokens or treasure tiles from the map.\n\nKey rules:\n\n- A *Loot X* ability lets a figure loot **all loot tokens and treasure tiles within range X**, including in their own hex. It ignores figures and overlay tiles. If there’s nothing in range, the ability can’t be performed.  \n  > “Loot X is an ability that allows a figure to loot all loot tokens and treasure tiles within range X, including any in their current hex.” — Rulebook, Loot\n\n- When a **loot token** is looted, remove it from the map.\n  - If a **character** loots it, they draw one card from the loot deck, unless the deck is empty.\n  - If a **monster** loots it, nothing else happens.\n  - Money/resources from loot cards are gained at the **end of the scenario**, not immediately. — Rulebook, Loot\n\n- When a **treasure tile** is looted, remove it from the map.\n  - Monsters cannot loot treasure tiles.\n  - If it’s a numbered treasure, check the Treasure Index and apply its effect; usually only the looting character gains the reward. — Rulebook, Loot / Treasure rules",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 37758,
+      "tokenInput": 187577,
+      "tokenOutput": 1072,
+      "tokenTotal": 188649,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 9,
+      "retryCount": 0,
+      "loopIterations": 10,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:rule-looting-definition",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Arule-looting-definition",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-looting-definition",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "In Frosthaven, *Loot* is the ability that lets a figure collect all loot tokens and treasure tiles within a specified range.\n\n> “*Loot X* is an ability that allows a figure to loot all loot tokens and treasure tiles within range X, including any in their current hex.” — Rulebook\n\nKey points:\n- It collects **all** loot tokens and treasure tiles in range.\n- It ignores figures and overlay tiles when checking that range.\n- If there’s nothing in range, the ability can’t be performed.\n- Looted tokens/treasures are removed from the map.\n\nFor characters:\n- Looting a loot token makes you draw from the loot deck.\n- Money/resources from loot cards are generally gained at the **end of the scenario**.\n- Looting a treasure tile removes it and gives its listed treasure reward.\n\nFor monsters:\n- They can loot loot tokens, but “nothing else happens.”\n- They **cannot** loot treasure tiles.\n\nIf you want, I can also explain **end-of-turn looting** versus using a *Loot X* ability.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8397,
+      "tokenInput": 15009,
+      "tokenOutput": 259,
+      "tokenTotal": 15268,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:rule-looting-definition",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Arule-looting-definition",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-looting-definition",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "*Loot* is an ability that lets a figure collect loot tokens and treasure tiles within a specified range.\n\n> “Loot X” is an ability that allows a figure to loot all loot tokens and treasure tiles within range X, including any in their current hex. This ability is unaffected by the presence of figures or overlay tiles. If there are no loot tokens or treasure tiles within the specified range, the ability cannot be performed. — Rulebook\n\nA few key points:\n- Loot tokens are removed from the map when looted.\n- If a **character** loots a token, they draw from the loot deck.\n- If a **monster** loots a token, nothing else happens.\n- Treasure tiles are removed from the map when looted.\n- Monsters cannot loot treasure tiles.\n\nIf you want, I can also explain **end-of-turn looting** versus the *Loot X* ability.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4648,
+      "tokenInput": 15016,
+      "tokenOutput": 219,
+      "tokenTotal": 15235,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:rule-looting-definition",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Arule-looting-definition",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-looting-definition",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In *Frosthaven*, *Lo[oting/oting]* means **using a *Loot* ability/action to open lootables on the map (like treasure, chests, crates, barrels, or similar tiles) and gain whatever reward they contain**.\n\nA few key points from the rulebook:\n\n- **Looting is tied to an action/ability** (the rulebook shows it under the *Loot* section and examples of characters using abilities that “move and loot”).  \n- **If the looted treasure tile is numbered**, you look it up in the *Treasure Index* and apply that treasure’s effect.  \n- **Only the looting character gains the reward** (except in specific cases like random item blueprints / random scenarios, as noted in the rulebook passage).  \n\nIf you tell me *what you’re looting* (crate/crate tile, treasure tile, barrel, etc.) and *what ability/card is being used*, I can point to the exact timing and reward rules for that case.",
+      "score": 0.4,
+      "pass": false,
+      "latencyMs": 6271,
+      "tokenInput": 15720,
+      "tokenOutput": 248,
+      "tokenTotal": 15968,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:rule-looting-definition",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Arule-looting-definition",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-vermling-scout",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here are the stats for a **normal Vermling Scout at level 1** in Frosthaven:\n\n| Stat | Value |\n|------|-------|\n| **HP** | 3 |\n| *Move* | 3 |\n| *Attack* | 1 |\n| **Immunities** | None |\n\nNo special attributes or immunities are listed for the normal Vermling Scout at this level. For reference, the **elite** version at level 1 has 5 HP, *Move* 3, and *Attack* 2.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6831,
+      "tokenInput": 8685,
+      "tokenOutput": 306,
+      "tokenTotal": 8991,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:monster-vermling-scout",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Amonster-vermling-scout",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-vermling-scout",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "A **normal Vermling Scout at level 1** has:\n\n- **HP:** 3\n- **Move:** 3\n- **Attack:** 1\n- **Immunities:** none\n\nNo special attributes are listed at this level.\n\nSource: Card Index (monster stats, Vermling Scout, level 0–3 card).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6544,
+      "tokenInput": 11615,
+      "tokenOutput": 280,
+      "tokenTotal": 11895,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:monster-vermling-scout",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Amonster-vermling-scout",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-vermling-scout",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Perfect! Based on the search results, here are the stats for a normal Vermling Scout at level 1 in Frosthaven:\n\n**Normal Vermling Scout (Level 1):**\n- **HP:** 3\n- **Move:** 3\n- **Attack:** 1\n\nThis monster has no immunities. (Card Index)",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4230,
+      "tokenInput": 13826,
+      "tokenOutput": 352,
+      "tokenTotal": 14178,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:monster-vermling-scout",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Amonster-vermling-scout",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-vermling-scout",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "A **normal Vermling Scout at level 1** has:\n\n- **HP:** 3\n- *Move 3*\n- *Attack 1*\n\nSource: Frosthaven Card Index, Vermling Scout monster stats (`vermling-scout/0-3`).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 15318,
+      "tokenInput": 51106,
+      "tokenOutput": 513,
+      "tokenTotal": 51619,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:monster-vermling-scout",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Amonster-vermling-scout",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-vermling-scout",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "A normal Vermling Scout at level 1 has:\n\n- HP 3\n- *Move 3*\n- *Attack 1*\n\nIt has no listed immunities in the checked-in data. Source: monster stats card “Vermling Scout” (`gloomhavensecretariat:monster-stat/vermling-scout/0-3`).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10551,
+      "tokenInput": 30240,
+      "tokenOutput": 406,
+      "tokenTotal": 30646,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:monster-vermling-scout",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Amonster-vermling-scout",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-vermling-scout",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "A **normal Vermling Scout at level 1** has:\n\n- **HP 3**\n- **Move 3**\n- **Attack 1**\n\nSource: Frosthaven monster stats card for *Vermling Scout* (`levelRange 0-3`, normal level 1).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5591,
+      "tokenInput": 30960,
+      "tokenOutput": 139,
+      "tokenTotal": 31099,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:monster-vermling-scout",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Amonster-vermling-scout",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-vermling-scout",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In *Frosthaven*, a **normal Vermling Scout** at **level 1** has:\n\n- **HP:** 3  \n- **Move:** 3  \n- **Attack:** 1  \n\n(Source: *monster-stats* card “Vermling Scout”, normal level 1)",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 12266,
+      "tokenInput": 59576,
+      "tokenOutput": 231,
+      "tokenTotal": 59807,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 6,
+      "retryCount": 0,
+      "loopIterations": 7,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:monster-vermling-scout",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Amonster-vermling-scout",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-living-bones-immunity",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "According to the Living Bones monster stat card data (levels 0–7), the **immunities list is empty** — Living Bones have **no condition immunities** in Frosthaven.\n\nThey are susceptible to all conditions. Their notable persistent bonuses are:\n- *Shield 1* (at levels 1+)\n- *Target 2* (normal) / *Target 3* (elite) at levels 1+\n\nSo feel free to apply *Poison*, *Wound*, *Muddle*, *Immobilize*, *Stun*, or any other condition to them — none are blocked by their stat card.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 17322,
+      "tokenInput": 34035,
+      "tokenOutput": 749,
+      "tokenTotal": 34784,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 8,
+      "retryCount": 0,
+      "loopIterations": 7,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:monster-living-bones-immunity",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Amonster-living-bones-immunity",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-living-bones-immunity",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "According to the Living Bones monster stat cards in the Frosthaven card data, the **immunities** field is empty for both level ranges (0–3 and 4–7). That means Living Bones have **no condition immunities** at any level.\n\nThey do, however, have *Shield 1* starting at level 1 (normal) and across all elite levels, so they have damage reduction even though they aren't immune to any conditions.\n\nSource: GHS Card Index — Living Bones monster stats (levels 0–3 and 4–7).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7593,
+      "tokenInput": 12615,
+      "tokenOutput": 447,
+      "tokenTotal": 13062,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:monster-living-bones-immunity",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Amonster-living-bones-immunity",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-living-bones-immunity",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Based on the card data, **Living Bones has no immunities** in Frosthaven. The immunities field on the Living Bones stat card is empty.\n\nHowever, note that Living Bones does have *Shield 1* and *Target 2* (or *Target 3* at higher levels) as noted abilities, which provide damage reduction and targeting restrictions, but these are not condition immunities.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6326,
+      "tokenInput": 20991,
+      "tokenOutput": 454,
+      "tokenTotal": 21445,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:monster-living-bones-immunity",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Amonster-living-bones-immunity",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-living-bones-immunity",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Living Bones have **no condition immunities** in Frosthaven.\n\nI checked both Living Bones stat records:\n- Levels 0–3: immunities field is empty.\n- Levels 4–7: immunities field is empty.\n\nSource: Card Index — Living Bones monster stats (`living-bones/0-3`, `living-bones/4-7`).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 21186,
+      "tokenInput": 63424,
+      "tokenOutput": 553,
+      "tokenTotal": 63977,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 7,
+      "retryCount": 0,
+      "loopIterations": 8,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:monster-living-bones-immunity",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Amonster-living-bones-immunity",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-living-bones-immunity",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "Living Bones have **no listed condition immunities** in the checked-in Frosthaven monster stat data.\n\nBoth Living Bones stat records show:\n- `immunities: []`\n\nSources:\n- Monster stats, Living Bones levels 0–3 — `gloomhavensecretariat:monster-stat/living-bones/0-3`\n- Monster stats, Living Bones levels 4–7 — `gloomhavensecretariat:monster-stat/living-bones/4-7`\n\nSo in this data, they are immune to **none**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 11162,
+      "tokenInput": 29018,
+      "tokenOutput": 439,
+      "tokenTotal": 29457,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:monster-living-bones-immunity",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Amonster-living-bones-immunity",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-living-bones-immunity",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "Living Bones have **no listed immunities** in the checked-in monster stats data. Their *immunities* field is empty.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7925,
+      "tokenInput": 45518,
+      "tokenOutput": 138,
+      "tokenTotal": 45656,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:monster-living-bones-immunity",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Amonster-living-bones-immunity",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-living-bones-immunity",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "Living Bones has **no listed condition immunities** in the checked-in Frosthaven card data (*immunities* field is empty) for both level ranges **0–3** and **4–7**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 13167,
+      "tokenInput": 66932,
+      "tokenOutput": 260,
+      "tokenTotal": 67192,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 7,
+      "retryCount": 0,
+      "loopIterations": 8,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:monster-living-bones-immunity",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Amonster-living-bones-immunity",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-flame-demon-elite",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here are the stats for an **elite Flame Demon at level 0** in Frosthaven:\n\n| Stat | Value |\n|------|-------|\n| **HP** | 3 |\n| **Move** | *Move 3* |\n| **Attack** | *Attack 2* |\n| **Shield** | *Shield 3* |\n\nNo immunities are listed for the Flame Demon at this level. The *Shield 3* makes it quite resilient early on — keep that in mind when planning your attacks!\n\n*(Source: Frosthaven Card Index – Flame Demon Monster Stats, Levels 0–3)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6683,
+      "tokenInput": 8786,
+      "tokenOutput": 324,
+      "tokenTotal": 9110,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:monster-flame-demon-elite",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Amonster-flame-demon-elite",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-flame-demon-elite",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here are the **Elite Flame Demon** stats at **Level 0**:\n\n- **HP:** 3\n- **Move:** 3\n- **Attack:** 2\n- ***Shield 3***\n\nNo immunities are listed at this level.\n\nSource: Card Index — Flame Demon monster stats (level 0–3).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5835,
+      "tokenInput": 11800,
+      "tokenOutput": 307,
+      "tokenTotal": 12107,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:monster-flame-demon-elite",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Amonster-flame-demon-elite",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-flame-demon-elite",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Based on the card data, here are the stats for an **elite Flame Demon at level 0** in Frosthaven:\n\n- **HP:** 3\n- **Move:** 3\n- **Attack:** 2\n- **Shield:** 3\n\nThe elite Flame Demon has no immunities at level 0.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6639,
+      "tokenInput": 32933,
+      "tokenOutput": 501,
+      "tokenTotal": 33434,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:monster-flame-demon-elite",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Amonster-flame-demon-elite",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-flame-demon-elite",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "An **elite Flame Demon** at **level 0** has:\n\n- **HP:** 3\n- **Move:** 3\n- **Attack:** 2\n- *Shield 3*\n\nSource: Frosthaven Card Index, Flame Demon monster stats level range 0–3.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 23144,
+      "tokenInput": 65858,
+      "tokenOutput": 845,
+      "tokenTotal": 66703,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 7,
+      "retryCount": 0,
+      "loopIterations": 8,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:monster-flame-demon-elite",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Amonster-flame-demon-elite",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-flame-demon-elite",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "An elite Flame Demon at level 0 has:\n\n- HP 3\n- *Move 3*\n- *Attack 2*\n- *Shield 3*\n\nThe checked-in monster stats data shows no immunities listed for Flame Demon.\n\nSource: monster stat card `gloomhavensecretariat:monster-stat/flame-demon/0-3`",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 15048,
+      "tokenInput": 29100,
+      "tokenOutput": 403,
+      "tokenTotal": 29503,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:monster-flame-demon-elite",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Amonster-flame-demon-elite",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-flame-demon-elite",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "An **elite Flame Demon** at **level 0** has:\n\n- **HP 3**\n- **Move 3**\n- **Attack 2**\n- **Shield 3**\n\nIt also has **no immunities** listed in the card data.\n\nSource: monster-stats card `gloomhavensecretariat:monster-stat/flame-demon/0-3` (search result summary).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9623,
+      "tokenInput": 45323,
+      "tokenOutput": 546,
+      "tokenTotal": 45869,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:monster-flame-demon-elite",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Amonster-flame-demon-elite",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "monster-flame-demon-elite",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "An *elite* **Flame Demon** at **level 0** has these stats:\n\n- **HP:** 3  \n- **Move:** 3  \n- **Attack:** 2  \n\n(From the checked-in Frosthaven monster stat data for *Flame Demon* elite **L0**.)",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 7838,
+      "tokenInput": 35876,
+      "tokenOutput": 178,
+      "tokenTotal": 36054,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:monster-flame-demon-elite",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Amonster-flame-demon-elite",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "building-alchemist",
+      "category": "buildings",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Based on the card data, the **Alchemist (Building #35) at Level 1** has **no build cost** — all resource fields (gold, hide, metal, lumber) and the prosperity requirement are all **0**.\n\nHowever, note the Level 1 effect:\n> Characters cannot use potions.\n\nThis is the starting/unbuilt state of the Alchemist. You'll likely want to upgrade it to Level 2+ to unlock its full potion-crafting functionality! Would you like to know the cost to upgrade it to a higher level?",
+      "score": 0.4,
+      "pass": false,
+      "latencyMs": 6860,
+      "tokenInput": 7249,
+      "tokenOutput": 296,
+      "tokenTotal": 7545,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "quality",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:building-alchemist",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Abuilding-alchemist",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "building-alchemist",
+      "category": "buildings",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "The **Alchemist (Level 1)** has no build cost — all resource and prosperity costs are 0:\n\n- Gold: 0\n- Hide: 0\n- Metal: 0\n- Lumber: 0\n- Prosperity: 0\n\nNote that at Level 1, the Alchemist is not yet operational — its effect reads: \"Characters cannot use potions.\" You'll need to upgrade it to a higher level to actually use the building.\n\nSource: Card Index (building 35, L1)",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 6842,
+      "tokenInput": 10477,
+      "tokenOutput": 373,
+      "tokenTotal": 10850,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:building-alchemist",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Abuilding-alchemist",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "building-alchemist",
+      "category": "buildings",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "The **Alchemist building at level 1 costs nothing to build** — all resource costs (gold, hide, metal, lumber) and prosperity are 0. \n\nIts effect is: Characters cannot use potions.",
+      "score": 0.4,
+      "pass": false,
+      "latencyMs": 2915,
+      "tokenInput": 7233,
+      "tokenOutput": 220,
+      "tokenTotal": 7453,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "quality",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:building-alchemist",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Abuilding-alchemist",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "building-alchemist",
+      "category": "buildings",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "The level 1 **Alchemist** building costs **nothing** to build: **0 gold, 0 hide, 0 metal, 0 lumber, and 0 prosperity**.\n\nSource: Card Index — `gloomhavensecretariat:building/35/L1`",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7963,
+      "tokenInput": 20464,
+      "tokenOutput": 153,
+      "tokenTotal": 20617,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:building-alchemist",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Abuilding-alchemist",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "building-alchemist",
+      "category": "buildings",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "The level 1 *Alchemist* has **no build cost** in the checked-in data: **0 gold, 0 hide, 0 metal, 0 lumber, and 0 prosperity**.  \nSource: Card Index, `gloomhavensecretariat:building/35/L1`",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6999,
+      "tokenInput": 20776,
+      "tokenOutput": 135,
+      "tokenTotal": 20911,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:building-alchemist",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Abuilding-alchemist",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "building-alchemist",
+      "category": "buildings",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "The **Alchemist** building at **level 1** costs **0 gold, 0 hide, 0 metal, 0 lumber, and 0 prosperity** to build.  \n\nSource: **GHS Card Data** for **Alchemist (Building 35, L1)**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5196,
+      "tokenInput": 20617,
+      "tokenOutput": 129,
+      "tokenTotal": 20746,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:building-alchemist",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Abuilding-alchemist",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "building-alchemist",
+      "category": "buildings",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In *Frosthaven*, the **Alchemist** building at **level 1** has a build cost of:\n\n- **Gold:** 0  \n- **Hide:** 0  \n- **Metal:** 0  \n- **Lumber:** 0  \n- **Prosperity requirement:** 0  \n\nSo, it costs **nothing** to build at level 1.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5639,
+      "tokenInput": 20422,
+      "tokenOutput": 152,
+      "tokenTotal": 20574,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:building-alchemist",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Abuilding-alchemist",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-spyglass",
+      "category": "items",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's what the **Spyglass** does in Frosthaven:\n\n- **Item Number:** 001\n- **Slot:** Head\n- **Effect:** During your attack ability, gain *advantage* on one attack.\n- **Usage:** It is a **spent** (↩) item — meaning you flip it facedown when used, but it is **not lost**. You can recover it through rest.\n\nIt's a straightforward and reusable head item that lets you gain *advantage* on a single attack once per scenario rest cycle!",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 6856,
+      "tokenInput": 7165,
+      "tokenOutput": 274,
+      "tokenTotal": 7439,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:item-spyglass",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Aitem-spyglass",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-spyglass",
+      "category": "items",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "**Spyglass** (Item 001) — *Head* slot.\n\n> \"During your attack ability, gain advantage on one attack.\"\n\nIt's a *Spent* item (flipped after use, refreshable between scenarios). The cost field isn't populated in the checked-in data.\n\nSource: Card Index (gloomhavensecretariat:item/1).",
+      "score": 0.6,
+      "pass": false,
+      "latencyMs": 6540,
+      "tokenInput": 9821,
+      "tokenOutput": 297,
+      "tokenTotal": 10118,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "quality",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:item-spyglass",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Aitem-spyglass",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-spyglass",
+      "category": "items",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "The **Spyglass** is item number **001** in Frosthaven. It is a head slot item with the following effect:\n\n> During your attack ability, gain advantage on one attack.\n\nThe item is spent after use (meaning it exhausts once used) but is not lost.",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 2862,
+      "tokenInput": 7174,
+      "tokenOutput": 228,
+      "tokenTotal": 7402,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:item-spyglass",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Aitem-spyglass",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-spyglass",
+      "category": "items",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "The **Spyglass** is Frosthaven item **001**.\n\nEffect: “During your attack ability, gain *advantage* on one attack.”\n\nIt is a **head** slot item, and it is **spent** when used, not lost.  \nSource: Card Index, `gloomhavensecretariat:item/1`.",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 8121,
+      "tokenInput": 20401,
+      "tokenOutput": 154,
+      "tokenTotal": 20555,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:item-spyglass",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Aitem-spyglass",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-spyglass",
+      "category": "items",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "**Spyglass** is item **001** in Frosthaven.\n\nIts effect is:\n\n> During your attack ability, gain advantage on one attack.\n\nIt is a head-slot item, and it is *spent* when used.  \nSource: Card Index, `gloomhavensecretariat:item/1`",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 7532,
+      "tokenInput": 20355,
+      "tokenOutput": 128,
+      "tokenTotal": 20483,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:item-spyglass",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Aitem-spyglass",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-spyglass",
+      "category": "items",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "The **Spyglass** item is **item 001**. Its effect is:\n\n> During your attack ability, gain *Advantage* on one attack.\n\nSource: Card Index, `gloomhavensecretariat:item/1`",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5490,
+      "tokenInput": 20351,
+      "tokenOutput": 112,
+      "tokenTotal": 20463,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:item-spyglass",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Aitem-spyglass",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-spyglass",
+      "category": "items",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In *Frosthaven*, **Spyglass** (item number **001**) is equipped in the **head** slot.  \n\n**Its effect:**  \n> *During your attack ability, gain advantage on one attack.*  \n\nSource: *Frosthaven* items card data (GHS): **Spyglass** (item **001**).",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 6133,
+      "tokenInput": 20215,
+      "tokenOutput": 134,
+      "tokenTotal": 20349,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:item-spyglass",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Aitem-spyglass",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-crude-boots",
+      "category": "items",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's what **Crude Boots** (Item #005) does in Frosthaven:\n\n- **Slot:** Legs\n- **Effect:** During your *move* ability, add *+1 Move*.\n- **Usage:** This is a **spent** (not lost) item, meaning you flip it facedown when used and can recover it later (e.g., via a *Recover* ability or at the end of the scenario).\n\nIt's a simple but useful early-game legs item that gives your character a little extra movement when you need it most.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7134,
+      "tokenInput": 7144,
+      "tokenOutput": 278,
+      "tokenTotal": 7422,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:item-crude-boots",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Aitem-crude-boots",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-crude-boots",
+      "category": "items",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "**Crude Boots** (Item 005, *Legs* slot):\n\n> During your move ability, add *+1 Move*\n\n- **Spent** when used (flip back up at the end of the scenario, not lost)\n- No cost listed in the checked-in data\n\nSource: Card Index, item 005.",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 6580,
+      "tokenInput": 9840,
+      "tokenOutput": 298,
+      "tokenTotal": 10138,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:item-crude-boots",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Aitem-crude-boots",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-crude-boots",
+      "category": "items",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "**Crude Boots** is a leg slot item in Frosthaven with the following effect:\n\n> During your move ability, add +1 Move\n\nThis is a spent item that grants an additional movement point when you activate a move ability. The item has no cost and uses no charges.",
+      "score": 0.6,
+      "pass": false,
+      "latencyMs": 2671,
+      "tokenInput": 7159,
+      "tokenOutput": 232,
+      "tokenTotal": 7391,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "quality",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:item-crude-boots",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Aitem-crude-boots",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-crude-boots",
+      "category": "items",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Crude Boots (item 005, legs) says:\n\n> During your move ability, add +1 *Move*.\n\nIt is a **spent** item, not lost.  \nSource: Card Index, `gloomhavensecretariat:item/5`.",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 9143,
+      "tokenInput": 20395,
+      "tokenOutput": 142,
+      "tokenTotal": 20537,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:item-crude-boots",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Aitem-crude-boots",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-crude-boots",
+      "category": "items",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "**Crude Boots** is a leg-slot item. Its effect is:\n\n> “During your move ability, add +1 Move”\n\nIt is a *spent* item, not a *lost* item, so it refreshes normally rather than being lost for the scenario. Source: Card Index, item 005 (`gloomhavensecretariat:item/5`).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6896,
+      "tokenInput": 20345,
+      "tokenOutput": 141,
+      "tokenTotal": 20486,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:item-crude-boots",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Aitem-crude-boots",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-crude-boots",
+      "category": "items",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "**Crude Boots** are a *legs* item with this effect:\n\n> During your *Move* ability, add +1 *Move*.\n\nIt is a **spent** item, meaning you use it and then it is marked spent for the scenario. Source: Card Index, `gloomhavensecretariat:item/5`.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5260,
+      "tokenInput": 20341,
+      "tokenOutput": 134,
+      "tokenTotal": 20475,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:item-crude-boots",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Aitem-crude-boots",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "item-crude-boots",
+      "category": "items",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In *Frosthaven*, **Crude Boots** (legs) do this:\n\n- **During your move ability, add +1 Move.**",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 5332,
+      "tokenInput": 20181,
+      "tokenOutput": 89,
+      "tokenTotal": 20270,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:item-crude-boots",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Aitem-crude-boots",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "scenario-61-unlock",
+      "category": "scenarios",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "**Section 79.4** (Section Book 62-81, p. 79) is what unlocks Scenario 61 – *Life and Death*. Here is the full text:\n\n---\n\n> A single row of metal shells—Unfettered brought back from your latest foray—lie arranged on the floor of Crain's room. Each one is damaged beyond repair, crushed or pierced, destroyed in battle or by the elements. He stands over them, scribbling in a book. An oil lamp on the floor casts his shadow against the far wall.\n>\n> \"Makes you wonder what else we've forgotten,\" he says. \"Metallurgical technique,\" he taps an Unfettered foot with his lead stylus. \"Automated mechanics,\" he taps a head. \"The Unfettered were built by Quatryl some time ago. But their construction, how their limbs are joined, the way they move—that's all been lost. Look here.\" Crain turns over one of the machine's breastplates and shines his light where it's been pierced.\n>\n> \"This metal is treated.\" He angles the metal and it shimmers like fish scales. \"That's why they're so strong; why they don't rust. Logren mentions it in her study. She said her team used this treatment when they worked on the symbol of power.\" This is the first you've heard of such a thing, and it sounds like something that will require another quest.\n>\n> \"The symbol of power is everything,\" Crain waxes. \"But it isn't an object at all. It's a symbol, a seal, and there's more than one of them. But they are created with an object.\" Crain leads you to his desk, where a drawing of a three-legged contraption is featured prominently.\n>\n> \"The symbols of power, the seals, are created with this device, but in order to build it, I still need a few things. The most pressing, I believe, is this.\" He pulls out Torfi's journal, turns a few pages, and taps on an illustration of a cuboid stone, a mineral of some sort. \"Star iron.\"\n>\n> Your eyebrow rises skeptically.\n>\n> \"I didn't name it—you can blame my ancestors for that. But I do have a way to detect it, so we won't be going in blind.\" He directs you to the far end of his bench where a small cage is sitting, all strung with cord and glass vials. \"This can detect the metal within a relatively small radius. It's nearly ready. And I know it sounds risky, I know what's in the Copperneck Mountains, but—\" Crain hesitates. His voice becomes low, serious. \"There isn't a way around it. This will be hard, very hard, but we need to do it.\"\n>\n> **Rewards — New Scenario: Life and Death 61**\n\n---\n\nIn short, this is a **puzzle solution section** (labeled as such in the data) in which Crain explains his need for **star iron** from the Copperneck Mountains, and completing/reading it grants access to Scenario 61.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 14318,
+      "tokenInput": 14008,
+      "tokenOutput": 976,
+      "tokenTotal": 14984,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:scenario-61-unlock",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Ascenario-61-unlock",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "scenario-61-unlock",
+      "category": "scenarios",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "**Section 79.4** (labeled \"Puzzle Solution\" in the Section Book 62-81) unlocks scenario 61 *Life and Death*. Here's the text:\n\n> A single row of metal shells—Unfettered brought back from your latest foray—lie arranged on the floor of Crain's room. Each one is damaged beyond repair, crushed or pierced, destroyed in battle or by the elements. He stands over them, scribbling in a book. An oil lamp on the floor casts his shadow against the far wall.\n>\n> \"Makes you wonder what else we've forgotten,\" he says. \"Metallurgical technique,\" he taps an Unfettered foot with his lead stylus. \"Automated mechanics,\" he taps a head. \"The Unfettered were built by Quatryl some time ago. But their construction, how their limbs are joined, the way they move—that's all been lost. Look here.\" Crain turns over one of the machine's breastplates and shines his light where it's been pierced.\n>\n> \"This metal is treated.\" He angles the metal and it shimmers like fish scales. \"That's why they're so strong; why they don't rust. Logren mentions it in her study. She said her team used this treatment when they worked on the symbol of power.\" This is the first you've heard of such a thing, and it sounds like something that will require another quest.\n>\n> \"The symbol of power is everything,\" Crain waxes. \"But it isn't an object at all. It's a symbol, a seal, and there's more than one of them. But they are created with an object.\" Crain leads you to his desk, where a drawing of a three-legged contraption is featured prominently.\n>\n> \"The symbols of power, the seals, are created with this device, but in order to build it, I still need a few things. The most pressing, I believe, is this.\" He pulls out Torfi's journal, turns a few pages, and taps on an illustration of a cuboid stone, a mineral of some sort. \"Star iron.\"\n>\n> Your eyebrow rises skeptically.\n>\n> \"I didn't name it—you can blame my ancestors for that. But I do have a way to detect it, so we won't be going in blind.\" He directs you to the far end of his bench where a small cage is sitting, all strung with cord and glass vials. You saw it when you first entered, but you'd taken it as garbage. \"This can detect the metal within a relatively small radius. It's nearly ready. And I know it sounds risky, I know what's in the Copperneck Mountains, but—\" Crain hesitates. His voice becomes low, serious. \"There isn't a way around it. This will be hard, very hard, but we need to do it.\"\n>\n> **Rewards:** New Scenario: Life and Death (61)\n\nThis is a Puzzle Solution section, so it's reached by solving the puzzle book rather than completing a prior scenario. (Source: Section Book 62-81, section 79.4.)",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 14087,
+      "tokenInput": 19085,
+      "tokenOutput": 1265,
+      "tokenTotal": 20350,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:scenario-61-unlock",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Ascenario-61-unlock",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "scenario-61-unlock",
+      "category": "scenarios",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "**Section 79.4** unlocks scenario 61 (Life and Death) in Frosthaven. \n\nThe section describes Crain examining damaged Unfettered and discussing star iron—a metal treatment used in their construction. He explains that star iron is needed to build a device for creating symbols of power, and despite the danger in the Copperneck Mountains, this quest is necessary. The section ends with the reward line: **\"New Scenario: Life and Death 61\"** (from *Section Book 62-81*, section 79.4).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6372,
+      "tokenInput": 16968,
+      "tokenOutput": 516,
+      "tokenTotal": 17484,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:scenario-61-unlock",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Ascenario-61-unlock",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "scenario-61-unlock",
+      "category": "scenarios",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Scenario 61, **Life and Death**, is unlocked by **Section 79.4** in the Frosthaven Section Book.\n\nRelevant unlock text:\n\n> Rewards  \n> New Scenario: Life and Death 61\n\nCitation: *Section Book 62–81*, section 79.4.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 13061,
+      "tokenInput": 42767,
+      "tokenOutput": 233,
+      "tokenTotal": 43000,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:scenario-61-unlock",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Ascenario-61-unlock",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "scenario-61-unlock",
+      "category": "scenarios",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "Scenario 61, **Life and Death**, is unlocked by **Section 79.4**. The unlock text is:\n\n> “The symbols of power, the seals, are created with this device, but in order to build it, I still need a few things. The most pressing, I believe, is this.” He pulls out Torfi’s journal, turns a few pages, and taps on an illustration of a cuboid stone, a mineral of some sort. “Star iron.”  \n> …  \n> “This can detect the metal within a relatively small radius. It’s nearly ready. And I know it sounds risky, I know what’s in the Copperneck Mountains, but—” Crain hesitates. His voice becomes low, serious. “There isn’t a way around it. This will be hard, very hard, but we need to do it.”  \n> **Rewards**  \n> **New Scenario: Life and Death 61**\n\nSource: **Section 79.4, Section Book 62–81**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 16709,
+      "tokenInput": 41862,
+      "tokenOutput": 327,
+      "tokenTotal": 42189,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:scenario-61-unlock",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Ascenario-61-unlock",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "scenario-61-unlock",
+      "category": "scenarios",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "Scenario 61 (*Life and Death*) is unlocked by **Section 79.4**.\n\nRelevant reward text:\n> **Rewards**  \n> New Scenario: *Life and Death* 61\n\nSource: Section Book 62-81, section 79.4.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7028,
+      "tokenInput": 30856,
+      "tokenOutput": 152,
+      "tokenTotal": 31008,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:scenario-61-unlock",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Ascenario-61-unlock",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "scenario-61-unlock",
+      "category": "scenarios",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "Scenario 61 (*Life and Death*) is unlocked by **Section 79.4** in the Frosthaven *Section Book 62-81*.\n\nSource text (Section 79.4 “Puzzle Solution”):\n\n> “Rewards  \n> New Scenario: Life and Death61”",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8228,
+      "tokenInput": 34433,
+      "tokenOutput": 145,
+      "tokenTotal": 34578,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:scenario-61-unlock",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Ascenario-61-unlock",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-wound",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's what the Frosthaven Rulebook says about the *Wound* condition:\n\n> **Wound:** The figure suffers 1 damage at the start of each of their turns. *Wound* is removed when the figure is healed.\n\n*(Rulebook, p. 29 / chunk 99)*\n\n### Key points:\n- *Wound* is a **negative condition**.\n- It deals **1 damage at the start of each turn** of the affected figure — this applies to both heroes and monsters.\n- It is **removed by any healing effect** (even a *Heal 1* is enough to remove it, though the healing and damage happen at different times).\n\n### Interaction with *Regenerate*:\nIf a figure has both *Regenerate* and *Wound* at the start of their turn, the *Regenerate* effect (Heal 1, self) is applied **first**, which removes *Wound* before it can deal its damage. So the two conditions effectively cancel each other out that turn.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7671,
+      "tokenInput": 7765,
+      "tokenOutput": 313,
+      "tokenTotal": 8078,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:rule-wound",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-wound",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-wound",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "From the Frosthaven Rulebook (Negative Conditions, p. 29):\n\n> *Wound*: The figure suffers 1 damage at the start of each of their turns. *Wound* is removed when the figure is healed.\n\nA couple of useful interactions also called out in the rules:\n- If a figure has both *Regenerate* and *Wound*, the *Regenerate* effect is applied first, which heals the figure and removes *Wound* before it can deal its damage that turn.\n- Because healing removes *Wound*, even a *Heal 1* is enough to clear it.\n\nSource: Frosthaven Rulebook, Negative Conditions section.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6395,
+      "tokenInput": 10412,
+      "tokenOutput": 312,
+      "tokenTotal": 10724,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:rule-wound",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Arule-wound",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-wound",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "According to the **Rulebook**, *Wound* is a negative condition that works as follows:\n\n> The figure suffers 1 damage at the start of each of their turns. Wound is removed when the figure is healed.\n\nIn other words, a figure with *Wound* takes 1 damage automatically at the beginning of each of their turns, and the condition persists until the figure is healed.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 3250,
+      "tokenInput": 7763,
+      "tokenOutput": 170,
+      "tokenTotal": 7933,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:rule-wound",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Arule-wound",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-wound",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "In Frosthaven, *Wound* is a negative condition:\n\n> “Wound: The figure suffers 1 damage at the start of each of their turns. Wound is removed when the figure is healed.”  \n> — Frosthaven Rulebook, Negative Conditions\n\nA single *Heal* can remove *Wound* along with other removable negative conditions like *Poison*, *Brittle*, or *Bane*. If the figure also has *Poison*, the heal removes the conditions but does **not** restore HP.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9076,
+      "tokenInput": 26160,
+      "tokenOutput": 236,
+      "tokenTotal": 26396,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:rule-wound",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Arule-wound",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-wound",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "In Frosthaven, *Wound* means:\n\n> “The figure suffers 1 damage at the start of each of their turns. *Wound* is removed when the figure is healed.”  \n> — Rulebook, “Negative Conditions”\n\nSo at the table:\n- A wounded figure takes **1 damage at the start of every turn**\n- This keeps happening until they receive **any healing**\n- Once healed, the *Wound* condition is removed\n\nIf you want, I can also give you the quick difference between *Wound*, *Bane*, and *Poison*.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8455,
+      "tokenInput": 27543,
+      "tokenOutput": 191,
+      "tokenTotal": 27734,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:rule-wound",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Arule-wound",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-wound",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "*Wound* makes a figure **suffer 1 damage at the start of each of their turns**. It is **removed when the figure is healed**.  \nSource: Frosthaven Rulebook, Sticker 5, *Negative Conditions*.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 3810,
+      "tokenInput": 14647,
+      "tokenOutput": 82,
+      "tokenTotal": 14729,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:rule-wound",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Arule-wound",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "rule-wound",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In Frosthaven, the *Wound* condition is a **status condition that represents you being badly injured**.\n\nHowever, in the checked-in rules data I can access right now, I’m **not finding the actual rules definition / mechanical text for the *Wound* condition** (the search results are returning narrative “wounded” text from scenario books, but not the condition rules entry itself).\n\nTo answer precisely, I need the rule text for *Wound* from the Frosthaven rulebook/condition reference, but it isn’t present in the searchable results I’m getting.\n\nIf you tell me **where you’re seeing *Wound*** (e.g., a specific character ability, monster ability, or item/sticker/card name), or paste the exact *Wound* text you have, I can interpret it and explain exactly what it does in that context.",
+      "score": 0.2,
+      "pass": false,
+      "latencyMs": 15924,
+      "tokenInput": 84224,
+      "tokenOutput": 362,
+      "tokenTotal": 84586,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 6,
+      "retryCount": 0,
+      "loopIterations": 7,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:rule-wound",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Arule-wound",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "tool-free-assistant-game",
+      "category": "tool-free",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "This assistant is for **Frosthaven**, the dungeon-crawling board game by Cephalofair Games.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 1284,
+      "tokenInput": 2108,
+      "tokenOutput": 30,
+      "tokenTotal": 2138,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 0,
+      "retryCount": 0,
+      "loopIterations": 1,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:tool-free-assistant-game",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atool-free-assistant-game",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "tool-free-assistant-game",
+      "category": "tool-free",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "This assistant is for Frosthaven (and related Gloomhaven-family games).",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 1750,
+      "tokenInput": 2943,
+      "tokenOutput": 30,
+      "tokenTotal": 2973,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 0,
+      "retryCount": 0,
+      "loopIterations": 1,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:tool-free-assistant-game",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atool-free-assistant-game",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "tool-free-assistant-game",
+      "category": "tool-free",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "This assistant is for **Frosthaven**, a cooperative dungeon-crawling board game.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 539,
+      "tokenInput": 2107,
+      "tokenOutput": 24,
+      "tokenTotal": 2131,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 0,
+      "retryCount": 0,
+      "loopIterations": 1,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:tool-free-assistant-game",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atool-free-assistant-game",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "tool-free-assistant-game",
+      "category": "tool-free",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "This assistant is for Frosthaven.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 2610,
+      "tokenInput": 6591,
+      "tokenOutput": 11,
+      "tokenTotal": 6602,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 0,
+      "retryCount": 0,
+      "loopIterations": 1,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:tool-free-assistant-game",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atool-free-assistant-game",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "tool-free-assistant-game",
+      "category": "tool-free",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "This assistant is for **Frosthaven**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 2471,
+      "tokenInput": 6591,
+      "tokenOutput": 14,
+      "tokenTotal": 6605,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 0,
+      "retryCount": 0,
+      "loopIterations": 1,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:tool-free-assistant-game",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atool-free-assistant-game",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "tool-free-assistant-game",
+      "category": "tool-free",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "This assistant is for **Frosthaven**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 3165,
+      "tokenInput": 13606,
+      "tokenOutput": 28,
+      "tokenTotal": 13634,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:tool-free-assistant-game",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atool-free-assistant-game",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "tool-free-assistant-game",
+      "category": "tool-free",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "This assistant is for Frosthaven rules.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 2644,
+      "tokenInput": 6591,
+      "tokenOutput": 12,
+      "tokenTotal": 6603,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 0,
+      "retryCount": 0,
+      "loopIterations": 1,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:tool-free-assistant-game",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atool-free-assistant-game",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-source-discovery",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's a full breakdown of what I can access for **Frosthaven**:\n\n---\n\n## 📚 Sources\n\n### 1. Frosthaven Rulebook\n- **Ref:** `source:frosthaven/rulebook`\n- **Kinds:** Rules passages\n- **Searchable:** ✅ Yes — I can search through rulebook text\n- **Openable:** ❌ No — individual passages cannot be opened directly by ref\n\n---\n\n### 2. Scenario & Section Books\n- **Ref:** `source:frosthaven/scenario-section-books`\n- **Kinds:** Scenarios, Sections\n- **Searchable:** ✅ Yes\n- **Openable:** ✅ Yes — by exact canonical ref (e.g. `scenario:frosthaven/61` or `section:frosthaven/90.2`)\n- **Live Counts:** 162 scenarios · 731 sections · 1,104 relations\n- **Traversable Relations:** *conclusion*, *read_now*, *section_link*, *unlock*, *cross_reference*\n\n---\n\n### 3. GHS Card Data\n- **Ref:** `source:frosthaven/cards`\n- **Kinds:** Card types & individual cards\n- **Searchable:** ✅ Yes\n- **Openable:** ✅ Yes — by exact canonical ref (e.g. `card:frosthaven/items/some-id`)\n- **Live Counts:**\n  | Category | Count |\n  |---|---|\n  | Monster Stats | 136 |\n  | Monster Abilities | 386 |\n  | Character Abilities | 504 |\n  | Character Mats | 17 |\n  | Items | 264 |\n  | Events | 266 |\n  | Battle Goals | 60 |\n  | Buildings | 78 |\n  | Scenarios | 159 |\n  | Personal Quests | 23 |\n\n---\n\n**In summary:** I can search all three sources, and can open exact records from the Scenario/Section Books and the Card Data. The Rulebook is search-only. Ask me anything about Frosthaven rules, scenarios, sections, cards, items, monsters, buildings, and more!",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8712,
+      "tokenInput": 4770,
+      "tokenOutput": 582,
+      "tokenTotal": 5352,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-source-discovery",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-source-discovery",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-source-discovery",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here's an overview of the Frosthaven knowledge sources I can work with:\n\n## Searchable sources\n\n- **Frosthaven Rulebook** (`source:frosthaven/rulebook`) — *rules_passage* entries. Searchable, but **not directly openable** by source ref; I open individual rules chunks via refs returned from search (e.g., `rules:frosthaven/rulebook#chunk=N`).\n- **Scenario and Section Books** (`source:frosthaven/scenario-section-books`) — searchable **and** openable.\n  - 162 scenarios\n  - 731 sections\n  - 1,104 traversable relations: *conclusion*, *read_now*, *section_link*, *unlock*, *cross_reference*\n- **GHS Card Data** (`source:frosthaven/cards`) — searchable and openable, with `belongs_to_type` relations.\n\n## Card data record counts\n\n| Kind | Count |\n|---|---|\n| monster-stats | 136 |\n| monster-abilities | 386 |\n| character-abilities | 504 |\n| character-mats | 17 |\n| items | 264 |\n| events | 266 |\n| battle-goals | 60 |\n| buildings | 78 |\n| scenarios (card form) | 159 |\n| personal-quests | 23 |\n\n## What I can open exactly\n\n- **Scenarios** via `scenario:frosthaven/<id>`\n- **Sections** via `section:frosthaven/<id>`\n- **Cards** via `card:frosthaven/<type>/<sourceId>` (items, monsters, buildings, events, battle goals, personal quests, character mats, ability cards, etc.)\n- **Rules passages** via `rules:frosthaven/rulebook#chunk=N` (found through search; the rulebook source itself isn't a single openable record)\n\nIf you want, I can resolve a specific scenario, section, item, monster, or building name into an exact ref so we can open it.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9403,
+      "tokenInput": 6525,
+      "tokenOutput": 684,
+      "tokenTotal": 7209,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-source-discovery",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-source-discovery",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-source-discovery",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Here are the Frosthaven sources available:\n\n## Searchable Sources\n\n1. **Frosthaven Rulebook** (rules_passage)\n   - Contains rulebook passages\n   - Searchable: ✓ | Openable: ✗\n\n2. **Scenario and Section Books** (scenario, section)\n   - 162 scenarios and 731 sections\n   - Searchable: ✓ | Openable: ✓\n   - Relations: conclusion, read-now, section links, unlocks, cross-references\n\n3. **GHS Card Data** (cards)\n   - Monster stats (136) and abilities (386)\n   - Character abilities (504) and mats (17)\n   - Items (264), events (266), battle goals (60)\n   - Buildings (78), scenarios (159), personal quests (23)\n   - Searchable: ✓ | Openable: ✓\n\n## Exact Opens\n\nYou can open exact entities using canonical refs:\n- **Rules**: `rules:frosthaven/<source>#chunk=N`\n- **Scenarios**: `scenario:frosthaven/<id>`\n- **Sections**: `section:frosthaven/<id>`\n- **Cards**: `card:frosthaven/<type>/<sourceId>`\n\nThe rulebook itself cannot be opened as a whole source, but rules passages are searchable and individual sections/scenarios/cards are directly openable.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4021,
+      "tokenInput": 4759,
+      "tokenOutput": 374,
+      "tokenTotal": 5133,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-source-discovery",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-source-discovery",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-source-discovery",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "For Frosthaven, I can inspect these knowledge sources:\n\n| Source | Ref | Kinds | Searchable? | Open exact records? |\n|---|---|---:|---:|---:|\n| Frosthaven Rulebook | `source:frosthaven/rulebook` | rules passages | Yes | **No** |\n| Scenario and Section Books | `source:frosthaven/scenario-section-books` | scenarios, sections | Yes | **Yes** |\n| GHS Card Data | `source:frosthaven/cards` | card types, cards | Yes | **Yes** |\n\nExact-openable records include:\n\n- Scenarios, e.g. `scenario:frosthaven/001`\n- Sections, e.g. `section:frosthaven/90.2`\n- Cards, using canonical card refs such as character abilities, items, events, buildings, monsters, etc.\n\nThe scenario/section source also supports relationship traversal for:\n\n- conclusions\n- read-now links\n- section links\n- unlocks\n- cross-references\n\nCurrent checked-in counts:\n\n- Scenarios: 162\n- Sections: 731\n- Relations: 1104\n- Cards:\n  - Monster stats: 136\n  - Monster abilities: 386\n  - Character abilities: 504\n  - Character mats: 17\n  - Items: 264\n  - Events: 266\n  - Battle goals: 60\n  - Buildings: 78\n  - Scenarios card data: 159\n  - Personal quests: 23",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7265,
+      "tokenInput": 13628,
+      "tokenOutput": 348,
+      "tokenTotal": 13976,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-source-discovery",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-source-discovery",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-source-discovery",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "For **Frosthaven**, I can inspect these sources:\n\n1. **Frosthaven Rulebook**\n   - Kind: `rules_passage`\n   - Searchable: **yes**\n   - Open exactly: **no**\n\n2. **Scenario and Section Books**\n   - Kinds: `scenario`, `section`\n   - Searchable: **yes**\n   - Open exactly: **yes**\n   - Traversable relations: `conclusion`, `read_now`, `section_link`, `unlock`, `cross_reference`\n\n3. **GHS Card Data**\n   - Kinds: `card_type`, `card`\n   - Searchable: **yes**\n   - Open exactly: **yes**\n   - Includes card data for:\n     - `monster-stats` (136)\n     - `monster-abilities` (386)\n     - `character-abilities` (504)\n     - `character-mats` (17)\n     - `items` (264)\n     - `events` (266)\n     - `battle-goals` (60)\n     - `buildings` (78)\n     - `scenarios` (159)\n     - `personal-quests` (23)\n\n### What I can open exactly\nI can open exact Frosthaven records for:\n- **Scenarios**\n- **Sections**\n- **Cards** in the listed card-data categories\n\nI **cannot** open exact rulebook passages directly from the rulebook source; I can search them and cite the matching passage instead.\n\nIf you want, I can also show you the exact canonical ref formats for openable Frosthaven records.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6080,
+      "tokenInput": 13614,
+      "tokenOutput": 345,
+      "tokenTotal": 13959,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-source-discovery",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-source-discovery",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-source-discovery",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "For **Frosthaven**, I can inspect these sources:\n\n1. **Frosthaven Rulebook**\n   - Kind: `rules_passage`\n   - **Searchable:** yes\n   - **Openable exactly:** no\n\n2. **Scenario and Section Books**\n   - Kinds: `scenario`, `section`\n   - **Searchable:** yes\n   - **Openable exactly:** yes\n   - Relations available: *conclusion*, *read_now*, *section_link*, *unlock*, *cross_reference*\n\n3. **GHS Card Data**\n   - Kinds: `card_type`, `card`\n   - **Searchable:** yes\n   - **Openable exactly:** yes\n   - Relations available: *belongs_to_type*\n\nSo the sources I can **open exactly** are:\n- **Scenario and Section Books**\n- **GHS Card Data**\n\nThe **Rulebook** can be searched, but not opened exactly.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 2859,
+      "tokenInput": 13614,
+      "tokenOutput": 211,
+      "tokenTotal": 13825,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-source-discovery",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-source-discovery",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-source-discovery",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "Here’s what I can inspect for *Frosthaven*, and which ones I can open *exactly*:\n\n## Sources I can inspect\n1. **Frosthaven Rulebook**  \n   - Ref: `source:frosthaven/rulebook`  \n   - Can inspect/search: **yes** (rules passages)  \n   - Can open exactly: **no**\n\n2. **Scenario and Section Books**  \n   - Ref: `source:frosthaven/scenario-section-books`  \n   - Can inspect/search: **yes** (scenario + section records)  \n   - Can open exactly: **yes**\n\n3. **GHS Card Data**  \n   - Ref: `source:frosthaven/cards`  \n   - Can inspect/search: **yes** (card records)  \n   - Can open exactly: **yes**\n\n## What I can open exactly (record types)\nWhen opening exact records, the following kinds are available in the checked-in data:\n- **scenario**\n- **section**\n- **card** (including subtypes like items, buildings, monsters, etc.)\n\nIf you tell me what you want to look up (e.g., “section 90.2” or “item X”), I’ll resolve it to the exact canonical record and open it.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 3863,
+      "tokenInput": 13614,
+      "tokenOutput": 277,
+      "tokenTotal": 13891,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-source-discovery",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-source-discovery",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-open",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here is **Section 67.1** — the conclusion of Scenario 61: *Life and Death* (Section Book 62–81, p. 67):\n\n---\n\n> **Conclusion**\n>\n> Your ears fill with the sound of your own breathing: heavy, stinging, rib-pulling breaths. Your legs are full of acid, ready to seize, but you push through the pain and exhaustion, struggling to keep up with Moonshard. The shadows are close behind, reaching, stretching out. They will not let you leave, and even now, they claw at the edges of your mind, yearning for your fear. But then, all at once, you pass into open air and the cave behind you fills with frustrated screams. The fear is gone. The pain. You are beyond the terror's reach now, safe.\n>\n> Outside the cave, it is late. Much time has passed since you entered the cave, and that sinks a lead ball in your gut. You realize just how lost you really were and that, had Moonshard not arrived when she did, you would not be alive.\n>\n> Moonshard begins walking towards what you see is a circle of cloaked figures in the distance, all gathered around a small fire. You follow, and a voice calls out…\n>\n> *(The group meets Terra, an ancient Orchid, and the Shattersong — a unique quartz Savvas lineage attuned to the Harbinger's intentions. Terra reveals a long-laid plan to stop the Harbinger from breaking through its seals, and confirms that both Crain's ingenuity and your group's courage are essential to that effort.)*\n\n---\n\n**Rewards:**\n- Unlock **class box**.\n\n**Section Links:**\n- Add **section 140.3** to the calendar in **one week**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 11917,
+      "tokenInput": 14662,
+      "tokenOutput": 665,
+      "tokenTotal": 15327,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-scenario-conclusion-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-scenario-conclusion-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-open",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "At the conclusion of **Scenario 61: Life and Death**, read **Section 67.1** (Section Book 62-81). Here's the full section:\n\n> **Conclusion**\n>\n> Your ears fill with the sound of your own breathing: heavy, stinging, rib-pulling breaths. Your legs are full of acid, ready to seize, but you push through the pain and exhaustion, struggling to keep up with Moonshard. The shadows are close behind, reaching, stretching out. They will not let you leave, and even now, they claw at the edges of your mind, yearning for your fear. But then, all at once, you pass into open air and the cave behind you fills with frustrated screams. The fear is gone. The pain. You are beyond the terror's reach now, safe.\n>\n> Outside the cave, it is late. Much time has passed since you entered the cave, and that sinks a lead ball in your gut. You realize just how lost you really were and that, had Moonshard not arrived when she did, you would not be alive.\n>\n> Moonshard begins walking towards what you see is a circle of cloaked figures in the distance, all gathered around a small fire. You follow, and a voice calls out.\n>\n> \"How did you find them?\" A female voice asks, anxious for news.\n>\n> \"Just like I said I would,\" Moonshard answers.\n>\n> \"In danger then.\"\n>\n> \"I believe my words were, 'about to get themselves flayed.'\"\n>\n> You move close to the fire and Crain hurries to one side, eager to warm his hands. His face is gaunt, skin paled. You have no idea what the Quatryl saw down there in the dark, but you hope it was not too much.\n>\n> Looking over the fire, you can make out Moonshard's companion—a smaller Orchid—and you see that both her and Moonshard are quite old. The smaller one sits on a traveling stool and inspects you with easy purple eyes. Behind her are half a dozen other figures, each roughly the size of a human, and each hidden beneath heavy, wool robes.\n>\n> \"I am thankful for your service, as always, my friend,\" the new Orchid says to Moonshard. And then to you: \"We have waited very long to meet you. My name is Terra.\"\n>\n> \"Well, ah, thank you,\" he says. He rubs his swollen jaw, trying to hide his suspicion. \"But how is it you knew we would be here? Even I didn't know where exactly we were going this morning.\"\n>\n> \"Because,\" Terra explains, \"I have seen this moment in my meditations for the last two hundred years.\" Crain's eyes widen.\n>\n> \"We have been planning for a long time,\" Terra explains. \"All in preparation for the days that are now upon us—for the emergence of the Harbinger.\"\n>\n> At the mention of this name, the cloaked figures all rotate their heads to the east. One of them adjusts its hood, a long, bone-white hand emerging briefly and then disappearing back into its sleeve.\n>\n> \"Our friends here are part of our preparations,\" Terra says. She gestures to one of the figures and it comes forward. \"They are the Shattersong.\"\n>\n> The figure lowers its hood and reveals itself to be a Savvas of a unique and rather incredible form. Unlike other Savvas, whose bodies take on a variety of ochre or brown or slate, this one is made entirely of quartz that glimmers with the reds and yellows rising from the campfire. It would be beautiful were it not for its black eyes that stare at you with cold disregard.\n>\n> \"We have been helping them,\" Terra says and rises to her feet. Her movements are slow, pained. It must have cost her a great deal to come here. \"We have been fortifying this line of Savvas for generations now, providing them with only the purest of energy and sustenance and, because of that, the Shattersong are a lineage uniquely tuned to the thoughts and intentions of the Harbinger. Of malice and spite.\"\n>\n> Terra shuffles around the fire, moving a little easier now. \"But you.\" She raises her eyes, sharp beneath her arched brow. \"You play a crucial role here as well. The Harbinger means to invade everything around us, to break through the seals that contain it.\" She nods to Crain. \"But with your ingenuity,\" then to you, \"And with your might and courage, we have a slim chance of stopping it.\n>\n> \"It's the best we can manage. The force we are trying to stop is far greater than any that exists on this plane. It is something of a miracle the Harbinger was ever bound at all, but there it sleeps, deep within the earth. In its dreams, it corrupts and plots its escape. Through its machinations, the seals grow weak.\"\n>\n> Crain jumps up excitedly. \"Yes, the seals! This is what I've been trying to tell them all along. Logren wanted to strengthen the seals, but we require a device made of star iron!\"\n>\n> Moonshard groans loudly. \"Star iron is a myth used to lure gullible adventurers to their deaths. Don't worry, we'll get you the materials you need.\"\n>\n> **Rewards**\n> Unlock class box.\n>\n> **Section Links**\n> Add section 140.3 to the calendar in one week.\n\n**Key takeaways:**\n- **Reward:** Unlock a class box.\n- **Follow-up:** Add **section 140.3** to the calendar in one week.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 18297,
+      "tokenInput": 19939,
+      "tokenOutput": 2061,
+      "tokenTotal": 22000,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-scenario-conclusion-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-scenario-conclusion-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-open",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "At the conclusion of scenario 61 \"Life and Death,\" you should read **Section 67.1**.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 3023,
+      "tokenInput": 9199,
+      "tokenOutput": 191,
+      "tokenTotal": 9390,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-scenario-conclusion-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-scenario-conclusion-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-open",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "At the conclusion of **Scenario 61: Life and Death**, read **Section 67.1**. *(Scenario Book 62–81, scenario 61; Section Book 62–81, section 67.1)*\n\nSection 67.1’s rewards/next step are:\n\n- **Reward:** Unlock class box.\n- **Section Link:** Add **section 140.3** to the calendar in one week.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10668,
+      "tokenInput": 43283,
+      "tokenOutput": 237,
+      "tokenTotal": 43520,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-scenario-conclusion-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-scenario-conclusion-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-open",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "At the conclusion of Scenario 61 (*Life and Death*), you should read **Section 67.1**. Source: Section Book 62–81, section 67.1.\n\n> **Conclusion**  \n> Your ears fill with the sound of your own breathing: heavy, stinging, rib-pulling breaths. Your legs are full of acid, ready to seize, but you push through the pain and exhaustion, struggling to keep up with Moonshard. The shadows are close behind, reaching, stretching out. They will not let you leave, and even now, they claw at the edges of your mind, yearning for your fear. But then, all at once, you pass into open air and the cave behind you fills with frustrated screams. The fear is gone.  \n> The pain. You are beyond the terror’s reach now, safe.  \n> Outside the cave, it is late. Much time has passed since you entered the cave, and that sinks a lead ball in your gut. You realize just how lost you really were and that, had Moonshard not arrived when she did, you would not be alive.  \n> Moonshard begins walking towards what you see is a circle of cloaked figures in the distance, all gathered around a small fire.  \n> You follow, and a voice calls out.  \n> “How did you find them?” A female voice asks, anxious for news.  \n> “Just like I said I would,” Moonshard answers.  \n> “In danger then.”  \n> “I believe my words were, ‘about to get themselves flayed.’”  \n> You move close to the fire and Crain hurries to one side, eager to warm his hands. His face is gaunt, skin paled. You have no idea what the Quatryl saw down there in the dark, but you hope it was not too much.  \n> Looking over the fire, you can make out Moonshard’s companion—a smaller Orchid—and you see that both her and Moonshard are quite old...  \n> “We have waited very long to meet you. My name is Terra.”  \n> ...  \n> “You play a crucial role here as well. The Harbinger means to invade everything around us, to break through the seals that contain it.” She nods to Crain. “But with your ingenuity,” then to you, “And with your might and courage, we have a slim chance of stopping it.”  \n> ...  \n> Moonshard groans loudly. “Star iron is a myth used to lure gullible adventurers to their deaths. Don’t worry, we’ll get you the materials you need.”\n\n**Rewards**\n- Unlock class box.\n\n**Section Links**\n- Add section **140.3** to the calendar in one week.\n\nIf you want, I can also pull up **Section 140.3** or summarize the important consequences of 67.1.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 12111,
+      "tokenInput": 31465,
+      "tokenOutput": 694,
+      "tokenTotal": 32159,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-scenario-conclusion-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-scenario-conclusion-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-open",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "At the conclusion of scenario 61, read **Section 67.1**. Source: *Scenario Book 62–81*.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 3431,
+      "tokenInput": 24203,
+      "tokenOutput": 89,
+      "tokenTotal": 24292,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-scenario-conclusion-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-scenario-conclusion-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-open",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "Read **Section 67.1** (*Section Book 62-81*) as the conclusion of **Scenario 61: Life and Death**.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 4115,
+      "tokenInput": 24203,
+      "tokenOutput": 91,
+      "tokenTotal": 24294,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-scenario-conclusion-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-scenario-conclusion-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-read-now-chain",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's the full two-hop chain starting from **Section 103.1**:\n\n1. **Section 103.1** → read-now link → **Section 11.5**\n   *\"With the 'dance' complete, the bell chain drops again.\"*\n\n2. **Section 11.5** → read-now link → **Section 155.1**\n\nAfter following the next two read-now links, you end up at **Section 155.1** (Section Book 142–161).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9062,
+      "tokenInput": 10799,
+      "tokenOutput": 402,
+      "tokenTotal": 11201,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-section-read-now-chain",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-section-read-now-chain",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-read-now-chain",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Following the two read-now links from section 103.1:\n\n1. **Section 103.1** (\"My Private Empire\" — Section Book 102-121): When the third episode is overcome, read **11.5**.\n2. **Section 11.5** (\"My Private Empire\" — Section Book 2-21): The next time any character enters, read **155.1**.\n\nYou end up at **Section 155.1** (Section Book 142-161).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8434,
+      "tokenInput": 14734,
+      "tokenOutput": 487,
+      "tokenTotal": 15221,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-section-read-now-chain",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-section-read-now-chain",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-read-now-chain",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Following the two read-now links from section 103.1:\n\n1. Section 103.1 → Section 11.5 (first read-now link)\n2. Section 11.5 → Section 155.1 (second read-now link)\n\n**You end up at section 155.1** (Section Book 142-161).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4533,
+      "tokenInput": 10830,
+      "tokenOutput": 394,
+      "tokenTotal": 11224,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-section-read-now-chain",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-section-read-now-chain",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-read-now-chain",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Starting at **section 103.1**:\n\n1. First read-now link: **103.1 → 11.5**  \n   > “When the third episode is overcome, read 11.5.”  \n   — Section Book 102–121, section 103.1\n\n2. Second read-now link: **11.5 → 155.1**  \n   > “The next time any character enters read 155.1.”  \n   — Section Book 2–21, section 11.5\n\nYou end up at **section 155.1** — in the **Section Book 142–161**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 15728,
+      "tokenInput": 54016,
+      "tokenOutput": 442,
+      "tokenTotal": 54458,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 6,
+      "retryCount": 0,
+      "loopIterations": 7,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-section-read-now-chain",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-section-read-now-chain",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-read-now-chain",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "Following *read-now* links from section 103.1:\n\n1. **Section 103.1** → **Section 11.5**  \n   Source: Section Book 102–121, section 103.1\n\n2. **Section 11.5** → **Section 155.1**  \n   Source: Section Book 2–21, section 11.5\n\nSo after the next two *read-now* links, you end up at **section 155.1**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10041,
+      "tokenInput": 36239,
+      "tokenOutput": 233,
+      "tokenTotal": 36472,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-section-read-now-chain",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-section-read-now-chain",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-read-now-chain",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "Starting from **section 103.1**, the next two *read-now* links take you to:\n\n1. **section 11.5**\n2. **section 155.1**\n\nSo you end up at **section 155.1**.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 11179,
+      "tokenInput": 41764,
+      "tokenOutput": 198,
+      "tokenTotal": 41962,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-section-read-now-chain",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-section-read-now-chain",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-read-now-chain",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "Starting from **section 103.1**:\n\n1. Follow the first *read-now* link → you end up at **section 11.5**.  \n2. Follow the next *read-now* link → you end up at **section 155.1**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9416,
+      "tokenInput": 35643,
+      "tokenOutput": 159,
+      "tokenTotal": 35802,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-section-read-now-chain",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-section-read-now-chain",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-exact-item-open",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's what you need to know about **Item 1**:\n\n---\n\n**Item 001 — Spyglass** *(Head slot)*\n\n> During your attack ability, gain *Advantage* on one attack.\n\n- **Type:** Spent (flip after use; recoverable)\n- **Lost:** No (it is not lost after use)\n- **Cost:** Not listed in the data\n\n---\n\n**Source ID used:** `gloomhavensecretariat:item/1`\nThis was opened via the canonical ref `card:frosthaven/items/gloomhavensecretariat:item/1` from the Card Index source.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9799,
+      "tokenInput": 11158,
+      "tokenOutput": 419,
+      "tokenTotal": 11577,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-exact-item-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-exact-item-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-exact-item-open",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "**Item 001 — Spyglass** (head slot)\n\n> During your attack ability, gain advantage on one attack.\n\nIt's a *Spent* item (flipped after use, refreshed between scenarios).\n\n- **Source ID used to open it:** `card:frosthaven/items/gloomhavensecretariat:item/1` (locator `gloomhavensecretariat:item/1`, from the Card Index).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8391,
+      "tokenInput": 10951,
+      "tokenOutput": 380,
+      "tokenTotal": 11331,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-exact-item-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-exact-item-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-exact-item-open",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "**Item 1 is Spyglass**, a head slot item. It grants **advantage on one attack during your attack ability**.\n\nThe source ID I used to open it was **`gloomhavensecretariat:item/1`**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5120,
+      "tokenInput": 11942,
+      "tokenOutput": 338,
+      "tokenTotal": 12280,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-exact-item-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-exact-item-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-exact-item-open",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Item 001 is **Spyglass**.\n\n- Slot: head\n- Effect: “During your attack ability, gain advantage on one attack.”\n- It is spent, not lost.\n\nSource ID used to open it: `gloomhavensecretariat:item/1`",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 12690,
+      "tokenInput": 37046,
+      "tokenOutput": 528,
+      "tokenTotal": 37574,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-exact-item-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-exact-item-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-exact-item-open",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "Item 1 is **Spyglass**.\n\nIt does:\n> During your attack ability, gain advantage on one attack.\n\nIt is a head item, and the source ID I used to open it was:\n\n`gloomhavensecretariat:item/1`\n\nSource: GHS Card Data, item `001` (Spyglass).",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 20805,
+      "tokenInput": 48002,
+      "tokenOutput": 689,
+      "tokenTotal": 48691,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-exact-item-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-exact-item-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-exact-item-open",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "I couldn’t reliably resolve **“item 1”** from the indexed data. The lookup returned fuzzy matches like **Fireshield Potion (#88)**, **Freezing Crystal (#188)**, etc., but none confirmed as item 1.\n\nSo I **did not open a specific item source ID** for item 1.\n\nIf you want, I can try again with a more specific name or with a different item number format.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 4811,
+      "tokenInput": 21935,
+      "tokenOutput": 148,
+      "tokenTotal": 22083,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-exact-item-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-exact-item-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-exact-item-open",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "Item 1 does: **During your turn, create one 1-hex hazardous terrain, icy terrain, or water tile in an adjacent featureless hex.** (Gloomhaven *Freezing Crystal*.)\n\nI opened it using the source ID: **`gloomhavensecretariat:item/188`**.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 5708,
+      "tokenInput": 29487,
+      "tokenOutput": 138,
+      "tokenTotal": 29625,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-exact-item-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-exact-item-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-brittle-citation",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here are the rules for *Brittle*, quoted directly from the Frosthaven Rulebook (chunk 99, Negative Conditions section):\n\n> **Brittle:** The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.\n\n**Source:** Frosthaven Rulebook, Negative Conditions section.\n\n---\n\n**Key points to remember:**\n\n- *Brittle* doubles the **next instance** of damage from **any source** (attacks, hazardous terrain, self-inflicted damage, etc.).\n- It is removed **immediately after** that damage is applied.\n- It is also removed if the figure is **healed**, even if no damage has been taken yet.\n- Like all conditions, a figure cannot have multiple instances of *Brittle* — but gaining it again while already *Brittle* simply resets the duration (though since *Brittle* has no duration, this has no practical effect beyond confirming it stays active).\n- Note that *Brittle* interacts with *Ward* (the positive condition that halves damage) — both effects are applied when calculating damage taken.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9716,
+      "tokenInput": 8008,
+      "tokenOutput": 357,
+      "tokenTotal": 8365,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-rule-brittle-citation",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-rule-brittle-citation",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-brittle-citation",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here are the rules for *Brittle*, from the Frosthaven Rulebook:\n\n> **Brittle:** The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.\n\nA couple of related interactions worth noting:\n\n- *Brittle* is a negative condition, so the standard condition rules apply: it remains until its removal requirement is met, cannot be removed voluntarily, and gaining it again while already afflicted just resets its duration (Rulebook, Conditions section).\n- When a character would suffer damage, *ward* and *brittle* are applied **before** they decide whether to reduce HP or negate the damage:\n\n> \"When a character would suffer any amount of damage (after ward or brittle is applied), they must either reduce their red hit point dial by that amount or negate the damage.\"\n\nSources: Frosthaven Rulebook — Negative Conditions (chunk 99) and Character Damage (chunk 125).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10145,
+      "tokenInput": 10846,
+      "tokenOutput": 436,
+      "tokenTotal": 11282,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-rule-brittle-citation",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-rule-brittle-citation",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-brittle-citation",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Based on the Frosthaven Rulebook, here are the rules for *Brittle*:\n\n> The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.\n\n**Source:** Rulebook, Negative Conditions section (chunk 99).\n\nIn summary: *Brittle* causes the affected figure to take double damage on the next hit they receive, after which the condition is removed. It is also removed immediately if the figure is healed.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 3459,
+      "tokenInput": 8156,
+      "tokenOutput": 207,
+      "tokenTotal": 8363,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-rule-brittle-citation",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-rule-brittle-citation",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-brittle-citation",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "The *Brittle* condition means the next damage the figure suffers is doubled, then *Brittle* is removed. Healing also removes it.\n\n> “Brittle: The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.”  \n> — *Frosthaven* Rulebook, Negative Conditions, chunk 99\n\nFor characters, the doubled damage amount is determined before choosing whether to lose cards or use an effect to negate damage:\n\n> “When a character would suffer any amount of damage (after ward or brittle is applied), they must either reduce their red hit point dial by that amount or negate the damage.”  \n> — *Frosthaven* Rulebook, Character Damage, chunk 125",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 14433,
+      "tokenInput": 59805,
+      "tokenOutput": 481,
+      "tokenTotal": 60286,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-rule-brittle-citation",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-rule-brittle-citation",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-brittle-citation",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "*Brittle* is a negative condition.\n\nFrom the **Frosthaven Rulebook**:\n\n> *Brittle*: “The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.”\n\nA related rule from the general conditions section says:\n\n> “Once gained, a condition remains until the requirements for its removal are met.”\n\nSo in play:\n- the **next** damage they suffer from **any source** is doubled,\n- then *Brittle* is removed,\n- and it also goes away if that figure is healed before taking damage.\n\nSource: **Frosthaven Rulebook**, negative conditions entry for *Brittle* (fh-rule-book.pdf).",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 7513,
+      "tokenInput": 14980,
+      "tokenOutput": 194,
+      "tokenTotal": 15174,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-rule-brittle-citation",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-rule-brittle-citation",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-brittle-citation",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "*Brittle* is a negative condition that works like this:\n\n> *Brittle*: The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and *Brittle* is then removed. *Brittle* is also removed if the figure is healed.\n\nSource: Frosthaven Rulebook, “Negative Conditions” (the rulebook passage shown in search results).",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 3477,
+      "tokenInput": 22498,
+      "tokenOutput": 131,
+      "tokenTotal": 22629,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-rule-brittle-citation",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-rule-brittle-citation",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-brittle-citation",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "I can’t answer this from the checked-in Frosthaven rules data I have access to.\n\nI searched the rulebook/section text for the status/keyword *Brittle* and didn’t find any matching rules passage to quote or cite. If you can share **where you saw Brittle** (card name, monster name, item/ability name, or the book/section/page), I can look that specific source up and extract the exact rules text from it.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 6923,
+      "tokenInput": 41352,
+      "tokenOutput": 189,
+      "tokenTotal": 41541,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-rule-brittle-citation",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-rule-brittle-citation",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-ambiguous-algox-archer",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here are the results! The **Algox Archer** monster stat record was resolved with two stat cards (levels 0–3 and 4–7), and additional ability cards. The best matching monster stat record is the **levels 0–3** entry:\n\n---\n\n## 🏹 Algox Archer — Monster Stats (Levels 0–3)\n\n| Level | Type   | HP | *Move* | *Attack* |\n|-------|--------|----|--------|----------|\n| 0     | Normal | 4  | 1      | 3        |\n| 0     | Elite  | 6  | 2      | 4        |\n| 1     | Normal | 5  | 2      | 3        |\n| 1     | Elite  | 8  | 2      | 4        |\n| 2     | Normal | 7  | 2      | 3        |\n| 2     | Elite  | 11 | 2      | 4        |\n| 3     | Normal | 7  | 2      | 4        |\n| 3     | Elite  | 12 | 2      | 5        |\n\n- **Immunities:** None\n- **Notes:** None\n\n---\n\n**Other records found:**\n- A second stat card covering **levels 4–7** (`algox-archer/4-7`)\n- Several **ability cards** for the Archer monster deck, including *Calculated Strike*, *Close In*, *Hasty Assault*, and *Nothing Special*\n\nWould you like me to open the levels 4–7 stat card or any of the ability cards?",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9991,
+      "tokenInput": 9810,
+      "tokenOutput": 609,
+      "tokenTotal": 10419,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-ambiguous-algox-archer",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-ambiguous-algox-archer",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-ambiguous-algox-archer",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here are the **Algox Archer** monster stat records (two cards, split by level range). No immunities are listed on either card.\n\n## Levels 0–3\n\n| Level | Normal HP / Move / Atk | Elite HP / Move / Atk |\n|---|---|---|\n| 0 | 4 / 1 / 3 | 6 / 2 / 4 |\n| 1 | 5 / 2 / 3 | 8 / 2 / 4 |\n| 2 | 7 / 2 / 3 | 11 / 2 / 4 |\n| 3 | 7 / 2 / 4 | 12 / 2 / 5 |\n\n## Levels 4–7\n\n| Level | Normal HP / Move / Atk | Elite HP / Move / Atk |\n|---|---|---|\n| 4 | 10 / 2 / 4 | 16 / 2 / 5 |\n| 5 | 13 / 2 / 4 | 18 / 2 / 6 |\n| 6 | 19 / 2 / 4 | 28 / 2 / 6 |\n| 7 | 22 / 2 / 5 | 33 / 2 / 7 |\n\nSource: Card Index (GHS Card Data), `monster-stat/algox-archer/0-3` and `/4-7`. The resolver also returned several Archer monster ability cards (e.g., *Calculated Strike*, *Close In*, *Hasty Assault*, *Nothing Special*) — let me know if you'd like those opened too.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10627,
+      "tokenInput": 12411,
+      "tokenOutput": 818,
+      "tokenTotal": 13229,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-ambiguous-algox-archer",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-ambiguous-algox-archer",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-ambiguous-algox-archer",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Perfect! Here's the **Algox Archer** monster stat record (Difficulty Level 0-3):\n\n| Level | Normal | Elite |\n|-------|--------|-------|\n| | HP / Move / Attack | HP / Move / Attack |\n| **0** | 4 / 1 / 3 | 6 / 2 / 4 |\n| **1** | 5 / 2 / 3 | 8 / 2 / 4 |\n| **2** | 7 / 2 / 3 | 11 / 2 / 4 |\n| **3** | 7 / 2 / 4 | 12 / 2 / 5 |\n\n**Immunities:** None\n\nThere's also a higher difficulty variant (4-7) available if you need that instead.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4389,
+      "tokenInput": 8749,
+      "tokenOutput": 444,
+      "tokenTotal": 9193,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-ambiguous-algox-archer",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-ambiguous-algox-archer",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-ambiguous-algox-archer",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Found Algox Archer records. Best matching **monster stat** record opened:\n\n**Algox Archer** — level range **0–3**  \nSource: Card Index, `gloomhavensecretariat:monster-stat/algox-archer/0-3`\n\n| Level | Normal | Elite |\n|---|---|---|\n| 0 | HP 4, *Move 1*, *Attack 3* | HP 6, *Move 2*, *Attack 4* |\n| 1 | HP 5, *Move 2*, *Attack 3* | HP 8, *Move 2*, *Attack 4* |\n| 2 | HP 7, *Move 2*, *Attack 3* | HP 11, *Move 2*, *Attack 4* |\n| 3 | HP 7, *Move 2*, *Attack 4* | HP 12, *Move 2*, *Attack 5* |\n\nImmunities: none listed.  \nNotes: not available in the checked-in data.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 11422,
+      "tokenInput": 22560,
+      "tokenOutput": 435,
+      "tokenTotal": 22995,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-ambiguous-algox-archer",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-ambiguous-algox-archer",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-ambiguous-algox-archer",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "I found two matching *Algox Archer* monster stat records:\n\n- `gloomhavensecretariat:monster-stat/algox-archer/4-7`\n- `gloomhavensecretariat:monster-stat/algox-archer/0-3`\n\nI opened the top match: **`gloomhavensecretariat:monster-stat/algox-archer/4-7`**.\n\n**Algox Archer** — monster stats, levels 4–7  \nSource: card `gloomhavensecretariat:monster-stat/algox-archer/4-7`\n\n- **Normal**\n  - L4: HP 10, *Move 2*, *Attack 4*\n  - L5: HP 13, *Move 2*, *Attack 4*\n  - L6: HP 19, *Move 2*, *Attack 4*\n  - L7: HP 22, *Move 2*, *Attack 5*\n\n- **Elite**\n  - L4: HP 16, *Move 2*, *Attack 5*\n  - L5: HP 18, *Move 2*, *Attack 6*\n  - L6: HP 28, *Move 2*, *Attack 6*\n  - L7: HP 33, *Move 2*, *Attack 7*\n\n- Immunities: none listed\n- Notes: not available in the checked-in data\n\nIf you want, I can also open the **0–3** record.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 18129,
+      "tokenInput": 48067,
+      "tokenOutput": 957,
+      "tokenTotal": 49024,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-ambiguous-algox-archer",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-ambiguous-algox-archer",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-ambiguous-algox-archer",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "I found two *Algox Archer* monster stat records:\n\n- **Level 0–3**: `gloomhavensecretariat:monster-stat/algox-archer/0-3`\n- **Level 4–7**: `gloomhavensecretariat:monster-stat/algox-archer/4-7`\n\nThe **best matching** record is the **4–7** monster stat record, which I opened:\n\n**Algox Archer** — `gloomhavensecretariat:monster-stat/algox-archer/4-7`  \n- **Normal**\n  - 4: HP 10, Move 2, Attack 4\n  - 5: HP 13, Move 2, Attack 4\n  - 6: HP 19, Move 2, Attack 4\n  - 7: HP 22, Move 2, Attack 5\n- **Elite**\n  - 4: HP 16, Move 2, Attack 5\n  - 5: HP 18, Move 2, Attack 6\n  - 6: HP 28, Move 2, Attack 6\n  - 7: HP 33, Move 2, Attack 7\n- **Immunities:** none listed\n- **Notes:** none listed",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 5542,
+      "tokenInput": 33987,
+      "tokenOutput": 365,
+      "tokenTotal": 34352,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-ambiguous-algox-archer",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-ambiguous-algox-archer",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-ambiguous-algox-archer",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "Found **Algox Archer** monster stat records:\n\n- `gloomhavensecretariat:monster-stat/algox-archer/4-7` (level range **4-7**)  \n- `gloomhavensecretariat:monster-stat/algox-archer/0-3` (level range **0-3**)\n\nOpened the best matching monster stat record: **`gloomhavensecretariat:monster-stat/algox-archer/4-7`**.\n\n**Algox Archer (Normal / Elite by level)**\n- **Level 4:** Normal **HP 10, Move 2, Attack 4** / Elite **HP 16, Move 2, Attack 5**\n- **Level 5:** Normal **HP 13, Move 2, Attack 4** / Elite **HP 18, Move 2, Attack 6**\n- **Level 6:** Normal **HP 19, Move 2, Attack 4** / Elite **HP 28, Move 2, Attack 6**\n- **Level 7:** Normal **HP 22, Move 2, Attack 5** / Elite **HP 33, Move 2, Attack 7**\n\nSource: *monster-stats* record `gloomhavensecretariat:monster-stat/algox-archer/4-7`.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 7071,
+      "tokenInput": 24172,
+      "tokenOutput": 356,
+      "tokenTotal": 24528,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-ambiguous-algox-archer",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-ambiguous-algox-archer",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-neighbors",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here are all the scenarios and sections directly related to **Scenario 61 – Life and Death**:\n\n---\n\n### 🏁 Conclusion\n- **Section 67.1** — Read at the end of the round when all enemies are dead (scenario completion trigger).\n\n---\n\n### 🔗 Section Links (read during the scenario)\n- **Section 105.1** — Read when door 1 is opened.\n- **Section 67.1** — Also referenced as a section link (in addition to being the conclusion).\n- **Section 82.2** — Linked section during the scenario.\n- **Section 97.3** — Linked section during the scenario.\n\n---\n\n### 🔓 Unlock\n- **Section 79.4** — Unlocked by completing this scenario.\n\n---\n\n**Summary:** Scenario 61 references sections **67.1**, **105.1**, **82.2**, and **97.3** during play, concludes by reading **67.1**, and unlocks **section 79.4**. There are no directly linked scenarios (only sections).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9758,
+      "tokenInput": 9134,
+      "tokenOutput": 406,
+      "tokenTotal": 9540,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-scenario-neighbors",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-scenario-neighbors",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-neighbors",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "**Scenario 61 — *Life and Death*** has the following directly related records (from Scenario Book 62–81):\n\n**Conclusion**\n- **Section 67.1** — read at the end of the round when all enemies are dead.\n\n**Section Links** (referenced from the scenario)\n- **Section 105.1** — read when door 1 is opened.\n- **Section 67.1** — also linked as a section reference.\n- **Section 82.2**\n- **Section 97.3**\n\n**Unlock**\n- **Section 79.4**\n\nLet me know if you'd like the full text of any of these sections.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7568,
+      "tokenInput": 12450,
+      "tokenOutput": 393,
+      "tokenTotal": 12843,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-scenario-neighbors",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-scenario-neighbors",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-neighbors",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Based on the neighbors result, here are the scenarios and sections directly related to scenario 61 \"Life and Death\":\n\n**Conclusion:**\n- **Section 67.1** — Read at the end of the scenario when all enemies are dead.\n\n**Section Links:**\n- **Section 105.1** — Linked when door 1 is opened.\n- **Section 67.1** — Also appears as a section link.\n- **Section 82.2** — Linked section.\n- **Section 97.3** — Linked section.\n\n**Unlocks:**\n- **Section 79.4** — Unlocked by completing scenario 61.\n\nIn total, scenario 61 directly connects to **5 distinct sections** (67.1, 79.4, 82.2, 97.3, and 105.1).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4396,
+      "tokenInput": 9632,
+      "tokenOutput": 354,
+      "tokenTotal": 9986,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-scenario-neighbors",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-scenario-neighbors",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-neighbors",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Scenario 61 is **Life and Death**. In the checked relation data, I found **no directly related scenarios**, but these **sections** are directly related:\n\n| Relation | Target |\n|---|---|\n| Conclusion | Section 67.1 |\n| Section link | Section 105.1 |\n| Section link | Section 82.2 |\n| Section link | Section 97.3 |\n| Unlock | Section 79.4 |\n\nSource: *Frosthaven* Scenario Book 62–81, scenario 61; related Section Book entries as indexed.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 14339,
+      "tokenInput": 32168,
+      "tokenOutput": 614,
+      "tokenTotal": 32782,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-scenario-neighbors",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-scenario-neighbors",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-neighbors",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "For **Scenario 61: Life and Death**, the directly related records are:\n\n- **Conclusion:** Section **67.1** — read when the scenario is complete.  \n  Source: *Scenario Book 62–81*\n\n- **Section link:** Section **105.1** — read when **door 1** is opened.  \n  Source: *Scenario Book 62–81*\n\n- **Unlock:** Section **79.4**  \n  Source: scenario relationship data\n\n- Additional direct **section links** associated with Scenario 61:\n  - Section **82.2**\n  - Section **97.3**\n  - Section **67.1** again appears as a linked section\n\nI don’t see any directly related **scenarios** in the indexed relationship data for Scenario 61—only these related **sections**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6595,
+      "tokenInput": 22038,
+      "tokenOutput": 235,
+      "tokenTotal": 22273,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-scenario-neighbors",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-scenario-neighbors",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-neighbors",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "Scenario 61, **“Life and Death,”** is directly related to these records:\n\n- **Section 67.1** — listed as a *conclusion* and also a *section link*\n- **Section 105.1** — *section link*\n- **Section 79.4** — *unlock*\n- **Section 82.2** — *section link*\n- **Section 97.3** — *section link*\n\nSource: Scenario 61 neighbor relations.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 3314,
+      "tokenInput": 24560,
+      "tokenOutput": 160,
+      "tokenTotal": 24720,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-scenario-neighbors",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-scenario-neighbors",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-neighbors",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "Scenarios/sections **directly related** to **Scenario 61: *Life and Death*** are:\n\n**Section links (mentioned/used by the scenario):**\n- **Section 105.1** (Section Book 102-121)\n- **Section 67.1** (Section Book 62-81)\n- **Section 82.2** (Section Book 82-101)\n- **Section 97.3** (Section Book 82-101)\n\n**Unlocks from this scenario:**\n- **Section 79.4** (Section Book 62-81)",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 6769,
+      "tokenInput": 35685,
+      "tokenOutput": 218,
+      "tokenTotal": 35903,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-scenario-neighbors",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-scenario-neighbors",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-unlocks-scenario",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Section 66.2 (\"The Pass is Ready\") unlocks **Scenario 116 – Caravan Guards**.\n\n> New Scenario: Caravan Guards\n\nThe canonical ref is **`scenario:frosthaven/116`**. Let me know if you'd like more details about that scenario!",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6201,
+      "tokenInput": 7660,
+      "tokenOutput": 243,
+      "tokenTotal": 7903,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-section-unlocks-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-section-unlocks-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-unlocks-scenario",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Section 66.2 (\"The Pass is Ready\") unlocks **Scenario 116: Caravan Guards** (`scenario:frosthaven/116`).\n\nSource: Section Book 62-81, Section 66.2 — Rewards: \"New Scenario: Caravan Guards\".",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6222,
+      "tokenInput": 10554,
+      "tokenOutput": 317,
+      "tokenTotal": 10871,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-section-unlocks-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-section-unlocks-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-unlocks-scenario",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Based on the neighbors result, section 66.2 unlocks **scenario:frosthaven/116** (Caravan Guards).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 2816,
+      "tokenInput": 7665,
+      "tokenOutput": 216,
+      "tokenTotal": 7881,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-section-unlocks-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-section-unlocks-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-unlocks-scenario",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Section 66.2 unlocks:\n\n**scenario:frosthaven/116** — *Caravan Guards*\n\nSource: Section Book 62–81, section 66.2.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8942,
+      "tokenInput": 28996,
+      "tokenOutput": 167,
+      "tokenTotal": 29163,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-section-unlocks-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-section-unlocks-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-unlocks-scenario",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "Section 66.2 unlocks **scenario:frosthaven/116**, **Caravan Guards**.  \nSource: Section 66.2, Section Book 62–81.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4881,
+      "tokenInput": 20747,
+      "tokenOutput": 106,
+      "tokenTotal": 20853,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-section-unlocks-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-section-unlocks-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-unlocks-scenario",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "Section **66.2** unlocks **scenario:frosthaven/116** — **Caravan Guards**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4444,
+      "tokenInput": 28614,
+      "tokenOutput": 101,
+      "tokenTotal": 28715,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-section-unlocks-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-section-unlocks-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-section-unlocks-scenario",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "Section *66.2* (“The Pass is Ready”) unlocks the scenario **Caravan Guards** (scenario ref **116**): `scenario:frosthaven/116`.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 2473,
+      "tokenInput": 13695,
+      "tokenOutput": 60,
+      "tokenTotal": 13755,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-section-unlocks-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-section-unlocks-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-next-links",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here is the full picture for **Scenario 61 – \"Life and Death\"**:\n\n---\n\n### Conclusion Section: 67.1 *(Section Book 62-81, p. 67)*\n\nThe section is labelled **\"Conclusion\"** and narrates the party escaping the cave with Moonshard, then meeting a group of cloaked figures around a fire — including an ancient Orchid named **Terra** and a unique quartz Savvas lineage called the **Shattersong**. Terra reveals a long-running plan tied to the emergence of a being called **the Harbinger**, setting up the larger story arc.\n\n---\n\n### Rewards & Forward Links\n\n| Type | Detail |\n|---|---|\n| **Reward** | Unlock a **class box** |\n| **Section Link (calendar)** | Add **Section 140.3** to the calendar in **one week** |\n\n---\n\n### What it unlocks / points to next\n\n- **Section 140.3** — added to the campaign calendar one week out. This is the only forward pointer from this conclusion; there are no scenario unlocks directly listed in section 67.1.\n- The neighbors traversal returned only the back-link to Scenario 61 itself, confirming that **Section 140.3** (via the calendar) is the sole next step referenced here.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 14836,
+      "tokenInput": 16503,
+      "tokenOutput": 667,
+      "tokenTotal": 17170,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-scenario-conclusion-next-links",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-scenario-conclusion-next-links",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-next-links",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "## Scenario 61: *Life and Death* — Conclusion\n\n**Conclusion section: 67.1** (Section Book 62-81)\n\nAfter defeating all enemies, the scenario directs you to read **section 67.1**, where Moonshard leads you to safety and you meet Terra and the Shattersong Savvas, learning of the coming Harbinger.\n\n### What 67.1 unlocks / points to next\n\n- **Rewards:** Unlock a class box (the specific class is not named in the section text — it's referred to only as \"class box\").\n- **Section Links:** *\"Add section 140.3 to the calendar in one week.\"*\n\nSo the conclusion unlocks one new class and queues **section 140.3** onto the calendar one week out. The traversal index only tracks the back-link to scenario 61 itself; the calendar add for 140.3 comes from the section's own text rather than a structured neighbor link.\n\n> Source: Section Book 62-81, section 67.1.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 13644,
+      "tokenInput": 22217,
+      "tokenOutput": 715,
+      "tokenTotal": 22932,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-scenario-conclusion-next-links",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-scenario-conclusion-next-links",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-next-links",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Based on the traversal results, here's what scenario 61 \"Life and Death\" unlocks and points to:\n\n**Conclusion Section: Section 67.1** (Section Book 62-81, page 67)\n\n**Unlocks and Next References:**\n\n1. **Section 140.3** — Added to the calendar in one week (per the \"Section Links\" instruction in the conclusion)\n\n2. **Class box unlock** — The conclusion grants a class box reward\n\nThe conclusion section itself links back to Scenario 61 (Life and Death), but the forward progression points to Section 140.3, which will become available one week later on the campaign calendar.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6191,
+      "tokenInput": 20991,
+      "tokenOutput": 495,
+      "tokenTotal": 21486,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-scenario-conclusion-next-links",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-scenario-conclusion-next-links",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-next-links",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Scenario 61 (*Life and Death*) concludes by reading **section 67.1**. The conclusion section is **67.1 — “Life and Death”**. *(Scenario Book 62–81, scenario 61; Section Book 62–81, section 67.1)*\n\nFrom opened section 67.1:\n\n> Rewards  \n> Unlock class box.  \n> Section Links  \n> Add section 140.3 to the calendar in one week.\n\nScenarios/sections it unlocks or points to next:\n\n- **Section 140.3 — “The Work Continues”**: add to the calendar **in one week**. *(Section Book 122–141, section 140.3)*\n- **No scenario unlocks** are listed in the opened conclusion data.\n- It also says **Unlock class box**, but that is not a scenario or section.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 18484,
+      "tokenInput": 69997,
+      "tokenOutput": 741,
+      "tokenTotal": 70738,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 6,
+      "retryCount": 0,
+      "loopIterations": 7,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-scenario-conclusion-next-links",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-scenario-conclusion-next-links",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-next-links",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "Scenario 61 (*Life and Death*) points to **conclusion section 67.1**.  \nSource: Scenario Book 62–81, scenario 61; Section Book 62–81, section 67.1.\n\nFrom the scenario:\n> “The scenario is complete when all enemies in it are dead. At the end of that round, read 67.1.”\n\nI opened **section 67.1**, and its relevant outcome is:\n\n> “Section Links  \n> Add section 140.3 to the calendar in one week.”\n\n### Next scenarios/sections unlocked or pointed to\n- **Section 140.3** — added to the calendar **in one week**\n\n### Other rewards noted in the conclusion\n- **Unlock class box**\n\nI did **not** find any direct scenario unlocks listed from section 67.1 in the indexed data, only the future section link to **140.3**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 13095,
+      "tokenInput": 55132,
+      "tokenOutput": 341,
+      "tokenTotal": 55473,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-scenario-conclusion-next-links",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-scenario-conclusion-next-links",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-next-links",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "Scenario 61, *Life and Death*:\n\n**Conclusion section:** Section 67.1\n\n**It unlocks / points to:**\n- **Unlock class box.**\n- **Add section 140.3 to the calendar in one week.**\n\nSource: Section 67.1, *Conclusion* (Section Book 62–81).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6149,
+      "tokenInput": 31525,
+      "tokenOutput": 166,
+      "tokenTotal": 31691,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-scenario-conclusion-next-links",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-scenario-conclusion-next-links",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-scenario-conclusion-next-links",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "For **Scenario 61: *Life and Death***, the **Conclusion** is **Section 67.1**. (*fh-section-book-62-81.pdf, Section 67.1*)\n\n### What it unlocks / points to next\n- **Unlocks:** **“Unlock class box.”**\n- **Section link / next step:** **“Add section *140.3* to the calendar in one week.”**",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 6237,
+      "tokenInput": 35110,
+      "tokenOutput": 174,
+      "tokenTotal": 35284,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-scenario-conclusion-next-links",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-scenario-conclusion-next-links",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-during-scenario",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Scenario 61 has no special *Brittle*-related rules. Here is the full answer:\n\n---\n\n## *Brittle* — Rules Summary\n\n> **Brittle:** The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and *Brittle* is then removed. *Brittle* is also removed if the figure is healed.\n\n*(Frosthaven Rulebook, chunk 99 — Negative Conditions)*\n\n### Key points at the table:\n\n| Point | Detail |\n|---|---|\n| **Trigger** | The *very next* damage from **any source** (attacks, hazardous terrain, *Wound*, etc.) |\n| **Effect** | That damage is **doubled**, then *Brittle* is removed |\n| **Early removal** | *Brittle* is also removed if the figure receives any *Heal* |\n| **Stacking** | A figure cannot have two instances of *Brittle*; gaining it again only resets the duration |\n| **Interaction with *Ward*** | *Ward* and *Brittle* are applied before the character reduces their HP dial *(Rulebook chunk 125)* |\n| **Condition immunity** | If a figure is immune to *Brittle*, they cannot receive it at all |\n\n### Were the Scenario/Section Books needed?\n\n**No.** *Brittle* is a core negative condition defined entirely in the **Frosthaven Rulebook**. Scenario 61 (*Life and Death*) has no special rules, enemy interactions, or section text that modifies or references *Brittle* in any way — so the Scenario Book and Section Book were **not needed** to answer this question.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 15682,
+      "tokenInput": 16463,
+      "tokenOutput": 685,
+      "tokenTotal": 17148,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-rule-during-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-rule-during-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-during-scenario",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "## *Brittle*\n\n> \"The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.\"\n\n— Frosthaven Rulebook (Negative Conditions section)\n\nA couple of supporting clarifications from the rulebook's damage rules:\n\n- Damage is doubled **after** *Ward* and *Brittle* are applied (so *Ward* halves first, then *Brittle* doubles what's left), per the Character Damage rules.\n- *Brittle* is cleared by any healing, even *Heal 1*, regardless of whether the figure was missing hit points.\n\n## Scenario/section book usage\n\nThe *Brittle* rule itself lives entirely in the **Rulebook** — no scenario or section book is needed to resolve the question. Scenario 61 (\"Life and Death,\" Scenario Book 62–81) doesn't add any custom *Brittle* mechanics, so the table only needs the Rulebook reference here.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10732,
+      "tokenInput": 11397,
+      "tokenOutput": 548,
+      "tokenTotal": 11945,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-rule-during-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-rule-during-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-during-scenario",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Perfect! I found the rules about *Brittle*. Here's the answer:\n\n## *Brittle* Rule\n\nAccording to the **Rulebook**:\n\n> Brittle: The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.\n\n## Answer Summary\n\n*Brittle* is a **negative condition** that causes the next damage a figure takes to be doubled. Once that damage is applied or the figure is healed, *Brittle* is removed.\n\n**Source cited:** Rulebook, Negative Conditions section  \n**Were scenario/section books needed?** No. The rule is in the core Rulebook and does not require scenario 61 or the scenario/section books to answer the question.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4826,
+      "tokenInput": 8695,
+      "tokenOutput": 338,
+      "tokenTotal": 9033,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-rule-during-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-rule-during-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-during-scenario",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "*Brittle* is a general condition rule, not a scenario-specific rule.\n\nRulebook quote:\n\n> “Brittle: The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.”  \n> — Frosthaven Rulebook, Negative Conditions\n\nSo during scenario 61, if a figure has *Brittle*, the next damage they would suffer — from **any source** — is doubled, then *Brittle* is removed. If the figure is healed before that damage happens, *Brittle* is removed instead.\n\nRelated rule: if the figure has both *Ward* and *Brittle*, they cancel each other and both are removed.  \n— Frosthaven Rulebook, Positive Conditions\n\nI checked scenario 61 for context, but the scenario/section books were **not needed** to answer how *Brittle* works; the rule comes from the Rulebook.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 28674,
+      "tokenInput": 49033,
+      "tokenOutput": 1420,
+      "tokenTotal": 50453,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-rule-during-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-rule-during-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-during-scenario",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "The *Brittle* rule is the same in scenario 61 as anywhere else unless the scenario specifically changes it, and scenario 61 does **not** appear to add any special rule for *Brittle*.\n\nFrom the **Frosthaven Rulebook**:\n\n> *Brittle*: “The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.”\n\nAlso relevant from the **Rulebook** damage rules:\n\n> “When a character would suffer any amount of damage (**after ward or brittle is applied**), they must either reduce their red hit point dial by that amount or negate the damage.”\n\nSo for a player asking during **Scenario 61: Life and Death**:\n- If they have *Brittle* and would suffer damage from **any source**, double that damage.\n- Then remove *Brittle*.\n- If the damage is later negated normally, *Brittle* was still already applied as part of determining the damage amount.\n\n**Scenario/section books needed?**  \n**No, not for the *Brittle* rule itself.** I checked **Scenario 61: Life and Death**, and its special rules mention Moonshard and scenario-specific damage redirection to her, but nothing that changes how *Brittle* works. So the answer comes from the **Rulebook**, not the scenario or section book.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 8469,
+      "tokenInput": 24928,
+      "tokenOutput": 364,
+      "tokenTotal": 25292,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-rule-during-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-rule-during-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-during-scenario",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "In scenario 61, *Brittle* works normally: **the next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and *Brittle* is then removed. *Brittle* is also removed if the figure is healed.**  \n**Rule source:** Frosthaven Rulebook, Negative Conditions.\n\nThe scenario/section books were **not needed** for this ruling; the rulebook alone covers *Brittle*.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 4705,
+      "tokenInput": 32572,
+      "tokenOutput": 189,
+      "tokenTotal": 32761,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-rule-during-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-rule-during-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-rule-during-scenario",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "In *Frosthaven*, the *Brittle* condition works like this:\n\n> “**Brittle:** The next time the figure would suffer damage from any source, they instead suffer **double that amount of damage**, and brittle is then removed. **Brittle is also removed if the figure is healed.**”\n\n— **Rulebook → Conditions / Negative Conditions (Sticker 5)**\n\n**Were the scenario/section books needed for scenario 61?**  \nNo. The rules for *Brittle* are in the general **Rulebook**; scenario 61 (“Life and Death”) doesn’t appear necessary to determine what *Brittle* does.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 7785,
+      "tokenInput": 46385,
+      "tokenOutput": 268,
+      "tokenTotal": 46653,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-rule-during-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-rule-during-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-card-fuzzy-vs-exact",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here is a full breakdown of all records found and which are exact vs. fuzzy matches.\n\n---\n\n## ✅ Exact Data Records — Algox Archer Monster Stats\n\n*(Source: GHS Card Index — `monster-stats`)*\n\nThese two records are the **canonical stat records** for the Algox Archer, covering all scenario levels:\n\n### Levels 0–3\n\n| Level | Type | HP | *Move* | *Attack* |\n|-------|------|----|--------|----------|\n| 0 | Normal | 4 | 1 | 3 |\n| 1 | Normal | 5 | 2 | 3 |\n| 2 | Normal | 7 | 2 | 3 |\n| 3 | Normal | 7 | 2 | 4 |\n| 0 | **Elite** | 6 | 2 | 4 |\n| 1 | **Elite** | 8 | 2 | 4 |\n| 2 | **Elite** | 11 | 2 | 4 |\n| 3 | **Elite** | 12 | 2 | 5 |\n\n### Levels 4–7\n\n| Level | Type | HP | *Move* | *Attack* |\n|-------|------|----|--------|----------|\n| 4 | Normal | 10 | 2 | 4 |\n| 5 | Normal | 13 | 2 | 4 |\n| 6 | Normal | 19 | 2 | 4 |\n| 7 | Normal | 22 | 2 | 5 |\n| 4 | **Elite** | 16 | 2 | 5 |\n| 5 | **Elite** | 18 | 2 | 6 |\n| 6 | **Elite** | 28 | 2 | 6 |\n| 7 | **Elite** | 33 | 2 | 7 |\n\n**No immunities** are listed. Notes field is empty.\n\n---\n\n## ✅ Exact Data Records — Monster Ability Cards (Archer Deck)\n\nThe resolve step returned four ability cards from the **\"archer\" ability deck** (search score 0.86 — matched because this deck belongs to Algox Archer). These are exact structured card records:\n\n| Card Title | Ref |\n|---|---|\n| **Calculated Strike** | `monster-ability/archer/760` |\n| **Close In** | `monster-ability/archer/756` |\n| **Hasty Assault** | `monster-ability/archer/757` |\n| **Nothing Special** | `monster-ability/archer/759` |\n\nThese are the ability cards drawn from the Algox Archer's ability deck during play.\n\n---\n\n## 🔶 Fuzzy / Contextual Matches — \"Algox Archer\" Mentioned In Text\n\nThese records **mention** the Algox Archer by name in prose or setup text, but are not stat or ability data records:\n\n| Record | Score | Why It Matches |\n|---|---|---|\n| **Outpost Event WO-39** (Winter) | 0.86 | Flavor text mentions Algox archers attacking the eastern wall — a narrative event, not a monster stat |\n| **Section 123.3** | 0.80 | Special rules text: *\"Place one fallen Algox Archer in C.\"* — a scenario section instruction |\n| **Scenario Book 2-21, chunk 8** (Algox Scouting, Scenario 2) | 0.63 | Monster roster listing: `[Algox Archer — Algox Guard]` with counts |\n| **Scenario Book 2-21, chunk 10** (Algox Offensive, Scenario 3) | 0.57 | Same — monster roster listing |\n| **Scenario Book 2-21, chunk 13** (Heart of Ice, Scenario 4) | 0.55 | Monster roster: Algox Archer listed among enemies |\n| **Rulebook chunk 80** | 0.56 | Tutorial example: *\"is at Range 2 from the Algox Archer 1\"* — used as a range example |\n| **Scenario Card: Algox Scouting (Scenario 2)** | 0.48 | Scenario metadata lists `\"monsters\": [\"Algox Archer\", \"Algox Guard\"]` |\n\n---\n\n## Summary\n\n- **Exact records**: The two monster-stat records (levels 0–3 and 4–7) and the four archer ability cards are direct, structured data sourced from the GHS Card Index.\n- **Fuzzy matches**: All other results are rules passages, section book entries, event cards, and scenario metadata that reference \"Algox Archer\" in text — useful for context, but not the primary stat source.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 30322,
+      "tokenInput": 18971,
+      "tokenOutput": 1504,
+      "tokenTotal": 20475,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-card-fuzzy-vs-exact",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-card-fuzzy-vs-exact",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-card-fuzzy-vs-exact",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "I have enough to answer. The two stat records are exact data; the search hits are contextual (fuzzy) matches. Let me open the two stat records to confirm details — actually, the search snippets already contain the full stat blocks, so I'll answer directly.\n\n## Algox Archer — Exact Monster Stat Records\n\nThere are two exact monster-stat cards (sourced from GHS Card Data) covering different level ranges:\n\n**Levels 0–3** — `card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/0-3`\n\n| Lvl | Normal HP/Move/Atk | Elite HP/Move/Atk |\n|---|---|---|\n| 0 | 4 / 1 / 3 | 6 / 2 / 4 |\n| 1 | 5 / 2 / 3 | 8 / 2 / 4 |\n| 2 | 7 / 2 / 3 | 11 / 2 / 4 |\n| 3 | 7 / 2 / 4 | 12 / 2 / 5 |\n\n**Levels 4–7** — `card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/4-7`\n\n| Lvl | Normal HP/Move/Atk | Elite HP/Move/Atk |\n|---|---|---|\n| 4 | 10 / 2 / 4 | 16 / 2 / 5 |\n| 5 | 13 / 2 / 4 | 18 / 2 / 6 |\n| 6 | 19 / 2 / 4 | 28 / 2 / 6 |\n| 7 | 22 / 2 / 5 | 33 / 2 / 7 |\n\nNo immunities are listed on either record, and `notes` is null.\n\n## Ability / Card Mentions — Classification\n\n**Exact data records (canonical Algox Archer entries):**\n- The two monster-stat cards above are the only exact stat records keyed to the Algox Archer.\n\n**Fuzzy / contextual matches (mention \"Archer\" or appear alongside Algox Archer but are not Algox Archer's own data):**\n- *Calculated Strike* (`monster-ability/archer/760`), *Close In* (`/756`), *Hasty Assault* (`/757`), *Nothing Special* (`/759`) — these are entries from a generic **\"archer\"** monster ability deck, surfaced by card-text matching, not from a deck named \"Algox Archer.\" The resolver flagged them at lower confidence (0.86) for that reason. Whether the Algox Archer actually draws from this deck is a deck-assignment question that the stat record itself doesn't answer (its `notes` field is null).\n- **Event WO-39** (Winter Outpost event) — flavorful narrative referencing \"Algox\" and \"archers\"; not a stat or ability record.\n- **Section 123.3** — instructs placing \"one fallen Algox Archer in C\" as a scenario setup detail, not stat data.\n- **Scenario Book passages (chunks 8 and 10)** from *Algox Scouting* and *Algox Offensive* — these list Algox Archer in monster spawn tables for those scenarios, again not ability data.\n\n### Bottom line\nThe Algox Archer's checked-in **exact data** consists solely of the two level-banded monster-stat cards (0–3 and 4–7). Every other hit — the four \"archer\" ability cards, the event, the section, and the scenario-book passages — is a **fuzzy/contextual match** from search, not an Algox-Archer-specific record. In particular, no ability deck record in the index is explicitly labeled \"Algox Archer,\" so I can't confirm from the checked-in data which ability deck this monster uses.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 23013,
+      "tokenInput": 11638,
+      "tokenOutput": 1412,
+      "tokenTotal": 13050,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-card-fuzzy-vs-exact",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-card-fuzzy-vs-exact",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-card-fuzzy-vs-exact",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "## Summary\n\n### Algox Archer Monster Stat Records (Exact Data)\n\nI found **two exact monster stat records** from the GHS Card Data:\n\n**Levels 0–3:**\n| Level | Normal HP | Normal Move | Normal Attack | Elite HP | Elite Move | Elite Attack |\n|-------|-----------|-------------|---------------|----------|-----------|--------------|\n| 0     | 4         | 1           | 3             | 6        | 2         | 4            |\n| 1     | 5         | 2           | 3             | 8        | 2         | 4            |\n| 2     | 7         | 2           | 3             | 11       | 2         | 4            |\n| 3     | 7         | 2           | 4             | 12       | 2         | 5            |\n\n**Levels 4–7:**\n| Level | Normal HP | Normal Move | Normal Attack | Elite HP | Elite Move | Elite Attack |\n|-------|-----------|-------------|---------------|----------|-----------|--------------|\n| 4     | 10        | 2           | 4             | 16       | 2         | 5            |\n| 5     | 13        | 2           | 4             | 18       | 2         | 6            |\n| 6     | 19        | 2           | 4             | 28       | 2         | 6            |\n| 7     | 22        | 2           | 5             | 33       | 2         | 7            |\n\nNo immunities or special notes are recorded.\n\n---\n\n### Search Results: Ability and Card Mentions\n\nThe search for \"Algox Archer\" returned **6 results** with these match types:\n\n**Exact Data Records (Direct matches):**\n1. **Algox Archer (Levels 0–3)** — Monster stat card (confidence 0.99, Card Index)\n2. **Algox Archer (Levels 4–7)** — Monster stat card (confidence 0.99, Card Index)\n\n**Fuzzy/Contextual Matches (Text mentions, not exact stat records):**\n3. **Winter Outpost Event WO-39** (score 0.856) — Narrative event card that mentions \"Algox\" and archers in flavor text and outcomes; not an ability or stat record for Algox Archer specifically\n4. **Section 123.3** (score 0.80) — Scenario instruction text mentioning \"fallen Algox Archer\" placement; contextual scenario reference\n5. **Scenario Book 2-21, Chunk 8** (score 0.626) — Scenario narrative mentioning both \"Algox Archer\" and \"Algox Guard\" as enemies; not a dedicated ability card\n6. **Scenario Book 2-21, Chunk 10** (score 0.572) — Similar scenario narrative with \"Algox Guard\" and \"Algox Archer\" mentioned together\n\n**No dedicated ability cards found** for Algox Archer specifically. The resolve step did return several Archer-class monster ability cards (Calculated Strike, Close In, Hasty Assault, Nothing Special), but these are generic Archer abilities, not exclusive to Algox Archer.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10257,
+      "tokenInput": 16467,
+      "tokenOutput": 1080,
+      "tokenTotal": 17547,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-card-fuzzy-vs-exact",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-card-fuzzy-vs-exact",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-card-fuzzy-vs-exact",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": false,
+      "answer": "",
+      "score": null,
+      "pass": false,
+      "latencyMs": 30264,
+      "tokenInput": 200914,
+      "tokenOutput": 1109,
+      "tokenTotal": 202023,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 10,
+      "retryCount": 0,
+      "loopIterations": 10,
+      "failureClass": "loop_limit",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-card-fuzzy-vs-exact",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-card-fuzzy-vs-exact",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-card-fuzzy-vs-exact",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "I found the exact *Algox Archer* monster stat records, then searched for other card data mentioning “Algox Archer.”\n\n## Exact data: monster stat records\nThese are exact records because the card name is exactly **Algox Archer**.\n\n- **Algox Archer** — level range **0–3**  \n  Source ID: `gloomhavensecretariat:monster-stat/algox-archer/0-3`\n- **Algox Archer** — level range **4–7**  \n  Source ID: `gloomhavensecretariat:monster-stat/algox-archer/4-7`\n\n### Stat summary\n**0–3 record**\n- Normal:\n  - 0: HP 4, Move 1, Attack 3\n  - 1: HP 5, Move 2, Attack 3\n  - 2: HP 7, Move 2, Attack 3\n  - 3: HP 7, Move 2, Attack 4\n- Elite:\n  - 0: HP 6, Move 2, Attack 4\n  - 1: HP 8, Move 2, Attack 4\n  - 2: HP 11, Move 2, Attack 4\n  - 3: HP 12, Move 2, Attack 5\n- Immunities: none in the checked-in data\n\n**4–7 record**\n- Normal:\n  - 4: HP 10, Move 2, Attack 4\n  - 5: HP 13, Move 2, Attack 4\n  - 6: HP 19, Move 2, Attack 4\n  - 7: HP 22, Move 2, Attack 5\n- Elite:\n  - 4: HP 16, Move 2, Attack 5\n  - 5: HP 18, Move 2, Attack 6\n  - 6: HP 28, Move 2, Attack 6\n  - 7: HP 33, Move 2, Attack 7\n- Immunities: none in the checked-in data\n\n## Ability records mentioning Algox Archer\nI checked for exact monster ability records by filtering `monster-abilities` on `monsterType: \"Algox Archer\"` and got **no results**.\n\nSo, in the checked-in card data:\n\n- **Exact monster-ability records for Algox Archer:** **none found**\n- That means there is **no exact ability card record** surfaced here for *Algox Archer* by that monster type field.\n\n## Fuzzy matches from search\nA keyword search for “Algox Archer” returned other records that mention the string, but these are **fuzzy matches**, not exact monster stat/ability records for the monster itself.\n\n### Fuzzy match examples\n- **Winter Outpost Event 39**  \n  Source ID: `gloomhavensecretariat:event/WO-39`  \n  Why fuzzy: it contains “Algox” and “archers” in event text, but it is an **event**, not an *Algox Archer* monster record.\n\n- **Scenario 002 – Algox Scouting**  \n  Source ID: `gloomhavensecretariat:scenario/002`  \n  Why fuzzy: *Algox Archer* appears in the scenario’s `monsters` list.\n\n- **Scenario 003 – Algox Offensive**  \n  Source ID: `gloomhavensecretariat:scenario/003`  \n  Why fuzzy: *Algox Archer* appears in the scenario’s `monsters` list.\n\n- Other scenario fuzzy matches included:\n  - `gloomhavensecretariat:scenario/029` — War of the Spire A\n  - `gloomhavensecretariat:scenario/030` — War of the Spire B\n  - `gloomhavensecretariat:scenario/028` — Summit Meeting\n  - `gloomhavensecretariat:scenario/116` — Caravan Guards\n  - `gloomhavensecretariat:scenario/055` — Change of Heart\n  - and more\n\n## Exact vs fuzzy distinction\n- **Exact data**\n  - The two `monster-stats` records named **Algox Archer**\n- **No exact ability data found**\n  - No `monster-abilities` records matched *Algox Archer* exactly in the checked-in data\n- **Fuzzy matches**\n  - Events and scenarios where “Algox Archer” appears in text or in a monster/allies list\n\nIf you want, I can next search specifically for likely *Algox Archer* monster ability card names by broader Algox/archer-related keywords and separate those from pure scenario/event mentions.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 24008,
+      "tokenInput": 56372,
+      "tokenOutput": 1326,
+      "tokenTotal": 57698,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-card-fuzzy-vs-exact",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-card-fuzzy-vs-exact",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-card-fuzzy-vs-exact",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "I found the **Algox Archer** monster stat record:\n\n- **Exact data:** `gloomhavensecretariat:monster-stat/algox-archer/0-3`  \n  - Level range: **0–3**\n  - Normal / elite stats are present in the record\n  - Source data confirms the monster name is exactly **Algox Archer**\n\nI also searched for records mentioning **Algox Archer**. In the returned results, I found these **exact matches in card data**:\n- `monster-stats` record for Algox Archer, 0–3\n- `monster-stats` record for Algox Archer, 4–7\n\nAnd these **fuzzy matches**:\n- Several **scenario** records that list Algox Archer among their monsters or allies, such as:\n  - `A Town in Flames`\n  - `Algox Scouting`\n  - `Algox Offensive`\n  - `War of the Spire A/B`\n  - `Summit Meeting`\n  - `Change of Heart`\n  - others in the search results\n- One **event** record (`WO-39`) that mentions Algox in flavor text, but not as a card record for Algox Archer itself\n\nWhat I can say precisely from the checked-in data:\n- There are **no ability card records returned** by the search that mention **Algox Archer**.\n- The matches returned by the search are mostly **monster-stats** and **scenario** records, not **monster-abilities** or other ability/card records.\n\nSo the distinction is:\n\n- **Exact data:** the Algox Archer monster stat records\n- **Fuzzy matches:** scenarios and the event record that mention Algox Archer/Algox Archer-related text, but are not direct Algox Archer ability/card records\n\nIf you want, I can do a second pass specifically targeting **monster-abilities** and other **card** types to confirm whether any ability cards mention Algox Archer by name.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 8690,
+      "tokenInput": 48962,
+      "tokenOutput": 517,
+      "tokenTotal": 49479,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-card-fuzzy-vs-exact",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-card-fuzzy-vs-exact",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-card-fuzzy-vs-exact",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "## Algox Archer monster stat record (exact)\nI found **two exact monster-stat records** for *Algox Archer*:\n\n1) **Normal/Elite level range 0–3**\n- **Ref:** `card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/0-3`\n- **Exact match criteria:** record title/name is exactly “Algox Archer”\n- **Source:** GHS Card Data / Card Index\n\n2) **Normal/Elite level range 4–7**\n- **Ref:** `card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/4-7`\n- **Exact match criteria:** record title/name is exactly “Algox Archer”\n- **Source:** GHS Card Data / Card Index\n\n## Ability or card records that mention “Algox Archer”\nI searched the card index for mentions of “Algox Archer”.\n\n### Exact data records that mention “Algox Archer”\nThese are **not fuzzy**; they contain the exact monster name as a field value (e.g., in a scenario’s monster list):\n\n- **Scenario cards (exact mention in monsters list):**\n  - `card:frosthaven/scenarios:gloomhavensecretariat:scenario/003` — *Algox Offensive* (mentions “Algox Archer” in its monsters list)\n  - `card:frosthaven/scenarios:gloomhavensecretariat:scenario/002` — *Algox Scouting* (mentions “Algox Archer” in its monsters list)\n  - `card:frosthaven/scenarios:gloomhavensecretariat:scenario/029` — *War of the Spire A* (mentions “Algox Archer” in its allies list)\n\n### Card/event record that mentions Algox Archer *conceptually* (fuzzy with respect to “Algox Archer”)\n- **Outpost event:**\n  - `card:frosthaven/events:gloomhavensecretariat:event/WO-39`\n  - **Note:** This event text discusses “Algox” and “Archers,” but the returned match score is lower and it’s not an explicit “Algox Archer” name citation like the scenarios above. So this is best treated as a **fuzzy/keyword match for “Algox” and/or “archers”**, not an exact “Algox Archer” data reference.\n\n## Are there any *ability* or *monster-ability* records that mention “Algox Archer”?\n- Search for **“Algox Archer ability”** returned **no results** in the checked card index (**empty results**), so there are **no exact ability/card records** found that reference *Algox Archer* by name in an ability context.\n\nIf you want, I can broaden the search to other likely spellings/variants (e.g., just “Algox” or “Archer”) and then sort exact-name hits vs keyword hits.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 13123,
+      "tokenInput": 62738,
+      "tokenOutput": 812,
+      "tokenTotal": 63550,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 6,
+      "retryCount": 0,
+      "loopIterations": 7,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-card-fuzzy-vs-exact",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-card-fuzzy-vs-exact",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-invalid-cross-game-ref",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's a full breakdown of both paths:\n\n---\n\n## Path 1 — `section:frosthaven/67.1` ✅ Resolved & Opened\n\n**resolve_entity** matched it with **0.99 confidence** as an exact section ref from the *Section Book 62–81* source.\n\n**open_entity** then returned the full record:\n\n| Field | Value |\n|---|---|\n| Title | Section 67.1 |\n| Label | *Life and Death* |\n| Source | `fh-section-book-62-81.pdf`, page 67 |\n| Scenario link | Scenario 61 — *Life and Death* |\n\n**Content summary:** This is the **Conclusion** section for Scenario 61. The party escapes the cave with Moonshard, meets the ancient Orchid **Terra** and the crystalline Savvas lineage known as **the Shattersong**, and learns about the Harbinger's seals and the need for star iron. The section ends with:\n\n> **Rewards:** Unlock class box.\n> **Section Links:** Add section 140.3 to the calendar in one week.\n\n---\n\n## Path 2 — `section:gloomhaven2/67.1` ❌ Rejected\n\n> `\"code\": \"not_found\"` — **\"Section not found: section:gloomhaven2/67.1\"**\n\nThe game qualifier `gloomhaven2` is **not a valid game** in the knowledge base. The canonical game prefix for this section is `frosthaven`. The grounding rules require preserving an explicit game qualifier as given rather than silently correcting it — so the explicit `gloomhaven2` qualifier correctly **failed** instead of falling back to a Frosthaven match.\n\n---\n\n**Takeaway:** Always qualify section refs with the correct game prefix (`frosthaven/…`). A bare ref like `67.1` is resolvable via natural language, but an explicit **wrong** game qualifier such as `gloomhaven2/67.1` is neither invented nor silently corrected — it is rejected outright.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 14642,
+      "tokenInput": 8709,
+      "tokenOutput": 730,
+      "tokenTotal": 9439,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-sonnet-4-6:traj-invalid-cross-game-ref",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-invalid-cross-game-ref",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-invalid-cross-game-ref",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here's what happened on each path:\n\n**Path 1 — Frosthaven section 67.1 (resolved + opened):**\n- `resolve_entity` returned a 0.99 confidence match: `ref: 67.1`, source `Section Book 62-81` (Frosthaven).\n- `open_entity` on the bare legacy ref `67.1` succeeded and the opener normalized it to the canonical form `section:frosthaven/67.1`. It's the **\"Life and Death\"** conclusion section, with reward *Unlock class box* and a section link adding section 140.3 to the calendar in one week.\n\n**Path 2 — Same bare ref under explicit Gloomhaven 2:**\n- `resolve_entity` for \"section 67.1 Gloomhaven 2\" still surfaced the Frosthaven candidate (the resolver doesn't gate by game qualifier and there is no Gloomhaven 2 section 67.1 in the checked-in data).\n- `open_entity` on `section:gloomhaven2/67.1` was correctly **rejected** with `not_found`: *\"Section not found: section:gloomhaven2/67.1\"*.\n\nSo the canonical-ref contract held: the Frosthaven path returned a real record under `section:frosthaven/67.1`, and the Gloomhaven 2 path required a real record at that game-qualified ref and refused to fall back to the Frosthaven one. Citations: Frosthaven Section Book 62-81, section 67.1.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 14621,
+      "tokenInput": 12641,
+      "tokenOutput": 940,
+      "tokenTotal": 13581,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-opus-4-7:traj-invalid-cross-game-ref",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Atraj-invalid-cross-game-ref",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-invalid-cross-game-ref",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-haiku-4-5",
+      "ok": true,
+      "answer": "Perfect! Here's what happened:\n\n**First path (Frosthaven):**\n✓ `resolve_entity` resolved the bare reference \"section 67.1\" to the canonical Frosthaven ref with high confidence (0.99).\n✓ `open_entity` with `section:frosthaven/67.1` successfully opened **Section 67.1** from the Frosthaven Section Book 62-81, titled \"Life and Death\" — a conclusion section describing the encounter with Terra and the Shattersong.\n\n**Second path (Gloomhaven 2):**\n✗ `open_entity` with `section:gloomhaven2/67.1` returned a **not_found error**. There is no section 67.1 in the Gloomhaven 2 game knowledge base.\n\nThis confirms the behavior: a bare legacy ref like \"section 67.1\" auto-resolves to Frosthaven (the default context), but an explicit game-qualified ref like `section:gloomhaven2/67.1` requires that exact resource to exist in the checked-in data. The second path correctly rejected the non-existent Gloomhaven 2 section rather than falling back or inventing a URI form.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5047,
+      "tokenInput": 6328,
+      "tokenOutput": 498,
+      "tokenTotal": 6826,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:anthropic:claude-haiku-4-5:traj-invalid-cross-game-ref",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-invalid-cross-game-ref",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-haiku-4-5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-invalid-cross-game-ref",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "- **Frosthaven resolution:** `section 67.1` resolves to `section:frosthaven/67.1`, titled “Section 67.1,” from **Section Book 62–81**, locator **section 67.1**. It is labeled “Life and Death” and contains a conclusion with rewards and a section link.\n\n- **Explicit Gloomhaven 2 path:** I did **not** reuse the bare legacy ref as Frosthaven. With the explicit game qualifier, the canonical ref must be `section:gloomhaven2/67.1`. Opening that exact ref returned: **Section not found**.\n\nSo the second path is rejected/unavailable in the checked-in data unless a valid canonical game-qualified Gloomhaven 2 section ref exists.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 19453,
+      "tokenInput": 39160,
+      "tokenOutput": 668,
+      "tokenTotal": 39828,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.5:traj-invalid-cross-game-ref",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-invalid-cross-game-ref",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-invalid-cross-game-ref",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4",
+      "ok": true,
+      "answer": "I resolved **Frosthaven** section 67.1 successfully:\n\n- Resolved ref: `67.1`\n- Source: **Frosthaven Section Book 62–81**\n- Label: **Life and Death**\n\nIt opens to the full section text, ending with:\n\n- **Rewards:** “Unlock class box.”\n- **Section Links:** “Add section 140.3 to the calendar in one week.”\n\nThen I tried the same section number with an explicit **Gloomhaven 2** canonical game-qualified ref:\n\n- Tried: `section:gloomhaven2/67.1`\n- Result: **not found** — “Section not found: section:gloomhaven2/67.1”\n\nSo yes: the bare legacy ref `67.1` resolves in Frosthaven, but for **Gloomhaven 2** you need a canonical game-qualified ref, and in this case that explicit canonical ref was rejected as not found.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 12792,
+      "tokenInput": 29503,
+      "tokenOutput": 274,
+      "tokenTotal": 29777,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4:traj-invalid-cross-game-ref",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-invalid-cross-game-ref",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-invalid-cross-game-ref",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-mini",
+      "ok": true,
+      "answer": "For **Frosthaven**, `section 67.1` resolves to:\n\n- **Section 67.1** — *Life and Death*  \n  Source: **Section Book 62–81**  \n  It links to **scenario 61** (*Life and Death*).\n\nFor the second attempt, I tried the same bare ref again. It still resolves as a **Frosthaven** section, not a Gloomhaven 2-qualified one, so the bare legacy ref is **not enough to disambiguate by game**. A game-qualified canonical ref would be required for a Gloomhaven 2 lookup.\n\nIf you want, I can also demonstrate the proper canonical form for a game-qualified section ref.",
+      "score": 1,
+      "pass": false,
+      "latencyMs": 7129,
+      "tokenInput": 29972,
+      "tokenOutput": 239,
+      "tokenTotal": 30211,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-mini:traj-invalid-cross-game-ref",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-mini%3Atraj-invalid-cross-game-ref",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-mini",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-expanded-full-matrix-2026-05-02",
+      "caseId": "traj-invalid-cross-game-ref",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.4-nano",
+      "ok": true,
+      "answer": "### 1) Resolve legacy ref `section 67.1` (Frosthaven)\n**Section Book 62–81, page 67 (`67.1`)**. Its content is the *Conclusion* of the scenario, and it includes these mechanics text items:\n\n- **Rewards:** “Unlock class box.”\n- **Section Link:** “Add section 140.3 to the calendar in one week.”\n\n(Full conclusion narrative is also present in the section text.)\n\n---\n\n### 2) Try the same bare legacy ref with an explicit *Gloomhaven 2* game\nWhen using the bare legacy ref `67.1` (i.e., without an explicit canonical game-qualified ref like `section:gloomhaven2/...`), the lookup does **not** produce a *Gloomhaven 2* section candidate—it only resolves to the **Frosthaven** section (`67.1`).  \n\nSo the second path effectively **rejects** the “explicit Gloomhaven 2” requirement because the unqualified ref does not map to a canonical `section:gloomhaven2/...` record in the checked-in data.",
+      "score": 0.8,
+      "pass": false,
+      "latencyMs": 10284,
+      "tokenInput": 29578,
+      "tokenOutput": 318,
+      "tokenTotal": 29896,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-expanded-full-matrix-2026-05-02:openai:gpt-5.4-nano:traj-invalid-cross-game-ref",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4-nano%3Atraj-invalid-cross-game-ref",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.4-nano",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 15,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    }
+  ],
+  "estimatedCostUsd": 10.15
+}

--- a/docs/plans/sqr-134-full-matrix-report.json
+++ b/docs/plans/sqr-134-full-matrix-report.json
@@ -1,0 +1,3400 @@
+{
+  "generatedAt": "2026-05-02T19:10:56.252Z",
+  "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+  "rows": [
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-long-rest-init",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "A *long rest* has an initiative value of **99** — the highest possible initiative, meaning the resting character acts last in the turn order for that round.\n\n> \"Any character long resting has an initiative of 99.\"\n— Frosthaven Rulebook, Ordering of Initiative\n\nThis makes sense thematically: the character is taking the full round to recover, so they go last. If another monster or character also has initiative 99 (rare, but possible), a character always acts before a monster set with the same initiative value.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 5929,
+      "tokenInput": 8135,
+      "tokenOutput": 199,
+      "tokenTotal": 8334,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:rule-long-rest-init",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-long-rest-init",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-long-rest-init",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "A long rest is performed on **initiative 99**.\n\n> \"During the Card Selection step…, a character may declare a long rest. This constitutes their entire turn for the round, instead of playing two cards, and it is performed on initiative 99.\"\n> — Frosthaven Rulebook, p. 38",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6447,
+      "tokenInput": 10902,
+      "tokenOutput": 198,
+      "tokenTotal": 11100,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:rule-long-rest-init",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Arule-long-rest-init",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-long-rest-init",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "A *long rest* has initiative **99** in Frosthaven.\n\nRulebook: “Any character long resting has an initiative of 99.”  \nSource: Frosthaven Rulebook, initiative order / resting passages.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9634,
+      "tokenInput": 27863,
+      "tokenOutput": 140,
+      "tokenTotal": 28003,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:rule-long-rest-init",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-long-rest-init",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-long-rest-steps",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "The first result contains the full rules text. Here is a complete breakdown:\n\n---\n\n## Long Rest Steps (Frosthaven Rulebook)\n\nA character declares a long rest during the **Card Selection** step. It counts as their **entire turn** for the round and is performed on **initiative 99**. When a character long rests, they follow these steps in order:\n\n1. **Lose one card of their choice** from their discard pile and return the remaining cards to their hand. *(Mandatory)*\n\n2. **Perform *Heal 2*, self.** *(Optional)*\n\n3. **Recover all of their spent items.** Items can even be used during the same turn in which they are recovered. *(Optional)*\n\n---\n\n**Key details to keep in mind:**\n\n- A long rest can only be declared if the character has **at least two cards** in their discard pile (since one must be lost).\n- Because the initiative is **99**, long-resting characters act very late in the round and are vulnerable to enemy attacks before their turn.\n- Steps 2 and 3 are optional — you are not forced to heal or recover items if you don't want to (though there's rarely a reason to skip them).\n\n*(Source: Frosthaven Rulebook)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 12417,
+      "tokenInput": 8287,
+      "tokenOutput": 368,
+      "tokenTotal": 8655,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:rule-long-rest-steps",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-long-rest-steps",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-long-rest-steps",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "A long rest is declared during the **Card Selection** step and constitutes the character's entire turn for the round, performed on initiative **99**. The character must have at least 2 cards in their discard pile to rest.\n\nThe steps, in order, are:\n\n1. **Lose one card of their choice** from their discard pile and return the remaining cards to their hand (mandatory).\n2. **Perform \"*Heal 2*, self\"** (optional).\n3. **Recover all of their spent items** (optional). Items can be used during the same turn in which they are recovered.\n\nSource: Frosthaven Rulebook, p. 46 (Resting).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8260,
+      "tokenInput": 11191,
+      "tokenOutput": 318,
+      "tokenTotal": 11509,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:rule-long-rest-steps",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Arule-long-rest-steps",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-long-rest-steps",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "When a character takes a *long rest* in Frosthaven:\n\n1. **Declare the long rest during Card Selection** instead of playing two cards.\n2. The character’s entire turn for the round is the long rest.\n3. They act at **initiative 99**.\n4. On their turn, they perform these steps:\n   - **Lose one card of their choice** from their discard pile, then return the remaining discarded cards to their hand. This is mandatory.\n   - Optionally perform *Heal 2, self*.\n   - Optionally recover all of their spent items. Those items can be used later that same turn after being recovered.\n\nPrerequisite: a character can rest only if they have **at least two cards in their discard pile**.\n\n> “When a character long rests, they follow these steps: Lose one card of their choice from their discard pile and return the remaining cards to their hand (mandatory). Perform ‘Heal 2, self’ (optional). Recover all of their spent items (optional).”  \n> — Frosthaven Rulebook, *Resting*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 11150,
+      "tokenInput": 15416,
+      "tokenOutput": 337,
+      "tokenTotal": 15753,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:rule-long-rest-steps",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-long-rest-steps",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-scenario-level",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "The rulebook gives a clear answer. Here's how it works:\n\n---\n\n## Recommended Scenario Level\n\n> At recommended difficulty, the scenario level is equal to the **average level of the characters divided by 2 (rounded up)**.\n\n**Example:** If all characters are level 2, the average level (2) ÷ 2 = 1, so the scenario is **level 1**. A character would need to reach level 3 before the scenario level potentially increases.\n\n---\n\n### Adjusting Difficulty\n\nThe recommended level is just a starting point. At the start of **any** scenario, you can freely set the scenario level to any number from **0–7**:\n- **Decrease** it if your party is struggling.\n- **Increase** it to keep the game challenging as your party grows stronger.\n\n---\n\n### What Scenario Level Affects\n\nThe scenario level feeds into the following values (from the Scenario Level chart):\n\n| Scenario Level | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |\n|---|---|---|---|---|---|---|---|---|\n| Monster Level | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |\n| Gold Conversion | 2 | 2 | 3 | 3 | 4 | 4 | 5 | 6 |\n| Trap Damage | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |\n| Hazardous Terrain | 1 | 2 | 2 | 2 | 3 | 3 | 3 | 4 |\n| Bonus Experience | 4 | 6 | 8 | 10 | 12 | 14 | 16 | 18 |\n\n*(Source: Frosthaven Rulebook)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 14489,
+      "tokenInput": 7305,
+      "tokenOutput": 547,
+      "tokenTotal": 7852,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:rule-scenario-level",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-scenario-level",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-scenario-level",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "At recommended difficulty, the scenario level is the **average level of the characters divided by 2, rounded up**.\n\n- Example: with an all-level-2 party, average level (2) ÷ 2 = 1, so the scenario stays at level 1. The scenario level only starts to rise once a character reaches level 3.\n- This is just the *recommended* level. At the start of any scenario you may set the scenario level to any value from **0–7** — lower it if the party is struggling, or raise it to keep things challenging as the party grows stronger.\n\nThe scenario level then drives monster level, gold conversion, trap damage, hazardous terrain damage, and bonus experience per the level chart in the rulebook.\n\nSource: Frosthaven Rulebook (passage 68).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8574,
+      "tokenInput": 9941,
+      "tokenOutput": 350,
+      "tokenTotal": 10291,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:rule-scenario-level",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Arule-scenario-level",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-scenario-level",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "At recommended difficulty, Frosthaven’s scenario level is:\n\n> “equal to the average level of the characters divided by 2 (rounded up).”  \n> — Frosthaven Rulebook, *Scenario Level*\n\nSo:\n\n1. Add up all character levels.\n2. Divide by the number of characters to get the party’s average level.\n3. Divide that average by 2.\n4. Round up.\n\nExample: if the characters are levels 2, 2, 3, and 4:\n\n- Average level = 11 ÷ 4 = 2.75\n- Divide by 2 = 1.375\n- Round up = scenario level 2\n\nThe rulebook also notes that this is only the **recommended** difficulty; at the start of any scenario, you can set the scenario level to any number from 0–7.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7626,
+      "tokenInput": 15381,
+      "tokenOutput": 226,
+      "tokenTotal": 15607,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:rule-scenario-level",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-scenario-level",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-poison",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here is what the Frosthaven Rulebook says about *Poison*:\n\n> **Poison:** All attacks targeting the figure gain \"+1 Attack.\" *Poison* is removed when the figure is healed but, unlike *Wound*/*Brittle*/*Bane*, poison prevents the heal from increasing the figure's current hit point value.\n\n*(Rulebook, chunk 100 — Negative Conditions)*\n\n**In summary:**\n- Any figure that attacks the *Poisoned* figure gets **+1 to their attack value**.\n- *Poison* is removed by a *Heal* effect — but that heal does **not** restore any hit points; it only removes the condition.\n- *Poison* has **no automatic expiry** (unlike conditions such as *Muddle* or *Stun* which wear off at end of turn) — it sticks around until a heal removes it.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 12486,
+      "tokenInput": 7852,
+      "tokenOutput": 286,
+      "tokenTotal": 8138,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:rule-poison",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-poison",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-poison",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Found it in the Frosthaven Rulebook's negative conditions section.\n\n## *Poison*\n\n> All attacks targeting the figure gain \"+1 *Attack*\". *Poison* is removed when the figure is healed but, unlike *wound*/*brittle*/*bane*, *poison* prevents the heal from increasing the figure's current hit point value.\n\nA few practical takeaways:\n- While *poisoned*, every attack against the figure deals 1 extra damage.\n- Healing removes *poison*, but that heal does **not** restore any hit points — it just clears the condition.\n- Like other conditions (except *bless* and *curse*), *poison* lasts until removed, and gaining it again while already *poisoned* simply resets the duration; you can't stack multiple instances.\n\nSource: Frosthaven Rulebook, Negative Conditions (chunk 101).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8605,
+      "tokenInput": 10574,
+      "tokenOutput": 386,
+      "tokenTotal": 10960,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:rule-poison",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Arule-poison",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-poison",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "In Frosthaven, *Poison* does two things:\n\n> “All attacks targeting the figure gain ‘+1 Attack.’ Poison is removed when the figure is healed but, unlike wound/brittle/bane, poison prevents the heal from increasing the figure’s current hit point value.”  \n> — Frosthaven Rulebook, Negative Conditions\n\nSo at the table:\n\n- While a figure has *Poison*, every attack against it gets **+1 Attack**.\n- A *Heal* removes *Poison*.\n- If the figure was poisoned, that heal **does not restore any hit points**; it only removes the poison.\n- One heal can remove *Poison* along with *Wound*, *Brittle*, and/or *Bane*, but if *Poison* is among them, the HP increase is still prevented.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 11240,
+      "tokenInput": 28600,
+      "tokenOutput": 356,
+      "tokenTotal": 28956,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:rule-poison",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-poison",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-brittle",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's what *Brittle* does, straight from the Frosthaven Rulebook:\n\n> **Brittle:** The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and *Brittle* is then removed. *Brittle* is also removed if the figure is healed.\n\n### Key Points:\n- **Doubles the next instance of damage** the affected figure takes, regardless of the source (attack, hazardous terrain, etc.).\n- **Removed immediately** after that doubled damage is applied — it's a one-time effect.\n- **Also removed by healing**, even if no damage has been taken yet, so healing can cleanse it before it triggers.\n- It is a **negative condition**, so it can be applied to both enemies and characters.\n\n*(Rulebook, Negative Conditions section)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7573,
+      "tokenInput": 8154,
+      "tokenOutput": 272,
+      "tokenTotal": 8426,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:rule-brittle",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-brittle",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-brittle",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "**Brittle** is a negative condition. Per the Frosthaven Rulebook:\n\n> Brittle: The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.\n\nA couple of useful interactions also called out in the rulebook's damage section:\n\n- Damage doubling from *Brittle* (and reduction from *Ward*) is applied **before** the figure decides how to handle the incoming damage — so any negation (active ability/effect or card loss) applies to the already-doubled amount.\n- Healing the figure removes *Brittle* without it ever triggering, so applying *Brittle* to an enemy right before a big hit (and keeping them from being healed) is the typical play.\n\nSource: Frosthaven Rulebook, Negative Conditions and Character Damage sections.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9049,
+      "tokenInput": 11000,
+      "tokenOutput": 388,
+      "tokenTotal": 11388,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:rule-brittle",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Arule-brittle",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-brittle",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "*Brittle* means:\n\n> “The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.”  \n> — Frosthaven Rulebook, *Negative Conditions*\n\nA few key points:\n- It applies to damage from **any source**, not just attacks.\n- For attacks, apply normal attack resolution first, including modifiers and *Shield*, then apply *Brittle*.\n- If the figure also has *Ward*, the two conditions cancel each other and both are removed.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10917,
+      "tokenInput": 29391,
+      "tokenOutput": 223,
+      "tokenTotal": 29614,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:rule-brittle",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-brittle",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-advantage",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here is the full breakdown of how *Advantage* works with attack modifier cards in Frosthaven, directly from the Rulebook (chunks 95–96):\n\n---\n\n## Advantage with Attack Modifier Cards\n\n### Basic Rule\n> With advantage, the attacker draws two modifiers and uses one of them. A monster always uses the better one, but a **character may use either one**.\n\n> With disadvantage, the attacker draws two modifiers and always uses the worse one.\n\n---\n\n### Rolling Modifiers Interact Specially\n\nIf the **first** card drawn (with advantage or disadvantage) is a *rolling modifier*, the rules change:\n\n> If the first draw with advantage or disadvantage is a rolling modifier, the attacker draws additional modifiers, one at a time, until a non-rolling modifier is drawn. They then draw one more modifier and ignore any rolling icon on it.\n\n- **With advantage:** Keep all initial *rolling modifiers* and then choose whichever of the last two non-rolling cards you prefer.\n- **With disadvantage:** Ignore all initial *rolling modifiers* and use whichever of the last two cards is **worse**.\n\n> If the first draw with advantage or disadvantage is **not** a rolling modifier, but the second draw **is**, the rolling icon on the second modifier is still ignored.\n\n---\n\n### Handling Ambiguity\n> When there is ambiguity about which modifier is worse, the attacker must use the one drawn first. Ambiguity occurs when comparing the non-numeric effects of some modifiers (e.g., elemental infusions or negative conditions). Any non-numeric effect is considered to have a positive but undefined value.\n\n---\n\n### Advantage + Disadvantage Cancel Out\n> An attack cannot gain multiple instances of advantage or disadvantage. If an attack has both advantage and disadvantage, it is considered to have neither.\n\n---\n\n### Automatic Disadvantage Case\n> Any ranged attack on an **adjacent** enemy automatically gains disadvantage.\n\n---\n\n### Quick Summary Table\n\n| Situation | Result |\n|---|---|\n| Advantage, no rolling cards | Draw 2, pick the better (or either, for characters) |\n| Disadvantage, no rolling cards | Draw 2, use the worse |\n| Advantage, first card is rolling | Keep rolling cards, draw until non-rolling, draw one more (ignore its rolling icon), pick the better of the last two |\n| Disadvantage, first card is rolling | Discard rolling cards, draw until non-rolling, draw one more (ignore its rolling icon), use the worse of the last two |\n| Both advantage AND disadvantage | Neither applies — draw normally |",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 16398,
+      "tokenInput": 8366,
+      "tokenOutput": 673,
+      "tokenTotal": 9039,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:rule-advantage",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-advantage",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-advantage",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here's how *advantage* works with attack modifier cards in Frosthaven:\n\n**Basic rule:** When an attack has *advantage*, the attacker draws **two** modifier cards and uses **one** of them.\n- A **monster** always uses the better one.\n- A **character** may choose either one.\n\nWith *disadvantage*, the attacker draws two and always uses the worse one.\n\n**Rolling modifiers complicate things.** If the first draw is a *rolling modifier*:\n1. Keep drawing one at a time until you get a non‑rolling modifier.\n2. Then draw **one more** modifier, ignoring any rolling icon on it.\n3. Compare the first non‑rolling modifier and the extra one drawn after it.\n   - With *advantage*: you apply **all** the initial rolling modifiers, plus whichever of the last two you choose.\n   - With *disadvantage*: you **ignore** all the initial rolling modifiers and use whichever of the last two is worse.\n\nIf the first draw is non‑rolling but the second draw is a rolling modifier, the rolling icon on that second card is still ignored.\n\n**Ambiguity:** When it's unclear which modifier is worse (e.g., comparing elemental infusions or negative conditions), the attacker must use the one drawn first. Any non‑numeric effect counts as a positive but undefined value.\n\n**Stacking:** An attack cannot gain multiple instances of *advantage* or *disadvantage*. If an attack has both, they cancel and it's treated as having neither.\n\nSource: Frosthaven Rulebook, \"Advantage and Disadvantage\" (p. 26, rulebook chunk 95–96).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 13059,
+      "tokenInput": 11223,
+      "tokenOutput": 652,
+      "tokenTotal": 11875,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:rule-advantage",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Arule-advantage",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-advantage",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "In Frosthaven, *advantage* changes how you draw and apply attack modifier cards:\n\n> “With advantage, the attacker draws two modifiers and uses one of them. A monster always uses the better one, but a character may use either one.”  \n> — Frosthaven Rulebook, *Advantage and Disadvantage*\n\nSo for a normal advantaged attack:\n\n- Draw 2 attack modifier cards.\n- If you are a **character**, choose either card.\n- If it is a **monster**, it uses the better card.\n\nFor *rolling modifiers*:\n\n> “If the first draw with advantage or disadvantage is a rolling modifier, the attacker draws additional modifiers, one at a time, until a non-rolling modifier is drawn. They then draw one more modifier and ignore any rolling icon on it.”  \n> — Frosthaven Rulebook, *Advantage and Disadvantage*\n\nWith *advantage*, that means:\n\n1. If the first card is *rolling*, keep drawing until you get a non-rolling card.\n2. Then draw one additional card.\n3. Use all the initial *rolling* modifiers.\n4. Then, for the final choice, a character chooses between the two non-rolling results; a monster uses the better one.\n5. If the second card is *rolling* but the first was not, ignore the rolling icon on the second card.\n\nAlso:\n\n- Multiple sources of *advantage* do not stack.\n- If an attack has both *advantage* and *disadvantage*, it has neither.\n- Each target of a multi-target attack gets its own separate modifier draw.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 15566,
+      "tokenInput": 27909,
+      "tokenOutput": 619,
+      "tokenTotal": 28528,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:rule-advantage",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-advantage",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-small-items",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "The rulebook's **Item Limits** section covers this directly. The number of *Small* (*I*) items a character can bring into a scenario is:\n\n> …a number of **I** items up to **half their level (rounded up)**.\n\nSo the limit scales with the character's level:\n\n| Character Level | Max Small (*I*) Items |\n|---|---|\n| 1 | 1 |\n| 2 | 1 |\n| 3 | 2 |\n| 4 | 2 |\n| 5 | 3 |\n| 6 | 3 |\n| 7 | 4 |\n| 8 | 4 |\n| 9 | 5 |\n\n*(Source: Frosthaven Rulebook, Item Limits section)*\n\nThis is in addition to the other item slots: one *Head* (E), one *Body* (B), one *Feet* (L), and up to two *One Hand* (H) **or** one *Two Hands* (h) item(s).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10417,
+      "tokenInput": 20470,
+      "tokenOutput": 475,
+      "tokenTotal": 20945,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:rule-small-items",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-small-items",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-small-items",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "A character can bring a number of *small* items (type **I**) into a scenario equal to **half their level, rounded up**.\n\nSo:\n- Level 1–2: 1 small item\n- Level 3–4: 2 small items\n- Level 5–6: 3 small items\n- Level 7–8: 4 small items\n- Level 9: 5 small items\n\n> \"Each character can bring one E item, one B item, one L item, up to two H items -or- one h item, and a number of I items up to half their level (rounded up).\"\n— *Frosthaven* Rulebook, Item Limits (p. 35), also reiterated in Appendix C: Important Reminders.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6753,
+      "tokenInput": 10667,
+      "tokenOutput": 318,
+      "tokenTotal": 10985,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:rule-small-items",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Arule-small-items",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-small-items",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "A character can bring **small items equal to half their level, rounded up** into a Frosthaven scenario.\n\nSo by level:\n\n- Levels 1–2: **1** small item\n- Levels 3–4: **2** small items\n- Levels 5–6: **3** small items\n- Levels 7–8: **4** small items\n- Level 9: **5** small items\n\nRulebook, Item Limits:  \n> “Each character can bring … a number of [small] items up to half their level (rounded up).”  \n— Frosthaven Rulebook, Item Limits, chunks 118–119",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 17452,
+      "tokenInput": 64762,
+      "tokenOutput": 477,
+      "tokenTotal": 65239,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:rule-small-items",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-small-items",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-looting-definition",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's a full breakdown of **looting** based on the Frosthaven Rulebook:\n\n---\n\n## The *Loot* Ability\n\n> \"*Loot X* is an ability that allows a figure to loot all loot tokens and treasure tiles within range X, including any in their current hex. This ability is unaffected by the presence of figures or overlay tiles. If there are no loot tokens or treasure tiles within the specified range, the ability cannot be performed.\"\n\n---\n\n## Looting Loot Tokens\n\nWhen a character uses a *Loot* ability on a **loot token**:\n- The token is **removed from the map**.\n- The character **draws one card from the loot deck** (unless it's empty).\n- If the loot card provides a **random item**, the character checks off the item slot in the scenario's loot table and draws from the random item deck, adding it to their item pool for the rest of the scenario.\n  - If the random item deck is empty, treat it as a money card with three coins.\n- If the loot card provides **money or resources**, the character does **not** gain them until the **end of the scenario**.\n\n**Monsters** that loot a token remove it from the map, but nothing else happens — they gain no rewards.\n\n---\n\n## Looting Treasure Tiles\n\nWhen a **treasure tile** is looted:\n- It is **removed from the map**.\n- **Monsters cannot loot treasure tiles** — only characters can.\n- If it's a **numbered treasure**, look it up in the Treasure Index and apply the effect.\n- The reward goes only to the looting character, **unless** it is a random item blueprint or random scenario (those are shared).\n- If a character gains an item they cannot keep for any reason, they must **give it to another character or sell it immediately**.\n\n---\n\n## Key Reminder\n\n> \"Monsters and summons do not perform end-of-turn looting.\"\n\n*(Rulebook, Appendix C)*\n\nThis implies characters **do** have some form of end-of-turn looting — though the exact trigger for that would need a separate rules lookup.",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 24780,
+      "tokenInput": 31491,
+      "tokenOutput": 844,
+      "tokenTotal": 32335,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:rule-looting-definition",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-looting-definition",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-looting-definition",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "# Looting\n\nLooting is how figures pick up loot tokens and treasure tiles from the map. The core rule comes from the Frosthaven rulebook:\n\n> \"*Loot X*\" is an ability that allows a figure to loot all loot tokens and treasure tiles within range X, including any in their current hex. This ability is unaffected by the presence of figures or overlay tiles. If there are no loot tokens or treasure tiles within the specified range, the ability cannot be performed.\n\n**Loot tokens.** When a loot token is looted, it is removed from the map.\n- If the looter is a **monster**, nothing else happens.\n- If the looter is a **character**, they draw one card from the loot deck (unless it's empty).\n  - If the loot card provides a **random item**, check off T (x1) on the scenario's loot table, draw from the random item deck, and add it to your pool. You may use it for the rest of the scenario even if it puts you above your item limit. If the random item deck is empty, the card counts as a money card worth 3 coins.\n  - If the loot card provides **money or resources**, you don't actually gain them until the end of the scenario.\n\n**Treasure tiles.** When a treasure tile is looted, it is removed from the map. **Monsters cannot loot treasure tiles.** If the tile is numbered, look it up in the Treasure Index and apply the effect. Only the looting character gains the reward, unless it's a random item blueprint or random scenario. If they can't gain a granted item, they must give it to another character or sell it immediately.\n\n**End-of-turn looting.** Per the rulebook's reminders appendix:\n\n> Monsters and summons do not perform end-of-turn looting.\n\nSo characters automatically perform a free *Loot* at the end of their turn (range covers their own hex), but monsters and summons don't.\n\nSources: Frosthaven Rulebook (Loot ability, p. ~32; Treasure Index reference, p. 78; Appendix C reminders).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 25113,
+      "tokenInput": 39260,
+      "tokenOutput": 1026,
+      "tokenTotal": 40286,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:rule-looting-definition",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Arule-looting-definition",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-looting-definition",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": false,
+      "answer": "",
+      "score": null,
+      "pass": false,
+      "latencyMs": 27214,
+      "tokenInput": 200196,
+      "tokenOutput": 693,
+      "tokenTotal": 200889,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 10,
+      "retryCount": 0,
+      "loopIterations": 10,
+      "failureClass": "loop_limit",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:rule-looting-definition",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-looting-definition",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "monster-vermling-scout",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here are the stats for a **normal Vermling Scout at level 1** in Frosthaven:\n\n| Stat | Value |\n|------|-------|\n| **HP** | 3 |\n| *Move* | 3 |\n| *Attack* | 1 |\n| **Immunities** | None |\n\nNo special attributes or immunities are listed for this monster at this level. (Source: Frosthaven Monster Stat Card — Vermling Scout, levels 0–3)",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8976,
+      "tokenInput": 8657,
+      "tokenOutput": 280,
+      "tokenTotal": 8937,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:monster-vermling-scout",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Amonster-vermling-scout",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "monster-vermling-scout",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "At level 1, a **normal Vermling Scout** has:\n\n- **HP:** 3\n- **Move:** 3\n- **Attack:** 1\n- **Immunities:** none\n\nNo special attributes are listed for the normal version at this level.\n\nSource: Card Index — Vermling Scout monster stats (levels 0–3).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6725,
+      "tokenInput": 11615,
+      "tokenOutput": 284,
+      "tokenTotal": 11899,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:monster-vermling-scout",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Amonster-vermling-scout",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "monster-vermling-scout",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "A **normal Vermling Scout** at **monster level 1** has:\n\n- **HP:** 3  \n- ***Move 3***  \n- ***Attack 1***  \n- **Immunities / notes:** none listed\n\nSource: GHS Card Data, *Vermling Scout* monster stats (`vermling-scout/0-3`).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 20360,
+      "tokenInput": 142697,
+      "tokenOutput": 615,
+      "tokenTotal": 143312,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 6,
+      "retryCount": 0,
+      "loopIterations": 7,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:monster-vermling-scout",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Amonster-vermling-scout",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "monster-living-bones-immunity",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "According to the Living Bones monster stat card data (levels 0–7), the **immunities list is empty** — Living Bones have **no condition immunities** in Frosthaven.\n\nThey can be affected by all standard conditions (*Poison*, *Wound*, *Muddle*, *Immobilize*, *Stun*, *Disarm*, *Brittle*, *Bane*, *Curse*, etc.). Their notable persistent bonuses at higher levels are *Shield 1* and *Target 2/3*, but no immunities.\n\n*(Source: GHS Card Index — Living Bones monster stat cards, levels 0–3 and 4–7)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 19061,
+      "tokenInput": 45247,
+      "tokenOutput": 825,
+      "tokenTotal": 46072,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 9,
+      "retryCount": 0,
+      "loopIterations": 8,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:monster-living-bones-immunity",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Amonster-living-bones-immunity",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "monster-living-bones-immunity",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "According to the Living Bones monster stat cards (both level 0–3 and 4–7), the **immunities** field is empty — Living Bones have **no condition immunities** at any level.\n\nFor reference, their special traits across levels are *Shield 1* (from level 1 onward) and *Target 2* / *Target 3* on their multi-target attacks, but those are traits, not immunities.\n\nSource: GHS Card Index, Living Bones monster-stat cards (levels 0–3 and 4–7).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9389,
+      "tokenInput": 12609,
+      "tokenOutput": 441,
+      "tokenTotal": 13050,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:monster-living-bones-immunity",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Amonster-living-bones-immunity",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "monster-living-bones-immunity",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Living Bones have **no condition immunities** in the checked Frosthaven monster stat data — the immunities field is empty for both level ranges 0–3 and 4–7.\n\nSource: Card Index, Living Bones monster stats.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 17765,
+      "tokenInput": 52143,
+      "tokenOutput": 551,
+      "tokenTotal": 52694,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 6,
+      "retryCount": 0,
+      "loopIterations": 7,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:monster-living-bones-immunity",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Amonster-living-bones-immunity",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "monster-flame-demon-elite",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here are the stats for an **elite Flame Demon at level 0** in Frosthaven:\n\n| Stat | Value |\n|------|-------|\n| **HP** | 3 |\n| **Move** | 3 |\n| **Attack** | 2 |\n| **Shield** | *Shield 3* |\n\nNo immunities are listed for the Flame Demon at this level.\n\n*(Source: GHS Card Data — Flame Demon monster stat card, levels 0–3)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6491,
+      "tokenInput": 8758,
+      "tokenOutput": 280,
+      "tokenTotal": 9038,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:monster-flame-demon-elite",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Amonster-flame-demon-elite",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "monster-flame-demon-elite",
+      "category": "monster-stats",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here are the **Elite Flame Demon (Level 0)** stats:\n\n- **HP:** 3\n- **Move:** 3\n- **Attack:** 2\n- **Special:** *Shield 3*\n- **Immunities:** none listed\n\nSource: Card Index — Flame Demon monster stats (level 0–3).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6588,
+      "tokenInput": 11800,
+      "tokenOutput": 310,
+      "tokenTotal": 12110,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:monster-flame-demon-elite",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Amonster-flame-demon-elite",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "monster-flame-demon-elite",
+      "category": "monster-stats",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Elite **Flame Demon**, level 0:\n\n- **HP:** 3\n- **Move:** 3\n- **Attack:** 2\n- **Special:** *Shield 3*\n- **Immunities:** none listed\n\nSource checked: Frosthaven monster stats record `gloomhavensecretariat:monster-stat/flame-demon/0-3`.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 13139,
+      "tokenInput": 71944,
+      "tokenOutput": 528,
+      "tokenTotal": 72472,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:monster-flame-demon-elite",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Amonster-flame-demon-elite",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "building-alchemist",
+      "category": "buildings",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "The **Alchemist** building (Building #35) at **Level 1** has **no build cost** — all resource and prosperity fields are 0:\n\n| Resource | Cost |\n|----------|------|\n| Gold | 0 |\n| Hide | 0 |\n| Metal | 0 |\n| Lumber | 0 |\n| Prosperity | 0 |\n\n**Note:** At Level 1, the Alchemist's effect is actually a restriction: *\"Characters cannot use potions.\"* You'll want to upgrade it to unlock its more useful functionality!\n\n*(Source: GHS Card Data — Alchemist, Building #35, Level 1)*",
+      "score": 0.4,
+      "pass": false,
+      "latencyMs": 9210,
+      "tokenInput": 7693,
+      "tokenOutput": 323,
+      "tokenTotal": 8016,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "quality",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:building-alchemist",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Abuilding-alchemist",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "building-alchemist",
+      "category": "buildings",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "At level 1, the **Alchemist** (building #35) has no build cost — all resource costs (gold, hide, metal, lumber) and prosperity are 0. At this level, however, the building is non-functional: \"Characters cannot use potions.\"\n\nIn other words, level 1 represents the ruined/unbuilt state. You'd typically need to look at the level 2 card to see the actual cost to construct/repair it into a working Alchemist.\n\nSource: GHS Card Index (Frosthaven buildings, #35 Alchemist L1).",
+      "score": 0.4,
+      "pass": false,
+      "latencyMs": 8925,
+      "tokenInput": 10425,
+      "tokenOutput": 363,
+      "tokenTotal": 10788,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "quality",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:building-alchemist",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Abuilding-alchemist",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "building-alchemist",
+      "category": "buildings",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "The **Alchemist** building, **level 1**, costs **nothing to build**:\n\n- 0 gold\n- 0 hide\n- 0 metal\n- 0 lumber\n- Prosperity requirement: 0\n\nSource: Card Index, `gloomhavensecretariat:building/35/L1`",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8875,
+      "tokenInput": 20458,
+      "tokenOutput": 159,
+      "tokenTotal": 20617,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:building-alchemist",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Abuilding-alchemist",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "item-spyglass",
+      "category": "items",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's the details on the **Spyglass**:\n\n- **Item Number:** 001\n- **Slot:** Head\n- **Effect:** During your attack ability, gain *Advantage* on one attack.\n- **Usage:** This is a *spent* (flip) item — meaning you flip it facedown when used, but it is **not** lost (so it can be refreshed during a rest).\n\nIt's a straightforward but powerful head item that lets you squeeze *Advantage* out of a single attack in your ability, great for ensuring an important hit or fishing for a high damage modifier card!",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 8714,
+      "tokenInput": 7191,
+      "tokenOutput": 298,
+      "tokenTotal": 7489,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:item-spyglass",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Aitem-spyglass",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "item-spyglass",
+      "category": "items",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "**Spyglass (Item 001)** — Head slot\n\n> During your attack ability, gain advantage on one attack.\n\nIt's a *Spent* item (flipped after use, refreshed between scenarios). The cost is not listed in the checked-in card data.\n\nSource: Card Index, gloomhavensecretariat:item/1.",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 6843,
+      "tokenInput": 9821,
+      "tokenOutput": 292,
+      "tokenTotal": 10113,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:item-spyglass",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Aitem-spyglass",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "item-spyglass",
+      "category": "items",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "The *Spyglass* is **item 001**.\n\nEffect: “During your attack ability, gain advantage on one attack.”\n\nIt is a **head-slot** item and is **spent** when used, not lost.  \nSource: Card Index, `gloomhavensecretariat:item/1`.",
+      "score": 0.6,
+      "pass": false,
+      "latencyMs": 9557,
+      "tokenInput": 20427,
+      "tokenOutput": 161,
+      "tokenTotal": 20588,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:item-spyglass",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Aitem-spyglass",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "item-crude-boots",
+      "category": "items",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's what **Crude Boots** (Item 005) does in Frosthaven:\n\n- **Slot:** Legs\n- **Effect:** During your *move* ability, add *+1 Move*.\n- **Usage:** This is a **spent** (not lost) item, meaning you flip it facedown after use and can recover it through rest or other recovery effects. It has no limited uses — you can use it once per scenario \"refresh cycle.\"\n\nIt's a straightforward boots item that gives your movement a small boost whenever you use a *move* ability.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7403,
+      "tokenInput": 7144,
+      "tokenOutput": 279,
+      "tokenTotal": 7423,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:item-crude-boots",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Aitem-crude-boots",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "item-crude-boots",
+      "category": "items",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "**Crude Boots** (Item 005, *Legs* slot):\n\n> During your move ability, add +1 Move\n\nUsage: **Spent** when activated (flip the card; it refreshes at the end of the scenario rather than being permanently lost).\n\nSource: Card Index, item 005.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6962,
+      "tokenInput": 9808,
+      "tokenOutput": 280,
+      "tokenTotal": 10088,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:item-crude-boots",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Aitem-crude-boots",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "item-crude-boots",
+      "category": "items",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "**Crude Boots** — item 005, legs slot:\n\nWhen spent: “During your move ability, add +1 *Move*.”\n\nIt is a spent item, not lost. Its cost is not available in the checked-in card data.  \nSource: Card Index, `gloomhavensecretariat:item/5`.",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 11098,
+      "tokenInput": 20381,
+      "tokenOutput": 151,
+      "tokenTotal": 20532,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:item-crude-boots",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Aitem-crude-boots",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "scenario-61-unlock",
+      "category": "scenarios",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here is the full text of **Section 79.4** (Section Book 62-81, p. 79), which is the section that unlocks Scenario 61 — *Life and Death*:\n\n---\n\n> A single row of metal shells—Unfettered brought back from your latest foray—lie arranged on the floor of Crain's room. Each one is damaged beyond repair, crushed or pierced, destroyed in battle or by the elements. He stands over them, scribbling in a book. An oil lamp on the floor casts his shadow against the far wall.\n>\n> \"Makes you wonder what else we've forgotten,\" he says. \"Metallurgical technique,\" he taps an Unfettered foot with his lead stylus. \"Automated mechanics,\" he taps a head. \"The Unfettered were built by Quatryl some time ago. But their construction, how their limbs are joined, the way they move—that's all been lost. Look here.\" Crain turns over one of the machine's breastplates and shines his light where it's been pierced.\n>\n> \"This metal is treated.\" He angles the metal and it shimmers like fish scales. \"That's why they're so strong; why they don't rust. Logren mentions it in her study. She said her team used this treatment when they worked on the symbol of power.\" This is the first you've heard of such a thing, and it sounds like something that will require another quest.\n>\n> \"The symbol of power is everything,\" Crain waxes. \"But it isn't an object at all. It's a symbol, a seal, and there's more than one of them. But they are created with an object.\" Crain leads you to his desk, where a drawing of a three-legged contraption is featured prominently.\n>\n> \"The symbols of power, the seals, are created with this device, but in order to build it, I still need a few things. The most pressing, I believe, is this.\" He pulls out Torfi's journal, turns a few pages, and taps on an illustration of a cuboid stone, a mineral of some sort. \"Star iron.\"\n>\n> Your eyebrow rises skeptically.\n>\n> \"I didn't name it—you can blame my ancestors for that. But I do have a way to detect it, so we won't be going in blind.\" He directs you to the far end of his bench where a small cage is sitting, all strung with cord and glass vials. You saw it when you first entered, but you'd taken it as garbage. \"This can detect the metal within a relatively small radius. It's nearly ready. And I know it sounds risky, I know what's in the Copperneck Mountains, but—\" Crain hesitates. His voice becomes low, serious. \"There isn't a way around it. This will be hard, very hard, but we need to do it.\"\n>\n> **Rewards — New Scenario: Life and Death 61**\n\n---\n\n**Summary:** Section 79.4 is a \"Puzzle Solution\" section in which Crain explains his research into the Unfettered, symbols of power, and his need for **star iron** found in the Copperneck Mountains. At the end, it rewards the party with the unlock of **Scenario 61: Life and Death**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 17332,
+      "tokenInput": 22887,
+      "tokenOutput": 1165,
+      "tokenTotal": 24052,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:scenario-61-unlock",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Ascenario-61-unlock",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "scenario-61-unlock",
+      "category": "scenarios",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "**Section 79.4** (\"Puzzle Solution\") unlocks scenario 61 — Life and Death. Here's the gist:\n\nCrain examines damaged Unfettered shells in his room and reflects on lost Quatryl metallurgy. He notes the treated metal matches Logren's notes on the *symbol of power* — which he reveals isn't a single object but a set of seals, created using a three-legged device he's trying to build. The first thing he needs for it is **star iron**, a mineral illustrated in Torfi's journal. He's nearly finished a small caged detector for it, and despite the dangers in the **Copperneck Mountains**, he insists:\n\n> \"There isn't a way around it. This will be hard, very hard, but we need to do it.\"\n\n**Rewards:** New Scenario: *Life and Death* (61).\n\nSource: Section Book 62-81, section 79.4.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 13028,
+      "tokenInput": 20178,
+      "tokenOutput": 626,
+      "tokenTotal": 20804,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:scenario-61-unlock",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Ascenario-61-unlock",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "scenario-61-unlock",
+      "category": "scenarios",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Scenario 61, **Life and Death**, is unlocked by **Section 79.4** in the **Frosthaven Section Book 62–81**.\n\nRelevant reward text:\n\n> Rewards  \n> New Scenario: Life and Death 61\n\nSection 79.4’s story text is a Crain scene about needing “star iron” from the Copperneck Mountains; its reward unlocks Scenario 61.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 12726,
+      "tokenInput": 42837,
+      "tokenOutput": 298,
+      "tokenTotal": 43135,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:scenario-61-unlock",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Ascenario-61-unlock",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-wound",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's what the Frosthaven Rulebook says about the *Wound* condition:\n\n---\n\n**Wound** is a **negative condition** with the following effect:\n\n> **Wound:** The figure suffers 1 damage at the start of each of their turns. *Wound* is removed when the figure is healed.\n\n*(Frosthaven Rulebook, p. 29)*\n\n---\n\n**Key points to remember:**\n\n- The 1 damage triggers **at the start of every turn** for the afflicted figure (hero or monster).\n- It is **not removed automatically** after one turn — it persists until the figure receives a *Heal* effect.\n- If a figure has both *Regenerate* and *Wound*, the *Regenerate* effect (Heal 1, self) is applied **first**, which removes *Wound* before it can deal its damage that turn.\n- *Wound* stacks in the sense that applying it again while already *wounded* has no additional effect, since a figure can only have one instance of a given condition at a time.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7987,
+      "tokenInput": 7765,
+      "tokenOutput": 326,
+      "tokenTotal": 8091,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:rule-wound",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-wound",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-wound",
+      "category": "rulebook",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "From the Frosthaven Rulebook (Negative Conditions section):\n\n> *Wound*: The figure suffers 1 damage at the start of each of their turns. Wound is removed when the figure is healed.\n\nA couple of useful related interactions from the rulebook:\n\n- If a figure has both *Regenerate* and *Wound*, the *Regenerate* effect is applied first, which heals the figure and removes *Wound* before it would deal its damage.\n\nSource: Frosthaven Rulebook, Negative Conditions (p. 29 area).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 6375,
+      "tokenInput": 10412,
+      "tokenOutput": 278,
+      "tokenTotal": 10690,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:rule-wound",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Arule-wound",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "rule-wound",
+      "category": "rulebook",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "*Wound* makes the figure suffer 1 damage at the start of each of their turns.\n\n> “Wound: The figure suffers 1 damage at the start of each of their turns. Wound is removed when the figure is healed.”  \n> — Frosthaven Rulebook, *Negative Conditions*\n\nA couple of related notes:\n- Any *Heal* effect removes *Wound*.\n- If a figure has both *Regenerate* and *Wound*, *Regenerate* applies first, so it removes *Wound* before the wound damage happens.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9902,
+      "tokenInput": 26706,
+      "tokenOutput": 220,
+      "tokenTotal": 26926,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:rule-wound",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-wound",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "tool-free-assistant-game",
+      "category": "tool-free",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "This assistant is for **Frosthaven**, the dungeon-crawling board game by Cephalofair Games.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 1528,
+      "tokenInput": 2108,
+      "tokenOutput": 30,
+      "tokenTotal": 2138,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 0,
+      "retryCount": 0,
+      "loopIterations": 1,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:tool-free-assistant-game",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atool-free-assistant-game",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "tool-free-assistant-game",
+      "category": "tool-free",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "This assistant is for Frosthaven (and related Gloomhaven-family games).",
+      "score": 0.8,
+      "pass": true,
+      "latencyMs": 1319,
+      "tokenInput": 2943,
+      "tokenOutput": 30,
+      "tokenTotal": 2973,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 0,
+      "retryCount": 0,
+      "loopIterations": 1,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:tool-free-assistant-game",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atool-free-assistant-game",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "tool-free-assistant-game",
+      "category": "tool-free",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "This assistant is for *Frosthaven*.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 2702,
+      "tokenInput": 6591,
+      "tokenOutput": 13,
+      "tokenTotal": 6604,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 0,
+      "retryCount": 0,
+      "loopIterations": 1,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:tool-free-assistant-game",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atool-free-assistant-game",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-source-discovery",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's a full breakdown of what I can inspect and work with for **Frosthaven**:\n\n---\n\n## 📚 Sources\n\n### 1. Frosthaven Rulebook\n- **Ref:** `source:frosthaven/rulebook`\n- **Contains:** Rules passages\n- **Searchable:** ✅ Yes\n- **Openable:** ❌ No (passages are surfaced via search, not direct open)\n\n---\n\n### 2. Scenario and Section Books\n- **Ref:** `source:frosthaven/scenario-section-books`\n- **Contains:** Scenarios & Sections\n- **Searchable:** ✅ Yes\n- **Openable:** ✅ Yes (by exact ref)\n- **Record counts:**\n  - 162 scenarios\n  - 731 sections\n  - 1,104 relations\n- **Traversable relations:** *conclusion*, *read_now*, *section_link*, *unlock*, *cross_reference*\n\n---\n\n### 3. GHS Card Data\n- **Ref:** `source:frosthaven/cards`\n- **Contains:** All card types and individual cards\n- **Searchable:** ✅ Yes\n- **Openable:** ✅ Yes (by exact ref)\n- **Record counts:**\n  - 136 monster stat cards\n  - 386 monster ability cards\n  - 504 character ability cards\n  - 17 character mats\n  - 264 items\n  - 266 events\n  - 60 battle goals\n  - 78 buildings\n  - 159 scenarios\n  - 23 personal quests\n\n---\n\n## Summary\nI can **search** all three sources and **directly open** records from the Scenario/Section Books and Card Data. The Rulebook is search-only. Ask me about any rules, scenarios, sections, cards, items, monsters, buildings, events, or personal quests and I'll look it up!",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8778,
+      "tokenInput": 4770,
+      "tokenOutput": 507,
+      "tokenTotal": 5277,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-source-discovery",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-source-discovery",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-source-discovery",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here's what I can access for Frosthaven:\n\n## Searchable & Openable Sources\n\n**📘 Frosthaven Rulebook** (`source:frosthaven/rulebook`)\n- Kinds: `rules_passage`\n- **Searchable**, but **not directly openable** — I find rules via search, not by opening exact refs.\n\n**📜 Scenario and Section Books** (`source:frosthaven/scenario-section-books`)\n- Kinds: `scenario` (162), `section` (731)\n- **Searchable and openable** by canonical ref (e.g., `scenario:frosthaven/61`, `section:frosthaven/90.2`)\n- Supports traversal relations: `conclusion`, `read_now`, `section_link`, `unlock`, `cross_reference` (1,104 relations total)\n\n**🃏 GHS Card Data** (`source:frosthaven/cards`)\n- Kinds: `card_type`, `card`\n- **Searchable and openable** by canonical ref (e.g., `card:frosthaven/items/...`)\n- Supports `belongs_to_type` relation\n- Record counts:\n  - Monster stats: 136\n  - Monster abilities: 386\n  - Character abilities: 504\n  - Character mats: 17\n  - Items: 264\n  - Events: 266\n  - Battle goals: 60\n  - Buildings: 78\n  - Scenarios: 159\n  - Personal quests: 23\n\n## Summary\n- **Open exactly:** scenarios, sections, and cards (any of the card types above).\n- **Search only:** rulebook passages — I can find and cite them, but there's no direct \"open by ref\" for rulebook chunks the way there is for scenarios and cards.\n\nLet me know what you'd like to look up and I'll dig in.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10001,
+      "tokenInput": 6533,
+      "tokenOutput": 641,
+      "tokenTotal": 7174,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-source-discovery",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-source-discovery",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-source-discovery",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "I can inspect these Frosthaven sources:\n\n| Source | Kinds | Searchable? | Open exact records? | Relations |\n|---|---:|---:|---:|---|\n| Frosthaven Rulebook | `rules_passage` | Yes | **No** | — |\n| Scenario and Section Books | `scenario`, `section` | Yes | **Yes** | `conclusion`, `read_now`, `section_link`, `unlock`, `cross_reference` |\n| GHS Card Data | `card_type`, `card` | Yes | **Yes** | `belongs_to_type` |\n\nExact-openable records include:\n\n- Scenarios, e.g. `scenario:frosthaven/001`\n- Sections, e.g. `section:frosthaven/90.2`\n- Cards, using canonical card refs such as character abilities, items, events, buildings, monsters, etc.\n\nAvailable card-data counts:\n\n- Monster stats: 136\n- Monster abilities: 386\n- Character abilities: 504\n- Character mats: 17\n- Items: 264\n- Events: 266\n- Battle goals: 60\n- Buildings: 78\n- Scenarios: 159\n- Personal quests: 23",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 4913,
+      "tokenInput": 13628,
+      "tokenOutput": 286,
+      "tokenTotal": 13914,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-source-discovery",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-source-discovery",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-scenario-conclusion-open",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here is **Section 67.1** — the conclusion of Scenario 61: *Life and Death* (Section Book 62–81, p. 67):\n\n---\n\n> **Conclusion**\n>\n> Your ears fill with the sound of your own breathing: heavy, stinging, rib-pulling breaths. Your legs are full of acid, ready to seize, but you push through the pain and exhaustion, struggling to keep up with Moonshard. The shadows are close behind, reaching, stretching out. They will not let you leave, and even now, they claw at the edges of your mind, yearning for your fear. But then, all at once, you pass into open air and the cave behind you fills with frustrated screams. The fear is gone. The pain. You are beyond the terror's reach now, safe.\n>\n> Outside the cave, it is late. Much time has passed since you entered the cave, and that sinks a lead ball in your gut. You realize just how lost you really were and that, had Moonshard not arrived when she did, you would not be alive.\n>\n> Moonshard begins walking towards what you see is a circle of cloaked figures in the distance, all gathered around a small fire. You follow, and a voice calls out…\n>\n> *(…the group meets Terra, an elderly Orchid, and her companions — the Shattersong, a lineage of Savvas uniquely attuned to the Harbinger's malice. Terra reveals that you and Crain play a crucial role in stopping the Harbinger from breaking through the seals that contain it deep within the earth.)*\n\n---\n\n**Rewards:**\n- Unlock class box.\n\n**Section Links:**\n- Add **section 140.3** to the calendar in **one week**.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 11682,
+      "tokenInput": 14668,
+      "tokenOutput": 663,
+      "tokenTotal": 15331,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-scenario-conclusion-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-scenario-conclusion-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-scenario-conclusion-open",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "The conclusion of **Scenario 61: Life and Death** directs you to read **Section 67.1** at the end of the round when all enemies are dead.\n\n> \"The scenario is complete when all enemies in it are dead. At the end of that round, read 67.1.\"\n\n— *Scenario Book 62-81*, Scenario 61\n\nLet me know if you'd like me to open Section 67.1 for the full text.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 7479,
+      "tokenInput": 11984,
+      "tokenOutput": 362,
+      "tokenTotal": 12346,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-scenario-conclusion-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-scenario-conclusion-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-scenario-conclusion-open",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "At the conclusion of **Scenario 61 — Life and Death**, read **Section 67.1**. *(Scenario Book 62–81, scenario 61; Section Book 62–81, section 67.1)*\n\n> Conclusion  \n> Your ears fill with the sound of your own breathing: heavy, stinging, rib-pulling breaths. Your legs are full of acid, ready to seize, but you push through the pain and exhaustion, struggling to keep up with Moonshard. The shadows are close behind, reaching, stretching out. They will not let you leave, and even now, they claw at the edges of your mind, yearning for your fear. But then, all at once, you pass into open air and the cave behind you fills with frustrated screams. The fear is gone.  \n> The pain. You are beyond the terror’s reach now, safe.  \n>  \n> Outside the cave, it is late. Much time has passed since you entered the cave, and that sinks a lead ball in your gut. You realize just how lost you really were and that, had Moonshard not arrived when she did, you would not be alive.  \n>  \n> Moonshard begins walking towards what you see is a circle of cloaked figures in the distance, all gathered around a small fire.  \n> You follow, and a voice calls out.  \n>  \n> “How did you find them?” A female voice asks, anxious for news.  \n>  \n> “Just like I said I would,” Moonshard answers.  \n>  \n> “In danger then.”  \n>  \n> “I believe my words were, ‘about to get themselves flayed.’”  \n>  \n> You move close to the fire and Crain hurries to one side, eager to warm his hands. His face is gaunt, skin paled. You have no idea what the Quatryl saw down there in the dark, but you hope it was not too much.  \n>  \n> Looking over the fire, you can make out Moonshard’s companion—a smaller Orchid—and you see that both her and Moonshard are quite old. The smaller one sits on a traveling stool and inspects you with easy purple eyes. Behind her are half a dozen other figures, each roughly the size of a human, and each hidden beneath heavy, wool robes.  \n>  \n> “I am thankful for your service, as always, my friend,” the new Orchid says to Moonshard. And then to you: “We have waited very long to meet you. My name is Terra.”  \n>  \n> “Well, ah, thank you,” he says. He rubs his swollen jaw, trying to hide his suspicion. “But how is it you knew we would be here? Even I didn’t know where exactly we were going this morning.”  \n>  \n> “Because,” Terra explains, “I have seen this moment in my meditations for the last two hundred years.” Crain’s eyes widen.  \n>  \n> “We have been planning for a long time,” Terra explains. “All in preparation for the days that are now upon us—for the emergence of the Harbinger.”  \n>  \n> At the mention of this name, the cloaked figures all rotate their heads to the east. One of them adjusts its hood, a long, bone-white hand emerging briefly and then disappearing back into its sleeve.  \n>  \n> “Our friends here are part of our preparations,” Terra says. She gestures to one of the figures and it comes forward. “They are the Shattersong.”  \n>  \n> The figure lowers its hood and reveals itself to be a Savvas of a unique and rather incredible form. Unlike other Savvas, whose bodies take on a variety of ochre or brown or slate, this one is made entirely of quartz that glimmers with the reds and yellows rising from the campfire. It would be beautiful were it not for its black eyes that stare at you with cold disregard.  \n>  \n> “We have been helping them,” Terra says and rises to her feet. Her movements are slow, pained. It must have cost her a great deal to come here. “We have been fortifying this line of Savvas for generations now, providing them with only the purest of energy and sustenance and, because of that, the Shattersong are a lineage uniquely tuned to the thoughts and intentions of the Harbinger. Of malice and spite.”  \n>  \n> Terra shuffles around the fire, moving a little easier now. “But you.” She raises her eyes, sharp beneath her arched brow. “You play a crucial role here as well. The Harbinger means to invade everything around us, to break through the seals that contain it.” She nods to Crain. “But with your ingenuity,” then to you, “And with your might and courage, we have a slim chance of stopping it.  \n>  \n> “It’s the best we can manage. The force we are trying to stop is far greater than any that exists on this plane. It is something of a miracle the Harbinger was ever bound at all, but there it sleeps, deep within the earth. In its dreams, it corrupts and plots its escape. Through its machinations, the seals grow weak.”  \n>  \n> Crain jumps up excitedly. “Yes, the seals! This is what I’ve been trying to tell them all along. Logren wanted to strengthen the seals, but we require a device made of star iron!”  \n>  \n> Moonshard groans loudly. “Star iron is a myth used to lure gullible adventurers to their deaths. Don’t worry, we’ll get you the materials you need.”\n\n**Rewards:** Unlock class box.  \n**Section Link:** Add section **140.3** to the calendar in one week.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 19935,
+      "tokenInput": 43363,
+      "tokenOutput": 1386,
+      "tokenTotal": 44749,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-scenario-conclusion-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-scenario-conclusion-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-section-read-now-chain",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's the full two-hop chain:\n\n1. **Section 103.1** → *(read-now when the third episode is overcome)* → **Section 11.5**\n2. **Section 11.5** → *(read-now the next time any character enters)* → **Section 155.1**\n\nAfter following the next two read-now links from Section 103.1, you end up at **Section 155.1** (from Section Book 142–161).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9918,
+      "tokenInput": 10807,
+      "tokenOutput": 407,
+      "tokenTotal": 11214,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-section-read-now-chain",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-section-read-now-chain",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-section-read-now-chain",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Following the two read-now links from section 103.1:\n\n1. **103.1 → 11.5** — When the third episode is overcome (all revealed enemies dead), read *Section 11.5* (\"My Private Empire\", Section Book 2–21).\n2. **11.5 → 155.1** — \"The next time any character enters, read 155.1\" — landing you at **Section 155.1** (Section Book 142–161).\n\nSo after following both read-now links, you end up at **Section 155.1**. Note that the second link is conditional — it triggers the next time any character enters, not immediately upon reading 11.5.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8039,
+      "tokenInput": 10938,
+      "tokenOutput": 411,
+      "tokenTotal": 11349,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-section-read-now-chain",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-section-read-now-chain",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-section-read-now-chain",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Starting at **Section 103.1**:\n\n1. **103.1 → 11.5**  \n   Link: “When the third episode is overcome, read 11.5.”  \n   Source: Section Book 102–121, section 103.1\n\n2. **11.5 → 155.1**  \n   Link: “The next time any character enters read 155.1.”  \n   Source: Section Book 2–21, section 11.5\n\nYou end up at **Section 155.1** in the Section Book 142–161.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 21212,
+      "tokenInput": 53930,
+      "tokenOutput": 415,
+      "tokenTotal": 54345,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 6,
+      "retryCount": 0,
+      "loopIterations": 7,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-section-read-now-chain",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-section-read-now-chain",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-exact-item-open",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's the info on **Item 001 – Spyglass**:\n\n- **Slot:** Head\n- **Effect:** During your attack ability, gain *Advantage* on one attack.\n- **Usage:** *Spent* (flip to its spent side after use; it is **not** lost)\n- **Cost:** Not listed in the current data\n\nThe source ID used to open it was **`gloomhavensecretariat:item/1`**, from the Card Index (`source:frosthaven/cards/items`).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9187,
+      "tokenInput": 8093,
+      "tokenOutput": 312,
+      "tokenTotal": 8405,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-exact-item-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-exact-item-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-exact-item-open",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Item 001 is the **Spyglass** (head slot):\n\n> During your attack ability, gain advantage on one attack.\n\nIt is *Spent* on use (not *Lost*).\n\nI opened it using the canonical ref `card:frosthaven/items/gloomhavensecretariat:item/1` (sourceId `gloomhavensecretariat:item/1`). Source: Card Index.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8931,
+      "tokenInput": 10942,
+      "tokenOutput": 363,
+      "tokenTotal": 11305,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-exact-item-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-exact-item-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-exact-item-open",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Item 001 is **Spyglass**. It’s a head-slot item that is **spent** when used:\n\n> During your attack ability, gain advantage on one attack.\n\nSource ID used to open it: `gloomhavensecretariat:item/1`  \nCitation: Card Index, `gloomhavensecretariat:item/1`.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 13533,
+      "tokenInput": 37184,
+      "tokenOutput": 579,
+      "tokenTotal": 37763,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-exact-item-open",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-exact-item-open",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-rule-brittle-citation",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here are the rules for *Brittle*, quoted directly from the **Frosthaven Rulebook** (chunk 99, Negative Conditions section):\n\n> **Brittle:** The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.\n\n**Source:** Frosthaven Rulebook — Negative Conditions section (chunk 99)\n\n---\n\n**Key points to remember:**\n\n- *Brittle* doubles the **next instance of damage** from **any source** (attacks, hazardous terrain, self-inflicted damage, etc.).\n- It is removed **immediately after** that damage is applied.\n- It is also removed if the figure is **healed** (even for 0 HP, since healing triggers removal).\n- As with all conditions, it cannot be removed voluntarily, and if a figure gains *Brittle* while already *Brittle*, the effect simply resets (no stacking of the doubling effect).\n- Note that *Brittle* is applied **before** the damage is dealt — so *Ward* (which halves damage) and *Brittle* (which doubles it) would cancel each other out if both are in effect simultaneously (Rulebook chunk 125 confirms both are applied to incoming damage).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10219,
+      "tokenInput": 8008,
+      "tokenOutput": 387,
+      "tokenTotal": 8395,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-rule-brittle-citation",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-rule-brittle-citation",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-rule-brittle-citation",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here are the rules for *Brittle*, from the Frosthaven Rulebook's Negative Conditions list:\n\n> **Brittle:** The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.\n\nA couple of related interactions worth knowing, also from the Rulebook:\n\n- **Damage order:** When a character would suffer damage, *Brittle* (and *Ward*) is applied **before** the damage hits — \"When a character would suffer any amount of damage (after ward or brittle is applied), they must either reduce their red hit point dial by that amount or negate the damage.\"\n- **General condition rules:** A figure can't have multiple instances of the same condition, but reapplying *Brittle* resets its duration. Conditions can't be removed voluntarily, and if an attack inflicts *Brittle* as an added effect, the target gains it even if the attack dealt no damage — unless the attack killed/exhausted them or they're immune.\n\nSources: Frosthaven Rulebook, Negative Conditions section (chunk 99) and Character Damage section (chunk 125).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 11618,
+      "tokenInput": 10846,
+      "tokenOutput": 488,
+      "tokenTotal": 11334,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 1,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-rule-brittle-citation",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-rule-brittle-citation",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-rule-brittle-citation",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "*Brittle* is a negative condition.\n\n> “Brittle: The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.”  \n> — *Frosthaven* Rulebook, Negative Conditions, chunk 99\n\nKey implications from the cited rules:\n\n- It applies to the next damage from **any source**, not just attacks.\n- Double the damage amount, then remove *Brittle*.\n- Healing also removes *Brittle*.\n- If a figure has both *Ward* and *Brittle* when it suffers damage, they cancel each other and both are removed.  \n  — Rulebook, Positive Conditions / *Ward*, chunk 98\n- For attacks, *Brittle* is applied after attack bonuses/penalties, attack modifier card, and *Shield*.  \n  — Rulebook, Attack Modification Order, chunk 89\n- For characters, damage negation happens after *Ward*/*Brittle* is applied.  \n  — Rulebook, Character Damage, chunk 125",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 17943,
+      "tokenInput": 66968,
+      "tokenOutput": 594,
+      "tokenTotal": 67562,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 5,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-rule-brittle-citation",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-rule-brittle-citation",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-ambiguous-algox-archer",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here are the full **Algox Archer** monster stat records, sourced from the GHS Card Index:\n\n---\n\n## 🏹 Algox Archer — Monster Stats\n\n### Levels 0–3\n\n| Level | Type | HP | *Move* | *Attack* |\n|-------|------|----|--------|----------|\n| 0 | Normal | 4 | 1 | 3 |\n| 0 | **Elite** | 6 | 2 | 4 |\n| 1 | Normal | 5 | 2 | 3 |\n| 1 | **Elite** | 8 | 2 | 4 |\n| 2 | Normal | 7 | 2 | 3 |\n| 2 | **Elite** | 11 | 2 | 4 |\n| 3 | Normal | 7 | 2 | 4 |\n| 3 | **Elite** | 12 | 2 | 5 |\n\n---\n\n### Levels 4–7\n\n| Level | Type | HP | *Move* | *Attack* |\n|-------|------|----|--------|----------|\n| 4 | Normal | 10 | 2 | 4 |\n| 4 | **Elite** | 16 | 2 | 5 |\n| 5 | Normal | 13 | 2 | 4 |\n| 5 | **Elite** | 18 | 2 | 6 |\n| 6 | Normal | 19 | 2 | 4 |\n| 6 | **Elite** | 28 | 2 | 6 |\n| 7 | Normal | 22 | 2 | 5 |\n| 7 | **Elite** | 33 | 2 | 7 |\n\n---\n\n**Key notes:**\n- **No immunities** listed for the Algox Archer.\n- The Algox Archer has a notably **high *Attack*** for a ranged monster, trading off with a low *Move* of 1–2 throughout all levels.\n- Elite versions have significantly more HP and *Attack* than normal counterparts, especially at higher levels (e.g., Level 7 Elite: 33 HP, *Attack 7*).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 11825,
+      "tokenInput": 10438,
+      "tokenOutput": 837,
+      "tokenTotal": 11275,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-ambiguous-algox-archer",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-ambiguous-algox-archer",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-ambiguous-algox-archer",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here are the **Algox Archer** monster stat records. The data is split across two records by level range. No immunities or special notes are listed.\n\n## Algox Archer — Levels 0–3\n\n| Level | Normal HP / Move / Atk | Elite HP / Move / Atk |\n|---|---|---|\n| 0 | 4 / 1 / 3 | 6 / 2 / 4 |\n| 1 | 5 / 2 / 3 | 8 / 2 / 4 |\n| 2 | 7 / 2 / 3 | 11 / 2 / 4 |\n| 3 | 7 / 2 / 4 | 12 / 2 / 5 |\n\n## Algox Archer — Levels 4–7\n\n| Level | Normal HP / Move / Atk | Elite HP / Move / Atk |\n|---|---|---|\n| 4 | 10 / 2 / 4 | 16 / 2 / 5 |\n| 5 | 13 / 2 / 4 | 18 / 2 / 6 |\n| 6 | 19 / 2 / 4 | 28 / 2 / 6 |\n| 7 | 22 / 2 / 5 | 33 / 2 / 7 |\n\n- **Immunities:** none listed\n- **Notes:** none\n\nSource: Card Index — `gloomhavensecretariat:monster-stat/algox-archer/0-3` and `/4-7`.\n\nThe resolver also surfaced a few **Archer** ability deck cards (*Calculated Strike*, *Close In*, *Hasty Assault*, *Nothing Special*) if you want me to open the full ability deck next.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 11795,
+      "tokenInput": 12464,
+      "tokenOutput": 886,
+      "tokenTotal": 13350,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-ambiguous-algox-archer",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-ambiguous-algox-archer",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-ambiguous-algox-archer",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Found Algox Archer monster stat records:\n\n1. Algox Archer — levels 0–3  \n   `card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/0-3`\n2. Algox Archer — levels 4–7  \n   `card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/4-7`\n\nOpened best match: **Algox Archer, levels 0–3**.  \nSource: Card Index — `gloomhavensecretariat:monster-stat/algox-archer/0-3`\n\n| Level | Normal | Elite |\n|---|---|---|\n| 0 | HP 4, *Move 1*, *Attack 3* | HP 6, *Move 2*, *Attack 4* |\n| 1 | HP 5, *Move 2*, *Attack 3* | HP 8, *Move 2*, *Attack 4* |\n| 2 | HP 7, *Move 2*, *Attack 3* | HP 11, *Move 2*, *Attack 4* |\n| 3 | HP 7, *Move 2*, *Attack 4* | HP 12, *Move 2*, *Attack 5* |\n\nImmunities: none listed.  \nNotes: not available in the checked-in data.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 10312,
+      "tokenInput": 21033,
+      "tokenOutput": 496,
+      "tokenTotal": 21529,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-ambiguous-algox-archer",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-ambiguous-algox-archer",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-scenario-neighbors",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here are all the scenarios and sections directly related to **Scenario 61 – Life and Death**:\n\n---\n\n### 🏁 Conclusion\n- **Section 67.1** — Read at the end of the round when all enemies are dead (the scenario's completion trigger).\n\n---\n\n### 🔗 Section Links (triggered during the scenario)\n- **Section 105.1** — Read when **door 1 is opened**.\n- **Section 67.1** — Also listed as a section link (doubles as the conclusion read).\n- **Section 82.2** — Linked during the scenario.\n- **Section 97.3** — Linked during the scenario.\n\n---\n\n### 🔓 Unlock\n- **Section 79.4** — Unlocked by completing this scenario.\n\n---\n\n**Summary:** Scenario 61 references sections **67.1**, **105.1**, **82.2**, and **97.3** during play, concludes by reading **67.1**, and unlocks **79.4** upon completion. Would you like me to open any of these sections for their full text?",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9704,
+      "tokenInput": 9128,
+      "tokenOutput": 408,
+      "tokenTotal": 9536,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-scenario-neighbors",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-scenario-neighbors",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-scenario-neighbors",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "**Scenario 61: Life and Death** has the following directly related records (from *Scenario Book 62-81*):\n\n**Conclusion**\n- **Section 67.1** — read at end of round when all enemies are dead\n\n**Section links** (referenced from the scenario)\n- **Section 105.1** — read when door 1 is opened\n- **Section 67.1** — conclusion link\n- **Section 82.2**\n- **Section 97.3**\n\n**Unlock**\n- **Section 79.4**\n\nLet me know if you'd like the text of any of these sections opened.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 9343,
+      "tokenInput": 12450,
+      "tokenOutput": 384,
+      "tokenTotal": 12834,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-scenario-neighbors",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-scenario-neighbors",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-scenario-neighbors",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Scenario 61 is **Life and Death** (*Scenario Book 62–81*). The directly related records returned are all **sections**; no directly related scenarios were returned.\n\n- **Conclusion:** Section **67.1** — *Section Book 62–81*\n- **Door/section link:** Section **105.1** — *Section Book 102–121*\n- **Section link:** Section **82.2** — *Section Book 82–101*\n- **Section link:** Section **97.3** — *Section Book 82–101*\n- **Unlock-related section:** Section **79.4** — *Section Book 62–81*\n\nNote: Section **67.1** appears both as the scenario’s conclusion and as a section link in the relationship data.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 12412,
+      "tokenInput": 22130,
+      "tokenOutput": 532,
+      "tokenTotal": 22662,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-scenario-neighbors",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-scenario-neighbors",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-section-unlocks-scenario",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "The traversal is complete! Section 66.2 unlocks:\n\n- **Scenario 116 – Caravan Guards** (`scenario:frosthaven/116`)\n\nThe section, titled *\"The Pass is Ready,\"* tells the story of Pinter Droman completing a shortcut through the Frozen Pass, and its reward is unlocking Scenario 116 so you can escort the first caravan through Droman's Path.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7750,
+      "tokenInput": 7656,
+      "tokenOutput": 272,
+      "tokenTotal": 7928,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-section-unlocks-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-section-unlocks-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-section-unlocks-scenario",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Section 66.2 (\"The Pass is Ready\") unlocks **Scenario 116: Caravan Guards**.\n\n- Canonical ref: `scenario:frosthaven/116`\n- Source: Section Book 62–81 (rewards: \"New Scenario: Caravan Guards\")",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7411,
+      "tokenInput": 10546,
+      "tokenOutput": 314,
+      "tokenTotal": 10860,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-section-unlocks-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-section-unlocks-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-section-unlocks-scenario",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Section 66.2 unlocks:\n\n**scenario:frosthaven/116** — **Caravan Guards**\n\nCitation: Section Book 62–81, section 66.2.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 8925,
+      "tokenInput": 28976,
+      "tokenOutput": 162,
+      "tokenTotal": 29138,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-section-unlocks-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-section-unlocks-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-scenario-conclusion-next-links",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here is the full picture for **Scenario 61 – \"Life and Death\"**:\n\n---\n\n## Conclusion: Section 67.1 *(Section Book 62–81, p. 67)*\n\nThe party escapes the cave with Moonshard's help and emerges into the night, where they meet a circle of cloaked figures gathered around a fire. There they are introduced to **Terra**, an ancient Orchid who reveals she has foreseen this meeting for two hundred years. Terra explains the threat of **the Harbinger** — a vast evil sleeping deep in the earth whose dreams corrupt the seals that bind it. She introduces the **Shattersong**, a lineage of Savvas uniquely attuned to the Harbinger's malice, who have been part of her long preparations. Crain excitedly connects this to his search for star iron, while Moonshard dismisses the notion.\n\n---\n\n## Rewards & Forward Links\n\n| Type | Detail |\n|---|---|\n| **Reward** | Unlock class box |\n| **Section Link** | Add **Section 140.3** to the calendar in **one week** |\n\n**Summary:** Section 67.1 does **not** directly unlock a new scenario. Instead, it instructs you to schedule **Section 140.3** on the campaign calendar one week out — that section will trigger whatever comes next in this story thread. There are no other unlocks or \"read now\" links from this conclusion.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 15365,
+      "tokenInput": 16456,
+      "tokenOutput": 668,
+      "tokenTotal": 17124,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-scenario-conclusion-next-links",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-scenario-conclusion-next-links",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-scenario-conclusion-next-links",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "## Scenario 61 — *Life and Death* — Conclusion\n\nThe conclusion section is **Section 67.1** (Scenario Book 62–81).\n\n### What it unlocks / points to next\n\n**Rewards:**\n- Unlock a class box (the specific class is not named in the section text — only \"Unlock class box\" is printed).\n\n**Section Links:**\n- > \"Add section 140.3 to the calendar in one week.\"\n\nThe neighbors traversal from 67.1 only returns a back-reference to scenario 61 itself (no forward scenario unlock link in the structured data); the only forward pointer in the conclusion text is the calendar entry for **section 140.3** in one week.\n\nSource: Section Book 62–81, Section 67.1.",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 13310,
+      "tokenInput": 20042,
+      "tokenOutput": 586,
+      "tokenTotal": 20628,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-scenario-conclusion-next-links",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-scenario-conclusion-next-links",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-scenario-conclusion-next-links",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "Scenario 61 (*Life and Death*) concludes by reading **section 67.1**. The scenario goal text says to read 67.1 at the end of the round when all enemies are dead. *(Scenario Book 62–81, scenario 61)*\n\nOpened conclusion **section 67.1**. Its actionable outcomes are:\n\n- **Scenarios unlocked:** None listed.\n- **Sections pointed to next:** **Section 140.3 — “The Work Continues”**  \n  - Instruction: “Add section 140.3 to the calendar in one week.”\n- **Other unlock/reward:** “Unlock class box.” *(Not a scenario or section.)*\n\nCitations: *(Section Book 62–81, section 67.1; Section Book 122–141, section 140.3)*",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 24384,
+      "tokenInput": 83299,
+      "tokenOutput": 844,
+      "tokenTotal": 84143,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 7,
+      "retryCount": 0,
+      "loopIterations": 8,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-scenario-conclusion-next-links",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-scenario-conclusion-next-links",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-rule-during-scenario",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Scenario 61 has no *Brittle*-specific special rules. Here is the full answer:\n\n---\n\n## *Brittle* — Rules Summary\n\n*Brittle* is a **negative condition**. The full rule from the Frosthaven Rulebook reads:\n\n> **Brittle:** The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and *Brittle* is then removed. *Brittle* is also removed if the figure is healed.\n\n*(Rulebook, chunk 99 — Negative Conditions)*\n\n### Key points at a glance\n\n| Situation | Result |\n|---|---|\n| Next damage taken (any source) | Doubled, then *Brittle* removed |\n| Figure is healed | *Brittle* removed immediately (no doubled damage) |\n| Multiple instances | Cannot stack; gaining it again only resets duration |\n| Attack deals 0 damage | *Brittle* is **not** triggered (no damage occurred) |\n| Immunity | An immune figure does not gain *Brittle* at all |\n\nThe Rulebook also notes that when a character suffers damage, *Ward* and *Brittle* are applied **before** the character decides whether to negate the damage (Rulebook, chunk 125). So doubling happens first, then the player chooses to take it or negate it with a card loss.\n\n---\n\n## Were the Scenario/Section Books Needed?\n\n**No.** Scenario 61, *Life and Death* (Scenario Book 62–81), has **no special rules involving *Brittle***. Its special rules concern the escort ally Moonshard, initiative-50 attacks, and section link 105.1 — none of which interact with *Brittle*. The question was answered entirely from the **Rulebook**; the scenario and section books were consulted to confirm there were no scenario-specific modifications, but they were not the source of the answer.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 16341,
+      "tokenInput": 16452,
+      "tokenOutput": 726,
+      "tokenTotal": 17178,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-rule-during-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-rule-during-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-rule-during-scenario",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "**Brittle rule:**\n\n> Brittle: The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.\n\nDamage order also matters: per the *Character Damage* rules, doubling from *Brittle* is applied **before** the player decides to negate damage (via an active ability/effect or by losing cards):\n\n> When a character would suffer any amount of damage (after ward or brittle is applied), they must either reduce their red hit point dial by that amount or negate the damage.\n\nSo at scenario 61, when a *Brittle* figure is hit, double the incoming damage first, then the target chooses how to handle the (doubled) total. *Brittle* is removed whether the damage is taken, negated, or the figure is healed.\n\nSources: Frosthaven Rulebook (conditions list, chunk 99–100; *Character Damage*, chunk 125–126).\n\n**Scenario/section books needed?** No — *Brittle* is a core rulebook condition, so you only need the **Rulebook**. The Scenario Book 62-81 (which contains scenario 61, *Life and Death*) and the Section Book aren't required to adjudicate it, unless that scenario's special rules introduce something specific (which the *Brittle* condition itself does not).",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 13744,
+      "tokenInput": 11399,
+      "tokenOutput": 651,
+      "tokenTotal": 12050,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-rule-during-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-rule-during-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-rule-during-scenario",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "*Brittle* is handled the same in scenario 61 as anywhere else:\n\n> “Brittle: The next time the figure would suffer damage from any source, they instead suffer double that amount of damage, and brittle is then removed. Brittle is also removed if the figure is healed.”  \n> — Frosthaven Rulebook, Negative Conditions\n\nSo: the next damage that figure would take is doubled, then *Brittle* goes away. If the figure is healed before that happens, *Brittle* is removed instead.\n\nThe scenario/section books were **not needed** to answer the rule question; this is a general condition rule from the Rulebook.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 29463,
+      "tokenInput": 67993,
+      "tokenOutput": 1279,
+      "tokenTotal": 69272,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 5,
+      "retryCount": 0,
+      "loopIterations": 6,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-rule-during-scenario",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-rule-during-scenario",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-card-fuzzy-vs-exact",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here is a full breakdown of everything found, with a clear distinction between **exact data records** and **fuzzy/contextual matches**.\n\n---\n\n## 🎯 Exact Data Records\n\n### Monster Stat Cards (GHS Card Data / Card Index)\n\nThese are the direct Algox Archer stat records — two cards covering levels 0–7 split across two physical stat cards.\n\n**Levels 0–3** (`card:frosthaven/monster-stats/…/algox-archer/0-3`)\n\n| Level | Type   | HP | Move | Attack |\n|-------|--------|----|------|--------|\n| 0     | Normal | 4  | 1    | 3      |\n| 0     | Elite  | 6  | 2    | 4      |\n| 1     | Normal | 5  | 2    | 3      |\n| 1     | Elite  | 8  | 2    | 4      |\n| 2     | Normal | 7  | 2    | 3      |\n| 2     | Elite  | 11 | 2    | 4      |\n| 3     | Normal | 7  | 2    | 4      |\n| 3     | Elite  | 12 | 2    | 5      |\n\n**Levels 4–7** (`card:frosthaven/monster-stats/…/algox-archer/4-7`)\n\n| Level | Type   | HP | Move | Attack |\n|-------|--------|----|------|--------|\n| 4     | Normal | 10 | 2    | 4      |\n| 4     | Elite  | 16 | 2    | 5      |\n| 5     | Normal | 13 | 2    | 4      |\n| 5     | Elite  | 18 | 2    | 6      |\n| 6     | Normal | 19 | 2    | 4      |\n| 6     | Elite  | 28 | 2    | 6      |\n| 7     | Normal | 22 | 2    | 5      |\n| 7     | Elite  | 33 | 2    | 7      |\n\n- **Immunities:** None listed\n- **Notes:** None\n\n---\n\n### Monster Ability Cards (Archer deck — exact records, GHS Card Data)\n\nThese four ability cards are exact `monsterType: Archer` records, meaning they belong directly to the Algox Archer's ability deck:\n\n| Card Name | Initiative | Abilities |\n|---|---|---|\n| **Hasty Assault** | 16 | *Move 1*, *Attack 1*, *Range 4* |\n| **Close In** | 32 | *Move 0*, *Attack 1*, *Range 3* |\n| **Nothing Special** | 31 | *Move 0*, *Attack 0*, *Range 4* |\n| **Calculated Strike** | 44 | *Move 1*, *Attack 1*, *Range 4* |\n\n> These ability cards add their bonuses **on top of** the base Move/Attack values from the stat card. For example, \"Calculated Strike\" at level 4 Normal would yield *Move 3* (2+1) and *Attack 5* (4+1) at *Range 4*.\n\n---\n\n## 🔍 Fuzzy / Contextual Matches\n\nThese records **mention** the Algox Archer but are not stat or ability cards for the monster itself. They were returned via text-search similarity:\n\n| Record | Type | How It Mentions Algox Archer |\n|---|---|---|\n| **Winter Outpost Event WO-39** | Event card | Flavor text and outcomes describe Algox archers on the eastern wall (narrative mention, not a stat record) |\n| **Section 123.3** | Section Book | Special Rules text: *\"Place one fallen Algox Archer in C.\"* — a scenario setup instruction |\n| **Scenario Book 2-21, chunk 8** | Rules passage | Monster deployment table for **Algox Scouting (Scenario 2)** listing Algox Archer + Algox Guard counts |\n| **Scenario Book 2-21, chunk 10** | Rules passage | Monster deployment for **Algox Offensive (Scenario 3)** — same pairing |\n| **Scenario Book 2-21, chunk 13** | Rules passage | Monster list for **Heart of Ice (Scenario 4)** — Algox Archer appears in the monster roster |\n| **Rulebook passage 81** | Rulebook | A *Range* example using an Algox Archer token (tutorial/rules illustration) |\n| **Scenario card: Algox Scouting (Scenario 2)** | Scenario card | Monster list field includes `\"Algox Archer\"` and `\"Algox Guard\"` as the scenario's monster types |\n\n---\n\n### Summary: Exact vs. Fuzzy\n\n| Category | Record Count | Basis for Match |\n|---|---|---|\n| **Exact stat cards** | 2 (levels 0–3, 4–7) | Named `algox-archer` monster-stat records |\n| **Exact ability cards** | 4 (Archer deck) | `monsterType: Archer` — the Algox Archer's own ability deck |\n| **Fuzzy / contextual** | 7 | Text mentions of \"Algox Archer\" in events, sections, scenario books, and rulebook examples |",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 33291,
+      "tokenInput": 30268,
+      "tokenOutput": 1937,
+      "tokenTotal": 32205,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 8,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-card-fuzzy-vs-exact",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-card-fuzzy-vs-exact",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-card-fuzzy-vs-exact",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "I have the exact monster stat records and the fuzzy-context matches. Per the system rules, I should open the exact stat records to confirm details, but the search snippets already give me complete stat data. Let me give the answer based on what I have.\n\n## Algox Archer — Monster Stat Records (Exact Data)\n\nThere are **two exact stat records**, one per level band:\n\n**Algox Archer — Levels 0–3** (`card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/0-3`)\n\n| Lvl | Normal HP / Move / Atk | Elite HP / Move / Atk |\n|---|---|---|\n| 0 | 4 / 1 / 3 | 6 / 2 / 4 |\n| 1 | 5 / 2 / 3 | 8 / 2 / 4 |\n| 2 | 7 / 2 / 3 | 11 / 2 / 4 |\n| 3 | 7 / 2 / 4 | 12 / 2 / 5 |\n\n**Algox Archer — Levels 4–7** (`card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/4-7`)\n\n| Lvl | Normal HP / Move / Atk | Elite HP / Move / Atk |\n|---|---|---|\n| 4 | 10 / 2 / 4 | 16 / 2 / 5 |\n| 5 | 13 / 2 / 4 | 18 / 2 / 6 |\n| 6 | 19 / 2 / 4 | 28 / 2 / 6 |\n| 7 | 22 / 2 / 5 | 33 / 2 / 7 |\n\nNo immunities, no special notes recorded for either band. Source: GHS Card Data / Card Index.\n\n---\n\n## Ability Cards — Fuzzy Matches Only\n\nThe search returned several \"Archer\" ability deck cards (*Calculated Strike*, *Close In*, *Hasty Assault*, *Nothing Special*) under `monster-ability/archer/...`. These are **fuzzy/contextual matches**, not exact-data hits:\n\n- They live in the generic shared **Archer** monster ability deck (`monster-ability/archer/...`), which is reused by every Archer-type monster (Algox Archer, City Archer, etc.) — the deck name is not \"Algox Archer\" specifically.\n- Resolver flagged them with `matchReason: \"Card text match\"` at confidence 0.86, versus 0.98 \"Exact card name\" for the two stat records.\n\nSo Algox Archer **uses** the shared Archer ability deck, but there are no ability cards uniquely named/scoped to Algox Archer in the data.\n\n---\n\n## Other Fuzzy Matches (Context, Not Stats)\n\n- **Section 123.3** — instructs placing a \"fallen Algox Archer\" in hex C as a scenario element. Narrative/setup mention, not stat data.\n- **Scenario Book passages (chunks 8 and 10)** — the scenarios *Algox Scouting* and *Algox Offensive* list Algox Archer in their monster spawn tables (×4/×2/×1 patterns by player count). Scenario context, not stat data.\n- **Event WO-39 (Winter Outpost event)** — a flavor-text mention of \"Algox\" and archers; the word match is incidental and unrelated to the monster.\n\n---\n\n### Summary: Exact vs. Fuzzy\n\n| Record | Type |\n|---|---|\n| `monster-stat/algox-archer/0-3` | ✅ Exact stat data |\n| `monster-stat/algox-archer/4-7` | ✅ Exact stat data |\n| `monster-ability/archer/756–760` | ⚠️ Fuzzy — shared Archer deck used by Algox Archer, not Algox-specific |\n| Section 123.3 | ⚠️ Fuzzy — scenario placement reference |\n| Scenario Book chunks 8, 10 | ⚠️ Fuzzy — spawn table mentions |\n| Event WO-39 | ⚠️ Fuzzy — incidental flavor text |",
+      "score": 0,
+      "pass": false,
+      "latencyMs": 23119,
+      "tokenInput": 11638,
+      "tokenOutput": 1558,
+      "tokenTotal": 13196,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-card-fuzzy-vs-exact",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-card-fuzzy-vs-exact",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-card-fuzzy-vs-exact",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": false,
+      "answer": "",
+      "score": null,
+      "pass": false,
+      "latencyMs": 35995,
+      "tokenInput": 140927,
+      "tokenOutput": 1052,
+      "tokenTotal": 141979,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 10,
+      "retryCount": 0,
+      "loopIterations": 10,
+      "failureClass": "loop_limit",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-card-fuzzy-vs-exact",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-card-fuzzy-vs-exact",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-invalid-cross-game-ref",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-6",
+      "ok": true,
+      "answer": "Here's a clear side-by-side account of what happened:\n\n---\n\n## Path 1 — Frosthaven `section:frosthaven/67.1` ✅\n\n**Resolved and opened successfully.**\n\n- **Source:** Section Book 62–81, page 67\n- **Label:** *Life and Death* (linked to Scenario 61)\n- **Type:** Conclusion section\n\nThe text is a rich narrative conclusion in which the party escapes a terror-filled cave with help from Moonshard, meets an ancient Orchid named **Terra** and a crystalline Savvas lineage called the **Shattersong**, and learns about the **Harbinger** threat. It ends with:\n\n> **Rewards:** Unlock class box.\n> **Section Links:** Add section 140.3 to the calendar in one week.\n\n---\n\n## Path 2 — Gloomhaven 2 `section:gloomhaven2/67.1` ❌\n\n**Rejected at open_entity with a hard `not_found` error:**\n\n```\n\"Section not found: section:gloomhaven2/67.1\"\n```\n\n### What this demonstrates\n\n| Step | Frosthaven | Gloomhaven 2 |\n|---|---|---|\n| `resolve_entity` | ✅ Matched — confidence 0.99, exact ref | ⚠️ Also matched (fuzzy fallback to FH data — resolver doesn't own game scoping) |\n| `open_entity` | ✅ Full record returned | ❌ `not_found` — canonical game-qualified ref has no backing data |\n\n**Key takeaway:** `resolve_entity` is fuzzy and will return a Frosthaven candidate even when you phrase the query as \"gloomhaven2 section 67.1\", because there is only one corpus in the knowledge base. The game qualifier only becomes authoritative at the `open_entity` step — using the canonical form `section:gloomhaven2/67.1` correctly produces a hard rejection rather than silently serving the wrong game's data. This is exactly the behavior the grounding rules are designed to enforce: **never invent URI forms, and never substitute a record from a different game.**",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 18484,
+      "tokenInput": 9320,
+      "tokenOutput": 886,
+      "tokenTotal": 10206,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 4,
+      "retryCount": 0,
+      "loopIterations": 3,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-invalid-cross-game-ref",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-invalid-cross-game-ref",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-sonnet-4-6",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-invalid-cross-game-ref",
+      "category": "trajectory",
+      "provider": "anthropic",
+      "model": "claude-opus-4-7",
+      "ok": true,
+      "answer": "Here's how the two paths resolved:\n\n**Path 1 — Frosthaven section 67.1** ✅\nResolved cleanly to the canonical ref `67.1` in *Section Book 62-81* (`source:frosthaven/scenario-section-books`), with 0.99 confidence as an exact section ref match.\n\n**Path 2 — `section:gloomhaven2/67.1`** ❌\nRejected with a `not_found` error: *\"Section not found: section:gloomhaven2/67.1\"*. There is no Gloomhaven 2 section 67.1 in the checked-in data, so the qualified ref correctly fails rather than silently falling back to the Frosthaven record.\n\nThis confirms the expected behavior: bare legacy refs resolve via `resolve_entity` against Frosthaven's section book, while game-qualified refs are validated strictly and won't match unless that exact `<game>/<id>` pair exists.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 7851,
+      "tokenInput": 6442,
+      "tokenOutput": 494,
+      "tokenTotal": 6936,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 2,
+      "retryCount": 0,
+      "loopIterations": 2,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-invalid-cross-game-ref",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-invalid-cross-game-ref",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-anthropic-tools-v1",
+      "toolSchemaHash": "sha256:4197758159f3e7901b10df7a68ac3b96a6f39c5fc84fada17a643c5626fe52b9",
+      "modelSettings": {
+        "model": "claude-opus-4-7",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    },
+    {
+      "runLabel": "sqr-134-full-matrix-2026-05-02-timeout60",
+      "caseId": "traj-invalid-cross-game-ref",
+      "category": "trajectory",
+      "provider": "openai",
+      "model": "gpt-5.5",
+      "ok": true,
+      "answer": "- **Frosthaven section 67.1** resolves successfully:\n  - Ref: `67.1`\n  - Title: Section 67.1\n  - Source: Frosthaven scenario/section books — “Section Book 62-81”\n\n- **Explicit Gloomhaven 2 section 67.1** should **not** be accepted as the same bare legacy ref. Using the canonical game-qualified form:\n  - Tried: `section:gloomhaven2/67.1`\n  - Result: **not found** — “Section not found: section:gloomhaven2/67.1”\n\nSo the Frosthaven bare ref resolves, but the Gloomhaven 2 path must use a canonical game-qualified ref and is currently unavailable in the checked-in data.",
+      "score": 1,
+      "pass": true,
+      "latencyMs": 14713,
+      "tokenInput": 27941,
+      "tokenOutput": 598,
+      "tokenTotal": 28539,
+      "estimatedCostUsd": 0.05,
+      "toolCallCount": 3,
+      "retryCount": 0,
+      "loopIterations": 4,
+      "failureClass": "none",
+      "traceId": "eval:sqr-134-full-matrix-2026-05-02-timeout60:openai:gpt-5.5:traj-invalid-cross-game-ref",
+      "traceUrl": "https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-invalid-cross-game-ref",
+      "promptVersion": "redesigned-agent-v1",
+      "promptHash": "sha256:eced79ab07a1a77f052b3d8b89851d51b2b1ff53f8a26701e101c4c525e9abd5",
+      "toolSurface": "redesigned",
+      "toolSchemaVersion": "squire-openai-tools-v1",
+      "toolSchemaHash": "c8877e9c8cdf29aff4d01f0d2947db8595d7803e01fdfb0f0abe441cb333d825",
+      "modelSettings": {
+        "model": "gpt-5.5",
+        "timeoutMs": 60000
+      },
+      "runSettings": {
+        "retryCount": 1,
+        "maxEstimatedCostUsd": 5,
+        "providerConcurrency": {
+          "anthropic": 2,
+          "openai": 2
+        }
+      }
+    }
+  ],
+  "estimatedCostUsd": 4.3500000000000005
+}

--- a/docs/plans/sqr-134-multi-model-eval-decision-report.md
+++ b/docs/plans/sqr-134-multi-model-eval-decision-report.md
@@ -1,0 +1,218 @@
+# SQR-134 Multi-Model Eval Decision Report
+
+Generated on 2026-05-02 for SQR-134.
+
+## Decision
+
+Keep Phase 1 production on the existing Anthropic-only path with
+`anthropic:claude-sonnet-4-6` as the default model.
+
+Do not add a production multi-provider abstraction now. The OpenAI eval lane is
+valuable for continued comparison work, but this run shows it is not stable
+enough to justify production routing. It used far more tokens, took longer on
+average, and hit loop-limit failures that the current Anthropic production path
+did not hit.
+
+Do not switch production to `anthropic:claude-opus-4-7`. Opus was faster and
+used slightly fewer tokens than Sonnet in this run, but it missed three
+trajectory cases that Sonnet passed.
+
+## Source Run
+
+Raw checked-in export:
+[`docs/plans/sqr-134-full-matrix-report.json`](./sqr-134-full-matrix-report.json)
+
+Run label: `sqr-134-full-matrix-2026-05-02-timeout60`
+
+Command:
+
+```bash
+npm run eval -- --matrix --allow-full-dataset --allow-estimated-cost \
+  --max-estimated-cost-usd=5 --retry-count=1 --timeout-ms=60000 \
+  --anthropic-concurrency=2 --openai-concurrency=2 \
+  --name=sqr-134-full-matrix-2026-05-02-timeout60 \
+  --local-report=docs/plans/sqr-134-full-matrix-report.json
+```
+
+The first attempt used the same matrix without `--timeout-ms`; it was stopped
+after roughly 11 minutes because no report had been written and the process was
+still waiting inside provider calls. The timeout-bounded run is the source of
+record for this report.
+
+Run settings:
+
+- Dataset: 29 eval cases, 87 model-case rows.
+- Tool surface: `redesigned`.
+- Models:
+  - `anthropic:claude-sonnet-4-6`
+  - `anthropic:claude-opus-4-7`
+  - `openai:gpt-5.5`
+- Provider timeout: 60 seconds.
+- Retry count: 1.
+- Provider concurrency: 2 Anthropic, 2 OpenAI.
+- Matrix guardrail estimate: $4.35 total, $1.45 per model.
+
+Pricing sources:
+
+- Claude pricing from the provided local PDF,
+  `/Users/bcm/Downloads/Models overview - Claude API Docs.pdf`: Opus 4.7 at
+  $5/input MTok and $25/output MTok; Sonnet 4.6 at $3/input MTok and
+  $15/output MTok.
+- OpenAI pricing from the provided screenshot: GPT-5.5 standard short context
+  at $5/input MTok and $30/output MTok. The screenshot also shows
+  long-context GPT-5.5 pricing at $10/input MTok and $45/output MTok; because
+  the eval export does not mark whether long-context pricing applied, the table
+  uses short-context pricing and notes the all-long-context upper estimate
+  separately.
+
+Cost note: the current matrix export records a flat guardrail estimate of
+$0.05 per model-case row. That remains useful for run safety, but the dollar
+cost below is calculated from the exported input/output token counts and the
+provided provider prices. The export does not break out cached input tokens, so
+cached-input discounts are not included.
+
+## Summary By Model
+
+| Model                         |     Pass rate | Scored avg | Avg latency | P95 latency | Input tokens | Output tokens | Total tokens | Provider cost | Avg tools | Avg loops |       Timeouts/errors |
+| ----------------------------- | ------------: | ---------: | ----------: | ----------: | -----------: | ------------: | -----------: | ------------: | --------: | --------: | --------------------: |
+| `anthropic:claude-sonnet-4-6` | 28/29 (96.6%) |      0.966 |       12.2s |       24.8s |      363,574 |        15,480 |      379,054 |         $1.32 |      2.55 |      3.10 |                     0 |
+| `anthropic:claude-opus-4-7`   | 25/29 (86.2%) |      0.862 |        9.8s |       23.1s |      350,593 |        13,678 |      364,271 |         $2.09 |      1.76 |      2.59 |                     0 |
+| `openai:gpt-5.5`              | 26/29 (89.7%) |      0.978 |       14.9s |       29.5s |    1,421,074 |        13,990 |    1,435,064 |         $7.53 |      3.55 |      4.48 | 2 loop-limit failures |
+
+`Scored avg` excludes unscored loop-limit rows where no final answer existed.
+GPT-5.5 would be $14.84 if every exported token were billed at the long-context
+rates shown in the provided OpenAI screenshot.
+
+## Category Results
+
+| Model                         | Rulebook | Monster stats | Buildings | Items | Scenarios | Tool-free | Trajectory |
+| ----------------------------- | -------: | ------------: | --------: | ----: | --------: | --------: | ---------: |
+| `anthropic:claude-sonnet-4-6` |      9/9 |           3/3 |       0/1 |   2/2 |       1/1 |       1/1 |      12/12 |
+| `anthropic:claude-opus-4-7`   |      9/9 |           3/3 |       0/1 |   2/2 |       1/1 |       1/1 |       9/12 |
+| `openai:gpt-5.5`              |      8/9 |           3/3 |       1/1 |   1/2 |       1/1 |       1/1 |      11/12 |
+
+## Representative Langfuse Traces
+
+Wins:
+
+- Sonnet rule answer win, `rule-poison`:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-poison>
+- Opus rule answer win, `rule-long-rest-steps`:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Arule-long-rest-steps>
+- OpenAI card-data win, `building-alchemist`:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Abuilding-alchemist>
+
+Losses:
+
+- Shared Anthropic data-quality loss, `building-alchemist`:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Abuilding-alchemist>
+- OpenAI loop-limit loss, `rule-looting-definition`:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-looting-definition>
+- Opus traversal loss, `traj-scenario-conclusion-open`:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-scenario-conclusion-open>
+
+Confusing cases:
+
+- Sonnet passed `traj-card-fuzzy-vs-exact`, but needed 8 tool calls and 32k
+  tokens:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-card-fuzzy-vs-exact>
+- OpenAI failed the same `traj-card-fuzzy-vs-exact` case at loop limit after
+  10 tool calls and 142k tokens:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-card-fuzzy-vs-exact>
+
+## Failure Modes
+
+### Sonnet 4.6
+
+Sonnet failed only `building-alchemist`. The answer correctly said the level 1
+Alchemist has no build cost, but also included unsupported/wrong framing about
+the building effect and upgrade state. This is a data/answer-quality issue, not
+a model access or loop issue.
+
+Operational profile:
+
+- No timeouts.
+- No loop-limit failures.
+- No provider API errors.
+- Lowest pass risk in the matrix.
+
+### Opus 4.7
+
+Opus failed the same `building-alchemist` case, plus three trajectory cases:
+
+- `traj-scenario-conclusion-open`
+- `traj-scenario-conclusion-next-links`
+- `traj-card-fuzzy-vs-exact`
+
+The pattern is not provider instability. It is a behavior problem: Opus often
+used fewer tools and shorter loops, but sometimes stopped before satisfying the
+trajectory contract. That makes it attractive for latency but worse as a Phase 1
+default.
+
+Operational profile:
+
+- No timeouts.
+- No loop-limit failures.
+- No provider API errors.
+- Fastest average latency and lowest token volume, but lower pass rate.
+
+### OpenAI GPT-5.5
+
+OpenAI passed many cases, including `building-alchemist`, but its failures are
+more concerning for production:
+
+- `rule-looting-definition` reached loop limit with 10 tool calls and 200,889
+  tokens.
+- `traj-card-fuzzy-vs-exact` reached loop limit with 10 tool calls and 141,979
+  tokens.
+- `item-spyglass` returned a judged answer but failed quality at score 0.6.
+
+The loop-limit cases are the blocker. They turn a normal user question into a
+large token spend with no answer. This is the exact behavior a production
+provider abstraction would need to prevent before OpenAI can safely sit behind
+the live `/api/ask` path.
+
+Operational profile:
+
+- No provider API errors.
+- No timeout rows under the 60s timeout.
+- Two loop-limit failures.
+- About 3.8x Sonnet's token volume across the same dataset.
+- About 5.7x Sonnet's provider-estimated dollar cost under GPT-5.5
+  short-context pricing.
+- Highest average latency.
+- Highest average tool-call and loop counts.
+
+## Production Call
+
+Recommended Phase 1 default: `anthropic:claude-sonnet-4-6`.
+
+Reasoning:
+
+1. It had the highest pass rate: 28/29.
+2. It passed every trajectory case, which matters most for Squire's retrieval
+   reliability.
+3. It had no timeout, retry, provider, or loop-limit failures.
+4. It used far fewer tokens than OpenAI.
+5. Its only failure is already in the known building-data/answer-quality area,
+   not in provider access or loop control.
+
+Production multi-provider refactor: defer.
+
+The eval lane should keep running OpenAI and Opus comparisons, but production
+should not add provider routing until a future eval shows OpenAI can avoid
+loop-limit failures and keep token volume closer to Anthropic. If SQR-135
+continues, it should be a plan for future production abstraction, not an
+implementation plan for the current Phase 1 default.
+
+## Follow-Up Work
+
+- SQR-143: Fix or re-evaluate the `building-alchemist` expected-answer/data
+  contract so correct "no build cost" answers are not mixed with unsupported
+  effect text.
+- SQR-140: Add provider/model price metadata to the matrix cost estimator. The
+  current flat $0.05 row estimate is not enough for dollar-cost decisions.
+- SQR-141: Investigate OpenAI loop behavior on broad rulebook and fuzzy/exact
+  card questions before any production OpenAI routing is considered.
+- SQR-142: Investigate why Opus stops early on traversal cases despite using
+  fewer tools.

--- a/docs/plans/sqr-134-multi-model-eval-decision-report.md
+++ b/docs/plans/sqr-134-multi-model-eval-decision-report.md
@@ -1,69 +1,84 @@
 # SQR-134 Multi-Model Eval Decision Report
 
-Generated on 2026-05-02 for SQR-134.
+Generated on 2026-05-02 for SQR-134. Updated after expanding the matrix from
+three models to seven candidate models from the provided pricing sheets.
 
 ## Decision
 
 Keep Phase 1 production on the existing Anthropic-only path with
 `anthropic:claude-sonnet-4-6` as the default model.
 
-Do not add a production multi-provider abstraction now. The OpenAI eval lane is
-valuable for continued comparison work, but this run shows it is not stable
-enough to justify production routing. It used far more tokens, took longer on
-average, and hit loop-limit failures that the current Anthropic production path
-did not hit.
+The expanded seven-model sweep does not change the production call. Sonnet 4.6
+still has the highest pass rate and is the only model that passed every
+trajectory case.
 
-Do not switch production to `anthropic:claude-opus-4-7`. Opus was faster and
-used slightly fewer tokens than Sonnet in this run, but it missed three
-trajectory cases that Sonnet passed.
+Do not add a production multi-provider abstraction now. The OpenAI eval lane is
+valuable for continued comparison work, but none of the OpenAI candidates
+matched Sonnet's trajectory reliability. `openai:gpt-5.5` also still hit a
+loop-limit failure in the expanded run.
+
+Do not switch production to `anthropic:claude-opus-4-7`. Opus is close, but it
+still missed one trajectory case and cost more than Sonnet in this run.
+
+Do not switch production to `anthropic:claude-haiku-4-5` yet. Haiku is the most
+interesting new candidate because it was fast and cheap, but it missed three
+cases including one trajectory case.
 
 ## Source Run
 
-Raw checked-in export:
+Primary raw checked-in export:
+[`docs/plans/sqr-134-expanded-full-matrix-report.json`](./sqr-134-expanded-full-matrix-report.json)
+
+Earlier three-model export:
 [`docs/plans/sqr-134-full-matrix-report.json`](./sqr-134-full-matrix-report.json)
 
-Run label: `sqr-134-full-matrix-2026-05-02-timeout60`
+Primary run label: `sqr-134-expanded-full-matrix-2026-05-02`
 
 Command:
 
 ```bash
 npm run eval -- --matrix --allow-full-dataset --allow-estimated-cost \
-  --max-estimated-cost-usd=5 --retry-count=1 --timeout-ms=60000 \
+  --max-estimated-cost-usd=15 --retry-count=1 --timeout-ms=60000 \
   --anthropic-concurrency=2 --openai-concurrency=2 \
-  --name=sqr-134-full-matrix-2026-05-02-timeout60 \
-  --local-report=docs/plans/sqr-134-full-matrix-report.json
+  --name=sqr-134-expanded-full-matrix-2026-05-02 \
+  --local-report=docs/plans/sqr-134-expanded-full-matrix-report.json
 ```
 
-The first attempt used the same matrix without `--timeout-ms`; it was stopped
-after roughly 11 minutes because no report had been written and the process was
-still waiting inside provider calls. The timeout-bounded run is the source of
-record for this report.
+The earlier three-model attempt used the same matrix without `--timeout-ms`; it
+was stopped after roughly 11 minutes because no report had been written and the
+process was still waiting inside provider calls. The expanded timeout-bounded
+run is now the source of record for this report.
 
 Run settings:
 
-- Dataset: 29 eval cases, 87 model-case rows.
+- Dataset: 29 eval cases, 203 model-case rows.
 - Tool surface: `redesigned`.
 - Models:
   - `anthropic:claude-sonnet-4-6`
   - `anthropic:claude-opus-4-7`
+  - `anthropic:claude-haiku-4-5`
   - `openai:gpt-5.5`
+  - `openai:gpt-5.4`
+  - `openai:gpt-5.4-mini`
+  - `openai:gpt-5.4-nano`
 - Provider timeout: 60 seconds.
 - Retry count: 1.
 - Provider concurrency: 2 Anthropic, 2 OpenAI.
-- Matrix guardrail estimate: $4.35 total, $1.45 per model.
+- Matrix guardrail estimate: $10.15 total, $1.45 per model.
 
 Pricing sources:
 
 - Claude pricing from the provided local PDF,
   `/Users/bcm/Downloads/Models overview - Claude API Docs.pdf`: Opus 4.7 at
   $5/input MTok and $25/output MTok; Sonnet 4.6 at $3/input MTok and
-  $15/output MTok.
+  $15/output MTok; Haiku 4.5 at $1/input MTok and $5/output MTok.
 - OpenAI pricing from the provided screenshot: GPT-5.5 standard short context
-  at $5/input MTok and $30/output MTok. The screenshot also shows
-  long-context GPT-5.5 pricing at $10/input MTok and $45/output MTok; because
-  the eval export does not mark whether long-context pricing applied, the table
-  uses short-context pricing and notes the all-long-context upper estimate
-  separately.
+  at $5/input MTok and $30/output MTok; GPT-5.4 at $2.50/input MTok and
+  $15/output MTok; GPT-5.4-mini at $0.75/input MTok and $4.50/output MTok;
+  GPT-5.4-nano at $0.20/input MTok and $1.25/output MTok. The screenshot also
+  shows long-context GPT-5.5 and GPT-5.4 pricing; because the eval export does
+  not mark whether long-context pricing applied, the table uses short-context
+  pricing and notes the all-long-context upper estimates separately.
 
 Cost note: the current matrix export records a flat guardrail estimate of
 $0.05 per model-case row. That remains useful for run safety, but the dollar
@@ -73,52 +88,65 @@ cached-input discounts are not included.
 
 ## Summary By Model
 
-| Model                         |     Pass rate | Scored avg | Avg latency | P95 latency | Input tokens | Output tokens | Total tokens | Provider cost | Avg tools | Avg loops |       Timeouts/errors |
-| ----------------------------- | ------------: | ---------: | ----------: | ----------: | -----------: | ------------: | -----------: | ------------: | --------: | --------: | --------------------: |
-| `anthropic:claude-sonnet-4-6` | 28/29 (96.6%) |      0.966 |       12.2s |       24.8s |      363,574 |        15,480 |      379,054 |         $1.32 |      2.55 |      3.10 |                     0 |
-| `anthropic:claude-opus-4-7`   | 25/29 (86.2%) |      0.862 |        9.8s |       23.1s |      350,593 |        13,678 |      364,271 |         $2.09 |      1.76 |      2.59 |                     0 |
-| `openai:gpt-5.5`              | 26/29 (89.7%) |      0.978 |       14.9s |       29.5s |    1,421,074 |        13,990 |    1,435,064 |         $7.53 |      3.55 |      4.48 | 2 loop-limit failures |
+| Model                         |     Pass rate | Scored avg | Avg latency | P95 latency | Input tokens | Output tokens | Total tokens | Provider cost | Avg tools | Avg loops | Failures |
+| ----------------------------- | ------------: | ---------: | ----------: | ----------: | -----------: | ------------: | -----------: | ------------: | --------: | --------: | -------: |
+| `anthropic:claude-sonnet-4-6` | 28/29 (96.6%) |      0.972 |       10.9s |       17.3s |      352,825 |        14,797 |      367,622 |         $1.28 |      2.41 |      3.10 |        1 |
+| `anthropic:claude-opus-4-7`   | 27/29 (93.1%) |      0.931 |        9.9s |       22.8s |      359,834 |        16,518 |      376,352 |         $2.21 |      1.97 |      2.69 |        2 |
+| `anthropic:claude-haiku-4-5`  | 26/29 (89.7%) |      0.924 |        4.6s |        9.9s |      349,456 |        10,360 |      359,816 |         $0.40 |      2.34 |      3.07 |        3 |
+| `openai:gpt-5.5`              | 26/29 (89.7%) |      0.936 |       14.9s |       30.3s |    1,476,957 |        13,742 |    1,490,699 |         $7.80 |      3.90 |      4.86 |        3 |
+| `openai:gpt-5.4`              | 24/29 (82.8%) |      0.821 |       10.3s |       20.8s |      820,786 |        10,003 |      830,789 |         $2.20 |      2.48 |      3.48 |        5 |
+| `openai:gpt-5.4-mini`         | 19/29 (65.5%) |      0.697 |        5.5s |        9.6s |      752,722 |         5,242 |      757,964 |         $0.59 |      2.34 |      3.34 |       10 |
+| `openai:gpt-5.4-nano`         | 15/29 (51.7%) |      0.559 |        7.6s |       13.2s |    1,018,180 |         6,460 |    1,024,640 |         $0.21 |      2.97 |      3.97 |       14 |
 
 `Scored avg` excludes unscored loop-limit rows where no final answer existed.
-GPT-5.5 would be $14.84 if every exported token were billed at the long-context
-rates shown in the provided OpenAI screenshot.
+GPT-5.5 would be $15.39 and GPT-5.4 would be $4.33 if every exported token for
+those models were billed at the long-context rates shown in the provided OpenAI
+screenshot.
 
 ## Category Results
 
 | Model                         | Rulebook | Monster stats | Buildings | Items | Scenarios | Tool-free | Trajectory |
 | ----------------------------- | -------: | ------------: | --------: | ----: | --------: | --------: | ---------: |
 | `anthropic:claude-sonnet-4-6` |      9/9 |           3/3 |       0/1 |   2/2 |       1/1 |       1/1 |      12/12 |
-| `anthropic:claude-opus-4-7`   |      9/9 |           3/3 |       0/1 |   2/2 |       1/1 |       1/1 |       9/12 |
-| `openai:gpt-5.5`              |      8/9 |           3/3 |       1/1 |   1/2 |       1/1 |       1/1 |      11/12 |
+| `anthropic:claude-opus-4-7`   |      9/9 |           3/3 |       1/1 |   1/2 |       1/1 |       1/1 |      11/12 |
+| `anthropic:claude-haiku-4-5`  |      9/9 |           3/3 |       0/1 |   1/2 |       1/1 |       1/1 |      11/12 |
+| `openai:gpt-5.5`              |      8/9 |           3/3 |       1/1 |   2/2 |       1/1 |       1/1 |      10/12 |
+| `openai:gpt-5.4`              |      9/9 |           3/3 |       1/1 |   2/2 |       1/1 |       1/1 |       7/12 |
+| `openai:gpt-5.4-mini`         |      8/9 |           3/3 |       1/1 |   2/2 |       1/1 |       1/1 |       3/12 |
+| `openai:gpt-5.4-nano`         |      5/9 |           3/3 |       1/1 |   2/2 |       1/1 |       1/1 |       2/12 |
 
 ## Representative Langfuse Traces
 
 Wins:
 
 - Sonnet rule answer win, `rule-poison`:
-  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-poison>
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Arule-poison>
 - Opus rule answer win, `rule-long-rest-steps`:
-  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Arule-long-rest-steps>
-- OpenAI card-data win, `building-alchemist`:
-  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Abuilding-alchemist>
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-opus-4-7%3Arule-long-rest-steps>
+- Haiku speed/cost win, `rule-long-rest-init`:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Arule-long-rest-init>
+- GPT-5.4 rulebook win, `rule-looting-definition`:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Arule-looting-definition>
 
 Losses:
 
 - Shared Anthropic data-quality loss, `building-alchemist`:
-  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Abuilding-alchemist>
-- OpenAI loop-limit loss, `rule-looting-definition`:
-  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-looting-definition>
-- Opus traversal loss, `traj-scenario-conclusion-open`:
-  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-opus-4-7%3Atraj-scenario-conclusion-open>
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Abuilding-alchemist>
+- OpenAI loop-limit loss, `traj-card-fuzzy-vs-exact`:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-card-fuzzy-vs-exact>
+- GPT-5.4 traversal loss, `traj-card-fuzzy-vs-exact`:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.4%3Atraj-card-fuzzy-vs-exact>
+- Haiku traversal loss, `traj-scenario-conclusion-open`:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-haiku-4-5%3Atraj-scenario-conclusion-open>
 
 Confusing cases:
 
-- Sonnet passed `traj-card-fuzzy-vs-exact`, but needed 8 tool calls and 32k
-  tokens:
-  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-card-fuzzy-vs-exact>
+- Sonnet passed `traj-card-fuzzy-vs-exact`, but still needed 4 tool calls and
+  20k tokens:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aanthropic%3Aclaude-sonnet-4-6%3Atraj-card-fuzzy-vs-exact>
 - OpenAI failed the same `traj-card-fuzzy-vs-exact` case at loop limit after
-  10 tool calls and 142k tokens:
-  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Atraj-card-fuzzy-vs-exact>
+  10 tool calls and 202k tokens:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-card-fuzzy-vs-exact>
 
 ## Failure Modes
 
@@ -138,36 +166,54 @@ Operational profile:
 
 ### Opus 4.7
 
-Opus failed the same `building-alchemist` case, plus three trajectory cases:
+Opus failed two cases:
 
-- `traj-scenario-conclusion-open`
-- `traj-scenario-conclusion-next-links`
+- `item-spyglass`
 - `traj-card-fuzzy-vs-exact`
 
-The pattern is not provider instability. It is a behavior problem: Opus often
-used fewer tools and shorter loops, but sometimes stopped before satisfying the
-trajectory contract. That makes it attractive for latency but worse as a Phase 1
-default.
+The pattern is not provider instability. It is still attractive for latency, but
+it does not beat Sonnet on reliability and it costs more.
 
 Operational profile:
 
 - No timeouts.
 - No loop-limit failures.
 - No provider API errors.
-- Fastest average latency and lowest token volume, but lower pass rate.
+- Slightly faster average latency than Sonnet, but lower pass rate and higher
+  provider-estimated dollar cost.
+
+### Haiku 4.5
+
+Haiku failed three cases:
+
+- `building-alchemist`
+- `item-crude-boots`
+- `traj-scenario-conclusion-open`
+
+This is the most interesting new candidate. It was the fastest model in the
+expanded run and cost about one third of Sonnet's provider-estimated cost, but
+it missed one trajectory case and two final-answer quality cases.
+
+Operational profile:
+
+- No timeouts.
+- No loop-limit failures.
+- No provider API errors.
+- Fastest average latency.
+- Lowest useful-model cost, but below Sonnet and Opus on pass rate.
 
 ### OpenAI GPT-5.5
 
-OpenAI passed many cases, including `building-alchemist`, but its failures are
-more concerning for production:
+GPT-5.5 passed many cases, including `building-alchemist`, but its failures are
+still concerning for production:
 
-- `rule-looting-definition` reached loop limit with 10 tool calls and 200,889
+- `rule-long-rest-steps` returned a judged answer but failed quality at score
+  0.6.
+- `traj-exact-item-open` failed the trajectory contract.
+- `traj-card-fuzzy-vs-exact` reached loop limit with 10 tool calls and 202,023
   tokens.
-- `traj-card-fuzzy-vs-exact` reached loop limit with 10 tool calls and 141,979
-  tokens.
-- `item-spyglass` returned a judged answer but failed quality at score 0.6.
 
-The loop-limit cases are the blocker. They turn a normal user question into a
+The loop-limit case is still the blocker. It turns a normal user question into a
 large token spend with no answer. This is the exact behavior a production
 provider abstraction would need to prevent before OpenAI can safely sit behind
 the live `/api/ask` path.
@@ -176,12 +222,26 @@ Operational profile:
 
 - No provider API errors.
 - No timeout rows under the 60s timeout.
-- Two loop-limit failures.
-- About 3.8x Sonnet's token volume across the same dataset.
-- About 5.7x Sonnet's provider-estimated dollar cost under GPT-5.5
+- One loop-limit failure.
+- About 4.1x Sonnet's token volume across the same dataset.
+- About 6.1x Sonnet's provider-estimated dollar cost under GPT-5.5
   short-context pricing.
 - Highest average latency.
 - Highest average tool-call and loop counts.
+
+### Other OpenAI Candidates
+
+GPT-5.4 is cheaper than GPT-5.5 and avoided loop-limit failures in this run, but
+it passed only 7/12 trajectory cases and 24/29 overall. That is not production
+default material for Squire.
+
+GPT-5.4-mini and GPT-5.4-nano are too weak for this eval suite today:
+
+- GPT-5.4-mini passed 19/29 overall and only 3/12 trajectory cases.
+- GPT-5.4-nano passed 15/29 overall and only 2/12 trajectory cases.
+
+They may still be useful later for a narrowly-scoped cheap classifier or
+tool-free helper, but not for the current answer path.
 
 ## Production Call
 
@@ -193,17 +253,19 @@ Reasoning:
 2. It passed every trajectory case, which matters most for Squire's retrieval
    reliability.
 3. It had no timeout, retry, provider, or loop-limit failures.
-4. It used far fewer tokens than OpenAI.
-5. Its only failure is already in the known building-data/answer-quality area,
+4. It used far fewer tokens than GPT-5.5 and beat every OpenAI candidate on
+   trajectory reliability.
+5. It was less expensive than Opus and materially more reliable than Haiku.
+6. Its only failure is already in the known building-data/answer-quality area,
    not in provider access or loop control.
 
 Production multi-provider refactor: defer.
 
-The eval lane should keep running OpenAI and Opus comparisons, but production
-should not add provider routing until a future eval shows OpenAI can avoid
-loop-limit failures and keep token volume closer to Anthropic. If SQR-135
-continues, it should be a plan for future production abstraction, not an
-implementation plan for the current Phase 1 default.
+The eval lane should keep running OpenAI, Opus, and Haiku comparisons, but
+production should not add provider routing until a future eval shows a candidate
+can match Sonnet on trajectory reliability. If SQR-135 continues, it should be a
+plan for future production abstraction, not an implementation plan for the
+current Phase 1 default.
 
 ## Follow-Up Work
 
@@ -216,3 +278,5 @@ implementation plan for the current Phase 1 default.
   card questions before any production OpenAI routing is considered.
 - SQR-142: Investigate why Opus stops early on traversal cases despite using
   fewer tools.
+- SQR-144: Investigate whether Haiku 4.5 can serve a constrained cheap
+  Anthropic lane after its three expanded-run failures are understood.

--- a/docs/plans/sqr-134-multi-model-eval-decision-report.md
+++ b/docs/plans/sqr-134-multi-model-eval-decision-report.md
@@ -68,10 +68,10 @@ Run settings:
 
 Pricing sources:
 
-- Claude pricing from the provided local PDF,
-  `/Users/bcm/Downloads/Models overview - Claude API Docs.pdf`: Opus 4.7 at
-  $5/input MTok and $25/output MTok; Sonnet 4.6 at $3/input MTok and
-  $15/output MTok; Haiku 4.5 at $1/input MTok and $5/output MTok.
+- Claude pricing from the provided local Claude pricing PDF ("Models overview -
+  Claude API Docs.pdf"): Opus 4.7 at $5/input MTok and $25/output MTok; Sonnet
+  4.6 at $3/input MTok and $15/output MTok; Haiku 4.5 at $1/input MTok and
+  $5/output MTok.
 - OpenAI pricing from the provided screenshot: GPT-5.5 standard short context
   at $5/input MTok and $30/output MTok; GPT-5.4 at $2.50/input MTok and
   $15/output MTok; GPT-5.4-mini at $0.75/input MTok and $4.50/output MTok;

--- a/eval/cli.ts
+++ b/eval/cli.ts
@@ -15,6 +15,11 @@ export const DEFAULT_EVAL_MODELS = {
   openai: 'gpt-5.5',
 } as const satisfies Record<EvalProvider, EvalProviderModel>;
 
+export const EVAL_MODELS_BY_PROVIDER = {
+  anthropic: ['claude-sonnet-4-6', 'claude-opus-4-7', 'claude-haiku-4-5'],
+  openai: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano'],
+} as const satisfies Record<EvalProvider, readonly EvalProviderModel[]>;
+
 export interface EvalProviderConfig {
   provider: EvalProvider;
   model: EvalProviderModel;
@@ -93,11 +98,7 @@ export function defaultEvalModelForProvider(provider: EvalProvider): EvalProvide
 }
 
 function assertModel(provider: EvalProvider, value: string): EvalProviderModel {
-  const modelsByProvider = {
-    anthropic: ['claude-sonnet-4-6', 'claude-opus-4-7', 'claude-haiku-4-5'],
-    openai: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano'],
-  } as const;
-  if ((modelsByProvider[provider] as readonly string[]).includes(value)) {
+  if ((EVAL_MODELS_BY_PROVIDER[provider] as readonly string[]).includes(value)) {
     return value as EvalProviderModel;
   }
 

--- a/eval/cli.ts
+++ b/eval/cli.ts
@@ -1,6 +1,13 @@
 export type EvalToolSurface = 'redesigned' | 'legacy';
 export type EvalProvider = 'anthropic' | 'openai';
-export type EvalProviderModel = 'claude-sonnet-4-6' | 'claude-opus-4-7' | 'gpt-5.5';
+export type EvalProviderModel =
+  | 'claude-sonnet-4-6'
+  | 'claude-opus-4-7'
+  | 'claude-haiku-4-5'
+  | 'gpt-5.5'
+  | 'gpt-5.4'
+  | 'gpt-5.4-mini'
+  | 'gpt-5.4-nano';
 export type EvalReasoningEffort = 'none' | 'low' | 'medium' | 'high' | 'max' | 'xhigh';
 
 export const DEFAULT_EVAL_MODELS = {
@@ -87,8 +94,8 @@ export function defaultEvalModelForProvider(provider: EvalProvider): EvalProvide
 
 function assertModel(provider: EvalProvider, value: string): EvalProviderModel {
   const modelsByProvider = {
-    anthropic: ['claude-sonnet-4-6', 'claude-opus-4-7'],
-    openai: ['gpt-5.5'],
+    anthropic: ['claude-sonnet-4-6', 'claude-opus-4-7', 'claude-haiku-4-5'],
+    openai: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano'],
   } as const;
   if ((modelsByProvider[provider] as readonly string[]).includes(value)) {
     return value as EvalProviderModel;

--- a/eval/experiments.ts
+++ b/eval/experiments.ts
@@ -10,7 +10,7 @@ import type { LangfuseTraceIngestionClient } from './trace.ts';
 
 type AnthropicEvalProviderConfig = EvalProviderConfig & {
   provider: 'anthropic';
-  model: 'claude-sonnet-4-6' | 'claude-opus-4-7';
+  model: 'claude-sonnet-4-6' | 'claude-opus-4-7' | 'claude-haiku-4-5';
 };
 
 function assertAnthropicProviderConfig(
@@ -18,7 +18,9 @@ function assertAnthropicProviderConfig(
 ): AnthropicEvalProviderConfig {
   if (
     providerConfig.provider === 'anthropic' &&
-    (providerConfig.model === 'claude-sonnet-4-6' || providerConfig.model === 'claude-opus-4-7')
+    (providerConfig.model === 'claude-sonnet-4-6' ||
+      providerConfig.model === 'claude-opus-4-7' ||
+      providerConfig.model === 'claude-haiku-4-5')
   ) {
     return providerConfig as AnthropicEvalProviderConfig;
   }

--- a/eval/experiments.ts
+++ b/eval/experiments.ts
@@ -1,6 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { LangfuseClient } from '@langfuse/client';
-import type { EvalProviderConfig, EvalToolSurface } from './cli.ts';
+import { EVAL_MODELS_BY_PROVIDER, type EvalProviderConfig, type EvalToolSurface } from './cli.ts';
 import { runAnthropicEvalCase, type AnthropicEvalCaseResult } from './anthropic-runner.ts';
 import { DATASET_NAME } from './dataset.ts';
 import { buildEvaluators, buildRunEvaluators, judgeAnswer } from './evaluators.ts';
@@ -10,7 +10,7 @@ import type { LangfuseTraceIngestionClient } from './trace.ts';
 
 type AnthropicEvalProviderConfig = EvalProviderConfig & {
   provider: 'anthropic';
-  model: 'claude-sonnet-4-6' | 'claude-opus-4-7' | 'claude-haiku-4-5';
+  model: (typeof EVAL_MODELS_BY_PROVIDER)['anthropic'][number];
 };
 
 function assertAnthropicProviderConfig(
@@ -18,9 +18,7 @@ function assertAnthropicProviderConfig(
 ): AnthropicEvalProviderConfig {
   if (
     providerConfig.provider === 'anthropic' &&
-    (providerConfig.model === 'claude-sonnet-4-6' ||
-      providerConfig.model === 'claude-opus-4-7' ||
-      providerConfig.model === 'claude-haiku-4-5')
+    (EVAL_MODELS_BY_PROVIDER.anthropic as readonly string[]).includes(providerConfig.model)
   ) {
     return providerConfig as AnthropicEvalProviderConfig;
   }

--- a/eval/matrix-runtime.ts
+++ b/eval/matrix-runtime.ts
@@ -1,6 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { LangfuseClient } from '@langfuse/client';
-import type { EvalProviderConfig } from './cli.ts';
+import { EVAL_MODELS_BY_PROVIDER, type EvalProviderConfig } from './cli.ts';
 import { runAnthropicEvalCase, type AnthropicEvalCaseResult } from './anthropic-runner.ts';
 import {
   createOpenAiResponsesClient,
@@ -19,7 +19,7 @@ import type { EvalTraceInput, LangfuseTraceIngestionClient } from './trace.ts';
 
 type AnthropicMatrixConfig = EvalProviderConfig & {
   provider: 'anthropic';
-  model: 'claude-sonnet-4-6' | 'claude-opus-4-7' | 'claude-haiku-4-5';
+  model: (typeof EVAL_MODELS_BY_PROVIDER)['anthropic'][number];
 };
 
 function traceClientFor(langfuse: LangfuseClient): LangfuseTraceIngestionClient {
@@ -29,9 +29,7 @@ function traceClientFor(langfuse: LangfuseClient): LangfuseTraceIngestionClient 
 function assertAnthropicMatrixConfig(config: EvalProviderConfig): AnthropicMatrixConfig {
   if (
     config.provider === 'anthropic' &&
-    (config.model === 'claude-sonnet-4-6' ||
-      config.model === 'claude-opus-4-7' ||
-      config.model === 'claude-haiku-4-5')
+    (EVAL_MODELS_BY_PROVIDER.anthropic as readonly string[]).includes(config.model)
   ) {
     return config as AnthropicMatrixConfig;
   }

--- a/eval/matrix-runtime.ts
+++ b/eval/matrix-runtime.ts
@@ -19,7 +19,7 @@ import type { EvalTraceInput, LangfuseTraceIngestionClient } from './trace.ts';
 
 type AnthropicMatrixConfig = EvalProviderConfig & {
   provider: 'anthropic';
-  model: 'claude-sonnet-4-6' | 'claude-opus-4-7';
+  model: 'claude-sonnet-4-6' | 'claude-opus-4-7' | 'claude-haiku-4-5';
 };
 
 function traceClientFor(langfuse: LangfuseClient): LangfuseTraceIngestionClient {
@@ -29,7 +29,9 @@ function traceClientFor(langfuse: LangfuseClient): LangfuseTraceIngestionClient 
 function assertAnthropicMatrixConfig(config: EvalProviderConfig): AnthropicMatrixConfig {
   if (
     config.provider === 'anthropic' &&
-    (config.model === 'claude-sonnet-4-6' || config.model === 'claude-opus-4-7')
+    (config.model === 'claude-sonnet-4-6' ||
+      config.model === 'claude-opus-4-7' ||
+      config.model === 'claude-haiku-4-5')
   ) {
     return config as AnthropicMatrixConfig;
   }

--- a/eval/matrix.ts
+++ b/eval/matrix.ts
@@ -89,6 +89,12 @@ export interface EvalMatrixResult {
   estimatedCostUsd: number;
 }
 
+export interface EvalMatrixProgressEvent {
+  completed: number;
+  total: number;
+  row: EvalMatrixRow;
+}
+
 export interface RunEvalMatrixOptions {
   cases: EvalCase[];
   runLabel: string;
@@ -98,6 +104,7 @@ export interface RunEvalMatrixOptions {
   runner: EvalMatrixRunner;
   guardrails: EvalMatrixGuardrails;
   langfuseBaseUrl: string;
+  onProgress?: (event: EvalMatrixProgressEvent) => void;
 }
 
 export const ESTIMATED_COST_PER_CASE_MODEL_USD = 0.05;
@@ -120,8 +127,40 @@ export const DEFAULT_EVAL_MATRIX_MODELS: EvalProviderConfig[] = [
     toolLoopLimit: undefined,
   },
   {
+    provider: 'anthropic',
+    model: 'claude-haiku-4-5',
+    reasoningEffort: undefined,
+    maxOutputTokens: undefined,
+    timeoutMs: undefined,
+    toolLoopLimit: undefined,
+  },
+  {
     provider: 'openai',
     model: 'gpt-5.5',
+    reasoningEffort: undefined,
+    maxOutputTokens: undefined,
+    timeoutMs: undefined,
+    toolLoopLimit: undefined,
+  },
+  {
+    provider: 'openai',
+    model: 'gpt-5.4',
+    reasoningEffort: undefined,
+    maxOutputTokens: undefined,
+    timeoutMs: undefined,
+    toolLoopLimit: undefined,
+  },
+  {
+    provider: 'openai',
+    model: 'gpt-5.4-mini',
+    reasoningEffort: undefined,
+    maxOutputTokens: undefined,
+    timeoutMs: undefined,
+    toolLoopLimit: undefined,
+  },
+  {
+    provider: 'openai',
+    model: 'gpt-5.4-nano',
     reasoningEffort: undefined,
     maxOutputTokens: undefined,
     timeoutMs: undefined,
@@ -363,6 +402,7 @@ async function runProviderQueue(
   concurrency: number,
   runner: EvalMatrixRunner,
   guardrails: EvalMatrixGuardrails,
+  onRowComplete: (row: EvalMatrixRow) => void,
 ): Promise<EvalMatrixRow[]> {
   const rows: EvalMatrixRow[] = [];
   let cursor = 0;
@@ -372,7 +412,9 @@ async function runProviderQueue(
       cursor += 1;
       const input = inputs[index];
       if (!input) return;
-      rows[index] = await runMatrixInput(input, runner, guardrails);
+      const row = await runMatrixInput(input, runner, guardrails);
+      rows[index] = row;
+      onRowComplete(row);
     }
   }
 
@@ -399,6 +441,12 @@ export async function runEvalMatrix(options: RunEvalMatrixOptions): Promise<Eval
     }),
   );
 
+  let completed = 0;
+  const onRowComplete = (row: EvalMatrixRow) => {
+    completed += 1;
+    options.onProgress?.({ completed, total: inputs.length, row });
+  };
+
   const rowsByProvider = await Promise.all(
     (['anthropic', 'openai'] as const).map((provider) =>
       runProviderQueue(
@@ -406,6 +454,7 @@ export async function runEvalMatrix(options: RunEvalMatrixOptions): Promise<Eval
         options.guardrails.providerConcurrency[provider],
         options.runner,
         options.guardrails,
+        onRowComplete,
       ),
     ),
   );

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -17,6 +17,7 @@ import {
   formatEvalMatrixTable,
   runEvalMatrix,
   writeEvalMatrixLocalReport,
+  type EvalMatrixProgressEvent,
   type EvalMatrixSelection,
 } from './matrix.ts';
 import { createEvalMatrixRunner } from './matrix-runtime.ts';
@@ -39,6 +40,29 @@ function describeProviderConfig(config: EvalProviderConfig): string {
   ].filter(Boolean);
 
   return `${config.provider}:${config.model}${tuning.length > 0 ? ` (${tuning.join(', ')})` : ''}`;
+}
+
+function formatProgressNullable(value: string | number | boolean | null | undefined): string {
+  if (value === undefined || value === null) return '-';
+  return String(value);
+}
+
+export function formatEvalMatrixProgress(event: EvalMatrixProgressEvent): string {
+  const { completed, total, row } = event;
+  const status = row.pass === null ? '-' : row.pass ? 'pass' : 'fail';
+  const latency = row.latencyMs === null ? '-' : `${row.latencyMs}ms`;
+  return [
+    `[${completed}/${total}]`,
+    status,
+    `${row.provider}:${row.model}`,
+    row.caseId,
+    `failure=${row.failureClass}`,
+    `score=${formatProgressNullable(row.score)}`,
+    `latency=${latency}`,
+    `tokens=${formatProgressNullable(row.tokenTotal)}`,
+    `tools=${formatProgressNullable(row.toolCallCount)}`,
+    `loops=${formatProgressNullable(row.loopIterations)}`,
+  ].join(' ');
 }
 
 function assertCurrentRunnerSupportsProviderConfig(config: EvalProviderConfig): void {
@@ -162,6 +186,7 @@ export async function runEval(options: EvalCliOptions, env: NodeJS.ProcessEnv = 
       runner: matrixRunner,
       guardrails: options.matrixGuardrails,
       langfuseBaseUrl,
+      onProgress: (event) => console.log(formatEvalMatrixProgress(event)),
     });
 
     console.log(formatEvalMatrixTable(result.rows));
@@ -204,6 +229,7 @@ export async function runEval(options: EvalCliOptions, env: NodeJS.ProcessEnv = 
         runner: createEvalMatrixRunner(langfuse, env),
         guardrails,
         langfuseBaseUrl,
+        onProgress: (event) => console.log(formatEvalMatrixProgress(event)),
       });
       console.log(formatEvalMatrixTable(result.rows));
       return;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -386,7 +386,7 @@ export interface TokenUsage {
   totalTokens: number;
 }
 
-export type AnthropicEvalModel = 'claude-sonnet-4-6' | 'claude-opus-4-7';
+export type AnthropicEvalModel = 'claude-sonnet-4-6' | 'claude-opus-4-7' | 'claude-haiku-4-5';
 
 export interface ToolTrajectoryStep {
   iteration: number;

--- a/test/eval-cli.test.ts
+++ b/test/eval-cli.test.ts
@@ -141,6 +141,34 @@ describe('parseEvalArgs', () => {
     });
   });
 
+  it('accepts expanded eval candidate models from the pricing sheets', () => {
+    for (const [provider, model] of [
+      ['anthropic', 'claude-haiku-4-5'],
+      ['openai', 'gpt-5.4'],
+      ['openai', 'gpt-5.4-mini'],
+      ['openai', 'gpt-5.4-nano'],
+    ] as const) {
+      expect(parseEvalArgs([`--provider=${provider}`, `--model=${model}`]).providerConfig).toEqual(
+        expect.objectContaining({ provider, model }),
+      );
+    }
+  });
+
+  it('uses expanded candidate models in replay diffs', () => {
+    expect(
+      parseEvalArgs([
+        '--replay',
+        '--trace-id=eval:debug-run:anthropic:claude-sonnet-4-6:case-1',
+        '--diff-trace-id=eval:debug-run:case-1:haiku',
+        '--diff-provider=anthropic',
+        '--diff-model=claude-haiku-4-5',
+      ]).replay,
+    ).toMatchObject({
+      diffProvider: 'anthropic',
+      diffModel: 'claude-haiku-4-5',
+    });
+  });
+
   it('parses local matrix report comparison inputs', () => {
     expect(parseEvalArgs(['--compare-runs=/tmp/before.json,/tmp/after.json']).comparison).toEqual({
       beforeReportPath: '/tmp/before.json',

--- a/test/eval-matrix-runtime.test.ts
+++ b/test/eval-matrix-runtime.test.ts
@@ -105,6 +105,17 @@ function input(provider: 'anthropic' | 'openai'): EvalMatrixRunnerInput {
   };
 }
 
+function anthropicInput(model: 'claude-sonnet-4-6' | 'claude-opus-4-7' | 'claude-haiku-4-5') {
+  return {
+    ...input('anthropic'),
+    providerConfig: {
+      ...input('anthropic').providerConfig,
+      provider: 'anthropic' as const,
+      model,
+    },
+  };
+}
+
 describe('eval matrix runtime adapter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -147,6 +158,33 @@ describe('eval matrix runtime adapter', () => {
       loopIterations: 2,
       failureClass: 'none',
     });
+  });
+
+  it('runs Haiku through the Anthropic matrix adapter', async () => {
+    mockRunAnthropicEvalCase.mockResolvedValue({
+      answer: 'Spyglass reveals the top card.',
+      trajectory: { toolCalls: [] },
+      durationMs: 1000,
+      toolSurface: 'redesigned',
+      traceId: 'haiku-trace',
+      trace: trace({
+        traceId: 'haiku-trace',
+        model: 'claude-haiku-4-5',
+        resolvedModel: 'claude-haiku-4-5',
+      }),
+    });
+
+    const runner = createEvalMatrixRunner({} as never, { OPENAI_API_KEY: 'test-key' });
+    await runner(anthropicInput('claude-haiku-4-5'));
+
+    expect(mockRunAnthropicEvalCase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerConfig: expect.objectContaining({
+          provider: 'anthropic',
+          model: 'claude-haiku-4-5',
+        }),
+      }),
+    );
   });
 
   it('falls back to the matrix cost estimate when provider traces have no cost', async () => {

--- a/test/eval-matrix.test.ts
+++ b/test/eval-matrix.test.ts
@@ -78,9 +78,13 @@ describe('eval matrix runner', () => {
     expect(result.rows.map((row) => `${row.provider}:${row.model}`)).toEqual([
       'anthropic:claude-sonnet-4-6',
       'anthropic:claude-opus-4-7',
+      'anthropic:claude-haiku-4-5',
       'openai:gpt-5.5',
+      'openai:gpt-5.4',
+      'openai:gpt-5.4-mini',
+      'openai:gpt-5.4-nano',
     ]);
-    expect(runner).toHaveBeenCalledTimes(3);
+    expect(runner).toHaveBeenCalledTimes(7);
     expect(result.rows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -130,8 +134,36 @@ describe('eval matrix runner', () => {
         broadSearchSynthesisThreshold: 2,
       }),
       expect.objectContaining({
+        provider: 'anthropic',
+        model: 'claude-haiku-4-5',
+        reasoningEffort: undefined,
+        timeoutMs: 30_000,
+        broadSearchSynthesisThreshold: 2,
+      }),
+      expect.objectContaining({
         provider: 'openai',
         model: 'gpt-5.5',
+        reasoningEffort: 'xhigh',
+        toolLoopLimit: 4,
+        broadSearchSynthesisThreshold: 2,
+      }),
+      expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-5.4',
+        reasoningEffort: 'xhigh',
+        toolLoopLimit: 4,
+        broadSearchSynthesisThreshold: 2,
+      }),
+      expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-5.4-mini',
+        reasoningEffort: 'xhigh',
+        toolLoopLimit: 4,
+        broadSearchSynthesisThreshold: 2,
+      }),
+      expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-5.4-nano',
         reasoningEffort: 'xhigh',
         toolLoopLimit: 4,
         broadSearchSynthesisThreshold: 2,
@@ -177,7 +209,7 @@ describe('eval matrix runner', () => {
       langfuseBaseUrl: 'https://langfuse.test',
     });
 
-    expect(runner).toHaveBeenCalledTimes(12);
+    expect(runner).toHaveBeenCalledTimes(28);
   });
 
   it('keeps successful rows when another model fails', async () => {
@@ -219,8 +251,8 @@ describe('eval matrix runner', () => {
       langfuseBaseUrl: 'https://langfuse.test',
     });
 
-    expect(result.rows).toHaveLength(3);
-    expect(result.rows.filter((row) => row.ok)).toHaveLength(2);
+    expect(result.rows).toHaveLength(7);
+    expect(result.rows.filter((row) => row.ok)).toHaveLength(3);
     expect(result.rows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -364,6 +396,47 @@ describe('eval matrix runner', () => {
       failureClass: 'timeout',
       retryCount: 1,
     });
+  });
+
+  it('emits progress after each completed matrix row', async () => {
+    const onProgress = vi.fn();
+
+    await runEvalMatrix({
+      cases: [selectedCase],
+      runLabel: 'matrix-progress',
+      toolSurface: 'redesigned',
+      selection: 'id',
+      modelConfigs: DEFAULT_EVAL_MATRIX_MODELS.slice(0, 2),
+      runner: successfulRunner(),
+      guardrails: {
+        allowFullDataset: false,
+        allowEstimatedCostOverride: false,
+        maxEstimatedCostUsd: 1,
+        retryCount: 0,
+        continueOnModelFailure: true,
+        providerConcurrency: { anthropic: 1, openai: 1 },
+      },
+      langfuseBaseUrl: 'https://langfuse.test',
+      onProgress,
+    });
+
+    expect(onProgress).toHaveBeenCalledTimes(2);
+    expect(onProgress).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        completed: 1,
+        total: 2,
+        row: expect.objectContaining({ caseId: 'item-spyglass' }),
+      }),
+    );
+    expect(onProgress).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        completed: 2,
+        total: 2,
+        row: expect.objectContaining({ caseId: 'item-spyglass' }),
+      }),
+    );
   });
 
   it('formats the matrix summary table with comparison fields and Langfuse links', async () => {

--- a/test/eval-runner.test.ts
+++ b/test/eval-runner.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { parseEvalArgs } from '../eval/cli.ts';
-import { runEval } from '../eval/runner.ts';
+import { formatEvalMatrixProgress, runEval } from '../eval/runner.ts';
 
 describe('eval runner', () => {
   afterEach(() => {
@@ -80,6 +80,50 @@ describe('eval runner', () => {
 
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining('Eval run comparison: before -> after'),
+    );
+  });
+
+  it('formats incremental matrix progress lines', () => {
+    expect(
+      formatEvalMatrixProgress({
+        completed: 3,
+        total: 7,
+        row: {
+          runLabel: 'progress',
+          caseId: 'rule-poison',
+          category: 'rulebook',
+          provider: 'openai',
+          model: 'gpt-5.4-mini',
+          ok: true,
+          answer: 'answer',
+          score: 1,
+          pass: true,
+          latencyMs: 1234,
+          tokenInput: 100,
+          tokenOutput: 20,
+          tokenTotal: 120,
+          estimatedCostUsd: 0.01,
+          toolCallCount: 2,
+          retryCount: 0,
+          loopIterations: 3,
+          failureClass: 'none',
+          traceId: 'trace',
+          traceUrl: 'https://langfuse.test/trace',
+          promptVersion: 'redesigned-agent-v1',
+          promptHash: 'sha256:prompt',
+          toolSurface: 'redesigned',
+          toolSchemaVersion: 'tools',
+          toolSchemaHash: 'sha256:tools',
+          modelSettings: { model: 'gpt-5.4-mini' },
+          runSettings: {
+            retryCount: 0,
+            maxEstimatedCostUsd: 1,
+            providerConcurrency: { anthropic: 1, openai: 1 },
+          },
+        },
+      }),
+    ).toBe(
+      '[3/7] pass openai:gpt-5.4-mini rule-poison failure=none score=1 latency=1234ms tokens=120 tools=2 loops=3',
     );
   });
 


### PR DESCRIPTION
## Summary

- Adds the additional Claude and OpenAI model candidates from the provided pricing sheets to the eval CLI and matrix runner.
- Adds incremental matrix progress output for future long eval runs.
- Checks in the original and expanded SQR-134 live eval reports, plus the decision report recommending that production stay on `anthropic:claude-sonnet-4-6`.

## Review

Pre-Landing Review: No issues found.

Scope Check: CLEAN
Intent: Run the SQR-134 model decision work and capture the data behind the production model choice.
Delivered: Expanded the eval model matrix, added progress output, captured live Langfuse-backed reports, and documented the production recommendation.

## Verification Results

- `npm run check` passed: 65 test files, 1021 tests.
- `git diff --check origin/main...HEAD` passed.
- Parsed both checked-in reports successfully:
  - `docs/plans/sqr-134-full-matrix-report.json`: 87 rows, estimated cost $4.35.
  - `docs/plans/sqr-134-expanded-full-matrix-report.json`: 203 rows, estimated cost $10.15.
- Live expanded run completed against Anthropic, OpenAI, and Langfuse as `sqr-134-expanded-full-matrix-2026-05-02`.

Fixes SQR-134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional evaluation model candidates (Anthropic Haiku and extra GPT-5.4 variants) and progress reporting during evaluation matrix runs.

* **Documentation**
  * Added Multi-Model Eval Decision Report summarizing model comparisons, production recommendation, failure analyses, cost context, and follow-up work.

* **Tests**
  * Expanded test coverage to validate new model candidates, matrix behavior, and progress event emissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->