### PR TITLE
fix(auth): mask Google email stdout logs

### DIFF
--- a/src/auth/google.ts
+++ b/src/auth/google.ts
@@ -102,6 +102,15 @@ function sanitizeAvatarUrl(url?: string): string | null {
   }
 }
 
+function maskEmailForLog(email: string): string {
+  const atIndex = email.indexOf('@');
+  if (atIndex <= 0 || atIndex === email.length - 1) {
+    return '[redacted-email]';
+  }
+
+  return `${email[0]}***${email.slice(atIndex)}`;
+}
+
 // ─── PKCE + state helpers ───────────────────────────────────────────────────
 
 /** Generate a random state parameter for CSRF protection during OAuth flow. */
@@ -223,16 +232,17 @@ export async function handleGoogleCallback(
 
   const { sub: googleSub, email, name } = tokenPayload;
   const avatarUrl = sanitizeAvatarUrl(tokenPayload.picture);
+  const maskedEmail = maskEmailForLog(email);
 
   // 4. Check allowlist
   const allowedEmails = getAllowedEmails();
   console.info(
     '[auth:google] verified user email=%s, checking allowlist (%d entries)',
-    email,
+    maskedEmail,
     allowedEmails.length,
   );
   if (!allowedEmails.includes(email.toLowerCase())) {
-    console.warn('[auth:google] email not in allowlist: %s', email);
+    console.warn('[auth:google] email not in allowlist: %s', maskedEmail);
     const { db } = getDb('server');
     await writeAuditEvent(db, {
       eventType: 'google_login_denied',
@@ -298,7 +308,7 @@ export async function handleGoogleCallback(
   // Log truncated session ID only (full ID is a session secret)
   console.info(
     '[auth:google] login succeeded: email=%s session=%s...',
-    email,
+    maskedEmail,
     result.sessionId.slice(0, 8),
   );
   return result;

--- a/test/auth-google.test.ts
+++ b/test/auth-google.test.ts
@@ -215,7 +215,23 @@ describe('Google OAuth callback', () => {
     expect(userRows[0].avatarUrl).toBeNull();
   });
 
-  it('1b. uses the request host for localhost worktree OAuth start URLs', async () => {
+  it('1b. masks email addresses in successful-login stdout logs', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    mockGoogleSuccess();
+
+    try {
+      const res = await walkOAuthFlow();
+      expect(res.status).toBe(302);
+
+      const renderedLogs = infoSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+      expect(renderedLogs).not.toContain(TEST_USER.email);
+      expect(renderedLogs).toContain('b***@example.com');
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('1c. uses the request host for localhost worktree OAuth start URLs', async () => {
     const res = await app.request('http://localhost:4450/auth/google/start', {
       redirect: 'manual',
     });
@@ -227,7 +243,7 @@ describe('Google OAuth callback', () => {
     );
   });
 
-  it('1c. keeps the configured callback for non-local hosts', async () => {
+  it('1d. keeps the configured callback for non-local hosts', async () => {
     const res = await app.request('http://example.com/auth/google/start', {
       redirect: 'manual',
     });
@@ -558,6 +574,36 @@ describe('Callback rejection', () => {
     const { db } = getDb('server');
     expect(await db.select().from(users)).toHaveLength(0);
     expect(await db.select().from(sessions)).toHaveLength(0);
+  });
+
+  it('5a. masks denied email in stdout but keeps full email in audit metadata', async () => {
+    process.env.SQUIRE_ALLOWED_EMAILS = 'other@example.com';
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockGoogleSuccess();
+
+    try {
+      const res = await walkOAuthFlow();
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('/not-invited');
+
+      const renderedLogs = [...infoSpy.mock.calls, ...warnSpy.mock.calls]
+        .map((call) => call.join(' '))
+        .join('\n');
+      expect(renderedLogs).not.toContain(TEST_USER.email);
+      expect(renderedLogs).toContain('b***@example.com');
+
+      const { db } = getDb('server');
+      const auditRows = await db
+        .select()
+        .from(oauthAuditLog)
+        .where(eq(oauthAuditLog.eventType, 'google_login_denied'));
+      expect(auditRows).toHaveLength(1);
+      expect(auditRows[0].metadata).toEqual({ email: TEST_USER.email });
+    } finally {
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
   });
 
   it('6. invalid state parameter -> redirect /login?error=...', async () => {


### PR DESCRIPTION
## Summary
- Mask Google OAuth email addresses before writing auth flow messages to stdout.
- Keep the full email in audit metadata for denied and successful login forensics.
- Add regression coverage for successful-login and denied-login log redaction.

## Pre-Landing Review
Pre-Landing Review: No issues found.

Scope Check: CLEAN
Intent: Mask PII in stdout auth logs for SQR-82.
Delivered: Focused `src/auth/google.ts` masking plus auth callback regression tests.

## Test plan
- Failing-first check: `npx vitest run test/auth-google.test.ts` failed before the implementation because stdout contained `brian@example.com`.
- `npx vitest run test/auth-google.test.ts` — 35 tests passed.
- `npm run check` — 76 test files, 1132 tests passed.

Fixes SQR-82
