### PR TITLE
SQR-44: make auto-merge trigger deploy workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,16 +4,22 @@ on:
   pull_request:
     types: [opened]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.AUTO_MERGE_APP_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_PRIVATE_KEY }}
+
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/docs/runbooks/deploy-rollback.md
+++ b/docs/runbooks/deploy-rollback.md
@@ -91,6 +91,11 @@ The smoke check calls:
 and fails unless `/api/health` reports `status`, `db.status`, `vector.status`,
 and `embedder.status` as `ok`.
 
+Keep `.github/workflows/auto-merge.yml` on the `AUTO_MERGE_APP_*` GitHub App
+token path. Merges performed with `secrets.GITHUB_TOKEN` do not start follow-up
+`push` workflows, which means the `CI` run on `main` would not exist and
+`Deploy to Fly` would have nothing to follow.
+
 CI installs actionlint and runs it against `.github/workflows`. To run the same
 check locally, install actionlint and run:
 

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -131,11 +131,25 @@ describe('deployment configuration', () => {
     expect(workflow).toContain('run: actionlint');
   });
 
+  it('enables auto-merge with an app token so main push workflows run', async () => {
+    const workflow = await readProjectFile('.github/workflows/auto-merge.yml');
+
+    expect(workflow).toContain(
+      'if: github.event.pull_request.head.repo.full_name == github.repository',
+    );
+    expect(workflow).toContain('uses: actions/create-github-app-token@v3');
+    expect(workflow).toContain('app-id: ${{ secrets.AUTO_MERGE_APP_ID }}');
+    expect(workflow).toContain('private-key: ${{ secrets.AUTO_MERGE_PRIVATE_KEY }}');
+    expect(workflow).toContain('GH_TOKEN: ${{ steps.app-token.outputs.token }}');
+    expect(workflow).not.toContain('GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}');
+  });
+
   it('documents GitHub deploy token setup and post-deploy smoke checks', async () => {
     const runbook = await readProjectFile('docs/runbooks/deploy-rollback.md');
 
     expect(runbook).toContain('fly tokens create deploy');
     expect(runbook).toContain('FLY_API_TOKEN');
+    expect(runbook).toContain('AUTO_MERGE_APP_*');
     expect(runbook).toContain('Deploy to Fly');
     expect(runbook).toContain('node scripts/check-deploy-health.ts');
     expect(runbook).toContain('https://maz-squire.fly.dev/api/live');


### PR DESCRIPTION
## Summary
- switch the auto-merge workflow from GITHUB_TOKEN to the existing auto-merge GitHub App token
- add a regression test so main push workflows continue to run after auto-merge
- document why this matters for the Fly deploy workflow_run chain

## Validation
- npm test -- deployment-config
- actionlint
- npm run check

Follow-up for SQR-44 after PR #363 showed that GITHUB_TOKEN auto-merge did not start CI on main, which prevented Deploy to Fly from running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment pipeline security by implementing stricter permission controls and GitHub App token authentication for automated pull request merging.

* **Tests**
  * Added validation tests for deployment configuration and GitHub App token setup in the automated merge workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->