### PR TITLE
docs: clarify SQR-91 runtime gates

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,7 +68,8 @@ The active baseline is:
   and presentation, then delegates domain reasoning to the knowledge agent.
 - `/api/ask`, the in-process service entry, the CLI wrapper, and the eval
   runner all route through the same service boundary.
-- Langfuse and OpenTelemetry remain the LLM trace and eval path for now.
+- Langfuse remains the authoritative LLM trace/eval path for now;
+  OpenTelemetry provides the trace export/transport feeding it.
 
 Existing regression coverage protects the current path:
 

--- a/docs/adr/0015-langchain-deep-agents-intelligence-layer.md
+++ b/docs/adr/0015-langchain-deep-agents-intelligence-layer.md
@@ -108,13 +108,21 @@ baseline before it can receive production traffic.
 Langfuse remains the authoritative LLM trace and eval path. LangSmith evals may
 be prototyped as a parallel export or comparison path, but replacing Langfuse
 requires a later decision with trace-link, dataset, judge, and report parity.
+Trace-link parity means the eval report can map each row back to the same
+logical run across systems: provider/model, run label, dataset item or case ID,
+Squire trace ID, request ID when present, judge run ID, report ID, timestamps,
+and parent-child relationships between the agent run, model calls, tool calls,
+and scores. Any LangSmith export must define that mapping in one schema or
+export spec before tests can treat it as equivalent to Langfuse.
 
 Any Deep Agents production experiment must use safe backends. The in-memory
-state backend is acceptable for eval-only runs; a store-backed memory namespace
-may be tested for user-scoped memory; local filesystem and local shell backends
-must not be used in the production web server. Shared writable memory is a
-prompt-injection surface and must be isolated by user, campaign, and agent
-purpose before it can affect answers.
+state backend is acceptable for eval-only runs only when each eval gets a fresh
+agent instance, no mutable state is shared across requests or tasks, and teardown
+or reset is explicit after the run. A store-backed memory namespace may be tested
+for user-scoped memory; local filesystem and local shell backends must not be
+used in the production web server. Shared writable memory becomes a
+prompt-injection surface when isolation fails, so it must be scoped by user,
+campaign, and agent purpose before it can affect answers.
 
 This decision should be re-opened if the LangChain runner beats the current
 runner on quality, traceability, latency, cost, or implementation clarity in the


### PR DESCRIPTION
## Summary

- Addresses CodeRabbit review-body notes from PR #333 after that PR auto-merged before this follow-up commit was included.
- Clarifies Langfuse as the authoritative trace/eval path and OpenTelemetry as transport.
- Makes trace-link parity measurable and tightens Deep Agents in-memory backend isolation requirements.

## Validation

- `npm run check`
- Pre-landing review: clean, docs-only diff

Refs SQR-91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated architecture documentation to clarify observability path definitions and the roles of trace collection and export systems.
* Enhanced requirements documentation for trace equivalence mapping between systems and strengthened constraints on evaluation backend implementations to ensure security and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->