### PR TITLE
Provision database for slow PDF CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,23 @@ jobs:
     name: Slow PDF extraction test
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: squire
+          POSTGRES_PASSWORD: squire
+          POSTGRES_DB: squire_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U squire -d squire_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://squire:squire@localhost:5432/squire_test
+      TEST_DATABASE_URL: postgres://squire:squire@localhost:5432/squire_test
 
     steps:
       - uses: actions/checkout@v6
@@ -119,6 +136,9 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
+
+      - name: Run database migrations
+        run: npm run db:migrate
 
       - name: Slow PDF extraction test
         run: npm run test:slow:pdf


### PR DESCRIPTION
## Summary
- give the scheduled/manual slow PDF extraction job the same Postgres service and DB env as normal CI
- run migrations before `npm run test:slow:pdf` so Vitest global setup can seed scenario/section tables

## Validation
- npm run lint:actions
- manual `workflow_dispatch` before this fix proved the slow job starts but failed with `ECONNREFUSED 127.0.0.1:5432`

Fixes SQR-147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD testing infrastructure to ensure proper database setup and isolation for slow extraction tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->