### PR TITLE
fix(auth): make logout audit atomic

### DIFF
--- a/src/db/repositories/session-repository.ts
+++ b/src/db/repositories/session-repository.ts
@@ -119,20 +119,17 @@ export async function create(
 }
 
 /**
- * Destroy a session. Returns the userId of the deleted session (for audit
- * logging by the caller), or null if the session didn't exist.
+ * Destroy a session through the provided handle. Returns the userId of the
+ * deleted session (for audit logging by the caller), or null if the session
+ * didn't exist.
  */
-export async function destroy(sessionId: string): Promise<string | null> {
-  const { db } = getDb('server');
+export async function destroy(handle: DbOrTx, sessionId: string): Promise<string | null> {
   const sessionHash = hashSecret(sessionId);
 
-  const rows = await db
-    .select({ userId: sessions.userId })
-    .from(sessions)
+  const rows = await handle
+    .delete(sessions)
     .where(eq(sessions.id, sessionHash))
-    .limit(1);
-
-  await db.delete(sessions).where(eq(sessions.id, sessionHash));
+    .returning({ userId: sessions.userId });
 
   return rows[0]?.userId ?? null;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -516,17 +516,21 @@ app.post('/auth/logout', requirePageSession(), requireCsrf(), async (c) => {
   const session = c.get('session')!;
   c.header('Cache-Control', 'no-store');
   c.header('Vary', 'Cookie');
-  const userId = await SessionRepository.destroy(session.id);
-  if (userId) {
-    const { db } = getDb('server');
-    await writeAuditEvent(db, {
+
+  const { db } = getDb('server');
+  await db.transaction(async (tx) => {
+    const userId = await SessionRepository.destroy(tx, session.id);
+    if (!userId) return;
+
+    await writeAuditEvent(tx, {
       eventType: 'google_logout',
       userId,
       outcome: 'success',
       ipAddress: c.req.header('x-forwarded-for') ?? c.req.header('x-real-ip'),
       userAgent: c.req.header('user-agent'),
     });
-  }
+  });
+
   clearSessionCookie(c);
   return c.redirect('/login');
 });

--- a/test/auth-google.test.ts
+++ b/test/auth-google.test.ts
@@ -70,7 +70,8 @@ import { app } from '../src/server.ts';
 import { resetAuthProvider } from '../src/auth.ts';
 import { shutdownServerPool, getDb } from '../src/db.ts';
 import { sessions, users } from '../src/db/schema/core.ts';
-import { eq } from 'drizzle-orm';
+import { oauthAuditLog } from '../src/db/schema/auth.ts';
+import { eq, sql } from 'drizzle-orm';
 // google.ts types used indirectly via the server routes
 
 // ─── Test fixtures ──────────────────────────────────────────────────────────
@@ -326,7 +327,7 @@ describe('Authenticated web UI', () => {
 });
 
 describe('Logout', () => {
-  it('4. POST /auth/logout destroys session, clears cookie, redirects /login', async () => {
+  it('4. POST /auth/logout destroys session, writes audit, clears cookie, redirects /login', async () => {
     mockGoogleSuccess();
     const loginRes = await walkOAuthFlow();
     const cookie = extractSessionCookie(loginRes)!;
@@ -345,6 +346,99 @@ describe('Logout', () => {
     const { db } = getDb('server');
     const remaining = await db.select().from(sessions);
     expect(remaining).toHaveLength(0);
+
+    const logoutAudits = await db
+      .select()
+      .from(oauthAuditLog)
+      .where(eq(oauthAuditLog.eventType, 'google_logout'));
+    expect(logoutAudits).toHaveLength(1);
+    expect(logoutAudits[0]).toMatchObject({
+      outcome: 'success',
+      userId: expect.any(String),
+    });
+  });
+
+  it('4a. rolls back the session delete when logout audit writing fails', async () => {
+    mockGoogleSuccess();
+    const loginRes = await walkOAuthFlow();
+    const cookie = extractSessionCookie(loginRes)!;
+    const csrfToken = await fetchCsrfToken(cookie);
+
+    const { db } = getDb('server');
+    await db.execute(sql`
+      ALTER TABLE oauth_audit_log
+      DROP CONSTRAINT IF EXISTS oauth_audit_log_no_logout_test
+    `);
+    await db.execute(sql`
+      ALTER TABLE oauth_audit_log
+      ADD CONSTRAINT oauth_audit_log_no_logout_test CHECK (event_type != 'google_logout')
+    `);
+
+    try {
+      const logoutRes = await withSession('http://localhost:3000/auth/logout', cookie, {
+        method: 'POST',
+        redirect: 'manual',
+        headers: { 'x-csrf-token': csrfToken },
+      });
+
+      expect(logoutRes.status).toBe(500);
+      expect(await db.select().from(sessions)).toHaveLength(1);
+      const logoutAudits = await db
+        .select()
+        .from(oauthAuditLog)
+        .where(eq(oauthAuditLog.eventType, 'google_logout'));
+      expect(logoutAudits).toHaveLength(0);
+    } finally {
+      await db.execute(sql`
+        ALTER TABLE oauth_audit_log
+        DROP CONSTRAINT IF EXISTS oauth_audit_log_no_logout_test
+      `);
+    }
+  });
+
+  it('4b. does not write a success audit row when session deletion fails', async () => {
+    mockGoogleSuccess();
+    const loginRes = await walkOAuthFlow();
+    const cookie = extractSessionCookie(loginRes)!;
+    const csrfToken = await fetchCsrfToken(cookie);
+
+    const { db } = getDb('server');
+    await db.execute(sql`DROP TRIGGER IF EXISTS fail_session_delete_for_test ON sessions`);
+    await db.execute(sql`
+      CREATE OR REPLACE FUNCTION fail_session_delete_for_test()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        RAISE EXCEPTION 'test session delete failure';
+      END;
+      $$;
+    `);
+    await db.execute(sql`
+      CREATE TRIGGER fail_session_delete_for_test
+      BEFORE DELETE ON sessions
+      FOR EACH ROW
+      EXECUTE FUNCTION fail_session_delete_for_test()
+    `);
+
+    try {
+      const logoutRes = await withSession('http://localhost:3000/auth/logout', cookie, {
+        method: 'POST',
+        redirect: 'manual',
+        headers: { 'x-csrf-token': csrfToken },
+      });
+
+      expect(logoutRes.status).toBe(500);
+      expect(await db.select().from(sessions)).toHaveLength(1);
+      const logoutAudits = await db
+        .select()
+        .from(oauthAuditLog)
+        .where(eq(oauthAuditLog.eventType, 'google_logout'));
+      expect(logoutAudits).toHaveLength(0);
+    } finally {
+      await db.execute(sql`DROP TRIGGER IF EXISTS fail_session_delete_for_test ON sessions`);
+      await db.execute(sql`DROP FUNCTION IF EXISTS fail_session_delete_for_test()`);
+    }
   });
 });
 
@@ -680,7 +774,6 @@ describe('Audit events', () => {
     await walkOAuthFlow();
 
     const { db } = getDb('server');
-    const { oauthAuditLog } = await import('../src/db/schema/auth.ts');
     const auditRows = await db
       .select()
       .from(oauthAuditLog)

--- a/test/session-repository.test.ts
+++ b/test/session-repository.test.ts
@@ -70,10 +70,16 @@ describe('SessionRepository', () => {
     const { sessionId } = await SessionRepository.create(db, { userId: user.id });
     const [stored] = await db.select().from(sessions).where(eq(sessions.userId, user.id));
 
-    await expect(SessionRepository.destroy(sessionId)).resolves.toBe(user.id);
+    await expect(SessionRepository.destroy(db, sessionId)).resolves.toBe(user.id);
 
     const remaining = await db.select().from(sessions).where(eq(sessions.id, stored.id));
     expect(remaining).toHaveLength(0);
-    await expect(SessionRepository.destroy(stored.id)).resolves.toBeNull();
+    await expect(SessionRepository.destroy(db, stored.id)).resolves.toBeNull();
+  });
+
+  it('returns null when destroying a missing session inside a transaction', async () => {
+    await db.transaction(async (tx) => {
+      await expect(SessionRepository.destroy(tx, randomUUID())).resolves.toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- run logout session deletion and `google_logout` audit writing inside one database transaction
- change session deletion to `DELETE ... RETURNING` so success audit rows are only written when this transaction actually removed a session
- add regression coverage for successful logout audit, audit-write rollback, delete failure, and missing-session idempotency

## Validation
- `npx vitest run test/session-repository.test.ts test/auth-google.test.ts`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" npm run check`
- `git diff --check`
- gstack `/review`: clean

Fixes SQR-74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout reliability by ensuring session cleanup and audit event logging occur atomically as a single database transaction, preventing partial failures.

* **Chores**
  * Refactored internal session management code to improve reliability and simplify database operations.

* **Tests**
  * Added comprehensive test coverage for logout transaction behavior, including failure scenarios and audit event validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->