### PR TITLE
fix(eval): nudge exact refs open in trajectory loop

### DIFF
--- a/docs/plans/sqr-142-opus-early-stopping-report.md
+++ b/docs/plans/sqr-142-opus-early-stopping-report.md
@@ -1,0 +1,87 @@
+# SQR-142 Opus 4.7 Trajectory Early-Stopping Report
+
+Generated on 2026-05-03 for SQR-142.
+
+## Summary
+
+The SQR-134 failures were not provider errors, timeouts, loop-limit stops, or a
+bad trajectory evaluator. Opus 4.7 reached `end_turn` with plausible answers
+before opening the exact records the user had asked to show or inspect.
+
+The root cause was prompt-loop wording: the system prompt said to open exact
+records, but the post-tool guidance made it too easy for Opus to answer from a
+scenario pointer, a neighbor result, or resolver/search summaries.
+
+The fix is a narrow eval-loop prompt adjustment:
+
+- after `resolve_entity` returns candidates, remind the model to open the best
+  exact ref before answering exact-record/source-text questions
+- after `neighbors` returns targets, explicitly require `open_entity` when the
+  user asks to show, open, quote, cite, list, or explain returned
+  scenario/section content
+
+No production model switch was made.
+
+## Original Failure Evidence
+
+Source run: `sqr-134-full-matrix-2026-05-02-timeout60`
+
+| Case                                  | Opus failed because                                                                                                           | Failed Opus trace                                                                                                                                                                                | Passing Sonnet trace                                                                                                                                                                                 |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `traj-scenario-conclusion-open`       | Opus used `resolve_entity -> neighbors`, then answered from the conclusion pointer without opening `section:frosthaven/67.1`. | [Opus trace](https://us.cloud.langfuse.com/project/cmn1deprv071ead07hellcosn/traces/eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-scenario-conclusion-open)       | [Sonnet trace](https://us.cloud.langfuse.com/project/cmn1deprv071ead07hellcosn/traces/eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-scenario-conclusion-open)       |
+| `traj-scenario-conclusion-next-links` | Opus used `resolve_entity -> neighbors -> neighbors`, then answered without opening the conclusion section.                   | [Opus trace](https://us.cloud.langfuse.com/project/cmn1deprv071ead07hellcosn/traces/eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-scenario-conclusion-next-links) | [Sonnet trace](https://us.cloud.langfuse.com/project/cmn1deprv071ead07hellcosn/traces/eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-scenario-conclusion-next-links) |
+| `traj-card-fuzzy-vs-exact`            | Opus used `resolve_entity -> search_knowledge`, then stated it should open exact stat records but answered without doing so.  | [Opus trace](https://us.cloud.langfuse.com/project/cmn1deprv071ead07hellcosn/traces/eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-opus-4-7:traj-card-fuzzy-vs-exact)            | [Sonnet trace](https://us.cloud.langfuse.com/project/cmn1deprv071ead07hellcosn/traces/eval:sqr-134-full-matrix-2026-05-02-timeout60:anthropic:claude-sonnet-4-6:traj-card-fuzzy-vs-exact)            |
+
+All three Opus traces had `status: completed` and `stop reason: end_turn`. The
+trajectory score failed only because `open_entity` was missing. That matches
+the eval contract: these prompts ask the assistant to show/open exact content,
+not merely identify a pointer to it.
+
+## Rerun Evidence
+
+After the prompt-loop adjustment, the three targeted Opus cases passed.
+
+Langfuse-backed run label: `sqr-142-opus-open-nudge-langfuse-2026-05-03`
+
+```bash
+npm run eval -- --id=<case-id> --provider=anthropic \
+  --model=claude-opus-4-7 --timeout-ms=60000 \
+  --name=sqr-142-opus-open-nudge-langfuse-2026-05-03
+```
+
+| Case                                  | Result | Tool path                                                          | Rerun trace                                                                                                                                                                                    |
+| ------------------------------------- | ------ | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `traj-scenario-conclusion-open`       | Pass   | `resolve_entity -> neighbors -> open_entity`                       | [Trace](https://us.cloud.langfuse.com/project/cmn1deprv071ead07hellcosn/traces/eval:sqr-142-opus-open-nudge-langfuse-2026-05-03:anthropic:claude-opus-4-7:traj-scenario-conclusion-open)       |
+| `traj-scenario-conclusion-next-links` | Pass   | `neighbors -> open_entity -> resolve_entity -> neighbors`          | [Trace](https://us.cloud.langfuse.com/project/cmn1deprv071ead07hellcosn/traces/eval:sqr-142-opus-open-nudge-langfuse-2026-05-03:anthropic:claude-opus-4-7:traj-scenario-conclusion-next-links) |
+| `traj-card-fuzzy-vs-exact`            | Pass   | `open_entity -> open_entity -> resolve_entity -> search_knowledge` | [Trace](https://us.cloud.langfuse.com/project/cmn1deprv071ead07hellcosn/traces/eval:sqr-142-opus-open-nudge-langfuse-2026-05-03:anthropic:claude-opus-4-7:traj-card-fuzzy-vs-exact)            |
+
+A local JSON rerun with the same code path also passed all three cases:
+
+| Case                                  | Tool calls | Iterations | Stop reason |
+| ------------------------------------- | ---------: | ---------: | ----------- |
+| `traj-scenario-conclusion-open`       |          3 |          4 | `end_turn`  |
+| `traj-scenario-conclusion-next-links` |          3 |          4 | `end_turn`  |
+| `traj-card-fuzzy-vs-exact`            |          4 |          3 | `end_turn`  |
+
+## Default-Routing Call
+
+Opus 4.7 can stay under consideration for future default routing because the
+early-stopping blocker reproduced by SQR-142 passed in the focused rerun.
+
+That is not enough to switch production. SQR-134 still showed Sonnet 4.6 as the
+best full-matrix default, and Opus had at least one non-trajectory miss
+(`item-spyglass`) plus higher cost. A production change would need another full
+matrix after this prompt-loop adjustment.
+
+## Verification
+
+```bash
+npx vitest run test/agent.test.ts
+npm run db:migrate
+npm run db:migrate:test
+npm run index
+npm run seed:dev
+npm run eval -- --id=traj-scenario-conclusion-open --provider=anthropic --model=claude-opus-4-7 --timeout-ms=60000 --name=sqr-142-opus-open-nudge-langfuse-2026-05-03
+npm run eval -- --id=traj-scenario-conclusion-next-links --provider=anthropic --model=claude-opus-4-7 --timeout-ms=60000 --name=sqr-142-opus-open-nudge-langfuse-2026-05-03
+npm run eval -- --id=traj-card-fuzzy-vs-exact --provider=anthropic --model=claude-opus-4-7 --timeout-ms=60000 --name=sqr-142-opus-open-nudge-langfuse-2026-05-03
+```

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -54,7 +54,10 @@ const FORCE_SYNTHESIS_PROMPT =
   'Use the retrieved rulebook context to answer now. Do not search again unless the existing tool results are empty or clearly unrelated.';
 
 const NEIGHBORS_TARGET_PROMPT =
-  'If this neighbors result completes the requested traversal, use it as the traversal answer. If the question asks for section text, call open_entity on the returned section ref now; otherwise answer from the neighbors result. Do not search for another path unless neighbors returned no relevant target.';
+  'If this neighbors result completes the requested traversal, use it as the traversal answer. If the question asks to show, open, quote, cite, list, or explain returned section/scenario content, call open_entity on the returned canonical ref before answering. Do not answer from a pointer alone when the user asked for the target text or its contents. Do not search for another path unless neighbors returned no relevant target.';
+
+const RESOLUTION_TARGET_PROMPT =
+  'You now have canonical candidate refs. If the user asked for an exact record or source text, open the best matching exact ref before answering. If the user also asked for fuzzy/contextual matches, keep those separate and use search only for the fuzzy part.';
 
 const ANSWER_FORMATTING_PROMPT = `Formatting:
 - Use *italics* only for named Frosthaven game terms — mechanics, abilities, conditions, status effects, keyword phrases (e.g., *Muddle*, *Shield 1*, *Retaliate*, *Loot 2*, *Move 3*). The UI renders these as a highlighted rule-term chip, so emphasizing prose words like *not* or *however* turns ordinary stress into a false rule citation. Use **bold** for general emphasis instead.
@@ -505,6 +508,18 @@ function hasUsefulNeighborsResult(result: ToolCallResult): boolean {
   }
 }
 
+function hasUsefulResolutionResult(result: ToolCallResult): boolean {
+  try {
+    const parsed = JSON.parse(result.content) as {
+      ok?: unknown;
+      candidates?: unknown;
+    };
+    return parsed.ok === true && Array.isArray(parsed.candidates) && parsed.candidates.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 function sourceLabelsFromResult(value: unknown): string[] {
   const seen = new Set<string>();
   const labels: string[] = [];
@@ -942,6 +957,7 @@ async function runAgentLoopInternal(
 
       const toolResults: ContentBlockParam[] = [];
       let sawNeighborsWithTargets = false;
+      let sawResolutionWithCandidates = false;
       for (const block of response.content) {
         if (block.type === 'tool_use') {
           const input = block.input as Record<string, unknown>;
@@ -1018,6 +1034,13 @@ async function runAgentLoopInternal(
           if (block.name === 'neighbors' && !isError && hasUsefulNeighborsResult(toolResult)) {
             sawNeighborsWithTargets = true;
           }
+          if (
+            block.name === 'resolve_entity' &&
+            !isError &&
+            hasUsefulResolutionResult(toolResult)
+          ) {
+            sawResolutionWithCandidates = true;
+          }
 
           if (emit) {
             await emit('tool_result', {
@@ -1037,6 +1060,9 @@ async function runAgentLoopInternal(
       }
 
       messages.push({ role: 'user', content: toolResults });
+      if (sawResolutionWithCandidates) {
+        messages.push({ role: 'user', content: RESOLUTION_TARGET_PROMPT });
+      }
       if (sawNeighborsWithTargets) {
         messages.push({ role: 'user', content: NEIGHBORS_TARGET_PROMPT });
       }

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -368,7 +368,7 @@ describe('runAgentLoop', () => {
     expect(mockMessagesCreate.mock.calls[1][0].messages).not.toContainEqual({
       role: 'user',
       content:
-        'If this neighbors result completes the requested traversal, use it as the traversal answer. If the question asks for section text, call open_entity on the returned section ref now; otherwise answer from the neighbors result. Do not search for another path unless neighbors returned no relevant target.',
+        'If this neighbors result completes the requested traversal, use it as the traversal answer. If the question asks to show, open, quote, cite, list, or explain returned section/scenario content, call open_entity on the returned canonical ref before answering. Do not answer from a pointer alone when the user asked for the target text or its contents. Do not search for another path unless neighbors returned no relevant target.',
     });
   });
 

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -346,7 +346,7 @@ describe('runAgentLoop', () => {
     expect(mockMessagesCreate.mock.calls[2][0].messages).toContainEqual({
       role: 'user',
       content:
-        'If this neighbors result completes the requested traversal, use it as the traversal answer. If the question asks for section text, call open_entity on the returned section ref now; otherwise answer from the neighbors result. Do not search for another path unless neighbors returned no relevant target.',
+        'If this neighbors result completes the requested traversal, use it as the traversal answer. If the question asks to show, open, quote, cite, list, or explain returned section/scenario content, call open_entity on the returned canonical ref before answering. Do not answer from a pointer alone when the user asked for the target text or its contents. Do not search for another path unless neighbors returned no relevant target.',
     });
   });
 
@@ -542,6 +542,78 @@ describe('runAgentLoop', () => {
     const result = await runAgentLoop('What card types are available?', { toolSurface: 'legacy' });
     expect(result).toBe('There are items and more.');
     expect(mockListCardTypes).toHaveBeenCalled();
+  });
+
+  it('nudges redesigned exact-record resolutions toward opening before answering', async () => {
+    mockResolveEntity.mockResolvedValueOnce({
+      ok: true,
+      query: 'Algox Archer',
+      candidates: [
+        {
+          ref: 'card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/0-3',
+          kind: 'card',
+          title: 'Algox Archer',
+          confidence: 0.98,
+          matchReason: 'Exact card name',
+        },
+      ],
+    });
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('resolve_entity', {
+          query: 'Algox Archer',
+          kinds: ['monster'],
+        }),
+      )
+      .mockResolvedValueOnce(textResponse('Algox Archer has two stat records.'));
+
+    await runAgentLoop('Find the Algox Archer monster stat record, then search for card records.', {
+      toolSurface: 'redesigned',
+    });
+
+    expect(mockMessagesCreate.mock.calls[1][0].messages.at(-1)).toEqual({
+      role: 'user',
+      content:
+        'You now have canonical candidate refs. If the user asked for an exact record or source text, open the best matching exact ref before answering. If the user also asked for fuzzy/contextual matches, keep those separate and use search only for the fuzzy part.',
+    });
+  });
+
+  it('makes traversal guidance explicit about opening returned section refs', async () => {
+    mockNeighbors.mockResolvedValueOnce({
+      ok: true,
+      from: {
+        kind: 'scenario',
+        ref: 'scenario:frosthaven/061',
+        title: 'Life and Death',
+        sourceLabel: 'Scenario Book',
+      },
+      neighbors: [
+        {
+          ref: 'section:frosthaven/67.1',
+          kind: 'section',
+          relation: 'conclusion',
+          title: 'Section 67.1',
+        },
+      ],
+    });
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('neighbors', {
+          ref: 'scenario:frosthaven/061',
+          relation: 'conclusion',
+        }),
+      )
+      .mockResolvedValueOnce(textResponse('Read section 67.1.'));
+
+    await runAgentLoop('Show the section I should read at the conclusion of scenario 61.', {
+      toolSurface: 'redesigned',
+    });
+
+    expect(mockMessagesCreate.mock.calls[1][0].messages.at(-1)).toEqual({
+      role: 'user',
+      content:
+        'If this neighbors result completes the requested traversal, use it as the traversal answer. If the question asks to show, open, quote, cite, list, or explain returned section/scenario content, call open_entity on the returned canonical ref before answering. Do not answer from a pointer alone when the user asked for the target text or its contents. Do not search for another path unless neighbors returned no relevant target.',
+    });
   });
 
   it('uses traversal tools for an exact scenario conclusion lookup', async () => {


### PR DESCRIPTION
## Summary

- add a post-`resolve_entity` eval-loop nudge so exact refs get opened before final answers
- tighten post-`neighbors` guidance so section/scenario targets are opened when the user asks to show, quote, cite, list, or explain returned content
- document the SQR-142 root cause and Opus rerun trace evidence in `docs/plans/sqr-142-opus-early-stopping-report.md`

## Review

Pre-landing review found no blocking issues. The change is scoped to successful `resolve_entity` and `neighbors` tool results, with regression tests for both injected guidance paths.

## Verification

- `npm run check`
- `npm run eval -- --id=traj-scenario-conclusion-open --provider=anthropic --model=claude-opus-4-7 --timeout-ms=60000 --name=sqr-142-opus-open-nudge-langfuse-2026-05-03`
- `npm run eval -- --id=traj-scenario-conclusion-next-links --provider=anthropic --model=claude-opus-4-7 --timeout-ms=60000 --name=sqr-142-opus-open-nudge-langfuse-2026-05-03`
- `npm run eval -- --id=traj-card-fuzzy-vs-exact --provider=anthropic --model=claude-opus-4-7 --timeout-ms=60000 --name=sqr-142-opus-open-nudge-langfuse-2026-05-03`

## Result

The focused Opus rerun passed all three SQR-142 trajectory cases. No production model switch is included.

Fixes SQR-142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent now opens relevant entity sections before answering when users ask to view, quote, cite, list, or explain content.

* **Bug Fixes**
  * Addressed early-stopping responses that terminated at end_turn without opening entities.
  * Improved resolution handling to prefer exact matches and steer next-step behavior.

* **Documentation**
  * Added detailed report on the early-stopping investigation and verification steps.

* **Tests**
  * Added tests covering traversal guidance and exact-match resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->