### PR TITLE
Harden item resourcesAny craft costs

### DIFF
--- a/src/extracted-data.ts
+++ b/src/extracted-data.ts
@@ -377,10 +377,12 @@ function recordToText(record: ExtractedRecord): string {
     const uses = r.uses ? ` (${r.uses} uses)` : '';
     const spent = r.spent ? ' [spent]' : '';
     const lost = r.lost ? ' [lost]' : '';
-    const costText =
-      typeof r.cost === 'number'
-        ? `Cost: ${r.cost}g`
-        : (formatItemCraftCost(r.craftCost) ?? 'Cost: not shown');
+    const craftCostText = formatItemCraftCost(r.craftCost);
+    const costParts = [
+      typeof r.cost === 'number' ? `Cost: ${r.cost}g` : null,
+      craftCostText,
+    ].filter((part): part is string => part !== null);
+    const costText = costParts.length > 0 ? costParts.join('. ') : 'Cost: not shown';
     return `Item #${r.number}: ${r.name}. Slot: ${r.slot}. ${costText}. Effect: ${r.effect}${uses}${spent}${lost}`;
   }
 

--- a/src/import-items.ts
+++ b/src/import-items.ts
@@ -126,11 +126,14 @@ export function resolveNestedDataRefs(text: string, labels: LabelData): string {
  */
 export function convertItem(ghs: GhsItem, labels: LabelData): ExtractedItem {
   const slot = SLOT_MAP[ghs.slot ?? ''] ?? 'small item';
+  const resources =
+    ghs.resources && Object.keys(ghs.resources).length > 0 ? ghs.resources : undefined;
+  const resourcesAny = ghs.resourcesAny?.filter((choice) => Object.keys(choice).length > 0);
   const craftCost =
-    ghs.resources || ghs.resourcesAny
+    resources || resourcesAny?.length
       ? {
-          ...(ghs.resources ? { resources: ghs.resources } : {}),
-          ...(ghs.resourcesAny ? { resourcesAny: ghs.resourcesAny } : {}),
+          ...(resources ? { resources } : {}),
+          ...(resourcesAny?.length ? { resourcesAny } : {}),
         }
       : null;
 

--- a/test/extracted-data.test.ts
+++ b/test/extracted-data.test.ts
@@ -365,6 +365,46 @@ describe('formatExtracted', () => {
     expect(text).not.toContain('Cost: nullg');
   });
 
+  it('formats item resource-any craft costs', () => {
+    const text = formatExtracted([
+      {
+        _type: 'items',
+        number: '098',
+        name: 'Unhealthy Mixture',
+        slot: 'small item',
+        cost: null,
+        craftCost: { resourcesAny: [{ herb_resources: 1 }, { herb_resources: 1 }] },
+        effect: 'During your turn, perform Wound, Poison self',
+        uses: null,
+        spent: false,
+        lost: false,
+      },
+    ]);
+
+    expect(text).toContain('Craft cost: any 1 herb_resources, any 1 herb_resources');
+    expect(text).not.toContain('Cost: nullg');
+  });
+
+  it('formats item gold cost and craft cost when both are present', () => {
+    const text = formatExtracted([
+      {
+        _type: 'items',
+        number: '777',
+        name: 'Future Hybrid Item',
+        slot: 'small item',
+        cost: 10,
+        craftCost: { resources: { hide: 1 } },
+        effect: 'Do the thing',
+        uses: null,
+        spent: false,
+        lost: false,
+      },
+    ]);
+
+    expect(text).toContain('Cost: 10g');
+    expect(text).toContain('Craft cost: 1 hide');
+  });
+
   it('formats character abilities with top and bottom actions', () => {
     const text = formatExtracted([
       {

--- a/test/import-items.test.ts
+++ b/test/import-items.test.ts
@@ -134,6 +134,51 @@ describe('convertItem', () => {
     });
   });
 
+  it('includes resource-any craft costs when present', () => {
+    const ghsItem = {
+      id: 98,
+      name: 'Unhealthy Mixture',
+      count: 2,
+      edition: 'fh',
+      slot: 'small',
+      resourcesAny: [{ herb_resources: 1 }, { herb_resources: 1 }],
+      actions: [{ type: 'custom', value: '%data.items.fh-98.1%', small: true }],
+    };
+
+    const result = convertItem(ghsItem, {
+      items: {
+        'fh-98': {
+          '': 'Unhealthy Mixture',
+          '1': 'During your turn, perform %game.condition.wound%, %game.condition.poison% self',
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      number: '098',
+      name: 'Unhealthy Mixture',
+      slot: 'small item',
+      cost: null,
+      craftCost: { resourcesAny: [{ herb_resources: 1 }, { herb_resources: 1 }] },
+      effect: 'During your turn, perform Wound, Poison self',
+    });
+  });
+
+  it('normalizes empty craft-cost payloads to null', () => {
+    const ghsItem = {
+      id: 200,
+      name: 'Empty Craft Cost',
+      count: 1,
+      edition: 'fh',
+      slot: 'small',
+      resources: {},
+      resourcesAny: [],
+      actions: [],
+    };
+
+    expect(convertItem(ghsItem, labels).craftCost).toBeNull();
+  });
+
   it('sets lost from the loss field', () => {
     const ghsItem = {
       id: 84,


### PR DESCRIPTION
## Summary
- Preserve non-empty GHS `resourcesAny` craft costs during item import
- Normalize empty `resources` / `resourcesAny` payloads to no craft cost
- Render craft costs alongside gold costs when both are present

## Validation
- `NODE_ENV=test npm run db:migrate`
- `npx vitest run import-items extracted-data`
- `npx prettier --check src/import-items.ts src/extracted-data.ts test/import-items.test.ts test/extracted-data.test.ts`
- `npx eslint src/import-items.ts src/extracted-data.ts test/import-items.test.ts test/extracted-data.test.ts`
- `npx tsc --noEmit`
- `npm run check`

Fixes SQR-146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced item cost display to properly combine and format numeric costs with craft cost details.
  * Improved data import to prevent empty craft cost structures from being stored for items.

* **Tests**
  * Added comprehensive test coverage for craft cost formatting and resource handling during item import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->