### PR TITLE
fix(eval): cap OpenAI eval tool loops

### DIFF
--- a/docs/plans/sqr-141-gpt55-loop-limit-investigation.md
+++ b/docs/plans/sqr-141-gpt55-loop-limit-investigation.md
@@ -1,0 +1,129 @@
+# SQR-141 GPT-5.5 Loop-Limit Investigation
+
+Generated on 2026-05-03 for SQR-141.
+
+## Decision
+
+Keep OpenAI out of production routing for now.
+
+The loop-limit symptom is mitigated in eval-only code, but the rerun still shows
+GPT-5.5 missing the trajectory contract on `traj-card-fuzzy-vs-exact`. It
+answers after the tool budget guard fires, but it does not use the required
+`resolve_entity` and `open_entity` path. That is enough reason not to put GPT-5.5
+behind production `/api/ask`.
+
+No production provider routing was added.
+
+## Root Cause
+
+There were two separate causes behind the SQR-134 loop-limit failures.
+
+1. The OpenAI eval runner did not apply the production agent's default repeated
+   rule-search synthesis guard. The live Anthropic path defaults to forcing a
+   final answer after three broad rule searches. The OpenAI eval runner only did
+   this when `--broad-search-synthesis-threshold` was explicitly set, so the
+   SQR-134 matrix let GPT-5.5 keep searching until the loop limit.
+
+2. Trajectory evals had a `maxToolCalls` contract, but the OpenAI eval runner did
+   not use that contract to stop tools. On `traj-card-fuzzy-vs-exact`, GPT-5.5
+   kept tool access after it had enough context and spent the remaining loop
+   budget on broad fallback searches, including high-volume `list_cards` calls.
+
+The traces do not show provider API errors or tool execution failures. They show
+tool-loop control failures and model/tool-choice drift.
+
+## Mitigation
+
+The eval-only OpenAI runner now:
+
+- defaults repeated broad rule-search synthesis to three searches, matching the
+  production Anthropic agent path;
+- disables tools and asks for final synthesis once a trajectory case reaches its
+  `maxToolCalls` budget.
+
+This is intentionally limited to `eval/openai-runner.ts`.
+
+## Evidence
+
+### `rule-looting-definition`
+
+Before:
+
+- Trace:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-full-matrix-2026-05-02-timeout60%3Aopenai%3Agpt-5.5%3Arule-looting-definition>
+- Result: loop limit, no final answer.
+- Tool calls: 10.
+- Loop iterations: 10.
+- Tokens: 200,889.
+
+After:
+
+- Trace:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-141-gpt55-rule-mitigated%3Aopenai%3Agpt-5.5%3Arule-looting-definition>
+- Result: pass.
+- Tool calls: 3.
+- Loop iterations: 4.
+- Tokens: 35,722.
+
+The rule-search guard fixed this case and reduced token use by about 82%.
+
+### `traj-card-fuzzy-vs-exact`
+
+Before:
+
+- Trace:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-134-expanded-full-matrix-2026-05-02%3Aopenai%3Agpt-5.5%3Atraj-card-fuzzy-vs-exact>
+- Result: loop limit, no final answer.
+- Tool calls recorded by the runner: 10.
+- Loop iterations: 10.
+- Tokens: 202,023.
+- Notable behavior: GPT-5.5 used high-volume fallback calls including an
+  unfiltered `list_cards` over monster abilities.
+
+After:
+
+- Trace:
+  <https://us.cloud.langfuse.com/project/default/traces/eval%3Asqr-141-gpt55-traj-mitigated%3Aopenai%3Agpt-5.5%3Atraj-card-fuzzy-vs-exact>
+- Result: final answer produced, but trajectory failed.
+- Tool calls: 8.
+- Loop iterations: 9.
+- Tokens: 174,966.
+- Remaining failure:
+  missing required tool `resolve_entity`, missing required tool `open_entity`,
+  missing required tool kind `resolution`, and missing required tool kind
+  `open`.
+
+The tool-budget guard prevents the no-answer loop-limit failure, but it does not
+make GPT-5.5 follow the required trajectory. That remaining behavior is a prompt
+and model/tool-selection issue, not a loop-control issue.
+
+## Verification
+
+Focused regression tests:
+
+```bash
+npm test -- test/eval-openai-runner.test.ts
+```
+
+Live reruns:
+
+```bash
+npm run eval -- --provider=openai --model=gpt-5.5 \
+  --id=rule-looting-definition \
+  --run-label=sqr-141-gpt55-rule-mitigated \
+  --timeout-ms=60000
+
+npm run eval -- --provider=openai --model=gpt-5.5 \
+  --id=traj-card-fuzzy-vs-exact \
+  --run-label=sqr-141-gpt55-traj-mitigated \
+  --timeout-ms=60000
+```
+
+## Follow-Up
+
+Do not expand this ticket into production provider routing.
+
+If OpenAI production routing is revisited later, the next work should focus on
+OpenAI-specific trajectory prompting and tool-result shaping so it uses
+`resolve_entity` and `open_entity` for exact-record tasks instead of relying on
+large fuzzy searches.

--- a/eval/openai-runner.ts
+++ b/eval/openai-runner.ts
@@ -498,6 +498,8 @@ export async function runOpenAiResponsesEvalCase(
   let forceSynthesis = false;
   const broadSearchSynthesisThreshold = broadSearchSynthesisThresholdFor(options.providerConfig);
   const maxTrajectoryToolCalls = trajectoryToolBudget(options.evalCase);
+  const toolLoopLimit = options.providerConfig.toolLoopLimit ?? 10;
+  let allowForcedSynthesisTurn = false;
 
   const buildTrace = (
     statusReason: string,
@@ -605,7 +607,7 @@ export async function runOpenAiResponsesEvalCase(
     };
   };
 
-  for (let i = 0; i < (options.providerConfig.toolLoopLimit ?? 10); i++) {
+  for (let i = 0; i < toolLoopLimit + (allowForcedSynthesisTurn ? 1 : 0); i++) {
     iterations = i + 1;
     const request = createResponsesRequest(
       input,
@@ -749,6 +751,7 @@ export async function runOpenAiResponsesEvalCase(
 
     if (broadRuleSearches >= broadSearchSynthesisThreshold && !hasUsedNonRuleSearchTool) {
       forceSynthesis = true;
+      allowForcedSynthesisTurn = true;
       input.push({
         type: 'message',
         role: 'user',
@@ -756,6 +759,7 @@ export async function runOpenAiResponsesEvalCase(
       });
     } else if (maxTrajectoryToolCalls && toolCalls.length >= maxTrajectoryToolCalls) {
       forceSynthesis = true;
+      allowForcedSynthesisTurn = true;
       input.push({
         type: 'message',
         role: 'user',
@@ -764,7 +768,7 @@ export async function runOpenAiResponsesEvalCase(
     }
   }
 
-  const message = `OpenAI Responses loop reached ${options.providerConfig.toolLoopLimit ?? 10} iteration(s) without a final answer.`;
+  const message = `OpenAI Responses loop reached ${toolLoopLimit} iteration(s) without a final answer.`;
   errors.push(errorTrace('loop_limit', message));
   return finish(false, '', 'loop_limit', 'loop_limit', message);
 }

--- a/eval/openai-runner.ts
+++ b/eval/openai-runner.ts
@@ -91,6 +91,11 @@ interface OpenAiTranscriptTurn {
 const FORCE_SYNTHESIS_PROMPT =
   'Use the retrieved rulebook context to answer now. Do not search again unless the existing tool results are empty or clearly unrelated.';
 
+const DEFAULT_RULE_SEARCH_SYNTHESIS_THRESHOLD = 3;
+
+const TOOL_BUDGET_SYNTHESIS_PROMPT =
+  'The eval tool budget has been reached. Use the retrieved tool results to answer now. Do not call more tools.';
+
 export interface OpenAiResponsesEvalResult {
   ok: boolean;
   answer: string;
@@ -241,8 +246,17 @@ function modelSettingsFor(config: EvalProviderConfig): Record<string, string | n
     maxOutputTokens: config.maxOutputTokens,
     timeoutMs: config.timeoutMs,
     toolLoopLimit: config.toolLoopLimit,
-    broadSearchSynthesisThreshold: config.broadSearchSynthesisThreshold,
+    broadSearchSynthesisThreshold: broadSearchSynthesisThresholdFor(config),
   };
+}
+
+function broadSearchSynthesisThresholdFor(config: EvalProviderConfig): number {
+  return config.broadSearchSynthesisThreshold ?? DEFAULT_RULE_SEARCH_SYNTHESIS_THRESHOLD;
+}
+
+function trajectoryToolBudget(evalCase: EvalCase): number | undefined {
+  const budget = evalCase.trajectory?.maxToolCalls;
+  return typeof budget === 'number' && Number.isInteger(budget) && budget > 0 ? budget : undefined;
 }
 
 function createResponsesRequest(
@@ -482,6 +496,8 @@ export async function runOpenAiResponsesEvalCase(
   let broadRuleSearches = 0;
   let hasUsedNonRuleSearchTool = false;
   let forceSynthesis = false;
+  const broadSearchSynthesisThreshold = broadSearchSynthesisThresholdFor(options.providerConfig);
+  const maxTrajectoryToolCalls = trajectoryToolBudget(options.evalCase);
 
   const buildTrace = (
     statusReason: string,
@@ -731,16 +747,19 @@ export async function runOpenAiResponsesEvalCase(
       input.push(outputItem);
     }
 
-    if (
-      options.providerConfig.broadSearchSynthesisThreshold &&
-      broadRuleSearches >= options.providerConfig.broadSearchSynthesisThreshold &&
-      !hasUsedNonRuleSearchTool
-    ) {
+    if (broadRuleSearches >= broadSearchSynthesisThreshold && !hasUsedNonRuleSearchTool) {
       forceSynthesis = true;
       input.push({
         type: 'message',
         role: 'user',
         content: [{ type: 'input_text', text: FORCE_SYNTHESIS_PROMPT }],
+      });
+    } else if (maxTrajectoryToolCalls && toolCalls.length >= maxTrajectoryToolCalls) {
+      forceSynthesis = true;
+      input.push({
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: TOOL_BUDGET_SYNTHESIS_PROMPT }],
       });
     }
   }

--- a/test/eval-openai-runner.test.ts
+++ b/test/eval-openai-runner.test.ts
@@ -443,7 +443,11 @@ describe('OpenAI Responses eval runner', () => {
         id: 'rule-looting-definition',
         question: 'What is looting?',
       },
-      providerConfig: { ...providerConfig, broadSearchSynthesisThreshold: undefined },
+      providerConfig: {
+        ...providerConfig,
+        broadSearchSynthesisThreshold: undefined,
+        toolLoopLimit: 3,
+      },
       runLabel: 'rule-synthesis',
       toolSurface: 'redesigned',
       executeTool: vi.fn().mockResolvedValue({ content: 'Loot rule context.' }),

--- a/test/eval-openai-runner.test.ts
+++ b/test/eval-openai-runner.test.ts
@@ -376,6 +376,190 @@ describe('OpenAI Responses eval runner', () => {
     ]);
   });
 
+  it('uses the default repeated-rule-search synthesis guard', async () => {
+    const client = responsesClient(
+      {
+        id: 'resp_rule_1',
+        model: 'gpt-5.5-2026-04-23',
+        status: 'completed',
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_rule_1',
+            call_id: 'call_rule_1',
+            name: 'search_rules',
+            arguments: '{"query":"looting","topK":5}',
+          },
+        ],
+      },
+      {
+        id: 'resp_rule_2',
+        model: 'gpt-5.5-2026-04-23',
+        status: 'completed',
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_rule_2',
+            call_id: 'call_rule_2',
+            name: 'search_rules',
+            arguments: '{"query":"end-of-turn looting","topK":5}',
+          },
+        ],
+      },
+      {
+        id: 'resp_rule_3',
+        model: 'gpt-5.5-2026-04-23',
+        status: 'completed',
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_rule_3',
+            call_id: 'call_rule_3',
+            name: 'search_rules',
+            arguments: '{"query":"loot token current hex","topK":5}',
+          },
+        ],
+      },
+      {
+        id: 'resp_rule_final',
+        model: 'gpt-5.5-2026-04-23',
+        status: 'completed',
+        output_text: 'Looting collects loot tokens and treasure tiles.',
+        output: [
+          {
+            type: 'message',
+            content: [
+              { type: 'output_text', text: 'Looting collects loot tokens and treasure tiles.' },
+            ],
+          },
+        ],
+      },
+    );
+
+    const result = await runOpenAiResponsesEvalCase({
+      client,
+      evalCase: {
+        ...evalCase,
+        id: 'rule-looting-definition',
+        question: 'What is looting?',
+      },
+      providerConfig: { ...providerConfig, broadSearchSynthesisThreshold: undefined },
+      runLabel: 'rule-synthesis',
+      toolSurface: 'redesigned',
+      executeTool: vi.fn().mockResolvedValue({ content: 'Loot rule context.' }),
+    });
+
+    expect(result.ok).toBe(true);
+    const create = vi.mocked(client.responses.create);
+    const finalRequest = create.mock.calls[3]?.[0] as { input: unknown[]; tools: unknown[] };
+    expect(finalRequest.tools).toEqual([]);
+    expect(finalRequest.input).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'message',
+          role: 'user',
+          content: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'input_text',
+              text: expect.stringContaining('Use the retrieved rulebook context to answer now'),
+            }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it('forces synthesis when a trajectory eval reaches its tool budget', async () => {
+    const client = responsesClient(
+      {
+        id: 'resp_traj_1',
+        model: 'gpt-5.5-2026-04-23',
+        status: 'completed',
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_traj_1',
+            call_id: 'call_traj_1',
+            name: 'search_cards',
+            arguments: '{"query":"Algox Archer","topK":10}',
+          },
+        ],
+      },
+      {
+        id: 'resp_traj_2',
+        model: 'gpt-5.5-2026-04-23',
+        status: 'completed',
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_traj_2',
+            call_id: 'call_traj_2',
+            name: 'list_cards',
+            arguments: '{"type":"monster-abilities","filter":null}',
+          },
+        ],
+      },
+      {
+        id: 'resp_traj_final',
+        model: 'gpt-5.5-2026-04-23',
+        status: 'completed',
+        output_text: 'The exact record is the Algox Archer monster stat record.',
+        output: [
+          {
+            type: 'message',
+            content: [
+              {
+                type: 'output_text',
+                text: 'The exact record is the Algox Archer monster stat record.',
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    const result = await runOpenAiResponsesEvalCase({
+      client,
+      evalCase: {
+        ...evalCase,
+        id: 'traj-card-fuzzy-vs-exact',
+        category: 'trajectory',
+        question: 'Find Algox Archer and explain exact versus fuzzy matches.',
+        trajectory: {
+          requiredTools: ['search_cards'],
+          requiredToolKinds: ['search'],
+          forbiddenTools: [],
+          forbiddenToolKinds: [],
+          requiredRefs: [],
+          maxToolCalls: 2,
+        },
+      },
+      providerConfig,
+      runLabel: 'trajectory-budget',
+      toolSurface: 'redesigned',
+      executeTool: vi.fn().mockResolvedValue({ content: 'Tool context.' }),
+    });
+
+    expect(result.ok).toBe(true);
+    const create = vi.mocked(client.responses.create);
+    const finalRequest = create.mock.calls[2]?.[0] as { input: unknown[]; tools: unknown[] };
+    expect(finalRequest.tools).toEqual([]);
+    expect(finalRequest.input).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'message',
+          role: 'user',
+          content: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'input_text',
+              text: expect.stringContaining('The eval tool budget has been reached'),
+            }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
   it('classifies model access, API status, and timeout failures', () => {
     expect(classifyOpenAiResponsesFailure({ status: 401, message: 'missing model' })).toBe(
       'model_access',


### PR DESCRIPTION
## Summary

This PR fixes the SQR-141 OpenAI eval loop-limit failures without changing production provider routing.

- Adds the default repeated broad rule-search synthesis guard to the OpenAI eval runner.
- Forces final synthesis when a trajectory eval reaches its `maxToolCalls` budget.
- Adds focused regression coverage for both loop controls.
- Documents the GPT-5.5 investigation, trace evidence, and remaining production-routing decision.

Fixes SQR-141

## Pre-Landing Review

Pre-Landing Review: No issues found.

## Validation

- `npm test -- test/eval-openai-runner.test.ts`
- `npm run check`
- Live OpenAI + Langfuse rerun: `rule-looting-definition` now passes with 3 tool calls.
- Live OpenAI + Langfuse rerun: `traj-card-fuzzy-vs-exact` now produces a final answer instead of loop-limit, but still fails trajectory expectations because GPT-5.5 skips required `resolve_entity` / `open_entity`.

## Notes

No `VERSION` or `CHANGELOG.md` updates are included; Squire's ship rules do not use them for ordinary feature-branch PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an investigation and mitigation plan for GPT-5.5 loop-limit behavior.

* **Bug Fixes**
  * Added safeguards to prevent excessive repeated searches and to enforce tool-call budgets so evaluation runs conclude predictably.

* **Tests**
  * Added tests confirming synthesis is triggered appropriately when repeated searches or tool-call limits are reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->