### PR TITLE
Add Dependency Review gate

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,28 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v5
+        with:
+          # Start with a conservative blocking policy: high and critical
+          # runtime vulnerabilities fail the check; lower severities remain
+          # visible without blocking until the alert noise is better understood.
+          fail-on-severity: high
+          fail-on-scopes: runtime
+          license-check: false
+          show-patched-versions: true

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -262,6 +262,11 @@ HTML/JS and are rendered unsanitized, prompt injection becomes XSS.
 
 - Pin GHS to a specific commit, review diffs before updating
 - npm audit + Dependabot (already configured)
+- Dependency Review runs on pull requests via
+  `.github/workflows/dependency-review.yml`. The workflow blocks
+  high and critical runtime vulnerabilities introduced by dependency changes;
+  low and moderate findings stay non-blocking until alert noise is better
+  understood.
 - CodeQL code scanning runs on PRs, `main`, and a weekly schedule via
   `.github/workflows/codeql.yml` for JavaScript/TypeScript and GitHub Actions
   workflow analysis. The repository is public, so GitHub Copilot Autofix for
@@ -326,6 +331,7 @@ HTML/JS and are rendered unsanitized, prompt injection becomes XSS.
 
 ## Changelog
 
+- **2026-05-16:** Added Dependency Review PR workflow to block high/critical runtime vulnerability introductions (SQR-165).
 - **2026-05-16:** Added CodeQL code scanning workflow and noted Copilot Autofix eligibility/verification path (SQR-164).
 - **2026-04-07:** Reconciled with SPEC v3.0 / ARCHITECTURE v1.0 split. Migrated GitHub Issue references (#12, #55–#59) to Linear projects (User Accounts SQR-37/38/39/40, Security Hardening). Added header note pointing at the new product and tech specs.
 - **2026-04-07:** Renamed from `docs/security-review.md` to `docs/SECURITY.md` as part of the ALL_CAPS docs consolidation.

--- a/test/security-workflows.test.ts
+++ b/test/security-workflows.test.ts
@@ -1,0 +1,30 @@
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, it } from 'vitest';
+
+async function readProjectFile(path: string): Promise<string> {
+  return readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+describe('security workflows', () => {
+  it('reviews dependency changes on pull requests', async () => {
+    const workflow = await readProjectFile('.github/workflows/dependency-review.yml');
+    const securityDocs = await readProjectFile('docs/SECURITY.md');
+
+    expect(workflow).toContain('name: Dependency Review');
+    expect(workflow).toContain('pull_request:');
+    expect(workflow).toContain('branches: [main]');
+    expect(workflow).toContain('contents: read');
+    expect(workflow).toContain('name: dependency-review');
+    expect(workflow).toContain('uses: actions/checkout@v6');
+    expect(workflow).toContain('uses: actions/dependency-review-action@v5');
+    expect(workflow).toContain('fail-on-severity: high');
+    expect(workflow).toContain('fail-on-scopes: runtime');
+    expect(workflow).toContain('license-check: false');
+    expect(workflow).toContain('show-patched-versions: true');
+
+    expect(securityDocs).toContain('Dependency Review');
+    expect(securityDocs).toContain('high and critical runtime vulnerabilities');
+    expect(securityDocs).toContain('low and moderate findings stay non-blocking');
+  });
+});


### PR DESCRIPTION
## Summary

- add a PR-only Dependency Review workflow using actions/dependency-review-action@v5
- fail dependency-changing PRs that introduce high or critical runtime vulnerabilities
- document the policy in docs/SECURITY.md
- add a guard test that pins the workflow contract

## Validation

- npm run check
- actionlint v1.7.12 with verified GitHub attestation

## Landing note

After this workflow lands on main, add dependency-review to the required status checks alongside ci so vulnerable dependency additions block merges.

Fixes SQR-165


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation to describe dependency review workflow behavior and severity thresholds.

* **Tests**
  * Added test suite to verify security workflow configurations and documentation details.

* **Chores**
  * Added GitHub Actions workflow for automated dependency review on pull requests targeting the main branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->