### PR TITLE
SQR-44: automate Fly deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,19 @@ jobs:
       - name: Lint markdown
         run: npm run lint:md
 
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: v1.7.12
+        run: |
+          mkdir -p "$RUNNER_TEMP/actionlint"
+          curl -sSLo "$RUNNER_TEMP/actionlint.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION#v}_linux_amd64.tar.gz"
+          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP/actionlint" actionlint
+          echo "$RUNNER_TEMP/actionlint" >> "$GITHUB_PATH"
+
+      - name: Lint GitHub Actions
+        run: actionlint
+
       - name: Format check
         run: npx prettier --check src/ test/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  attestations: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -68,11 +72,25 @@ jobs:
       - name: Install actionlint
         env:
           ACTIONLINT_VERSION: v1.7.12
+          GH_TOKEN: ${{ github.token }}
         run: |
+          archive_name="actionlint_${ACTIONLINT_VERSION#v}_linux_amd64.tar.gz"
+          archive_path="$RUNNER_TEMP/actionlint.tar.gz"
           mkdir -p "$RUNNER_TEMP/actionlint"
-          curl -sSLo "$RUNNER_TEMP/actionlint.tar.gz" \
-            "https://github.com/rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION#v}_linux_amd64.tar.gz"
-          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP/actionlint" actionlint
+          curl -sSLo "$archive_path" \
+            "https://github.com/rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}/${archive_name}"
+          if command -v gh >/dev/null 2>&1; then
+            gh attestation verify --repo rhysd/actionlint "$archive_path"
+          else
+            checksums_path="$RUNNER_TEMP/actionlint_checksums.txt"
+            curl -sSLo "$checksums_path" \
+              "https://github.com/rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION#v}_checksums.txt"
+            expected_sha="$(grep "  ${archive_name}$" "$checksums_path" | cut -d ' ' -f 1)"
+            actual_sha="$(sha256sum "$archive_path" | cut -d ' ' -f 1)"
+            test -n "$expected_sha"
+            test "$actual_sha" = "$expected_sha"
+          fi
+          tar -xzf "$archive_path" -C "$RUNNER_TEMP/actionlint" actionlint
           echo "$RUNNER_TEMP/actionlint" >> "$GITHUB_PATH"
 
       - name: Lint GitHub Actions

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy to Fly
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: fly-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy maz-squire
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://squire.maz.org
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Verify Fly deploy token is configured
+        run: test -n "$FLY_API_TOKEN"
+
+      - name: Deploy to Fly
+        run: flyctl deploy -a maz-squire --remote-only
+
+      - name: Show Fly status
+        run: flyctl status -a maz-squire
+
+      - name: Smoke production health
+        run: node scripts/check-deploy-health.ts --base-url https://maz-squire.fly.dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,11 @@ concurrency:
 jobs:
   deploy:
     name: Deploy maz-squire
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -34,7 +38,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Verify Fly deploy token is configured
         run: test -n "$FLY_API_TOKEN"

--- a/docs/adr/0016-phase-1-hosting-platform.md
+++ b/docs/adr/0016-phase-1-hosting-platform.md
@@ -129,10 +129,11 @@ Postgres over Fly's private 6PN network — Postgres has no public ingress.
   into `fly.toml`. A non-zero exit code from the release machine aborts the
   deploy and leaves the prior version live, which is exactly the SQR-43
   acceptance criterion.
-- **SQR-44 (CI/CD)** — GitHub Actions workflow uses
-  `superfly/flyctl-actions/setup-flyctl@master`, then `flyctl deploy` on
-  release tag. The DATABASE_URL secret is scoped to the Fly app via
-  `fly secrets set`, never written to the repo.
+- **SQR-44 (CI/CD)** — GitHub Actions workflow runs after `CI` succeeds on
+  `main`, uses `superfly/flyctl-actions/setup-flyctl@master`, then runs
+  `flyctl deploy -a maz-squire --remote-only`. The deploy token lives in the
+  GitHub secret `FLY_API_TOKEN`; app secrets such as `DATABASE_URL` stay scoped
+  to the Fly app via `fly secrets set` and are never written to the repo.
 
 ### Operational shape
 

--- a/docs/runbooks/deploy-rollback.md
+++ b/docs/runbooks/deploy-rollback.md
@@ -67,6 +67,47 @@ curl https://maz-squire.fly.dev/api/health
 `/api/live` is the cheap platform liveness check. `/api/health` is the
 readiness check and exercises Postgres, pgvector, and embedder warmup.
 
+## GitHub deploy automation
+
+The `Deploy to Fly` GitHub Actions workflow runs after the `CI` workflow
+finishes successfully on `main`. It uses the Fly deploy token stored in the
+repository secret `FLY_API_TOKEN`, runs:
+
+```bash
+flyctl deploy -a maz-squire --remote-only
+```
+
+and then smoke-checks the direct Fly health endpoints with:
+
+```bash
+node scripts/check-deploy-health.ts --base-url https://maz-squire.fly.dev
+```
+
+The smoke check calls:
+
+- `https://maz-squire.fly.dev/api/live`
+- `https://maz-squire.fly.dev/api/health`
+
+and fails unless `/api/health` reports `status`, `db.status`, `vector.status`,
+and `embedder.status` as `ok`.
+
+CI installs actionlint and runs it against `.github/workflows`. To run the same
+check locally, install actionlint and run:
+
+```bash
+npm run lint:actions
+```
+
+Create or rotate the deploy token with a deploy-scoped Fly token, then write it
+to GitHub without putting it in a local env file:
+
+```bash
+fly tokens create deploy -a maz-squire -x 8760h -n github-actions-maz-squire |
+  gh secret set FLY_API_TOKEN --repo maz-org/squire
+```
+
+After the next successful deploy, revoke the old deploy token in Fly.
+
 ## CloudFront origin lock
 
 Production app traffic is expected to enter through CloudFront with AWS WAF

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint src/ test/ scripts/",
     "lint:css": "stylelint 'src/web-ui/**/*.css'",
     "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules' '#data' '#.beads' '#.gstack'",
+    "lint:actions": "actionlint",
     "format": "prettier --write src/ test/",
     "format:check": "prettier --check src/ test/",
     "hooks:install": "node scripts/setup-git-hooks.ts",

--- a/scripts/check-deploy-health.ts
+++ b/scripts/check-deploy-health.ts
@@ -1,0 +1,112 @@
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_BASE_URL = 'https://maz-squire.fly.dev';
+const HEALTH_COMPONENTS = ['db', 'vector', 'embedder'] as const;
+
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+type Logger = (message: string) => void;
+
+interface CheckDeployHealthOptions {
+  baseUrl?: string;
+  fetch?: FetchLike;
+  log?: Logger;
+}
+
+interface StatusPayload {
+  status?: unknown;
+  db?: { status?: unknown };
+  vector?: { status?: unknown };
+  embedder?: { status?: unknown };
+}
+
+export interface CheckDeployHealthResult {
+  baseUrl: string;
+  liveUrl: string;
+  healthUrl: string;
+}
+
+function normalizeBaseUrl(rawBaseUrl: string): string {
+  const url = new URL(rawBaseUrl);
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  url.search = '';
+  url.hash = '';
+  return url.toString().replace(/\/$/, '');
+}
+
+async function readJson(response: Response, path: string): Promise<StatusPayload> {
+  try {
+    return (await response.json()) as StatusPayload;
+  } catch (error) {
+    throw new Error(`${path} did not return valid JSON`, { cause: error });
+  }
+}
+
+async function checkEndpointStatus(
+  fetch: FetchLike,
+  url: string,
+  path: string,
+): Promise<StatusPayload> {
+  const response = await fetch(url);
+  const payload = await readJson(response, path);
+
+  if (!response.ok) {
+    throw new Error(`${path} returned ${response.status}`);
+  }
+  if (payload.status !== 'ok') {
+    throw new Error(`${path} status was ${String(payload.status)}`);
+  }
+  return payload;
+}
+
+function assertHealthComponents(payload: StatusPayload) {
+  for (const component of HEALTH_COMPONENTS) {
+    const status = payload[component]?.status;
+    if (status !== 'ok') {
+      throw new Error(`/api/health ${component} status was ${String(status)}`);
+    }
+  }
+}
+
+export async function checkDeployHealth(
+  options: CheckDeployHealthOptions = {},
+): Promise<CheckDeployHealthResult> {
+  const fetch = options.fetch ?? globalThis.fetch;
+  const log = options.log ?? console.log;
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? DEFAULT_BASE_URL);
+  const liveUrl = `${baseUrl}/api/live`;
+  const healthUrl = `${baseUrl}/api/health`;
+
+  const live = await checkEndpointStatus(fetch, liveUrl, '/api/live');
+  log(`✓ /api/live status=${String(live.status)}`);
+
+  const health = await checkEndpointStatus(fetch, healthUrl, '/api/health');
+  assertHealthComponents(health);
+  log(
+    `✓ /api/health status=${String(health.status)} db=${String(
+      health.db?.status,
+    )} vector=${String(health.vector?.status)} embedder=${String(health.embedder?.status)}`,
+  );
+
+  return { baseUrl, liveUrl, healthUrl };
+}
+
+function parseBaseUrl(argv: readonly string[]): string {
+  const baseUrlFlagIndex = argv.indexOf('--base-url');
+  if (baseUrlFlagIndex !== -1) {
+    const value = argv[baseUrlFlagIndex + 1];
+    if (!value) throw new Error('--base-url requires a value');
+    return value;
+  }
+  return process.env.SQUIRE_DEPLOY_HEALTH_BASE_URL ?? DEFAULT_BASE_URL;
+}
+
+async function main(): Promise<void> {
+  await checkDeployHealth({ baseUrl: parseBaseUrl(process.argv.slice(2)) });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/check-deploy-health.ts
+++ b/scripts/check-deploy-health.ts
@@ -77,12 +77,12 @@ export async function checkDeployHealth(
   const healthUrl = `${baseUrl}/api/health`;
 
   const live = await checkEndpointStatus(fetch, liveUrl, '/api/live');
-  log(`✓ /api/live status=${String(live.status)}`);
+  log(`OK /api/live status=${String(live.status)}`);
 
   const health = await checkEndpointStatus(fetch, healthUrl, '/api/health');
   assertHealthComponents(health);
   log(
-    `✓ /api/health status=${String(health.status)} db=${String(
+    `OK /api/health status=${String(health.status)} db=${String(
       health.db?.status,
     )} vector=${String(health.vector?.status)} embedder=${String(health.embedder?.status)}`,
   );

--- a/scripts/check-deploy-health.ts
+++ b/scripts/check-deploy-health.ts
@@ -47,11 +47,11 @@ async function checkEndpointStatus(
   path: string,
 ): Promise<StatusPayload> {
   const response = await fetch(url);
-  const payload = await readJson(response, path);
 
   if (!response.ok) {
     throw new Error(`${path} returned ${response.status}`);
   }
+  const payload = await readJson(response, path);
   if (payload.status !== 'ok') {
     throw new Error(`${path} status was ${String(payload.status)}`);
   }

--- a/test/check-deploy-health.test.ts
+++ b/test/check-deploy-health.test.ts
@@ -50,6 +50,20 @@ describe('checkDeployHealth', () => {
     ).rejects.toThrow('/api/live returned 503');
   });
 
+  it('reports response status before parsing non-ok bodies', async () => {
+    await expect(
+      checkDeployHealth({
+        baseUrl: 'https://maz-squire.fly.dev',
+        fetch: async () =>
+          new Response('<html>temporarily unavailable</html>', {
+            status: 503,
+            headers: { 'content-type': 'text/html' },
+          }),
+        log: () => undefined,
+      }),
+    ).rejects.toThrow('/api/live returned 503');
+  });
+
   it('fails when a readiness dependency is unhealthy', async () => {
     await expect(
       checkDeployHealth({

--- a/test/check-deploy-health.test.ts
+++ b/test/check-deploy-health.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { checkDeployHealth } from '../scripts/check-deploy-health.ts';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('checkDeployHealth', () => {
+  it('passes when liveness and all readiness dependencies are healthy', async () => {
+    const requested: string[] = [];
+    const result = await checkDeployHealth({
+      baseUrl: 'https://maz-squire.fly.dev/',
+      fetch: async (url) => {
+        requested.push(String(url));
+        if (String(url).endsWith('/api/live')) {
+          return jsonResponse(200, { status: 'ok' });
+        }
+        return jsonResponse(200, {
+          status: 'ok',
+          db: { status: 'ok' },
+          vector: { status: 'ok' },
+          embedder: { status: 'ok' },
+        });
+      },
+      log: () => undefined,
+    });
+
+    expect(result).toEqual({
+      baseUrl: 'https://maz-squire.fly.dev',
+      liveUrl: 'https://maz-squire.fly.dev/api/live',
+      healthUrl: 'https://maz-squire.fly.dev/api/health',
+    });
+    expect(requested).toEqual([
+      'https://maz-squire.fly.dev/api/live',
+      'https://maz-squire.fly.dev/api/health',
+    ]);
+  });
+
+  it('fails when the liveness endpoint is not ok', async () => {
+    await expect(
+      checkDeployHealth({
+        baseUrl: 'https://maz-squire.fly.dev',
+        fetch: async () => jsonResponse(503, { status: 'starting' }),
+        log: () => undefined,
+      }),
+    ).rejects.toThrow('/api/live returned 503');
+  });
+
+  it('fails when a readiness dependency is unhealthy', async () => {
+    await expect(
+      checkDeployHealth({
+        baseUrl: 'https://maz-squire.fly.dev',
+        fetch: async (url) => {
+          if (String(url).endsWith('/api/live')) {
+            return jsonResponse(200, { status: 'ok' });
+          }
+          return jsonResponse(200, {
+            status: 'ok',
+            db: { status: 'ok' },
+            vector: { status: 'degraded' },
+            embedder: { status: 'ok' },
+          });
+        },
+        log: () => undefined,
+      }),
+    ).rejects.toThrow('/api/health vector status was degraded');
+  });
+});

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -37,6 +37,14 @@ describe('deployment configuration', () => {
     expect(packageJson.scripts?.['build:web-assets']).toBe('node scripts/build-web-assets.ts');
   });
 
+  it('defines a manual GitHub Actions lint command', async () => {
+    const packageJson = JSON.parse(await readProjectFile('package.json')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.['lint:actions']).toBe('actionlint');
+  });
+
   it('keeps deploy-only and secret material out of the Docker context', async () => {
     const dockerignore = await readProjectFile('.dockerignore');
 
@@ -82,5 +90,45 @@ describe('deployment configuration', () => {
     expect(runbook).toContain('fly deploy --image <prior-image>');
     expect(runbook).toContain('node scripts/db-migrate.ts');
     expect(runbook).toContain('schemas are not rolled back automatically');
+  });
+
+  it('deploys main to Fly only after CI succeeds', async () => {
+    const workflow = await readProjectFile('.github/workflows/deploy.yml');
+
+    expect(workflow).toContain('name: Deploy to Fly');
+    expect(workflow).toContain('workflow_run:');
+    expect(workflow).toContain('workflows: [CI]');
+    expect(workflow).toContain('branches: [main]');
+    expect(workflow).toContain("github.event.workflow_run.conclusion == 'success'");
+    expect(workflow).toContain('deployments: write');
+    expect(workflow).toContain('name: production');
+    expect(workflow).toContain('url: https://squire.maz.org');
+    expect(workflow).toContain('group: fly-production');
+    expect(workflow).toContain('cancel-in-progress: false');
+    expect(workflow).toContain('FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}');
+    expect(workflow).toContain('flyctl deploy -a maz-squire --remote-only');
+    expect(workflow).not.toContain('npm run db:migrate');
+    expect(workflow).not.toContain('scripts/db-migrate.ts');
+  });
+
+  it('runs actionlint in CI for GitHub workflow changes', async () => {
+    const workflow = await readProjectFile('.github/workflows/ci.yml');
+
+    expect(workflow).toContain('ACTIONLINT_VERSION: v1.7.12');
+    expect(workflow).toContain('rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}');
+    expect(workflow).toContain('actionlint_${ACTIONLINT_VERSION#v}_linux_amd64.tar.gz');
+    expect(workflow).toContain('name: Lint GitHub Actions');
+    expect(workflow).toContain('run: actionlint');
+  });
+
+  it('documents GitHub deploy token setup and post-deploy smoke checks', async () => {
+    const runbook = await readProjectFile('docs/runbooks/deploy-rollback.md');
+
+    expect(runbook).toContain('fly tokens create deploy');
+    expect(runbook).toContain('FLY_API_TOKEN');
+    expect(runbook).toContain('Deploy to Fly');
+    expect(runbook).toContain('node scripts/check-deploy-health.ts');
+    expect(runbook).toContain('https://maz-squire.fly.dev/api/live');
+    expect(runbook).toContain('https://maz-squire.fly.dev/api/health');
   });
 });

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -100,12 +100,19 @@ describe('deployment configuration', () => {
     expect(workflow).toContain('workflows: [CI]');
     expect(workflow).toContain('branches: [main]');
     expect(workflow).toContain("github.event.workflow_run.conclusion == 'success'");
+    expect(workflow).toContain("github.event.workflow_run.event == 'push'");
+    expect(workflow).toContain("github.event.workflow_run.head_branch == 'main'");
+    expect(workflow).toContain(
+      'github.event.workflow_run.head_repository.full_name == github.repository',
+    );
     expect(workflow).toContain('deployments: write');
     expect(workflow).toContain('name: production');
     expect(workflow).toContain('url: https://squire.maz.org');
     expect(workflow).toContain('group: fly-production');
     expect(workflow).toContain('cancel-in-progress: false');
     expect(workflow).toContain('FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}');
+    expect(workflow).toMatch(/superfly\/flyctl-actions\/setup-flyctl@[a-f0-9]{40}/);
+    expect(workflow).not.toContain('setup-flyctl@master');
     expect(workflow).toContain('flyctl deploy -a maz-squire --remote-only');
     expect(workflow).not.toContain('npm run db:migrate');
     expect(workflow).not.toContain('scripts/db-migrate.ts');
@@ -115,8 +122,11 @@ describe('deployment configuration', () => {
     const workflow = await readProjectFile('.github/workflows/ci.yml');
 
     expect(workflow).toContain('ACTIONLINT_VERSION: v1.7.12');
+    expect(workflow).toContain('attestations: read');
     expect(workflow).toContain('rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}');
     expect(workflow).toContain('actionlint_${ACTIONLINT_VERSION#v}_linux_amd64.tar.gz');
+    expect(workflow).toContain('gh attestation verify --repo rhysd/actionlint');
+    expect(workflow).toContain('actionlint_${ACTIONLINT_VERSION#v}_checksums.txt');
     expect(workflow).toContain('name: Lint GitHub Actions');
     expect(workflow).toContain('run: actionlint');
   });


### PR DESCRIPTION
## Summary
- add a `Deploy to Fly` workflow that runs after CI succeeds on `main`
- serialize production deploys, publish GitHub environment status, and deploy `maz-squire` with the Fly deploy token
- add a post-deploy health smoke script for `/api/live` and `/api/health`
- add actionlint to CI and document token setup/rotation in the deploy runbook

## Validation
- `/tmp/squire-actionlint-darwin/actionlint`
- `npm run check`
- `npm test -- deployment-config check-deploy-health`
- `node scripts/check-deploy-health.ts --base-url https://maz-squire.fly.dev`
- confirmed `FLY_API_TOKEN` exists in GitHub repo secrets

Fixes SQR-44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic deploy workflow to Fly after CI and a post-deploy health-check script.

* **Documentation**
  * Added deploy automation/rollback runbook and updated hosting ADR to reflect CI/CD behavior.

* **Chores**
  * Added workflow-level Action linting and an npm script to run it.

* **Tests**
  * Expanded tests covering deploy workflow config and deploy health-check scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->