### PR TITLE
Fix OpenAI eval tool surface selection

### DIFF
--- a/eval/openai-runner.ts
+++ b/eval/openai-runner.ts
@@ -13,6 +13,7 @@ import {
   OPENAI_TOOL_SCHEMA_VERSION,
   executeOpenAiToolCall,
   getOpenAiToolSchemaHash,
+  openAiToolsForSurface,
   renderOpenAiStrictToolSchemas,
   type OpenAiStrictFunctionTool,
 } from './openai-schema.ts';
@@ -266,11 +267,12 @@ function createResponsesRequest(
   toolSurface: EvalToolSurface,
   allowTools: boolean,
 ): OpenAiResponsesCreateRequest {
+  const tools = openAiToolsForSurface(toolSurface);
   const request: OpenAiResponsesCreateRequest = {
     model: providerConfig.model,
     instructions: promptFor(toolSurface),
     input: [...input],
-    tools: allowTools ? renderOpenAiStrictToolSchemas() : [],
+    tools: allowTools ? renderOpenAiStrictToolSchemas(tools) : [],
     store: false,
     parallel_tool_calls: false,
     include: ['reasoning.encrypted_content'],
@@ -530,7 +532,7 @@ export async function runOpenAiResponsesEvalCase(
       promptHash: sha256(promptFor(options.toolSurface)),
       toolSurface: options.toolSurface,
       toolSchemaVersion: OPENAI_TOOL_SCHEMA_VERSION,
-      toolSchemaHash: getOpenAiToolSchemaHash(),
+      toolSchemaHash: getOpenAiToolSchemaHash(openAiToolsForSurface(options.toolSurface)),
       modelSettings: modelSettingsFor(options.providerConfig),
       inputQuestion: options.evalCase.question,
       finalAnswer,

--- a/eval/openai-schema.ts
+++ b/eval/openai-schema.ts
@@ -1,6 +1,13 @@
 import { createHash } from 'node:crypto';
 import { z } from 'zod';
-import { ALL_AGENT_TOOLS, executeToolCall, type AgentToolName } from '../src/agent.ts';
+import {
+  AGENT_TOOLS,
+  ALL_AGENT_TOOLS,
+  LEGACY_AGENT_TOOLS,
+  executeToolCall,
+  type AgentToolName,
+  type AgentToolSurface,
+} from '../src/agent.ts';
 import type { ToolCallResult } from '../src/agent.ts';
 import { SCHEMAS } from '../src/schemas.ts';
 
@@ -186,6 +193,10 @@ export function renderOpenAiStrictToolSchemas(
     strict: true,
     parameters: strictifySchema(normalizedInputSchema(tool), true, `${tool.name}.parameters`),
   }));
+}
+
+export function openAiToolsForSurface(toolSurface: AgentToolSurface): readonly AgentToolLike[] {
+  return toolSurface === 'legacy' ? LEGACY_AGENT_TOOLS : AGENT_TOOLS;
 }
 
 export function getOpenAiToolSchemaHash(tools: readonly AgentToolLike[] = ALL_AGENT_TOOLS): string {

--- a/eval/run-metadata.ts
+++ b/eval/run-metadata.ts
@@ -6,7 +6,11 @@ import {
   LEGACY_AGENT_TOOLS,
 } from '../src/agent.ts';
 import type { EvalMatrixGuardrails, EvalProviderConfig, EvalToolSurface } from './cli.ts';
-import { OPENAI_TOOL_SCHEMA_VERSION, getOpenAiToolSchemaHash } from './openai-schema.ts';
+import {
+  OPENAI_TOOL_SCHEMA_VERSION,
+  getOpenAiToolSchemaHash,
+  openAiToolsForSurface,
+} from './openai-schema.ts';
 
 export const ANTHROPIC_TOOL_SCHEMA_VERSION = 'squire-anthropic-tools-v1' as const;
 
@@ -43,7 +47,8 @@ export function evalToolSchemaHashFor(
   config: EvalProviderConfig,
   toolSurface: EvalToolSurface,
 ): string {
-  if (config.provider === 'openai') return getOpenAiToolSchemaHash();
+  if (config.provider === 'openai')
+    return getOpenAiToolSchemaHash(openAiToolsForSurface(toolSurface));
   const tools = toolSurface === 'legacy' ? LEGACY_AGENT_TOOLS : AGENT_TOOLS;
   return `sha256:${createHash('sha256').update(JSON.stringify(tools)).digest('hex')}`;
 }

--- a/src/extracted-data.ts
+++ b/src/extracted-data.ts
@@ -256,7 +256,16 @@ export async function searchExtractedRanked(
     card_type: CardType;
     payload: Record<string, unknown>;
     score: number;
-  }>(sql`SELECT card_type, payload, score FROM (${unioned}) s ORDER BY score DESC LIMIT ${k}`);
+  }>(
+    sql`
+      SELECT card_type, payload, score
+      FROM (${unioned}) s
+      ORDER BY
+        score DESC,
+        CASE WHEN card_type = 'monster-stats' THEN payload->>'sourceId' END ASC
+      LIMIT ${k}
+    `,
+  );
 
   return rows.rows.map((r) => ({
     record: {

--- a/test/eval-openai-runner.test.ts
+++ b/test/eval-openai-runner.test.ts
@@ -40,6 +40,45 @@ function responsesClient(...responses: unknown[]): OpenAiResponsesClient {
 }
 
 describe('OpenAI Responses eval runner', () => {
+  it('advertises only redesigned tools for redesigned eval runs', async () => {
+    const client = responsesClient({
+      id: 'resp_1',
+      model: 'gpt-5.5-2026-04-23',
+      status: 'completed',
+      output_text: 'Done.',
+      output: [
+        {
+          type: 'message',
+          content: [{ type: 'output_text', text: 'Done.' }],
+        },
+      ],
+    });
+
+    await runOpenAiResponsesEvalCase({
+      client,
+      evalCase,
+      providerConfig,
+      runLabel: 'unit-openai',
+      toolSurface: 'redesigned',
+    });
+
+    const request = vi.mocked(client.responses.create).mock.calls[0]?.[0] as {
+      tools: Array<{ name: string }>;
+    };
+    const toolNames = request.tools.map((tool) => tool.name);
+    expect(toolNames).toEqual([
+      'inspect_sources',
+      'schema',
+      'resolve_entity',
+      'open_entity',
+      'search_knowledge',
+      'neighbors',
+    ]);
+    expect(toolNames).not.toEqual(
+      expect.arrayContaining(['search_cards', 'list_cards', 'get_card']),
+    );
+  });
+
   it('runs a manual stateless Responses tool loop without previous_response_id', async () => {
     const reasoningItem = {
       type: 'reasoning',
@@ -92,7 +131,7 @@ describe('OpenAI Responses eval runner', () => {
       evalCase,
       providerConfig,
       runLabel: 'unit-openai',
-      toolSurface: 'redesigned',
+      toolSurface: 'legacy',
       executeTool,
       now: () => new Date('2026-05-01T00:00:00.000Z'),
     });
@@ -148,7 +187,7 @@ describe('OpenAI Responses eval runner', () => {
       resolvedModel: 'gpt-5.5-2026-04-23',
       caseId: 'item-spyglass',
       caseCategory: 'card-data',
-      toolSurface: 'redesigned',
+      toolSurface: 'legacy',
       statusReason: 'completed',
       stopReason: 'completed',
       finalAnswer: 'Spyglass reveals the top card.',

--- a/test/eval-scoring.test.ts
+++ b/test/eval-scoring.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { passFromTraceScores } from '../eval/scoring.ts';
+import { passFromTraceScores, traceScoresForEvalResult } from '../eval/scoring.ts';
 
 describe('eval scoring summaries', () => {
   it('requires both answer and trajectory verdicts to pass when both are present', () => {
@@ -16,5 +16,58 @@ describe('eval scoring summaries', () => {
         { name: 'trajectory_pass', value: 'pass' },
       ]),
     ).toBe(true);
+  });
+
+  it('includes the failed trajectory predicate in zero-score trace comments', async () => {
+    const scores = await traceScoresForEvalResult({} as never, {
+      evalCase: {
+        id: 'traj-card-fuzzy-vs-exact',
+        category: 'trajectory',
+        source: 'unit-test',
+        question: 'Find Algox Archer.',
+        trajectory: {
+          requiredTools: ['resolve_entity', 'open_entity'],
+          requiredToolKinds: ['resolution', 'open'],
+          forbiddenTools: [],
+          forbiddenToolKinds: [],
+          requiredRefs: [
+            'card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/0-3',
+          ],
+          maxToolCalls: 3,
+        },
+      },
+      answer: '',
+      toolCalls: [
+        {
+          iteration: 1,
+          id: 'call_1',
+          name: 'search_cards',
+          input: { query: 'Algox Archer' },
+          ok: true,
+          outputSummary: 'json array (2 items)',
+          sourceLabels: [],
+          canonicalRefs: [],
+          startedAt: '2026-05-03T00:00:00.000Z',
+          endedAt: '2026-05-03T00:00:00.001Z',
+          durationMs: 1,
+        },
+      ],
+    });
+
+    expect(scores).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'trajectory',
+          value: 0,
+          comment: expect.stringContaining('missing required tool: resolve_entity'),
+        }),
+        expect.objectContaining({
+          name: 'trajectory',
+          comment: expect.stringContaining(
+            'missing required ref: card:frosthaven/monster-stats/gloomhavensecretariat:monster-stat/algox-archer/0-3',
+          ),
+        }),
+      ]),
+    );
   });
 });

--- a/test/extracted-data.test.ts
+++ b/test/extracted-data.test.ts
@@ -229,6 +229,18 @@ describe('searchExtracted / searchExtractedRanked', () => {
     expect(ranked[0].record._type).toBe('monster-stats');
   });
 
+  it('orders tied monster stat level bands by the default lower band first', async () => {
+    const ranked = await searchExtractedRanked('algox archer', 6);
+    const algoxArcherStats = ranked
+      .filter((hit) => hit.record._type === 'monster-stats')
+      .map((hit) => hit.record.sourceId);
+
+    expect(algoxArcherStats.slice(0, 2)).toEqual([
+      'gloomhavensecretariat:monster-stat/algox-archer/0-3',
+      'gloomhavensecretariat:monster-stat/algox-archer/4-7',
+    ]);
+  });
+
   it('searchExtracted strips the score wrapper', async () => {
     const records = await searchExtracted('algox archer', 3);
     expect(records.length).toBeGreaterThan(0);

--- a/test/fixtures/search-queries/cards.json
+++ b/test/fixtures/search-queries/cards.json
@@ -2,8 +2,8 @@
   {
     "query": "algox archer",
     "expectedTopSourceIds": [
-      "gloomhavensecretariat:monster-stat/algox-archer/4-7",
       "gloomhavensecretariat:monster-stat/algox-archer/0-3",
+      "gloomhavensecretariat:monster-stat/algox-archer/4-7",
       "gloomhavensecretariat:event/WO-39",
       "gloomhavensecretariat:scenario/003",
       "gloomhavensecretariat:scenario/002",
@@ -84,8 +84,8 @@
   {
     "query": "flame demon",
     "expectedTopSourceIds": [
-      "gloomhavensecretariat:monster-stat/flame-demon/4-7",
       "gloomhavensecretariat:monster-stat/flame-demon/0-3",
+      "gloomhavensecretariat:monster-stat/flame-demon/4-7",
       "gloomhavensecretariat:scenario/067",
       "gloomhavensecretariat:scenario/068",
       "gloomhavensecretariat:monster-ability/flame-demon/549",


### PR DESCRIPTION
## Summary

- Limit OpenAI eval tool schemas to the selected tool surface so redesigned runs only expose redesigned tools.
- Keep OpenAI tool schema hashes surface-specific in trace/run metadata.
- Make tied monster-stat FTS results prefer the default lower level band, covering unqualified Algox Archer lookups.
- Add regressions for the SQR-157 trajectory failure reporting path and the SQR-155 level-band ordering case.

Fixes SQR-157
Fixes SQR-155

## Pre-Landing Review

Pre-Landing Review: No issues found.

## Verification

- npm run check
- npx eslint eval
- npx prettier --check eval