### PR TITLE
Fix exact item open trajectory

### DIFF
--- a/eval/schema.ts
+++ b/eval/schema.ts
@@ -85,6 +85,19 @@ const TOOL_KIND_BY_NAME = new Map<string, ToolKind>([
   ['follow_links', 'traversal'],
 ]);
 
+const CARD_TYPE_BY_SOURCE_PREFIX = new Map<string, string>([
+  ['item', 'items'],
+  ['monster-stat', 'monster-stats'],
+  ['monster-ability', 'monster-abilities'],
+  ['character-ability', 'character-abilities'],
+  ['character-mat', 'character-mats'],
+  ['building', 'buildings'],
+  ['event', 'events'],
+  ['battle-goal', 'battle-goals'],
+  ['personal-quest', 'personal-quests'],
+  ['scenario', 'scenarios'],
+]);
+
 export function evalCaseHasFinalAnswer(
   evalCase: EvalCase,
 ): evalCase is EvalCase & { finalAnswer: FinalAnswerExpectation } {
@@ -144,6 +157,17 @@ export function normalizeTrajectoryRef(ref: string): string {
   const sectionMatch = ref.match(/^(?:section:frosthaven\/|section:)?(\d+\.\d+)$/);
   if (sectionMatch) {
     return `section:frosthaven/${sectionMatch[1]}`;
+  }
+
+  const cardMatch = ref.match(
+    /^(?:card:frosthaven\/([^/]+)\/)?gloomhavensecretariat:([^/]+)\/(.+)$/,
+  );
+  if (cardMatch) {
+    const explicitType = cardMatch[1];
+    const sourcePrefix = cardMatch[2];
+    const sourceRest = cardMatch[3];
+    const type = explicitType ?? CARD_TYPE_BY_SOURCE_PREFIX.get(sourcePrefix);
+    if (type) return `card:frosthaven/${type}/gloomhavensecretariat:${sourcePrefix}/${sourceRest}`;
   }
 
   return ref;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -71,7 +71,7 @@ Grounding rules:
 - If the available data does not answer the question, say what is missing instead of guessing.
 - Resolve natural user language to refs when exact records are needed, then open or traverse those refs.
 - For scenario/section relationship questions, resolve the named scenario or section first, then open or traverse the canonical ref.
-- For named card-data records such as items, monsters, buildings, events, battle goals, personal quests, and character mats, resolve the record first and then open the exact ref.
+- For named or numbered card-data records such as item 1, Spyglass, monsters, buildings, events, battle goals, personal quests, and character mats, resolve the record first and then open the exact canonical ref returned by resolve_entity.
 - When an exact record has null or empty fields, state that the field is not available in the checked-in data. Do not recommend physical components, community knowledge, memory, or likely values as a substitute for missing tool data.
 - For building records, treat a cost object as known no-cost only when every numeric cost field is 0, including prosperity when present. If resources are 0 but prosperity is non-zero, say there is no resource cost but there is still a prosperity requirement.
 - If the user asks you to resolve something, call resolve_entity before opening or answering.
@@ -151,7 +151,7 @@ export const AGENT_TOOLS = [
   {
     name: 'resolve_entity',
     description:
-      'Resolve natural references like "scenario 61", "section 90.2", "Spyglass", "Alchemist building", or "Blinkblade level 4 cards" to ranked opener-ready entity refs.',
+      'Resolve natural references like "scenario 61", "section 90.2", "item 1", "Spyglass", "Alchemist building", or "Blinkblade level 4 cards" to ranked opener-ready entity refs.',
     input_schema: {
       type: 'object',
       properties: {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -281,6 +281,7 @@ const CARD_KIND_ALIASES: Record<string, CardType[]> = {
 };
 
 const CARD_TYPE_BY_SOURCE_PREFIX: Record<string, CardType> = {
+  scenario: 'scenarios',
   item: 'items',
   'monster-stat': 'monster-stats',
   'monster-ability': 'monster-abilities',

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -280,6 +280,18 @@ const CARD_KIND_ALIASES: Record<string, CardType[]> = {
   'character-mats': ['character-mats'],
 };
 
+const CARD_TYPE_BY_SOURCE_PREFIX: Record<string, CardType> = {
+  item: 'items',
+  'monster-stat': 'monster-stats',
+  'monster-ability': 'monster-abilities',
+  'character-ability': 'character-abilities',
+  'character-mat': 'character-mats',
+  building: 'buildings',
+  event: 'events',
+  'battle-goal': 'battle-goals',
+  'personal-quest': 'personal-quests',
+};
+
 const KIND_ALIASES: Record<string, KnowledgeKind> = {
   rules_passage: 'rules_passage',
   rule: 'rules_passage',
@@ -376,7 +388,12 @@ const SCHEMAS: Record<KnowledgeKind, Extract<SchemaResult, { ok: true }>> = {
     ],
     filterFields: ['type', 'name', 'cardName', 'level', 'class', 'number'],
     relations: ['belongs_to_type'],
-    examples: [{ label: 'Open item 1', ref: 'gloomhavensecretariat:item/1' }],
+    examples: [
+      {
+        label: 'Open item 1',
+        ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+      },
+    ],
     aliases: Object.keys(CARD_KIND_ALIASES),
   },
 };
@@ -442,6 +459,18 @@ function extractLevelQuery(query: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
+function extractExactItemNumberQuery(query: string): number | null {
+  const match = query.match(/\bitems?\s*#?\s*0*(\d{1,3})\b/i);
+  return match ? Number(match[1]) : null;
+}
+
+function normalizedCardNumber(record: Record<string, unknown>): number | null {
+  const value = record.number;
+  if (typeof value !== 'string' && typeof value !== 'number') return null;
+  const match = String(value).match(/^0*(\d{1,3})$/);
+  return match ? Number(match[1]) : null;
+}
+
 async function resolveCards(
   query: string,
   cardTypes: CardType[],
@@ -454,12 +483,32 @@ async function resolveCards(
   const level = extractLevelQuery(query);
   const lowered = query.toLowerCase();
   const candidates: EntityCandidate[] = [];
+  const exactItemNumber = cardTypes.includes('items') ? extractExactItemNumberQuery(query) : null;
 
   for (const type of cardTypes) {
     const records = await load(type, opts);
     for (const rawRecord of records) {
       const record = stripInternalKeys(rawRecord);
       if (level !== null && record.level !== level) continue;
+
+      const sourceId = record.sourceId;
+      if (typeof sourceId !== 'string') continue;
+      const title = displayTitleForCard(record, type);
+      if (type === 'items' && exactItemNumber !== null) {
+        if (normalizedCardNumber(record) !== exactItemNumber) continue;
+        candidates.push({
+          entity: {
+            kind: 'card',
+            ref: canonicalCardRef(type, sourceId, game),
+            title,
+            source: `source:${game}/cards`,
+            sourceLabel: 'GHS Card Data',
+          },
+          confidence: 0.99,
+          matchReason: 'Exact item number',
+        });
+        continue;
+      }
 
       const searchable = [
         record.name,
@@ -476,9 +525,6 @@ async function resolveCards(
       );
       if (!matches) continue;
 
-      const sourceId = record.sourceId;
-      if (typeof sourceId !== 'string') continue;
-      const title = displayTitleForCard(record, type);
       candidates.push({
         entity: {
           kind: 'card',
@@ -669,8 +715,20 @@ function parseCardRef(
   ref: string,
 ): { ok: true; game: string; type: CardType; sourceId: string } | { ok: false } {
   const match = ref.match(/^card:([^/]+)\/([^/]+)\/(.+)$/);
-  if (!match || !TYPES.includes(match[2] as CardType)) return { ok: false };
-  return { ok: true, game: match[1], type: match[2] as CardType, sourceId: match[3] };
+  if (match && TYPES.includes(match[2] as CardType)) {
+    return { ok: true, game: match[1], type: match[2] as CardType, sourceId: match[3] };
+  }
+
+  const sourceIdMatch = ref.match(/^gloomhavensecretariat:([^/]+)\/(.+)$/);
+  if (!sourceIdMatch) return { ok: false };
+  const type = CARD_TYPE_BY_SOURCE_PREFIX[sourceIdMatch[1]];
+  if (!type) return { ok: false };
+  return {
+    ok: true,
+    game: DEFAULT_GAME,
+    type,
+    sourceId: `gloomhavensecretariat:${sourceIdMatch[1]}/${sourceIdMatch[2]}`,
+  };
 }
 
 async function targetSummary(
@@ -1121,6 +1179,7 @@ export async function openEntity(ref: string, opts?: ToolOpts): Promise<Knowledg
         ...entity,
         data: {
           ...card,
+          canonicalRef: entity.ref,
           type: cardRef.type,
           sourceId,
           displayName: displayTitleForCard(card, cardRef.type),

--- a/test/eval-trajectory.test.ts
+++ b/test/eval-trajectory.test.ts
@@ -48,6 +48,29 @@ describe('scoreTrajectory', () => {
     expect(result).toEqual({ pass: true, failures: [] });
   });
 
+  it('matches exact card refs against opened GHS source IDs', () => {
+    const result = scoreTrajectory(
+      {
+        requiredTools: ['resolve_entity', 'open_entity'],
+        requiredToolKinds: ['resolution', 'open'],
+        forbiddenTools: ['search_rules'],
+        forbiddenToolKinds: [],
+        requiredRefs: ['card:frosthaven/items/gloomhavensecretariat:item/1'],
+        maxToolCalls: 3,
+      },
+      [
+        { name: 'resolve_entity', input: { query: 'item 1', kinds: ['item'] } },
+        {
+          name: 'open_entity',
+          input: { ref: 'gloomhavensecretariat:item/1' },
+          canonicalRefs: ['gloomhavensecretariat:item/1'],
+        },
+      ],
+    );
+
+    expect(result).toEqual({ pass: true, failures: [] });
+  });
+
   it('reports missing requirements and forbidden calls', () => {
     const result = scoreTrajectory(
       {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -227,6 +227,7 @@ describe('openEntity', () => {
     expect(result.entity.title).toBe('Spyglass');
     expect(result.entity.sourceLabel).toBe('Card Index');
     expect(result.entity.data).toMatchObject({
+      canonicalRef: 'card:frosthaven/items/gloomhavensecretariat:item/1',
       type: 'items',
       sourceId: 'gloomhavensecretariat:item/1',
       displayName: 'Spyglass',
@@ -238,6 +239,23 @@ describe('openEntity', () => {
         locator: 'gloomhavensecretariat:item/1',
       }),
     ]);
+  });
+
+  it('opens legacy GHS card source IDs as canonical card refs', async () => {
+    const result = await openEntity('gloomhavensecretariat:item/1');
+
+    expect(result).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'card',
+        ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+        data: {
+          canonicalRef: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+          sourceId: 'gloomhavensecretariat:item/1',
+          displayName: 'Spyglass',
+        },
+      },
+    });
   });
 
   it('opens a rule passage by canonical source and chunk ref', async () => {
@@ -616,6 +634,9 @@ describe('knowledge discovery tools', () => {
       entity: expect.objectContaining({
         kind: 'card',
         ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+        data: expect.objectContaining({
+          canonicalRef: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+        }),
       }),
     });
 
@@ -643,6 +664,34 @@ describe('knowledge discovery tools', () => {
       ]),
     );
     expect(ability.candidates[0].entity).not.toHaveProperty('data');
+  });
+
+  it('resolveEntity treats item number queries as exact item refs', async () => {
+    const result = await resolveEntity('item 1', { kinds: ['item'] });
+
+    expect(result.ok).toBe(true);
+    expect(result.candidates[0]).toEqual(
+      expect.objectContaining({
+        confidence: 0.99,
+        matchReason: 'Exact item number',
+        entity: expect.objectContaining({
+          kind: 'card',
+          ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+          title: 'Spyglass',
+        }),
+      }),
+    );
+    await expect(openEntity(result.candidates[0].entity.ref)).resolves.toMatchObject({
+      ok: true,
+      entity: expect.objectContaining({
+        ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+        data: expect.objectContaining({
+          number: '001',
+          sourceId: 'gloomhavensecretariat:item/1',
+          displayName: 'Spyglass',
+        }),
+      }),
+    });
   });
 
   it('resolveEntity accepts building aliases and returns openable building refs', async () => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -192,6 +192,19 @@ describe('openEntity', () => {
     );
   });
 
+  it('opens legacy GHS scenario source IDs as canonical scenario refs', async () => {
+    const result = await openEntity('gloomhavensecretariat:scenario/061');
+
+    expect(result).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'scenario',
+        ref: 'scenario:frosthaven/061',
+        title: 'Life and Death',
+      },
+    });
+  });
+
   it('opens a section with exact text, source metadata, and outgoing links', async () => {
     const result = await openEntity('section:frosthaven/66.2');
     expect(result.ok).toBe(true);


### PR DESCRIPTION
## Summary
- resolve numbered item references like `item 1` directly to the canonical item card ref
- let `open_entity` canonicalize legacy GHS card source IDs while returning the full `card:frosthaven/...` ref
- normalize GHS card source IDs in trajectory scoring so successful exact opens are not failed for source-ID formatting
- nudge the agent/tool surface toward resolving numbered card records before opening them

## Validation
- `npm run check`

Fixes SQR-154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Card references are now consistently normalized and matched for reliable comparisons.
  * Agent resolves named and numbered card records (e.g., "item 1") correctly before opening them.

* **New Features**
  * Legacy card reference formats are automatically converted to canonical references.
  * Card inspection now surfaces canonical reference information.

* **Tests**
  * Added coverage for trajectory scoring with exact card refs and legacy card resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->