### PR TITLE
SQR-58: add CloudFront origin lock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,11 @@ SQUIRE_ENV=development
 # PORT=8080
 # HOST=0.0.0.0
 #
+# Required in production when the app is locked behind CloudFront.
+# CloudFront sends this value as X-Origin-Secret; /api/live and /api/health
+# bypass the check so Fly machine health checks keep working.
+# ORIGIN_SHARED_SECRET=
+#
 # Public base URL used in OAuth metadata responses
 # SQUIRE_BASE_URL=http://localhost:3000
 

--- a/docs/runbooks/deploy-rollback.md
+++ b/docs/runbooks/deploy-rollback.md
@@ -31,7 +31,8 @@ flyctl secrets set \
   LANGFUSE_PUBLIC_KEY='...' \
   LANGFUSE_BASEURL='...' \
   GOOGLE_OAUTH_CLIENT_ID='...' \
-  GOOGLE_OAUTH_CLIENT_SECRET='...'
+  GOOGLE_OAUTH_CLIENT_SECRET='...' \
+  ORIGIN_SHARED_SECRET='...'
 ```
 
 `flyctl mpg attach` writes the `DATABASE_URL` secret with the managed Postgres
@@ -65,6 +66,26 @@ curl https://maz-squire.fly.dev/api/health
 
 `/api/live` is the cheap platform liveness check. `/api/health` is the
 readiness check and exercises Postgres, pgvector, and embedder warmup.
+
+## CloudFront origin lock
+
+Production app traffic is expected to enter through CloudFront with AWS WAF
+attached. CloudFront sends `X-Origin-Secret`, and Fly stores the matching value
+as `ORIGIN_SHARED_SECRET`. Requests that do not include the exact header are
+rejected with 403 before the app routes run.
+
+`/api/live` and `/api/health` intentionally bypass the origin lock so Fly's own
+machine health checks keep working without header support. User-facing routes,
+OAuth routes, API routes, and MCP routes must go through CloudFront or include
+the shared secret for operator checks.
+
+To rotate without downtime:
+
+1. Add support for the new secret in CloudFront as `X-Origin-Secret`.
+2. Update the Fly `ORIGIN_SHARED_SECRET` secret to the same value.
+3. Wait for the Fly release to become healthy.
+4. Verify direct Fly access without the header is 403 and with the header is 200.
+5. Remove the old value from any local/operator notes.
 
 ## Failed migration
 

--- a/docs/runbooks/deploy-rollback.md
+++ b/docs/runbooks/deploy-rollback.md
@@ -74,6 +74,11 @@ attached. CloudFront sends `X-Origin-Secret`, and Fly stores the matching value
 as `ORIGIN_SHARED_SECRET`. Requests that do not include the exact header are
 rejected with 403 before the app routes run.
 
+The production WAF web ACL is `squire-production-waf`. It includes AWS managed
+rules for IP reputation, common web exploits, known bad inputs, and SQL
+injection, plus a 2,000 requests per 5 minutes per-IP rate limit. Logging goes to
+the CloudWatch log group `aws-waf-logs-squire-production`.
+
 `/api/live` and `/api/health` intentionally bypass the origin lock so Fly's own
 machine health checks keep working without header support. User-facing routes,
 OAuth routes, API routes, and MCP routes must go through CloudFront or include

--- a/docs/runbooks/deploy-rollback.md
+++ b/docs/runbooks/deploy-rollback.md
@@ -84,10 +84,13 @@ machine health checks keep working without header support. User-facing routes,
 OAuth routes, API routes, and MCP routes must go through CloudFront or include
 the shared secret for operator checks.
 
-To rotate without downtime:
+To rotate the origin secret, plan a short maintenance window. The app accepts one
+origin secret at a time, so CloudFront and Fly can briefly disagree while the
+change propagates.
 
-1. Add support for the new secret in CloudFront as `X-Origin-Secret`.
-2. Update the Fly `ORIGIN_SHARED_SECRET` secret to the same value.
+1. Update CloudFront to send the new secret as `X-Origin-Secret`.
+2. Update the Fly `ORIGIN_SHARED_SECRET` secret to the same value immediately
+   after.
 3. Wait for the Fly release to become healthy.
 4. Verify direct Fly access without the header is 403 and with the header is 200.
 5. Remove the old value from any local/operator notes.

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,6 +76,9 @@ export function validateServerEnv(env: Env = process.env): ServerConfigResult {
   if (hasText(env.SESSION_SECRET) && env.SESSION_SECRET!.length < 32) {
     invalid.push({ name: 'SESSION_SECRET', message: 'must be at least 32 characters' });
   }
+  if (hasText(env.ORIGIN_SHARED_SECRET) && env.ORIGIN_SHARED_SECRET!.length < 32) {
+    invalid.push({ name: 'ORIGIN_SHARED_SECRET', message: 'must be at least 32 characters' });
+  }
   validateUrl('DATABASE_URL', env.DATABASE_URL, invalid);
   validateUrl('LANGFUSE_BASEURL', env.LANGFUSE_BASEURL, invalid);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ const REQUIRED_SERVER_ENV = [
   'LANGFUSE_BASEURL',
   'GOOGLE_OAUTH_CLIENT_ID',
   'GOOGLE_OAUTH_CLIENT_SECRET',
+  'ORIGIN_SHARED_SECRET',
 ] as const;
 
 function requiredServerEnv(nodeEnv: string): readonly (typeof REQUIRED_SERVER_ENV)[number][] {

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,7 +29,9 @@ const REQUIRED_SERVER_ENV = [
 
 function requiredServerEnv(nodeEnv: string): readonly (typeof REQUIRED_SERVER_ENV)[number][] {
   if (nodeEnv === 'production') return REQUIRED_SERVER_ENV;
-  return REQUIRED_SERVER_ENV.filter((name) => name !== 'DATABASE_URL');
+  return REQUIRED_SERVER_ENV.filter(
+    (name) => name !== 'DATABASE_URL' && name !== 'ORIGIN_SHARED_SECRET',
+  );
 }
 
 function isTestProcess(env: Env): boolean {

--- a/src/origin-lock.ts
+++ b/src/origin-lock.ts
@@ -1,0 +1,43 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { MiddlewareHandler } from 'hono';
+
+export const ORIGIN_SECRET_HEADER = 'x-origin-secret';
+export const ORIGIN_LOCK_BYPASS_PATHS = new Set(['/api/live', '/api/health']);
+
+function hasText(value: string | undefined): value is string {
+  return value !== undefined && value.trim().length > 0;
+}
+
+function secretsMatch(actual: string | undefined, expected: string): boolean {
+  if (!hasText(actual)) return false;
+
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  if (actualBuffer.length !== expectedBuffer.length) return false;
+  return timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+export function originSharedSecretMiddleware(options?: {
+  secret?: string;
+  bypassPaths?: ReadonlySet<string>;
+}): MiddlewareHandler {
+  return async (c, next) => {
+    const secret = options?.secret ?? process.env.ORIGIN_SHARED_SECRET;
+    if (!hasText(secret)) {
+      await next();
+      return;
+    }
+
+    const bypassPaths = options?.bypassPaths ?? ORIGIN_LOCK_BYPASS_PATHS;
+    if (bypassPaths.has(c.req.path)) {
+      await next();
+      return;
+    }
+
+    if (!secretsMatch(c.req.header(ORIGIN_SECRET_HEADER), secret)) {
+      return c.json({ error: 'Forbidden' }, 403);
+    }
+
+    await next();
+  };
+}

--- a/src/origin-lock.ts
+++ b/src/origin-lock.ts
@@ -2,7 +2,7 @@ import { timingSafeEqual } from 'node:crypto';
 import type { MiddlewareHandler } from 'hono';
 
 export const ORIGIN_SECRET_HEADER = 'x-origin-secret';
-export const ORIGIN_LOCK_BYPASS_PATHS = new Set(['/api/live', '/api/health']);
+export const ORIGIN_LOCK_BYPASS_PATHS: ReadonlySet<string> = new Set(['/api/live', '/api/health']);
 
 function hasText(value: string | undefined): value is string {
   return value !== undefined && value.trim().length > 0;

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { ask, ensureBootstrapStatus, isReady, startBootstrapLifecycle } from './
 import { getDb, getWorktreeRuntime } from './db.ts';
 import { loadServerConfig } from './config.ts';
 import { runReadinessChecks } from './health.ts';
+import { originSharedSecretMiddleware } from './origin-lock.ts';
 import { registerDevLoginRoute, shouldRegisterDevLogin } from './auth/dev-login.ts';
 import {
   toolSourceLabel,
@@ -82,6 +83,8 @@ import {
 } from './chat/conversation-service.ts';
 
 export const app = new Hono();
+
+app.use('*', originSharedSecretMiddleware());
 
 const HTML_CSP =
   "default-src 'self'; " +

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -55,6 +55,7 @@ describe('validateServerEnv', () => {
       ...validProductionEnv,
       NODE_ENV: 'development',
       DATABASE_URL: undefined,
+      ORIGIN_SHARED_SECRET: undefined,
     });
 
     expect(result.success).toBe(true);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -17,6 +17,7 @@ describe('validateServerEnv', () => {
     LANGFUSE_BASEURL: 'https://us.cloud.langfuse.com',
     GOOGLE_OAUTH_CLIENT_ID: 'google-client',
     GOOGLE_OAUTH_CLIENT_SECRET: 'google-secret',
+    ORIGIN_SHARED_SECRET: 'origin-secret'.repeat(3),
   };
 
   it('rejects missing production secrets with the missing variable names', () => {
@@ -33,6 +34,7 @@ describe('validateServerEnv', () => {
       'LANGFUSE_BASEURL',
       'GOOGLE_OAUTH_CLIENT_ID',
       'GOOGLE_OAUTH_CLIENT_SECRET',
+      'ORIGIN_SHARED_SECRET',
     ]);
     expect(formatServerConfigError(result.error)).toContain(
       'Missing required environment variables',

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -69,6 +69,7 @@ describe('validateServerEnv', () => {
       ...validProductionEnv,
       PORT: 'not-a-port',
       SESSION_SECRET: 'short',
+      ORIGIN_SHARED_SECRET: 'short',
     });
 
     expect(result.success).toBe(false);
@@ -77,6 +78,7 @@ describe('validateServerEnv', () => {
       expect.arrayContaining([
         { name: 'PORT', message: 'must be an integer between 1 and 65535' },
         { name: 'SESSION_SECRET', message: 'must be at least 32 characters' },
+        { name: 'ORIGIN_SHARED_SECRET', message: 'must be at least 32 characters' },
       ]),
     );
   });

--- a/test/origin-lock.test.ts
+++ b/test/origin-lock.test.ts
@@ -1,0 +1,53 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+
+import { originSharedSecretMiddleware } from '../src/origin-lock.ts';
+
+function makeApp(secret?: string) {
+  const app = new Hono();
+  app.use('*', originSharedSecretMiddleware({ secret }));
+  app.get('/api/live', (c) => c.json({ status: 'ok' }));
+  app.get('/api/health', (c) => c.json({ status: 'ok' }));
+  app.get('/login', (c) => c.text('login'));
+  return app;
+}
+
+describe('originSharedSecretMiddleware', () => {
+  it('does nothing when no shared secret is configured', async () => {
+    const res = await makeApp().request('/login');
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('login');
+  });
+
+  it('allows health endpoints without the shared secret for Fly machine checks', async () => {
+    const app = makeApp('cloudfront-secret');
+
+    await expect(app.request('/api/live')).resolves.toMatchObject({ status: 200 });
+    await expect(app.request('/api/health')).resolves.toMatchObject({ status: 200 });
+  });
+
+  it('rejects non-health requests without the shared secret', async () => {
+    const res = await makeApp('cloudfront-secret').request('/login');
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: 'Forbidden' });
+  });
+
+  it('rejects non-health requests with the wrong shared secret', async () => {
+    const res = await makeApp('cloudfront-secret').request('/login', {
+      headers: { 'X-Origin-Secret': 'wrong-secret' },
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('allows non-health requests with the exact shared secret', async () => {
+    const res = await makeApp('cloudfront-secret').request('/login', {
+      headers: { 'X-Origin-Secret': 'cloudfront-secret' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('login');
+  });
+});


### PR DESCRIPTION
## Summary
- add shared-secret origin lock middleware for production traffic behind CloudFront
- keep `/api/live` and `/api/health` open for Fly machine checks
- document the production CloudFront/WAF setup and secret rotation

## Production setup already applied
- ACM certificate for `squire.maz.org` issued in `us-east-1`
- CloudFront distribution `E3JJNKYCT7BXZ0` (`d1syzhlifinq9m.cloudfront.net`) deployed with AWS WAF
- Route 53 `squire.maz.org` A/AAAA now alias CloudFront
- WAF `squire-production-waf` has IP reputation, common rules, known bad inputs, SQLi rules, and a 2,000/5min/IP rate limit
- Fly secrets include `ORIGIN_SHARED_SECRET` and `SQUIRE_BASE_URL=https://squire.maz.org`

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm test -- origin-lock config server-api`
- `curl https://squire.maz.org/api/live` returned 200 through CloudFront
- SQLi probe to `https://squire.maz.org/login?...` returned 403 from CloudFront

Closes SQR-58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CloudFront origin lock: production requests must present a shared-secret header; health endpoints bypass the check.

* **Configuration**
  * Example environment file documents the optional origin shared secret.
  * Production validation enforces a minimum secret length when provided.

* **Documentation**
  * Runbook updated with origin-lock setup, AWS/WAF notes, logging, and zero-downtime secret rotation steps.

* **Tests**
  * Added tests covering origin-lock behavior and environment validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->