### PR TITLE
SQR-160 Include runtimes in matrix guardrail messages

### DIFF
--- a/eval/matrix.ts
+++ b/eval/matrix.ts
@@ -323,15 +323,12 @@ export function assertEvalMatrixGuardrails(
     'cases' | 'modelConfigs' | 'agentRuntimes' | 'selection' | 'guardrails'
   >,
 ): void {
-  const estimatedCostUsd = estimateMatrixCost(
-    options.cases,
-    options.modelConfigs,
-    agentRuntimesFor(options),
-  );
+  const agentRuntimes = agentRuntimesFor(options);
+  const estimatedCostUsd = estimateMatrixCost(options.cases, options.modelConfigs, agentRuntimes);
 
   if (options.selection === 'all' && !options.guardrails.allowFullDataset) {
     throw new Error(
-      `A full-dataset matrix run requires --allow-full-dataset (${options.cases.length} case(s), ${options.modelConfigs.length} model(s)).`,
+      `A full-dataset matrix run requires --allow-full-dataset (${options.cases.length} case(s), ${options.modelConfigs.length} model(s), ${agentRuntimes.length} runtime(s)).`,
     );
   }
 
@@ -340,7 +337,7 @@ export function assertEvalMatrixGuardrails(
     !options.guardrails.allowEstimatedCostOverride
   ) {
     throw new Error(
-      `Estimated matrix cost $${estimatedCostUsd.toFixed(2)} exceeds --max-estimated-cost-usd=${options.guardrails.maxEstimatedCostUsd} and requires --allow-estimated-cost to proceed.`,
+      `Estimated matrix cost $${estimatedCostUsd.toFixed(2)} for ${options.cases.length} case(s), ${options.modelConfigs.length} model(s), ${agentRuntimes.length} runtime(s) exceeds --max-estimated-cost-usd=${options.guardrails.maxEstimatedCostUsd} and requires --allow-estimated-cost to proceed.`,
     );
   }
 

--- a/test/eval-matrix.test.ts
+++ b/test/eval-matrix.test.ts
@@ -340,6 +340,7 @@ describe('eval matrix runner', () => {
         toolSurface: 'redesigned',
         selection: 'all',
         modelConfigs: DEFAULT_EVAL_MATRIX_MODELS,
+        agentRuntimes: ['claude-sdk', 'deep-agents'],
         runner,
         guardrails: {
           allowFullDataset: false,
@@ -351,7 +352,7 @@ describe('eval matrix runner', () => {
         },
         langfuseBaseUrl: 'https://langfuse.test',
       }),
-    ).rejects.toThrow(/requires --allow-full-dataset/);
+    ).rejects.toThrow(/2 case\(s\), 7 model\(s\), 2 runtime\(s\)/);
 
     await expect(
       runEvalMatrix({
@@ -360,6 +361,7 @@ describe('eval matrix runner', () => {
         toolSurface: 'redesigned',
         selection: 'id',
         modelConfigs: DEFAULT_EVAL_MATRIX_MODELS,
+        agentRuntimes: ['claude-sdk', 'deep-agents'],
         runner,
         guardrails: {
           allowFullDataset: false,
@@ -371,7 +373,7 @@ describe('eval matrix runner', () => {
         },
         langfuseBaseUrl: 'https://langfuse.test',
       }),
-    ).rejects.toThrow(/requires --allow-estimated-cost/);
+    ).rejects.toThrow(/1 case\(s\), 7 model\(s\), 2 runtime\(s\)/);
   });
 
   it('calculates row provider costs from model prices while keeping guardrail estimates', async () => {


### PR DESCRIPTION
## Summary
- follow up on CodeRabbit's #335 review comment
- include selected runtime count in full-dataset and estimated-cost guardrail errors
- cover the updated messages in matrix tests

## Verification
- npm test -- test/eval-matrix.test.ts
- npx eslint eval/matrix.ts test/eval-matrix.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when evaluation matrix runs are blocked, now displaying a detailed breakdown of matrix dimensions—case count, model count, and runtime count—for better clarity on constraint violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->