### PR TITLE
docs(adr): SQR-59 decide Phase 1 hosting platform (Fly + MPG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.7] - 2026-05-06
+
+### Changed
+
+- Picked the Phase 1 hosting platform: Fly.io app + Fly Managed Postgres (Basic) in one region, no staging tier. Cloudflare in front as the WAF. App-to-DB traffic stays on Fly's private 6PN. Migrations run via Fly's `release_command` before traffic cutover (failure aborts the deploy and leaves the prior version live).
+- Recorded reasoning, six alternatives evaluated (Neon-paired Fly, legacy unmanaged Fly Postgres, Railway, Render, VPS, Cloudflare Workers), and re-evaluation triggers in [ADR 0016](docs/adr/0016-phase-1-hosting-platform.md).
+- Updated `docs/ARCHITECTURE.md` §Deployment, §Cost, §Open Tech Questions, and §Changelog to reflect the concrete pick (production budget ~$55–75/mo within the $100/mo Phase 1 cap).
+
 ## [0.1.6] - 2026-04-29
 
 ### Changed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -683,7 +683,7 @@ The app is always-on (`auto_stop_machines = "off"`, `min_machines_running = 1`) 
 
 - Build and test on push
 - Deploy to production on release tag (no staging tier in Phase 1 — see ADR 0016)
-- Run `drizzle-kit migrate` via Fly's `release_command` before traffic cutover; non-zero exit aborts the deploy and leaves the prior version live
+- Run `node scripts/db-migrate.ts` via Fly's `release_command` before traffic cutover; non-zero exit aborts the deploy and leaves the prior version live
 - Smoke test after deploy (hit `/api/health`)
 - Rollback via `fly releases list` + `fly deploy --image <prior-sha>`
 
@@ -693,8 +693,8 @@ The app is always-on (`auto_stop_machines = "off"`, `min_machines_running = 1`) 
 
 **Estimated monthly cost (Phase 1 MVP):**
 
-- Fly app (`shared-cpu-1x@1GB`, always-on): ~$6
-- Fly Managed Postgres (Basic, Shared-2x / 1GB / 1 TB cap): ~$38
+- Fly app (`shared-cpu-1x@1GB`, always-on): $6
+- Fly Managed Postgres (Basic, Shared-2x / 1GB / 1 TB cap): $38
 - Cloudflare WAF: $0 (free tier)
 - Claude API (Sonnet 4.6): ~$10–30 depending on chat volume
 - **Total: ~$55–75/month** within the $100/mo Phase 1 budget. See [ADR 0016](adr/0016-phase-1-hosting-platform.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -675,23 +675,17 @@ Squire emits OpenTelemetry traces from the agent loop, tool calls, and HTTP hand
 
 ## Deployment
 
-**Hosting (open, decision deferred — see [Open Tech Questions](#open-tech-questions)):**
+**Hosting:** Fly.io. A single `shared-cpu-1x@1GB` machine in one region runs the Hono server, MCP transport, and web UI in one process. Postgres is **Fly Managed Postgres** (Basic plan) reached over Fly's private 6PN network — Postgres has no public ingress. Cloudflare sits in front as the WAF (Full Strict origin TLS, validated by Fly's Let's Encrypt cert). See [ADR 0016](adr/0016-phase-1-hosting-platform.md) for the alternatives weighed and why Fly+MPG won the single-vendor tradeoff at the Phase 1 budget.
 
-- **Fly.io** — VM-based, global regions, good Postgres story (Fly Postgres), Docker-native
-- **Railway** — simple deploys from a Dockerfile, included Postgres add-on, $5/mo hobby tier
-- **Render** — managed services + Postgres, similar to Railway, free tier for hobby
-- **Self-hosted VPS** (Hetzner, DigitalOcean) — most control, most ops work
-
-All four work with the Docker-first deployment plan. Cloudflare WAF sits in front regardless of host choice.
+The app is always-on (`auto_stop_machines = "off"`, `min_machines_running = 1`) so SSE connections aren't severed by scale-to-zero. `idle_timeout` is configured at 600s, past the longest knowledge-agent tool loop.
 
 **CI/CD:**
 
 - Build and test on push
-- Deploy to staging on `main` merge
-- Deploy to production on release tag
-- Run database migrations as part of deploy
+- Deploy to production on release tag (no staging tier in Phase 1 — see ADR 0016)
+- Run `drizzle-kit migrate` via Fly's `release_command` before traffic cutover; non-zero exit aborts the deploy and leaves the prior version live
 - Smoke test after deploy (hit `/api/health`)
-- Rollback capability
+- Rollback via `fly releases list` + `fly deploy --image <prior-sha>`
 
 ---
 
@@ -699,11 +693,11 @@ All four work with the Docker-first deployment plan. Cloudflare WAF sits in fron
 
 **Estimated monthly cost (Phase 1 MVP):**
 
-- Hosting: $0–10 (free tiers on Fly / Railway / Render, or hobby plan)
-- Postgres: $0–10 (included in host's free tier or hobby add-on)
+- Fly app (`shared-cpu-1x@1GB`, always-on): ~$6
+- Fly Managed Postgres (Basic, Shared-2x / 1GB / 1 TB cap): ~$38
 - Cloudflare WAF: $0 (free tier)
 - Claude API (Sonnet 4.6): ~$10–30 depending on chat volume
-- **Total: ~$10–50/month** for a single user with moderate usage
+- **Total: ~$55–75/month** within the $100/mo Phase 1 budget. See [ADR 0016](adr/0016-phase-1-hosting-platform.md).
 
 Costs grow when Phase 3 (multi-user) and Phase 5 (recommendation engine) ship. Per-user daily budget circuit breakers, embedding caching, and model tiering (Haiku for cheap cases) are the primary mitigations. Vision API costs (~$0.15–0.30 per character sync) are deferred to Phase 6 and only apply if the screenshot path is chosen over the browser-extension or GHS-as-tracker alternatives.
 
@@ -805,13 +799,14 @@ For developer setup, running the server, working on import scripts locally, and 
 ## Open Tech Questions
 
 - **APM / RUM stack.** Datadog as a one-stop shop for application metrics and real-user monitoring (with Langfuse staying for LLM-specific observability), or stay Langfuse-only and skip APM until volume demands it?
-- **Hosting platform.** Fly.io vs Railway vs Render vs self-hosted VPS — defer until Phase 1 deployment work begins.
 - **Character state ingestion path (Phase 6).** Browser extension vs JSON export vs storyline sync protocol vs screenshot+Vision vs GHS-as-tracker — defer until Phase 6 begins. The GH2 campaign may force this decision earlier than the Frosthaven one.
 - **Storyline GH2 support (Phase 2 prerequisite).** Confirm whether frosthaven-storyline.com supports Gloomhaven 2.0. If not, Brian's GH2 campaign-tracking workflow needs to switch (most likely to GHS).
 
 ---
 
 ## Changelog
+
+- **2026-05-06:** SQR-59 picked the Phase 1 hosting platform: Fly.io app + Fly Managed Postgres (Basic) in one region, no staging. Cloudflare in front as WAF. App-to-DB traffic on private 6PN. Migrations run via `release_command` before traffic cutover. ARCHITECTURE.md §Deployment and §Cost updated to reflect the concrete pick. Reasoning, alternatives (Neon, Railway, Render, VPS, Cloudflare Workers), and re-evaluation triggers in [ADR 0016](adr/0016-phase-1-hosting-platform.md). Unblocks SQR-58 (WAF), SQR-42 (Dockerize), SQR-43 (migrate-on-deploy), SQR-44 (CI/CD).
 
 - **2026-04-26:** SQR-110 added a narrow synthesis guard to the knowledge agent loop. If a turn only calls `search_rules` and reaches three broad rule-corpus searches, the next model call runs without tools and is instructed to answer from the retrieved context. This preserves the full loop budget for scenario traversal and card lookups while preventing simple rules questions from spending all ten iterations on repeated searches. The eval dataset now includes `rule-looting-definition` for the original "What is looting?" failure mode.
 

--- a/docs/adr/0016-phase-1-hosting-platform.md
+++ b/docs/adr/0016-phase-1-hosting-platform.md
@@ -1,0 +1,192 @@
+---
+type: ADR
+id: '0016'
+title: 'Phase 1 hosting platform: Fly.io app + Fly Managed Postgres'
+status: active
+date: 2026-05-06
+---
+
+## Context
+
+Phase 1 MVP needs a production hosting target. The decision had been deferred
+since the project moved off GitHub Issues to Linear (see
+[issue-workflow.md](../agent/issue-workflow.md)) and through the
+agent-native retrieval redesign. [ADR 0013](0013-phase-1-production-agent-baseline.md)
+froze the production agent runtime; SQR-115 then closed (Done, 2026-04-29) with
+the decision to keep the legacy retrieval surface for Phase 1, unblocking
+deployment work. SQR-59 is the gating decision for the rest of the Production
+Readiness project: SQR-58 (Cloudflare WAF), SQR-42 (Dockerization),
+SQR-43 (`drizzle-kit migrate` in the deploy pipeline), and SQR-44 (CI/CD).
+
+The host must satisfy:
+
+- Node 24 runtime via a Docker image (`.nvmrc` is `24.14.0`).
+- Postgres 16+ with `pgvector` for runtime retrieval (the local
+  [docker-compose.yml](../../docker-compose.yml) is pinned to
+  `pgvector/pgvector:pg16` precisely so the host decision could stay open).
+- Long-running SSE connections (the knowledge-agent loop streams tool calls and
+  tokens for tens of seconds; aggressive proxy buffering or sub-minute idle
+  timeouts would break the chat surface).
+- A first-class migrate-before-cutover hook so a failed migration aborts the
+  deploy without leaving production on a half-migrated schema (SQR-43 contract).
+- A Cloudflare-friendly origin: TLS cert validatable in Cloudflare Full (Strict)
+  mode (SQR-58 contract).
+- Logs and metrics passthrough to Langfuse + OpenTelemetry without per-platform
+  middleware.
+- Phase 1 budget: ~$100/month for hosting end-to-end, with headroom for
+  observability and future model upgrades.
+
+The Phase 1 user base is the maintainer plus 1–2 collaborators. Pre-production
+testing happens on the maintainer's local dev environment — there is no
+integration-testing tier that a staging environment would accelerate.
+
+## Decision
+
+**Phase 1 production runs on Fly.io: a single `shared-cpu-1x@1GB` machine in
+one region for the Hono app, paired with Fly Managed Postgres (Basic plan) for
+data. Migrations run via `release_command` before traffic cutover. No staging
+environment.**
+
+The Hono server, MCP transport, and web UI all run in one process on one
+machine. Cloudflare sits in front as the WAF (SQR-58). The app talks to
+Postgres over Fly's private 6PN network — Postgres has no public ingress.
+
+## Options considered
+
+- **Option A (chosen) — Fly.io app + Fly Managed Postgres (Basic).**
+  Single vendor, one `flyctl`, one dashboard, one billing line. `release_command`
+  runs on a temporary machine with the new image before traffic shifts, exiting
+  non-zero aborts the deploy — exactly the SQR-43 contract. MPG Basic includes
+  daily backups, point-in-time recovery, and connection pooling; pgvector is
+  available out of the box. App-to-DB traffic stays on private 6PN. Configurable
+  `idle_timeout` keeps SSE connections alive across the longest knowledge-agent
+  loops. Approximate Phase 1 cost: $5.92/mo app + $38/mo DB ≈ **$44/mo**, well
+  under budget with headroom for an APM tier later.
+
+- **Option B — Fly.io app + Neon (free tier) for Postgres.**
+  Cheapest combo at ~$6/mo total; Neon has first-class pgvector and PITR even
+  on the free tier. Rejected on single-vendor ergonomics: a solo maintainer
+  benefits more from one throat to choke than from saving $38/mo. Two billing
+  surfaces, two SLAs, and two failure modes for what would otherwise be a
+  single private-network hop. Kept on file as the fallback if MPG ever
+  disappoints — Drizzle migrations + Docker image make the swap a one-day
+  exercise.
+
+- **Option C — Fly.io app + legacy unmanaged Fly Postgres.**
+  Rejected. Fly's docs now lead with: _"We are not able to provide support or
+  guidance for unmanaged Postgres. We now offer Fly.io Managed Postgres, our
+  fully-managed database service."_ For a solo maintainer, owning Postgres
+  upgrades, replication, and PITR by hand is the wrong place to spend ops
+  budget. Legacy by Fly's own framing.
+
+- **Option D — Railway (app + Postgres).**
+  Strong runner-up. Hobby plan is $5/mo + $5 included usage; Railway provisions
+  a Postgres template with pgvector available via the separate pgvector
+  template. Cutover is healthcheck-gated rather than release-command-gated:
+  migrations have to run as a Dockerfile entrypoint (coupled to container
+  start) or as a separate pipeline stage, which makes diagnosing migration
+  failures harder than Fly's `release_command` model. No first-class
+  migrate-before-cutover hook means SQR-43's "abort deploy on migration
+  failure" requirement falls back to entrypoint orchestration.
+
+- **Option E — Render (app + Render Postgres).**
+  Viable. `preDeployCommand` in `render.yaml` is a first-class equivalent to
+  Fly's `release_command`. pgvector is documented on PG13+. Rejected because
+  Render's free Postgres tier expires after 90 days (paid required from day
+  one), pricing pages required account creation to extract, and Render didn't
+  win on any single criterion against Fly+MPG.
+
+- **Option F — Self-hosted VPS (Hetzner / DigitalOcean).**
+  Rejected on operations surface. ~€5/mo for a small ARM box is the cheapest
+  hosting option in absolute terms, but the maintainer would own TLS renewal,
+  Postgres backups, OS patches, monitoring stack, and incident response. For a
+  solo-maintainer Phase 1 with no integration-test tier, that ops surface is
+  not worth the savings. Reconsider only if Phase 3 multi-user economics push
+  managed-host costs past the budget.
+
+- **Option G — Cloudflare Workers.**
+  Rejected on architecture, as flagged in the SQR-59 ticket. Workers run in V8
+  isolates with execution-time limits, no persistent Node runtime, and a
+  request-scoped programming model that rules out the long-lived SSE
+  connections the knowledge-agent loop depends on. Persistent Postgres
+  connections would also require Hyperdrive or an external pooler. Disqualified
+  before cost or pgvector questions.
+
+## Consequences
+
+### What this unblocks (Linear)
+
+- **SQR-58 (Cloudflare WAF)** — origin is `https://<app>.fly.dev` (or a
+  Fly-issued cert on a custom hostname). Cloudflare Full (Strict) works because
+  Fly issues a Let's Encrypt cert for the public hostname.
+- **SQR-42 (Dockerize)** — Dockerfile must `EXPOSE 8080`, run as a non-root
+  user, run `npm run build:css` in the build stage, and bake `public/app.css`
+  into the runtime image (per ADR 0008).
+- **SQR-43 (migrate on deploy)** — wire `release_command = "node scripts/db-migrate.ts"`
+  into `fly.toml`. A non-zero exit code from the release machine aborts the
+  deploy and leaves the prior version live, which is exactly the SQR-43
+  acceptance criterion.
+- **SQR-44 (CI/CD)** — GitHub Actions workflow uses
+  `superfly/flyctl-actions/setup-flyctl@master`, then `flyctl deploy` on
+  release tag. The DATABASE_URL secret is scoped to the Fly app via
+  `fly secrets set`, never written to the repo.
+
+### Operational shape
+
+- **One environment.** Production only — no staging tier. Pre-production
+  testing happens on the maintainer's local dev environment (Docker Compose
+  Postgres + `npm run dev`). Revisit if multi-maintainer collaboration in a
+  later phase needs an integration-test surface.
+- **One region.** Phase 1 has 1–2 users. Multi-region is a Phase 3+ concern;
+  switching regions on Fly is a `fly.toml` edit.
+- **One machine, always-on.** `auto_stop_machines = "off"` and
+  `min_machines_running = 1` to prevent SSE connections from being severed by
+  scale-to-zero. Idle timeout configured to 600s, comfortably past the longest
+  knowledge-agent tool loop.
+- **Private DB only.** App reaches Postgres over 6PN; Postgres has no public
+  ingress. DATABASE_URL is a Fly secret.
+- **Backups + PITR** are MPG Basic defaults; no separate backup tooling needed
+  for Phase 1.
+- **Rollback** is `fly releases list` + `fly deploy --image <prior-sha>` for
+  the app, hand-rolled DDL or down-migration for schema.
+
+### Cost
+
+| Line                                                    | Monthly        |
+| ------------------------------------------------------- | -------------- |
+| Fly `shared-cpu-1x@1GB` machine (Amsterdam pricing)     | $5.92          |
+| Fly Managed Postgres Basic (Shared-2x / 1GB / 1 TB cap) | $38.00         |
+| Volume-snapshot storage (first 10 GB free)              | ~$0            |
+| Cloudflare WAF (free tier)                              | $0             |
+| Claude API (Sonnet 4.6, Phase 1 chat volume)            | $10–30         |
+| **Total Phase 1 estimate**                              | **~$55–75/mo** |
+
+Within the $100/mo Phase 1 budget. Headroom is reserved for the open
+APM/RUM question (see [docs/ARCHITECTURE.md §Open Tech Questions](../ARCHITECTURE.md#open-tech-questions)).
+
+### Lock-in and reversibility
+
+Reversibility 4/5. The Drizzle schema and Docker image are host-portable. The
+host-specific surface is `fly.toml` + `release_command` + Fly secret names —
+roughly a day's work to translate to `render.yaml` + `preDeployCommand` or to
+a Railway project. Postgres data is dump-and-restore; pgvector and Postgres 16
+are common across the candidate set.
+
+### What would trigger re-evaluation
+
+- Phase 3 multi-user economics push monthly cost past the $100 budget without a
+  clear path to revenue.
+- Fly platform reliability incidents materially affect availability.
+- A future ADR replaces this one — for example, when adding a managed agent
+  runtime or moving compute closer to a model provider's region.
+
+## Advice
+
+WebFetched current pricing and capability docs for Fly, Railway, and Render
+before drafting (May 2026). Initial recommendation paired Fly with Neon free
+under the prior `$0–10/mo` Postgres budget assumption captured in
+ARCHITECTURE.md §Cost. The user clarified that the actual Phase 1 budget is
+$100/mo, which made the single-vendor argument for Fly Managed Postgres
+dominant over the cheapest-possible-Neon-pairing. Staging tier was offered and
+declined: 1–2 users and local-dev-as-pre-prod doesn't justify a second
+environment. Both pivots are recorded above for future re-evaluation.

--- a/docs/adr/0016-phase-1-hosting-platform.md
+++ b/docs/adr/0016-phase-1-hosting-platform.md
@@ -58,19 +58,19 @@ Postgres over Fly's private 6PN network — Postgres has no public ingress.
   runs on a temporary machine with the new image before traffic shifts, exiting
   non-zero aborts the deploy — exactly the SQR-43 contract. MPG Basic includes
   daily backups, point-in-time recovery, and connection pooling; pgvector is
-  available out of the box. App-to-DB traffic stays on private 6PN. Configurable
-  `idle_timeout` keeps SSE connections alive across the longest knowledge-agent
-  loops. Approximate Phase 1 cost: $5.92/mo app + $38/mo DB ≈ **$44/mo**, well
-  under budget with headroom for an APM tier later.
+  available out of the box. App-to-DB traffic stays on private 6PN. Approximate
+  Phase 1 cost: $5.92/mo app + $38/mo DB ≈ **$44/mo**, well under budget with
+  headroom for an APM tier later.
 
 - **Option B — Fly.io app + Neon (free tier) for Postgres.**
-  Cheapest combo at ~$6/mo total; Neon has first-class pgvector and PITR even
-  on the free tier. Rejected on single-vendor ergonomics: a solo maintainer
-  benefits more from one throat to choke than from saving $38/mo. Two billing
-  surfaces, two SLAs, and two failure modes for what would otherwise be a
-  single private-network hop. Kept on file as the fallback if MPG ever
-  disappoints — Drizzle migrations + Docker image make the swap a one-day
-  exercise.
+  Cheapest combo at ~$6/mo total; Neon has first-class pgvector and branching
+  with 24-hour restore-from-history on the free tier. Rejected on single-vendor
+  ergonomics: a solo maintainer benefits more from one throat to choke than
+  from saving $38/mo, and the 24h restore window is materially weaker than
+  MPG Basic's daily backups + 7-day PITR. Two billing surfaces, two SLAs, and
+  two failure modes for what would otherwise be a single private-network hop.
+  Kept on file as the fallback if MPG ever disappoints — Drizzle migrations +
+  Docker image make the swap a one-day exercise.
 
 - **Option C — Fly.io app + legacy unmanaged Fly Postgres.**
   Rejected. Fly's docs now lead with: _"We are not able to provide support or
@@ -119,9 +119,12 @@ Postgres over Fly's private 6PN network — Postgres has no public ingress.
 - **SQR-58 (Cloudflare WAF)** — origin is `https://<app>.fly.dev` (or a
   Fly-issued cert on a custom hostname). Cloudflare Full (Strict) works because
   Fly issues a Let's Encrypt cert for the public hostname.
-- **SQR-42 (Dockerize)** — Dockerfile must `EXPOSE 8080`, run as a non-root
-  user, run `npm run build:css` in the build stage, and bake `public/app.css`
-  into the runtime image (per ADR 0008).
+- **SQR-42 (Dockerize)** — multi-stage Node 24 Dockerfile that `EXPOSE 8080`s
+  and runs as a non-root user. No static asset baking — per
+  [ADR 0011](0011-on-demand-asset-pipeline.md), Tailwind compiles in-process on
+  first request and caches in module memory. Squire runs TypeScript directly
+  via Node 24 strip-types (no JS compile step), so the runtime stage carries
+  the `src/` tree and `node_modules`.
 - **SQR-43 (migrate on deploy)** — wire `release_command = "node scripts/db-migrate.ts"`
   into `fly.toml`. A non-zero exit code from the release machine aborts the
   deploy and leaves the prior version live, which is exactly the SQR-43
@@ -140,9 +143,11 @@ Postgres over Fly's private 6PN network — Postgres has no public ingress.
 - **One region.** Phase 1 has 1–2 users. Multi-region is a Phase 3+ concern;
   switching regions on Fly is a `fly.toml` edit.
 - **One machine, always-on.** `auto_stop_machines = "off"` and
-  `min_machines_running = 1` to prevent SSE connections from being severed by
-  scale-to-zero. Idle timeout configured to 600s, comfortably past the longest
-  knowledge-agent tool loop.
+  `min_machines_running = 1` so the machine never scales to zero — the primary
+  protection against SSE streams being severed mid-flight. `[http_service]
+idle_timeout` set to 600s as belt-and-suspenders for any brief silent gap
+  between streamed events; the always-on machine is the load-bearing setting,
+  not the timeout.
 - **Private DB only.** App reaches Postgres over 6PN; Postgres has no public
   ingress. DATABASE_URL is a Fly secret.
 - **Backups + PITR** are MPG Basic defaults; no separate backup tooling needed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Picks **Fly.io app + Fly Managed Postgres (Basic)** as the Phase 1 hosting platform. One region, single always-on machine, no staging tier. Cloudflare in front as the WAF. App-to-DB traffic on Fly's private 6PN. Migrations run via `release_command` before traffic cutover.

ADR 0016 records six alternatives evaluated and the discriminators that mattered. Decision was driven by single-vendor ergonomics + first-class migrate-before-cutover hook at the $100/mo Phase 1 budget.

**Files changed (3 commits):**
- `docs/adr/0016-phase-1-hosting-platform.md` (new) — full ADR with Context, Decision, 7 options considered, Consequences (unblocks SQR-58/42/43/44), Cost table, lock-in/reversibility analysis, re-evaluation triggers, and Advice
- `docs/ARCHITECTURE.md` — §Deployment, §Cost, §Open Tech Questions, §Changelog updated to reflect the pick
- `CHANGELOG.md` + `package.json` — v0.1.7

## Pre-Landing Review

`/review` ran before push. 6 findings, all auto-fixed:
1. **CRITICAL** — `idle_timeout` misrepresentation (claimed it kept SSE alive; actually the always-on machine is the load-bearing setting). Recast §Operational shape.
2. **CRITICAL** — Stale ADR reference (ADR 0008 was superseded by ADR 0011) and dead `npm run build:css` claim.
3. **INFORMATIONAL** — \"Compiled JS sources\" misrepresented ADR 0011 (project uses Node 24 strip-types, no compile step).
4. **INFORMATIONAL** — ADR vs ARCHITECTURE.md migrate-command mismatch (`drizzle-kit migrate` vs the project's `node scripts/db-migrate.ts` wrapper).
5. **INFORMATIONAL** — Neon \"PITR\" claim qualified to its actual 24h restore-from-history window.
6. **INFORMATIONAL** — Cost-number consistency between ADR and ARCHITECTURE.md.

PR Quality Score: 9/10. Adversarial review (Claude subagent) caught issues 1, 3, 4, 5.

## Test Coverage

No new code paths — docs-only diff. All 1075 vitest tests pass on Node 24.14.0.

## Plan Completion

No plan file for this branch. Linear ticket SQR-59 acceptance criteria all addressed:
- [x] ADR under `docs/adr/` with next monotonic ID (0016)
- [x] `status: active`, follows `0000-template.md`
- [x] All ticket-listed candidates evaluated (Fly, Railway, Render, VPS, Cloudflare Workers)
- [x] All ticket-listed criteria addressed (Node 24, pgvector, SSE, low cost, deploy ergonomics, log/metric passthrough, Cloudflare Full Strict)
- [x] Pick made (Fly + MPG)
- [x] `docs/ARCHITECTURE.md` §Deployment + §Cost + §Open Tech Questions updated
- [x] Platform-specific follow-ups listed in Consequences (SQR-42 Dockerfile, SQR-43 release_command, SQR-44 GitHub Action, SQR-58 Cloudflare config)

## Test plan

- [x] All vitest tests pass (1075/1075 on Node 24.14.0)
- [x] `/review` clean (all findings auto-fixed)
- [x] ADR links resolve (ADR 0011, ADR 0013, issue-workflow.md, docker-compose.yml)
- [x] ADR cost numbers match ARCHITECTURE.md §Cost
- [x] No remaining \"open hosting platform\" references in docs

Closes SQR-59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation with hosting platform decisions, deployment details, and operational guidance.

* **Chores**
  * Version bumped to 0.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->