### PR TITLE
docs: add production operations guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install
 # Add your API keys
 cp .env.example .env
 # Edit .env: ANTHROPIC_API_KEY (required), Google OAuth keys + SESSION_SECRET
-# (required for web UI login). `GOOGLE_REDIRECT_URI` can stay on
+# (required for web UI login). `GOOGLE_OAUTH_REDIRECT_URI` can stay on
 # `http://localhost:3000/auth/google/callback`; linked worktrees reuse the
 # current localhost origin at runtime, but every localhost callback port you use
 # still has to be pre-registered in Google Cloud Console. The currently
@@ -72,6 +72,7 @@ For the full contributor walkthrough, see [docs/CONTRIBUTING.md](docs/CONTRIBUTI
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for local setup, env vars, MCP wiring, and data workflows
 - [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for the full macOS contributor walkthrough
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for system design, auth boundaries, and runtime topology
+- [docs/runbooks/production-operations.md](docs/runbooks/production-operations.md) for production deploy, edge, secret, verification, and rollback checks
 - [docs/SSE_CONTRACT.md](docs/SSE_CONTRACT.md) for the browser-visible chat streaming contract (`text-delta`, `done`, `error`, tool events)
 - [docs/SECURITY.md](docs/SECURITY.md) for the standing security review and mitigation backlog
 - [docs/markdown-rendering-styleguide.md](docs/markdown-rendering-styleguide.md) for the supported markdown subset and the shared `.squire-markdown` contract
@@ -91,9 +92,10 @@ The server initializes the vector index and embedder on startup, then
 serves:
 
 - **Web UI** — `GET /` (companion-first layout shell, server-rendered HTML;
-  `GET /app.css` compiles `src/web-ui/styles.css` in-process via
-  `@tailwindcss/node` on first request and caches the result — no build
-  step required on a fresh clone. Prod uses content-hashed URLs
+  `GET /app.css` compiles `src/web-ui/styles.css` in-process in development
+  so fresh clones do not need a build step before local rendering. Production
+  images prebuild assets with `npm run build:web-assets` and serve
+  content-hashed URLs
   (`/app.<hash>.css`) with immutable caching. See
   [ADR 0011](docs/adr/0011-on-demand-asset-pipeline.md)). Authenticated chat
   runs on `/chat` and `/chat/:conversationId`, with persisted per-user

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 **Version:** 1.0.11
 **Date:** 2026-04-07
-**Last Refreshed:** 2026-05-03
+**Last Refreshed:** 2026-05-16
 **Owner:** Architect
 **Companion doc:** [SPEC.md](SPEC.md) — product / PM concerns (what / why / who / when)
 
@@ -42,7 +42,8 @@ All channels (web UI, MCP, REST, future Discord / iMessage) talk to the same kno
 
 Phase 1 production stays on the current Hono server, Postgres + pgvector
 runtime store, Claude SDK tool loop, conversation service, SSE contract, and
-Langfuse/OpenTelemetry trace path while the deployment host is chosen.
+Langfuse/OpenTelemetry trace path. The deployed production host is the Fly app
+`maz-squire`, with Fly Managed Postgres, Route 53, CloudFront, and AWS WAF.
 [ADR 0015 — Evaluate LangChain and Deep Agents at the intelligence boundary](adr/0015-langchain-deep-agents-intelligence-layer.md)
 keeps Deep Agents and LangSmith Deployment out of the Phase 1 app-hosting
 decision, but treats LangChain, Deep Agents, and LangSmith evals as candidates
@@ -60,6 +61,8 @@ The active baseline is:
 
 - Hono hosts the web UI, REST endpoints, and MCP endpoint in one server.
 - Postgres + pgvector hold the runtime retrieval layers.
+- Fly hosts the production app and Fly Managed Postgres hosts the production
+  database.
 - The knowledge agent uses the current Claude SDK tool loop.
 - LangChain / Deep Agents may be added as a parallel eval-only runner behind
   the same service boundary, but production traffic stays on the current runner
@@ -146,11 +149,11 @@ Agents shouldn't need hard-coded knowledge of what data Squire has. They discove
 ### Web channel (frontend + server)
 
 - **Server framework:** Hono (`@hono/node-server`)
-- **UI rendering:** Hono JSX (server-rendered) + HTMX for interactivity + Tailwind CSS compiled in-process via `@tailwindcss/node`
+- **UI rendering:** Hono JSX (server-rendered) + HTMX for interactivity + Tailwind CSS compiled in-process in development and prebuilt in the production Docker image
 - **Assistant rendering boundary:** `markdown-it` on the server, with raw HTML
   disabled, non-HTTPS links rejected, and one shared renderer reused for both
   persisted transcript pages and final post-stream answer fragments
-- **Build pipeline:** no JavaScript bundler and no client-side build step. `GET /app.css` compiles `src/web-ui/styles.css` in-process via `@tailwindcss/node` on first request and caches the result in a module-level variable; dev keys the cache on source-file mtime so edits show up on the next request, prod compiles exactly once per process. Prod serves the compiled CSS at a content-hashed URL (`/app.<hash>.css`) with `Cache-Control: public, max-age=31536000, immutable` so Cloudflare and browsers can cache forever and invalidation is automatic on content change; dev serves the bare `/app.css` path with `Cache-Control: no-cache`. A parallel `/squire.js` handler serves vanilla-JS islands (currently the SQR-66 cite tap-toggle) with the same caching pattern. No `public/` build output, no `npm run build:css` — every fresh clone renders correctly without a build prerequisite.
+- **Build pipeline:** no JavaScript bundler and no client-side build step. In development, `GET /app.css` compiles `src/web-ui/styles.css` in-process via `@tailwindcss/node` and keys the cache on source-file mtime so edits show up on the next request. In production, the Docker `assets` stage runs `npm run build:web-assets`, writes `dist/web-ui/app.css` and `dist/web-ui/squire.js`, and the runtime serves content-hashed URLs (`/app.<hash>.css`, `/squire.<hash>.js`) with `Cache-Control: public, max-age=31536000, immutable`. No checked-in `public/` build output, no JavaScript bundler, and no runtime CSS compilation in production.
 
 HTML responses also carry a shared Content Security Policy set in
 `src/server.ts`. The policy is `self`-only except for the current Google Fonts
@@ -209,7 +212,7 @@ _Rationale: avoid SaaS vendor dependency in the auth path, no per-MAU pricing. S
 
 ### Edge layer
 
-- **Cloudflare** in front of the hosted app as a WAF. Provides DDoS protection, edge rate limiting, and bot mitigation. Application-level rate limiting on expensive endpoints (`/api/ask`, `/mcp`) still lives in-app for per-user cost budgets.
+- **Route 53 + CloudFront + AWS WAF** in front of the Fly app. Route 53 hosts `maz.org`; `squire.maz.org` aliases to a CloudFront distribution with AWS WAF managed rules, SQL-injection protection, IP reputation blocking, and a per-IP rate limit. CloudFront sends `X-Origin-Secret`; Fly stores the matching `ORIGIN_SHARED_SECRET` and rejects browser, OAuth, API, and MCP routes that bypass the edge. Application-level rate limiting on expensive endpoints (`/api/ask`, `/mcp`) still lives in-app for per-user cost budgets.
 
 ### Observability infrastructure
 
@@ -675,17 +678,17 @@ Squire emits OpenTelemetry traces from the agent loop, tool calls, and HTTP hand
 
 ## Deployment
 
-**Hosting:** Fly.io. A single `shared-cpu-1x@1GB` machine in one region runs the Hono server, MCP transport, and web UI in one process. Postgres is **Fly Managed Postgres** (Basic plan) reached over Fly's private 6PN network — Postgres has no public ingress. Cloudflare sits in front as the WAF (Full Strict origin TLS, validated by Fly's Let's Encrypt cert). See [ADR 0016](adr/0016-phase-1-hosting-platform.md) for the alternatives weighed and why Fly+MPG won the single-vendor tradeoff at the Phase 1 budget.
+**Hosting:** Fly.io. A single `shared-cpu-1x@1GB` machine in one region runs the Hono server, MCP transport, and web UI in one process. Postgres is **Fly Managed Postgres** (Basic plan) reached over Fly's private 6PN network — Postgres has no public ingress. Public traffic reaches `https://squire.maz.org` through Route 53, CloudFront, and AWS WAF, then forwards to `https://maz-squire.fly.dev` with the `X-Origin-Secret` header required by the Fly app. See [ADR 0016](adr/0016-phase-1-hosting-platform.md) for the alternatives weighed and why Fly+MPG won the single-vendor tradeoff at the Phase 1 budget.
 
 The app is always-on (`auto_stop_machines = "off"`, `min_machines_running = 1`) so SSE connections aren't severed by scale-to-zero. `idle_timeout` is configured at 600s, past the longest knowledge-agent tool loop.
 
 **CI/CD:**
 
 - Build and test on push
-- Deploy to production on release tag (no staging tier in Phase 1 — see ADR 0016)
+- Deploy to production from the `Deploy to Fly` GitHub Actions workflow after `CI` succeeds on `main`; the workflow runs `flyctl deploy -a maz-squire --remote-only`
 - Run `node scripts/db-migrate.ts` via Fly's `release_command` before traffic cutover; non-zero exit aborts the deploy and leaves the prior version live
-- Smoke test after deploy (hit `/api/health`)
-- Rollback via `fly releases list` + `fly deploy --image <prior-sha>`
+- Smoke test after deploy with `node scripts/check-deploy-health.ts --base-url https://maz-squire.fly.dev`
+- Rollback via `fly releases -a maz-squire --image` + `fly deploy --image <prior-image> -a maz-squire`
 
 ---
 
@@ -695,9 +698,9 @@ The app is always-on (`auto_stop_machines = "off"`, `min_machines_running = 1`) 
 
 - Fly app (`shared-cpu-1x@1GB`, always-on): $6
 - Fly Managed Postgres (Basic, Shared-2x / 1GB / 1 TB cap): $38
-- Cloudflare WAF: $0 (free tier)
+- CloudFront + AWS WAF + WAF logging: roughly $10–15 at Phase 1 traffic
 - Claude API (Sonnet 4.6): ~$10–30 depending on chat volume
-- **Total: ~$55–75/month** within the $100/mo Phase 1 budget. See [ADR 0016](adr/0016-phase-1-hosting-platform.md).
+- **Total: ~$65–90/month** within the $100/mo Phase 1 budget. See [ADR 0016](adr/0016-phase-1-hosting-platform.md).
 
 Costs grow when Phase 3 (multi-user) and Phase 5 (recommendation engine) ship. Per-user daily budget circuit breakers, embedding caching, and model tiering (Haiku for cheap cases) are the primary mitigations. Vision API costs (~$0.15–0.30 per character sync) are deferred to Phase 6 and only apply if the screenshot path is chosen over the browser-extension or GHS-as-tracker alternatives.
 
@@ -806,7 +809,7 @@ For developer setup, running the server, working on import scripts locally, and 
 
 ## Changelog
 
-- **2026-05-06:** SQR-59 picked the Phase 1 hosting platform: Fly.io app + Fly Managed Postgres (Basic) in one region, no staging. Cloudflare in front as WAF. App-to-DB traffic on private 6PN. Migrations run via `release_command` before traffic cutover. ARCHITECTURE.md §Deployment and §Cost updated to reflect the concrete pick. Reasoning, alternatives (Neon, Railway, Render, VPS, Cloudflare Workers), and re-evaluation triggers in [ADR 0016](adr/0016-phase-1-hosting-platform.md). Unblocks SQR-58 (WAF), SQR-42 (Dockerize), SQR-43 (migrate-on-deploy), SQR-44 (CI/CD).
+- **2026-05-06:** SQR-59 picked the Phase 1 hosting platform: Fly.io app + Fly Managed Postgres (Basic) in one region, no staging. SQR-58 later put Route 53, CloudFront, and AWS WAF in front of the Fly origin with an origin-secret lock. App-to-DB traffic stays on private 6PN. Migrations run via `release_command` before traffic cutover. ARCHITECTURE.md §Deployment and §Cost updated to reflect the concrete pick. Reasoning, alternatives (Neon, Railway, Render, VPS, Cloudflare Workers), and re-evaluation triggers in [ADR 0016](adr/0016-phase-1-hosting-platform.md). Unblocks SQR-58 (WAF), SQR-42 (Dockerize), SQR-43 (migrate-on-deploy), SQR-44 (CI/CD).
 
 - **2026-04-26:** SQR-110 added a narrow synthesis guard to the knowledge agent loop. If a turn only calls `search_rules` and reaches three broad rule-corpus searches, the next model call runs without tools and is instructed to answer from the retrieved context. This preserves the full loop budget for scenario traversal and card lookups while preventing simple rules questions from spending all ten iterations on repeated searches. The eval dataset now includes `rule-looting-definition` for the original "What is looting?" failure mode.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -15,6 +15,8 @@ Create a `.env` file in the project root:
 ```bash
 # Required
 ANTHROPIC_API_KEY=...
+# Required when running OpenAI-backed evals
+OPENAI_API_KEY=...
 
 # Google OAuth (required for web UI login)
 GOOGLE_OAUTH_CLIENT_ID=...
@@ -35,6 +37,16 @@ LANGFUSE_SECRET_KEY=...
 
 # Trace environment label for Langfuse and LangSmith; defaults to NODE_ENV.
 SQUIRE_ENV=development
+
+# Optional (LangSmith eval/prototype tracing)
+LANGSMITH_API_KEY=...
+LANGSMITH_PROJECT=squire-evals
+# LANGSMITH_ENDPOINT=https://api.smith.langchain.com
+# LANGSMITH_WORKSPACE_ID=...
+# SQUIRE_EVAL_LANGSMITH_TRACING=0
+
+# Production origin lock only. CloudFront sends this value as X-Origin-Secret.
+# ORIGIN_SHARED_SECRET=...
 ```
 
 Generate `SESSION_SECRET` with:
@@ -42,6 +54,10 @@ Generate `SESSION_SECRET` with:
 ```bash
 openssl rand -base64 48
 ```
+
+Do not set `LANGFUSE_TRACING_ENVIRONMENT`; `SQUIRE_ENV=development` is the
+local environment label that feeds Langfuse tracing. LangSmith variables are for
+eval/prototype tracing unless the runtime path explicitly starts using them.
 
 `GOOGLE_OAUTH_REDIRECT_URI` is still the configured fallback callback for
 production and non-local hosts. In local development, `/auth/google/start` and

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2,7 +2,7 @@
 
 **Version:** 3.1
 **Date:** 2026-04-07
-**Last Refreshed:** 2026-04-19
+**Last Refreshed:** 2026-05-16
 **Owner:** Product (PM)
 **Companion doc:** [docs/ARCHITECTURE.md](ARCHITECTURE.md) — architect-owned tech spec (how / with-what / where)
 **Status:** Phase 1 in progress, MVP scoped. GH2 content expansion (Phase 2) deadline ~mid-2026.
@@ -15,7 +15,7 @@ Squire is a deep game-knowledge agent for Gloomhaven and Frosthaven. It answers 
 
 Squire is **the agent**, not a specific app. It's reachable through multiple **channels** — primarily its own web UI today, with MCP-capable agent harnesses (Claude Code, Claude Desktop) as a second channel, and Discord / iMessage clients planned for the far future. All channels talk to the same underlying knowledge agent.
 
-**MVP (Phase 1):** A mobile-friendly web chat where Brian can pull out his phone at the table, log in with Google, and ask any Frosthaven rules question. Hosted publicly behind Cloudflare WAF. The agent answers using semantic search across the Frosthaven books, deterministic scenario/section-book traversal for anchored story-book questions, and a generalized atomic-tools API over Gloomhaven Secretariat (GHS) structured game data.
+**MVP (Phase 1):** A mobile-friendly web chat where Brian can pull out his phone at the table, log in with Google, and ask any Frosthaven rules question. Hosted publicly at `squire.maz.org` behind CloudFront and AWS WAF. The agent answers using semantic search across the Frosthaven books, deterministic scenario/section-book traversal for anchored story-book questions, and a generalized atomic-tools API over Gloomhaven Secretariat (GHS) structured game data.
 
 **Long-term product (Phases 2–8):** Gloomhaven 2.0 content expansion, multi-user platform, campaign and character state, the recommendation engine (card selection at level-up, inventory optimization, pre-combat hand selection, long-term build planning), character state ingestion, polish (voice input, share/export, spoiler protection), and additional channels (Discord, iMessage).
 
@@ -156,7 +156,7 @@ A user may have multiple characters across multiple campaigns. From Phase 4 onwa
 
 ### Platform
 
-Mobile-responsive web app, server-rendered (Hono JSX + HTMX + Tailwind compiled in-process via `@tailwindcss/node`, see [ADR 0011](adr/0011-on-demand-asset-pipeline.md)). Accessible via any modern mobile or desktop browser. No app installation, no PWA, no service worker.
+Mobile-responsive web app, server-rendered (Hono JSX + HTMX + Tailwind compiled in-process in development and prebuilt in production, see [ADR 0011](adr/0011-on-demand-asset-pipeline.md)). Accessible via any modern mobile or desktop browser. No app installation, no PWA, no service worker.
 
 ### Input Methods
 
@@ -223,9 +223,9 @@ The phases below reflect the **resequenced plan** as of the 2026-04-07 spec refr
 
 ### Phase 1: MVP — Rules Q&A at the table
 
-**Goal:** Brian can pull out his phone at the table, log in with Google, and ask Squire any Frosthaven rules question via a mobile-friendly web chat. Hosted publicly behind Cloudflare WAF.
+**Goal:** Brian can pull out his phone at the table, log in with Google, and ask Squire any Frosthaven rules question via a mobile-friendly web chat. Hosted publicly at `squire.maz.org` behind CloudFront and AWS WAF.
 
-**Status as of 2026-04-07:** rules RAG pipeline, GHS imports, atomic tools, and MCP server are all built. The main remaining work is the web channel + auth + deployment.
+**Status as of 2026-05-16:** rules RAG pipeline, GHS imports, atomic tools, MCP server, web channel, Google OAuth, Fly deployment, custom domain, CI/CD, production health checks, and AWS WAF edge protection are built.
 
 **Tasks:**
 
@@ -241,7 +241,7 @@ The phases below reflect the **resequenced plan** as of the 2026-04-07 spec refr
 - Docker containerization
 - CI/CD pipeline
 - Production health checks and readiness
-- Cloudflare WAF in front of the deployed app
+- CloudFront and AWS WAF in front of the deployed app
 - Hosting platform decision (Fly / Railway / Render / VPS)
 
 **Out of scope for Phase 1:**
@@ -252,7 +252,7 @@ The phases below reflect the **resequenced plan** as of the 2026-04-07 spec refr
 - Any recommendations beyond rules answers
 - Discord, iMessage, or other channels beyond the web UI and MCP
 
-**Deliverable:** Brian can pull out his phone at the table, log in with Google, and ask Squire any Frosthaven rules question via a mobile-friendly web chat. The agent answers using semantic book search, deterministic scenario/section traversal (`findScenario`, `getScenario`, `getSection`, `followLinks`), and the GHS card tools (`searchRules`, `searchCards`, `listCards`, `getCard`). Hosted publicly behind Cloudflare WAF. Test suite passing.
+**Deliverable:** Brian can pull out his phone at the table, log in with Google, and ask Squire any Frosthaven rules question via a mobile-friendly web chat. The agent answers using semantic book search, deterministic scenario/section traversal (`findScenario`, `getScenario`, `getSection`, `followLinks`), and the GHS card tools (`searchRules`, `searchCards`, `listCards`, `getCard`). Hosted publicly behind CloudFront and AWS WAF. Test suite passing.
 
 ---
 
@@ -290,7 +290,7 @@ The phases below reflect the **resequenced plan** as of the 2026-04-07 spec refr
 
 **Tasks:**
 
-- Production hardening: rate limiting (per-user, on top of Cloudflare edge rate limiting)
+- Production hardening: rate limiting (per-user, on top of CloudFront / AWS WAF edge rate limiting)
 - Daily LLM cost budget with circuit breaker
 - Prompt injection resistance test suite (E2E, daily CI)
 - SAST scanning (Semgrep / CodeQL free tier)
@@ -494,8 +494,8 @@ Squire is a deep Gloomhaven / Frosthaven knowledge agent. The MVP is small on pu
 
 - **2026-04-07 (v2.0):** Major refresh after the first month of real building.
   - **Product reframe:** Squire is the agent, not an app. Reachable via multiple channels (web UI today, MCP, future Discord / iMessage). Stopped conflating "personal assistant chatbot" with "\*haven game-knowledge agent" — Squire is only the latter.
-  - **MVP redefined:** rules Q&A at the table, on a phone, with Google login behind Cloudflare WAF. Recommendation engine, screenshot extraction, voice, PWA, multi-user — all moved to later phases.
-  - **Stack updates:** Hono JSX + HTMX + Tailwind CDN (no React, no Next.js, no build step). Drizzle (no Prisma). pgvector (no Pinecone). Custom Google OAuth (no NextAuth / Clerk). Sonnet 4.6. Local Xenova embeddings (`Xenova/all-MiniLM-L6-v2`) with Voyage AI as the planned upgrade path. Cloudflare WAF as edge layer.
+  - **MVP redefined:** rules Q&A at the table, on a phone, with Google login behind a real edge WAF. Recommendation engine, screenshot extraction, voice, PWA, multi-user — all moved to later phases.
+  - **Stack updates:** Hono JSX + HTMX + Tailwind CDN (no React, no Next.js, no build step). Drizzle (no Prisma). pgvector (no Pinecone). Custom Google OAuth (no NextAuth / Clerk). Sonnet 4.6. Local Xenova embeddings (`Xenova/all-MiniLM-L6-v2`) with Voyage AI as the planned upgrade path. Edge WAF as a Phase 1 deployment requirement.
   - **Game data:** Worldhaven and OCR pipeline retired (commit `34a26a1`). Replaced with Gloomhaven Secretariat (GHS) structured data — 10 import scripts in `src/import-*.ts`.
   - **Tools:** Reframed as a generalized atomic-tools API in `src/tools.ts` (`searchRules`, `searchCards`, `listCardTypes`, `listCards`, `getCard`) that works across all GHS card types. Per-feature operations are invocations, not new tools.
   - **MCP server:** Added as a first-class architectural fact. Treated as a third channel type alongside web UI and future Discord / iMessage. Internal MCP between conversation and knowledge agents was considered and dropped for simplicity.

--- a/docs/adr/0009-google-oauth-with-hardcoded-allowlist.md
+++ b/docs/adr/0009-google-oauth-with-hardcoded-allowlist.md
@@ -1,14 +1,14 @@
 ---
 type: ADR
-id: "0009"
-title: "Google OAuth + hard-coded email allowlist for Phase 1 Web UI"
+id: '0009'
+title: 'Google OAuth + hard-coded email allowlist for Phase 1 Web UI'
 status: active
 date: 2026-04-08
 ---
 
 ## Context
 
-Phase 1 MVP is the Web UI at the table: one user (Brian), deployed behind Cloudflare WAF, real auth so it's not bypassable, but no multi-tenant concerns yet. The SPEC (`docs/SPEC.md` §"Phase 1 — Out of scope") explicitly says single user but auth is real.
+Phase 1 MVP is the Web UI at the table: one user (Brian), deployed behind AWS WAF, real auth so it's not bypassable, but no multi-tenant concerns yet. The SPEC (`docs/SPEC.md` §"Phase 1 — Out of scope") explicitly says single user but auth is real.
 
 The pre-v2.0 tickets in the User Accounts project (SQR-37 "registration", SQR-38 "email + password login", SQR-40 "profile management") were written against an earlier design that assumed email + password self-service. That design predates the decision to extend the existing `@modelcontextprotocol/sdk` OAuth infrastructure in `src/auth.ts` into the web channel.
 
@@ -36,7 +36,7 @@ Specifically:
 - **Email + password with self-serve registration**: what the old tickets proposed. Requires password hashing, reset flow, email verification, account lockout — all work that doesn't serve a single-user MVP and predates the decision to reuse MCP OAuth infrastructure.
 - **Magic links**: no password, but requires email sending infrastructure (SES/Postmark/etc.) and a whole flow we don't need for one user.
 - **SSO (Google) with database-backed allowlist**: same as the chosen option but with the allowlist in Postgres. Rejected for Phase 1 because it adds a table, a CRUD UI, and zero value for one user. The chosen option intentionally picks the dumbest possible version so we can graduate to the table-backed version in Phase 3 without breaking anything.
-- **No auth, rely on Cloudflare WAF IP allowlist**: SPEC explicitly says "auth is real so it's not bypassable". Rejected.
+- **No auth, rely on an edge IP allowlist**: SPEC explicitly says "auth is real so it's not bypassable". Rejected.
 
 ## Consequences
 

--- a/docs/adr/0011-on-demand-asset-pipeline.md
+++ b/docs/adr/0011-on-demand-asset-pipeline.md
@@ -1,9 +1,9 @@
 ---
 type: ADR
-id: "0011"
-title: "On-demand asset pipeline via in-process Tailwind JIT"
+id: '0011'
+title: 'On-demand asset pipeline via in-process Tailwind JIT'
 status: active
-supersedes: "0008"
+supersedes: '0008'
 date: 2026-04-08
 ---
 
@@ -35,21 +35,23 @@ cost is small.
 
 ## Decision
 
-**Compile CSS in-process at request time.** A new module
-`src/web-ui/assets.ts` exposes `getAppCss()` and `getSquireJs()`. The
-route handlers in `src/server.ts` for `/app.css` and `/squire.js` call
-these functions and stream the result.
+**Compile CSS in-process at request time in development, but serve prebuilt
+assets in production.** A new module `src/web-ui/assets.ts` exposes
+`getAppCss()` and `getSquireJs()`. The route handlers in `src/server.ts` for
+`/app.css`, `/app.<hash>.css`, `/squire.js`, and `/squire.<hash>.js` call these
+functions and stream the result.
 
 - `getAppCss()` reads `src/web-ui/styles.css`, calls
   `compile(...)` from `@tailwindcss/node`, walks the project sources via
-  `@tailwindcss/oxide`'s `Scanner`, and returns the built CSS. In
-  production the result is minified via `optimize({ minify: true })`.
+  `@tailwindcss/oxide`'s `Scanner`, and returns the built CSS in development.
+  In production it reads `dist/web-ui/app.css`, which is produced by
+  `npm run build:web-assets` during the Docker image build.
 - `getSquireJs()` reads `src/web-ui/squire.js` from disk. No bundler,
   no transform — vanilla file-read-and-cache. `src/web-ui/squire.js`
   contains the SQR-66 cite tap-toggle that previously lived inline in
   `layout.ts`.
 - Both functions cache in module-level variables. The cache key is
-  `'static'` in production (compile/read once on first request) and
+  `'static'` in production (read once on first request) and
   `'dev-${mtimeMs}'` of the source file in development, so edits during
   `npm run serve` are picked up on the next request without a rebuild.
 - `npm run build:css` and the `@tailwindcss/cli` devDependency are
@@ -61,12 +63,12 @@ these functions and stream the result.
 Measured locally on Node 24.14.0, MacBook Pro M-series, against the
 current `src/web-ui/styles.css` (692 lines, full design-token block):
 
-| Stage | Time |
-| --- | --- |
-| `import('./src/web-ui/assets.ts')` | ~125 ms |
-| First `getAppCss()` (cold compile + scan) | ~38 ms |
-| Subsequent `getAppCss()` (cache hit) | <1 ms |
-| Compiled CSS payload | 13,897 bytes |
+| Stage                                     | Time         |
+| ----------------------------------------- | ------------ |
+| `import('./src/web-ui/assets.ts')`        | ~125 ms      |
+| First `getAppCss()` (cold compile + scan) | ~38 ms       |
+| Subsequent `getAppCss()` (cache hit)      | <1 ms        |
+| Compiled CSS payload                      | 13,897 bytes |
 
 Total time from a cold process to a served `/app.css` response is well
 under 200 ms, comfortably under the 300 ms expected upper bound and an
@@ -103,15 +105,15 @@ running this in a serverless function.
 - Edit `src/web-ui/styles.css` in dev → next `/app.css` request reflects
   the edit. No watcher, no rebuild ritual.
 - The first `/app.css` request after process start pays a one-time
-  ~38 ms compile cost. Behind Cloudflare in production this is hidden
-  by edge caching after the first hit; locally it's invisible to
-  developers because dev tools cache the response too.
+  ~38 ms compile cost in development. Production reads the checked Docker image's
+  prebuilt CSS from `dist/web-ui/app.css`; the build fails before deploy if that
+  file cannot be generated.
 - `@tailwindcss/node` and `@tailwindcss/oxide` become explicit
   devDependencies. They were already transitively pulled in by
   `@tailwindcss/cli`; we're just naming them.
 - SQR-61 (CSP headers) is now unblocked. The inline `<script>` in
   `layout.ts` is gone — the layout references `<script src="/squire.js"
-  defer></script>` instead, and `script-src 'self'` will allow it.
+defer></script>` instead, and `script-src 'self'` will allow it.
 - Re-evaluate this decision if: the in-process compile cost grows
   meaningfully as styles.css gets bigger, the resident memory becomes a
   problem under multi-tenant deployment (Phase 3+), or we add enough
@@ -132,7 +134,7 @@ The decision above stopped at "compile in-process, cache in memory"
 and left the route handlers serving the bare `/app.css` and
 `/squire.js` paths with no `Cache-Control` header. Eng review on the
 initial SQR-71 implementation flagged that gap: without an explicit
-cache header, Cloudflare's edge cache behavior is implicit and every
+cache header, edge-cache behavior is implicit and every
 browser load re-fetches the CSS. Setting a short `max-age` is a
 half-measure (stale-risk vs. cache-efficiency compromise); the
 complete answer is content-hash fingerprinting with long-lived
@@ -160,7 +162,7 @@ documented pattern.** Hono's own routing docs
 ([hono.dev/docs/api/routing#parameters](https://hono.dev/docs/api/routing#parameters))
 show this example for matching a file with a literal extension:
 `app.get('/posts/:filename{.+\.png}', ...)` — the literal `.png`
-suffix lives *inside* the regex constraint, not outside it. Our
+suffix lives _inside_ the regex constraint, not outside it. Our
 `/:file{app\.[a-f0-9]+\.css}` and `/:file{squire\.[a-f0-9]+\.js}`
 patterns follow the same shape, which is the supported approach.
 
@@ -208,7 +210,7 @@ callers await the same promise. On resolution the cache is populated
 and the in-flight promise is cleared in a `finally` block so a
 failed compile doesn't poison the cache (the next caller retries).
 
-Probability in practice: low, especially behind Cloudflare where
+Probability in practice: low, especially behind CloudFront where
 cache-miss fan-out is one request per PoP. But the fix is ~5 lines,
 it eliminates a whole class of "why did memory spike on deploy"
 forensics, and it makes the concurrent-cold-start behavior
@@ -228,7 +230,7 @@ async propagation — all callers already `await` it.
 
 ### Rolling-deploy caveat
 
-Phase 1 ships a single-instance deploy behind Cloudflare, so the
+Phase 1 ships a single-instance deploy behind CloudFront, so the
 cache-invalidation story is simple: when a deploy starts, the new
 process computes a new hash, and the `<link>` URL in the HTML
 matches the current compile. Edge cache on the HTML is short-lived
@@ -255,7 +257,7 @@ answers for later:
    requests to the matching instance via a sticky-session cookie.
    Overkill for Squire.
 3. **Write compiled assets to a shared object store** at deploy
-   time and serve via Cloudflare directly — bypasses the Node
+   time and serve from the edge directly — bypasses the Node
    process entirely. The "right" answer at scale but Phase 1
    doesn't need it.
 
@@ -277,7 +279,7 @@ future agent doesn't spend half an hour "discovering" them.
 - **Old-compile retention across deploys**. If an in-flight HTML
   response from deploy N references `/app.<oldhash>.css` and that
   request lands on deploy N+1, the hashed route 404s. Phase 1's
-  ~second-long restart behind Cloudflare makes this window narrow
+  ~second-long restart behind CloudFront makes this window narrow
   enough to ignore; flagged above as a Phase 3+ concern.
 - **Styled error fallback when asset compile itself fails.** The
   `/` route wraps `renderHomePage()` in a try/catch that re-invokes
@@ -305,12 +307,13 @@ future agent doesn't spend half an hour "discovering" them.
   process thus pays one Tailwind compile (~38 ms) before getting
   its 404. This is a one-time cost per process lifetime (the second
   probe hits the cache), not amplifiable, so it's not a DoS vector
-  in the Phase 1 single-instance deploy behind Cloudflare. We
+  in the Phase 1 single-instance deploy behind CloudFront. We
   accept it rather than adding a separate "current hash" accessor
   that would let us hash-compare before compile, because the
   one-time cost is invisible in practice and the accessor would
   duplicate state. Revisit if Phase 3+ deploys to a model where
   cold starts happen frequently.
+
 - **Dev mtime cache invalidation does not track `@source` scans.**
   `computeCssCacheKey()` keys on the `styles.css` mtime only. If a
   dev edits a TypeScript or HTML file that contributes Tailwind
@@ -333,3 +336,13 @@ future agent doesn't spend half an hour "discovering" them.
   costs one extra compile (~38 ms) per call and has no
   data-corruption or exfiltration pathway. Documented inline where
   the hooks are defined.
+
+## Addendum — production prebuild (2026-05-10 deployment work)
+
+SQR-42 changed the production half of this ADR: production must not compile CSS
+at request time. The Dockerfile now builds web assets in an `assets` stage with
+`npm run build:web-assets`, copies `dist/web-ui` into the runtime image, and
+starts with `NODE_ENV=production`. In that mode `getAppCss()` reads
+`dist/web-ui/app.css`; if the file is missing, startup-era requests fail loudly
+with an instruction to run the build. Development keeps the original on-demand
+compile path so local style edits do not require a watcher or rebuild.

--- a/docs/adr/0016-phase-1-hosting-platform.md
+++ b/docs/adr/0016-phase-1-hosting-platform.md
@@ -15,7 +15,7 @@ agent-native retrieval redesign. [ADR 0013](0013-phase-1-production-agent-baseli
 froze the production agent runtime; SQR-115 then closed (Done, 2026-04-29) with
 the decision to keep the legacy retrieval surface for Phase 1, unblocking
 deployment work. SQR-59 is the gating decision for the rest of the Production
-Readiness project: SQR-58 (Cloudflare WAF), SQR-42 (Dockerization),
+Readiness project: SQR-58 (AWS WAF + CloudFront), SQR-42 (Dockerization),
 SQR-43 (`drizzle-kit migrate` in the deploy pipeline), and SQR-44 (CI/CD).
 
 The host must satisfy:
@@ -29,8 +29,9 @@ The host must satisfy:
   timeouts would break the chat surface).
 - A first-class migrate-before-cutover hook so a failed migration aborts the
   deploy without leaving production on a half-migrated schema (SQR-43 contract).
-- A Cloudflare-friendly origin: TLS cert validatable in Cloudflare Full (Strict)
-  mode (SQR-58 contract).
+- A CloudFront-friendly origin: TLS to Fly's `fly.dev` hostname, custom-domain
+  DNS in Route 53, and an origin-secret lock between CloudFront and Fly
+  (SQR-58 contract).
 - Logs and metrics passthrough to Langfuse + OpenTelemetry without per-platform
   middleware.
 - Phase 1 budget: ~$100/month for hosting end-to-end, with headroom for
@@ -48,8 +49,10 @@ data. Migrations run via `release_command` before traffic cutover. No staging
 environment.**
 
 The Hono server, MCP transport, and web UI all run in one process on one
-machine. Cloudflare sits in front as the WAF (SQR-58). The app talks to
-Postgres over Fly's private 6PN network — Postgres has no public ingress.
+machine. Route 53, CloudFront, and AWS WAF sit in front of the Fly origin
+(SQR-58), and CloudFront sends `X-Origin-Secret` so the app can reject direct
+origin traffic. The app talks to Postgres over Fly's private 6PN network —
+Postgres has no public ingress.
 
 ## Options considered
 
@@ -116,13 +119,16 @@ Postgres over Fly's private 6PN network — Postgres has no public ingress.
 
 ### What this unblocks (Linear)
 
-- **SQR-58 (Cloudflare WAF)** — origin is `https://<app>.fly.dev` (or a
-  Fly-issued cert on a custom hostname). Cloudflare Full (Strict) works because
-  Fly issues a Let's Encrypt cert for the public hostname.
+- **SQR-58 (AWS WAF + CloudFront)** — public traffic enters through Route 53
+  and CloudFront, passes through the `squire-production-waf` AWS WAF web ACL,
+  then forwards to `https://maz-squire.fly.dev` with `X-Origin-Secret`. The Fly
+  app stores the matching `ORIGIN_SHARED_SECRET` and rejects direct browser,
+  OAuth, API, and MCP routes that bypass the edge.
 - **SQR-42 (Dockerize)** — multi-stage Node 24 Dockerfile that `EXPOSE 8080`s
-  and runs as a non-root user. No static asset baking — per
-  [ADR 0011](0011-on-demand-asset-pipeline.md), Tailwind compiles in-process on
-  first request and caches in module memory. Squire runs TypeScript directly
+  and runs as a non-root user. CSS and vanilla JS assets are prebuilt in the
+  Docker `assets` stage with `npm run build:web-assets`, while local
+  development keeps the in-process Tailwind path from
+  [ADR 0011](0011-on-demand-asset-pipeline.md). Squire runs TypeScript directly
   via Node 24 strip-types (no JS compile step), so the runtime stage carries
   the `src/` tree and `node_modules`.
 - **SQR-43 (migrate on deploy)** — wire `release_command = "node scripts/db-migrate.ts"`
@@ -130,10 +136,12 @@ Postgres over Fly's private 6PN network — Postgres has no public ingress.
   deploy and leaves the prior version live, which is exactly the SQR-43
   acceptance criterion.
 - **SQR-44 (CI/CD)** — GitHub Actions workflow runs after `CI` succeeds on
-  `main`, uses `superfly/flyctl-actions/setup-flyctl@master`, then runs
-  `flyctl deploy -a maz-squire --remote-only`. The deploy token lives in the
-  GitHub secret `FLY_API_TOKEN`; app secrets such as `DATABASE_URL` stay scoped
-  to the Fly app via `fly secrets set` and are never written to the repo.
+  `main`, uses a pinned `superfly/flyctl-actions/setup-flyctl` commit, then
+  runs `flyctl deploy -a maz-squire --remote-only`. The deploy token lives in
+  the GitHub secret `FLY_API_TOKEN`; app secrets such as `DATABASE_URL` stay
+  scoped to the Fly app via `fly secrets set` and are never written to the
+  repo. The auto-merge workflow uses `actions/create-github-app-token@v3` so
+  merges create the follow-up `push` event that the deploy workflow follows.
 
 ### Operational shape
 
@@ -153,8 +161,9 @@ idle_timeout` set to 600s as belt-and-suspenders for any brief silent gap
   ingress. DATABASE_URL is a Fly secret.
 - **Backups + PITR** are MPG Basic defaults; no separate backup tooling needed
   for Phase 1.
-- **Rollback** is `fly releases list` + `fly deploy --image <prior-sha>` for
-  the app, hand-rolled DDL or down-migration for schema.
+- **Rollback** is `fly releases -a maz-squire --image` +
+  `fly deploy --image <prior-image> -a maz-squire` for the app, hand-rolled DDL
+  or a forward repair migration for schema.
 
 ### Cost
 
@@ -163,9 +172,9 @@ idle_timeout` set to 600s as belt-and-suspenders for any brief silent gap
 | Fly `shared-cpu-1x@1GB` machine (Amsterdam pricing)     | $5.92          |
 | Fly Managed Postgres Basic (Shared-2x / 1GB / 1 TB cap) | $38.00         |
 | Volume-snapshot storage (first 10 GB free)              | ~$0            |
-| Cloudflare WAF (free tier)                              | $0             |
+| CloudFront + AWS WAF + WAF logging                      | ~$10–15        |
 | Claude API (Sonnet 4.6, Phase 1 chat volume)            | $10–30         |
-| **Total Phase 1 estimate**                              | **~$55–75/mo** |
+| **Total Phase 1 estimate**                              | **~$65–90/mo** |
 
 Within the $100/mo Phase 1 budget. Headroom is reserved for the open
 APM/RUM question (see [docs/ARCHITECTURE.md §Open Tech Questions](../ARCHITECTURE.md#open-tech-questions)).

--- a/docs/runbooks/deploy-rollback.md
+++ b/docs/runbooks/deploy-rollback.md
@@ -11,6 +11,10 @@ node scripts/db-migrate.ts
 That command is wired as Fly's `release_command`, so a non-zero exit from
 migration aborts the deploy and leaves the previous app image live.
 
+For the day-to-day operator checklist, including DNS, CloudFront, AWS WAF,
+OAuth, question-answer, and Langfuse checks, see
+[production-operations.md](production-operations.md).
+
 ## One-time provisioning
 
 Run these once from the repo root:
@@ -32,6 +36,8 @@ flyctl secrets set \
   LANGFUSE_BASEURL='...' \
   GOOGLE_OAUTH_CLIENT_ID='...' \
   GOOGLE_OAUTH_CLIENT_SECRET='...' \
+  SQUIRE_ALLOWED_EMAILS='...' \
+  SQUIRE_ENV='production' \
   ORIGIN_SHARED_SECRET='...'
 ```
 
@@ -146,8 +152,8 @@ change propagates.
 A migration failure appears as a failed release machine during deploy. Check:
 
 ```bash
-fly releases list
-fly logs
+fly releases -a maz-squire --image
+fly logs -a maz-squire
 ```
 
 If the release command failed, Fly does not cut traffic over to the new image.
@@ -162,8 +168,8 @@ committing.
 Find the previous image from the releases list, then redeploy it:
 
 ```bash
-fly releases list
-fly deploy --image <prior-image>
+fly releases -a maz-squire --image
+fly deploy --image <prior-image> -a maz-squire
 ```
 
 ## Schema rollback

--- a/docs/runbooks/production-operations.md
+++ b/docs/runbooks/production-operations.md
@@ -1,0 +1,181 @@
+# Production operations guide
+
+This is the current production runbook for Squire. Historical planning docs may
+mention older edge or release-tag deploy plans; production now runs at
+`https://squire.maz.org` through AWS edge services and deploys from GitHub
+Actions after CI passes on `main`.
+
+## Production shape
+
+- Public URL: `https://squire.maz.org`
+- Direct Fly URL: `https://maz-squire.fly.dev`
+- Fly app: `maz-squire`
+- Database: Fly Managed Postgres Basic, with `vector` enabled in the `public`
+  schema of `fly-db`
+- Edge path: Route 53 `squire.maz.org` alias -> CloudFront distribution -> AWS
+  WAF web ACL -> Fly origin
+- Origin lock: CloudFront sends `X-Origin-Secret`; Fly stores the matching value
+  in `ORIGIN_SHARED_SECRET`
+- Runtime environment label: `SQUIRE_ENV=production`
+
+`/api/live` and `/api/health` intentionally bypass the origin lock so Fly health
+checks work. Browser, OAuth, REST, and MCP routes should go through CloudFront
+or include the origin secret when an operator is deliberately testing the Fly
+origin.
+
+## Secrets and environment
+
+app-runtime secrets and settings belong in Fly:
+
+- `ANTHROPIC_API_KEY`
+- `DATABASE_URL`
+- `SESSION_SECRET`
+- `GOOGLE_OAUTH_CLIENT_ID`
+- `GOOGLE_OAUTH_CLIENT_SECRET`
+- `SQUIRE_ALLOWED_EMAILS`
+- `SQUIRE_ENV=production`
+- `LANGFUSE_BASEURL`
+- `LANGFUSE_PROJECT_ID`
+- `LANGFUSE_PUBLIC_KEY`
+- `LANGFUSE_SECRET_KEY`
+- `ORIGIN_SHARED_SECRET`
+
+GitHub repository secrets:
+
+- `FLY_API_TOKEN`
+- `AUTO_MERGE_APP_ID`
+- `AUTO_MERGE_PRIVATE_KEY`
+
+eval/developer-only variables stay out of Fly unless the runtime starts using
+them:
+
+- `OPENAI_API_KEY`
+- `LANGSMITH_API_KEY`
+- `LANGSMITH_PROJECT`
+- `LANGSMITH_ENDPOINT`
+- `LANGSMITH_WORKSPACE_ID`
+- `SQUIRE_EVAL_LANGSMITH_TRACING`
+- eval model/provider knobs from `.env.example`
+
+Do not set `LANGFUSE_TRACING_ENVIRONMENT`. `SQUIRE_ENV` is the single source for
+the Langfuse environment label. LangSmith variables are eval/prototype tracing variables; they are not required for the production ask path today.
+
+## Deploy
+
+Normal deploys happen by merging to `main`. The `CI` workflow must finish
+successfully, then the `Deploy to Fly` workflow deploys the exact tested commit
+with:
+
+```bash
+flyctl deploy -a maz-squire --remote-only
+```
+
+Check the current deploy path with:
+
+```bash
+gh run list --workflow "CI" --branch main --limit 5
+gh run list --workflow "Deploy to Fly" --branch main --limit 5
+gh run watch <run-id>
+gh run view <run-id> --log
+gh api 'repos/maz-org/squire/deployments?environment=production'
+```
+
+The GitHub deployment environment should show `production` and link to
+`https://squire.maz.org`.
+
+The workflow smoke check runs:
+
+```bash
+node scripts/check-deploy-health.ts --base-url https://maz-squire.fly.dev
+```
+
+Use a manual deploy only for operator recovery from a known local checkout:
+
+```bash
+flyctl deploy -a maz-squire --remote-only
+```
+
+## Post-deploy checks
+
+Start with platform and health:
+
+```bash
+flyctl status -a maz-squire
+fly releases -a maz-squire --image
+node scripts/check-deploy-health.ts --base-url https://maz-squire.fly.dev
+curl -I https://squire.maz.org
+curl https://squire.maz.org/api/live
+curl https://squire.maz.org/api/health
+```
+
+Then verify the user flow in a browser:
+
+1. Open `https://squire.maz.org/login`.
+2. Confirm the page shows `Sign in with Google`.
+3. Complete Google OAuth with an allowlisted account.
+4. Ask one real rules question.
+5. Confirm the answer renders, streams, and cites sources.
+
+Check Langfuse after the question:
+
+- Filter to `env:production`.
+- Confirm the root agent trace has the user input.
+- Confirm the final output is present.
+- Confirm agent-run tags include enough context to identify runtime, provider,
+  model, and production traffic.
+
+Probe the edge:
+
+```bash
+curl -sS -o /tmp/squire-waf-body -w '%{http_code}\n' "https://squire.maz.org/login?q=1%27%20OR%20%271%27%3D%271"
+curl -sS -o /tmp/squire-origin-body -w '%{http_code}\n' https://maz-squire.fly.dev/login
+```
+
+The WAF probe payload is `q=1' OR '1'='1`; it should be blocked by AWS WAF. The
+direct Fly login request should return 403 because it is missing
+`X-Origin-Secret`.
+
+## Inspect production
+
+Useful commands:
+
+```bash
+flyctl status -a maz-squire
+fly logs -a maz-squire
+fly releases -a maz-squire --image
+fly secrets list -a maz-squire
+```
+
+AWS resources to inspect:
+
+- Route 53 hosted zone: `maz.org`
+- CloudFront distribution for `squire.maz.org`
+- AWS WAF web ACL: `squire-production-waf`
+- WAF log group: `aws-waf-logs-squire-production`
+
+## Rollback
+
+Find the previous image, then redeploy it:
+
+```bash
+fly releases -a maz-squire --image
+fly deploy --image <prior-image> -a maz-squire
+```
+
+Schema changes are not rolled back automatically. If a migration has already
+run, prefer a forward repair migration unless restoring from backup is clearly
+safer.
+
+## Origin secret rotation
+
+The app accepts one `ORIGIN_SHARED_SECRET` value at a time. Rotate it during a
+short maintenance window:
+
+1. Update CloudFront to send the new `X-Origin-Secret` header.
+2. Immediately update the Fly secret with the same value.
+3. Wait for the Fly release to become healthy.
+4. Verify `https://squire.maz.org/login` still works.
+5. Verify `https://maz-squire.fly.dev/login` without the header is still 403.
+
+See [deploy-rollback.md](deploy-rollback.md) for the lower-level deploy token,
+origin-lock, and migration notes.

--- a/src/server.ts
+++ b/src/server.ts
@@ -114,7 +114,7 @@ app.use('*', cspMiddleware);
 // styles.css and squire.js show up immediately in devtools, while prod reads
 // CSS built by `npm run build:web-assets` during the Docker build and serves
 // content-hashed paths (`/app.<hash>.css`,
-// `/squire.<hash>.js`) with immutable caching so Cloudflare and
+// `/squire.<hash>.js`) with immutable caching so the edge and
 // browsers can cache forever and invalidation is automatic on
 // content change. Hash is enforced by the router regex
 // (`[a-f0-9]+`) so non-hex paths 404 before the handler runs; a

--- a/src/web-ui/assets.ts
+++ b/src/web-ui/assets.ts
@@ -138,7 +138,7 @@ export async function getAppCss(): Promise<AssetEntry> {
 /**
  * URL to emit in HTML for the app stylesheet. Rails Propshaft
  * semantics: in prod the URL is content-hashed
- * (`/app.<hash>.css`) so Cloudflare and browsers can cache it
+ * (`/app.<hash>.css`) so the edge and browsers can cache it
  * forever; in dev the URL is the bare `/app.css` path so devtools
  * stays readable and there's no hash-mismatch dance when editing
  * `styles.css`.

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -85,7 +85,7 @@ describe('deployment configuration', () => {
     expect(runbook).toContain('flyctl mpg attach <cluster-id>');
     expect(runbook).toContain('Extensions page');
     expect(runbook).toContain('Extension: `vector`');
-    expect(runbook).toContain('fly releases list');
+    expect(runbook).toContain('fly releases -a maz-squire --image');
     expect(runbook).toContain('fly logs');
     expect(runbook).toContain('fly deploy --image <prior-image>');
     expect(runbook).toContain('node scripts/db-migrate.ts');

--- a/test/deployment-operations-docs.test.ts
+++ b/test/deployment-operations-docs.test.ts
@@ -1,0 +1,105 @@
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, it } from 'vitest';
+
+async function readProjectFile(path: string): Promise<string> {
+  return readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+describe('deployment operations documentation', () => {
+  it('provides a production operations guide with the landed deploy and edge path', async () => {
+    const guide = await readProjectFile('docs/runbooks/production-operations.md');
+
+    for (const expected of [
+      '# Production operations guide',
+      'https://squire.maz.org',
+      'https://maz-squire.fly.dev',
+      'Route 53',
+      'CloudFront',
+      'AWS WAF',
+      'ORIGIN_SHARED_SECRET',
+      'Deploy to Fly',
+      'gh run list --workflow "Deploy to Fly" --branch main --limit 5',
+      "gh api 'repos/maz-org/squire/deployments?environment=production'",
+      'flyctl status -a maz-squire',
+      'fly releases -a maz-squire --image',
+      'node scripts/check-deploy-health.ts --base-url https://maz-squire.fly.dev',
+      'curl -I https://squire.maz.org',
+      'curl https://squire.maz.org/api/health',
+      "q=1' OR '1'='1",
+      'https://maz-squire.fly.dev/login',
+      'Sign in with Google',
+      'one real rules question',
+      'Langfuse',
+      'env:production',
+      'fly deploy --image <prior-image>',
+    ]) {
+      expect(guide).toContain(expected);
+    }
+
+    expect(guide).not.toContain('Cloudflare WAF');
+  });
+
+  it('keeps current architecture docs on AWS WAF and GitHub-driven Fly deploys', async () => {
+    const architecture = await readProjectFile('docs/ARCHITECTURE.md');
+    const adr = await readProjectFile('docs/adr/0016-phase-1-hosting-platform.md');
+    const spec = await readProjectFile('docs/SPEC.md');
+
+    for (const doc of [architecture, adr, spec]) {
+      expect(doc).toContain('AWS WAF');
+      expect(doc).toContain('CloudFront');
+    }
+
+    expect(architecture).toContain('Route 53');
+    expect(architecture).toContain('Deploy to Fly');
+    expect(architecture).toContain('flyctl deploy -a maz-squire --remote-only');
+    expect(architecture).not.toContain('Cloudflare sits in front as the WAF');
+    expect(architecture).not.toContain('- Cloudflare WAF:');
+
+    expect(adr).toContain('SQR-58 (AWS WAF + CloudFront)');
+    expect(adr).toContain('actions/create-github-app-token@v3');
+    expect(adr).not.toContain('SQR-58 (Cloudflare WAF)');
+    expect(adr).not.toContain('setup-flyctl@master');
+
+    const phaseOneSection = spec.slice(
+      spec.indexOf('### Phase 1: MVP'),
+      spec.indexOf('### Phase 2:'),
+    );
+    expect(phaseOneSection).toContain('AWS WAF');
+    expect(phaseOneSection).not.toContain('Cloudflare WAF');
+  });
+
+  it('documents production and eval variables without conflating them', async () => {
+    const envExample = await readProjectFile('.env.example');
+    const development = await readProjectFile('docs/DEVELOPMENT.md');
+    const guide = await readProjectFile('docs/runbooks/production-operations.md');
+
+    for (const expected of [
+      'ANTHROPIC_API_KEY',
+      'OPENAI_API_KEY',
+      'GOOGLE_OAUTH_CLIENT_ID',
+      'GOOGLE_OAUTH_CLIENT_SECRET',
+      'SESSION_SECRET',
+      'SQUIRE_ALLOWED_EMAILS',
+      'SQUIRE_ENV=development',
+      'LANGFUSE_BASEURL',
+      'LANGFUSE_PROJECT_ID',
+      'LANGFUSE_PUBLIC_KEY',
+      'LANGFUSE_SECRET_KEY',
+      'LANGSMITH_API_KEY',
+      'SQUIRE_EVAL_LANGSMITH_TRACING',
+      'ORIGIN_SHARED_SECRET',
+    ]) {
+      expect(envExample).toContain(expected);
+    }
+
+    expect(development).toContain('LANGSMITH_API_KEY');
+    expect(development).toContain('SQUIRE_EVAL_LANGSMITH_TRACING');
+    expect(development).toContain('SQUIRE_ENV=development');
+
+    expect(guide).toContain('app-runtime secrets');
+    expect(guide).toContain('eval/developer-only');
+    expect(guide).toContain('Do not set `LANGFUSE_TRACING_ENVIRONMENT`');
+    expect(guide).toContain('LangSmith variables are eval/prototype tracing variables');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a production operations guide for Squire's current Fly, Route 53, CloudFront, AWS WAF, and origin-lock setup.
- Refresh current deployment docs and ADRs so they match landed SQR-42, SQR-44, and SQR-58 behavior.
- Add regression tests that keep the docs aligned with the deployed path, required secrets/settings, and current Fly commands.

## Review
- GStack pre-landing review: no issues found.

## Test plan
- `npm run check`

Fixes SQR-41


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and deployment documentation to reflect current production infrastructure and edge configuration.
  * Added comprehensive production operations runbook with deployment, health checks, and rollback procedures.
  * Clarified development environment variable requirements for OpenAI API and tracing services.

* **Tests**
  * Added test coverage for deployment and operations documentation accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->