### PR TITLE
fix(auth): recover stale Redis rate-limit clients

### DIFF
--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'node:crypto';
 
-import { createClient, type RedisClientType } from '@redis/client';
+import { createClient as createRedisClient, type RedisClientType } from '@redis/client';
 
 import { errorLogFields, writeSecurityLog } from './security-log.ts';
 
@@ -170,6 +170,7 @@ function withRedisTimeout<T>(
 
 interface RedisTokenBucketStoreOptions {
   operationTimeoutMs?: number;
+  clientFactory?: () => RedisClientType;
 }
 
 function tokenBucketTtlMs(input: TokenBucketInput): number {
@@ -238,61 +239,112 @@ class NoopTokenBucketStore implements TokenBucketStore {
 }
 
 export class RedisTokenBucketStore implements TokenBucketStore {
-  private readonly client: RedisClientType;
+  private client: RedisClientType | undefined;
+  private readonly clientFactory: () => RedisClientType;
   private readonly operationTimeoutMs: number;
   private connectPromise: Promise<RedisClientType> | undefined;
 
   constructor(url: string, client?: RedisClientType, options: RedisTokenBucketStoreOptions = {}) {
-    this.client =
-      client ??
-      createClient({
-        url,
-        socket: {
-          connectTimeout: REDIS_OPERATION_TIMEOUT_MS,
-          socketTimeout: REDIS_SOCKET_TIMEOUT_MS,
-        },
-      });
+    this.clientFactory =
+      options.clientFactory ??
+      (() =>
+        createRedisClient({
+          url,
+          socket: {
+            connectTimeout: REDIS_OPERATION_TIMEOUT_MS,
+            socketTimeout: REDIS_SOCKET_TIMEOUT_MS,
+          },
+        }));
+    this.client = this.prepareClient(client ?? this.clientFactory());
     this.operationTimeoutMs = options.operationTimeoutMs ?? REDIS_OPERATION_TIMEOUT_MS;
-    this.client.on('error', (error: Error) => {
+  }
+
+  async consume(input: TokenBucketInput): Promise<TokenBucketDecision> {
+    const client = await this.connect();
+    try {
+      const raw = await withRedisTimeout(
+        client.eval(TOKEN_BUCKET_SCRIPT, {
+          keys: [input.key],
+          arguments: [
+            String(input.nowMs),
+            String(input.capacity),
+            String(input.refillIntervalMs),
+            String(input.refillTokens),
+            String(input.cost),
+            String(tokenBucketTtlMs(input)),
+          ],
+        }),
+        'redis rate-limit eval',
+        this.operationTimeoutMs,
+      );
+      return parseRedisDecision(raw);
+    } catch (error) {
+      this.resetClient(client);
+      throw error;
+    }
+  }
+
+  private createClient(): RedisClientType {
+    return this.prepareClient(this.clientFactory());
+  }
+
+  private prepareClient(client: RedisClientType): RedisClientType {
+    client.on('error', (error: Error) => {
+      this.resetClient(client);
       writeSecurityLog({
         event: 'rate_limit_redis_error',
         level: 'error',
         fields: errorLogFields(error),
       });
     });
+    return client;
   }
 
-  async consume(input: TokenBucketInput): Promise<TokenBucketDecision> {
-    await this.connect();
-    const raw = await withRedisTimeout(
-      this.client.eval(TOKEN_BUCKET_SCRIPT, {
-        keys: [input.key],
-        arguments: [
-          String(input.nowMs),
-          String(input.capacity),
-          String(input.refillIntervalMs),
-          String(input.refillTokens),
-          String(input.cost),
-          String(tokenBucketTtlMs(input)),
-        ],
-      }),
-      'redis rate-limit eval',
-      this.operationTimeoutMs,
-    );
-    return parseRedisDecision(raw);
+  private getClient(): RedisClientType {
+    this.client ??= this.createClient();
+    return this.client;
   }
 
-  private async connect(): Promise<void> {
-    if (this.client.isOpen) return;
-    this.connectPromise ??= this.client.connect().catch((error: unknown) => {
-      this.connectPromise = undefined;
+  private resetClient(client: RedisClientType): void {
+    if (this.client !== client) return;
+    this.connectPromise = undefined;
+    this.client = undefined;
+
+    try {
+      if (client.isOpen) client.destroy();
+    } catch {
+      // Discarding a broken limiter client is best-effort; the next request
+      // creates a fresh client and fails closed if Redis is still unavailable.
+    }
+  }
+
+  private async connect(): Promise<RedisClientType> {
+    let client = this.getClient();
+    if (client.isReady) return client;
+
+    if (client.isOpen) {
+      this.resetClient(client);
+      client = this.getClient();
+    }
+
+    this.connectPromise ??= client
+      .connect()
+      .then(() => client)
+      .catch((error: unknown) => {
+        this.resetClient(client);
+        throw error;
+      });
+
+    try {
+      return await withRedisTimeout(
+        this.connectPromise,
+        'redis rate-limit connect',
+        this.operationTimeoutMs,
+      );
+    } catch (error) {
+      this.resetClient(client);
       throw error;
-    });
-    await withRedisTimeout(
-      this.connectPromise,
-      'redis rate-limit connect',
-      this.operationTimeoutMs,
-    );
+    }
   }
 }
 

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -311,7 +311,7 @@ export class RedisTokenBucketStore implements TokenBucketStore {
     this.client = undefined;
 
     try {
-      if (client.isOpen) client.destroy();
+      client.destroy();
     } catch {
       // Discarding a broken limiter client is best-effort; the next request
       // creates a fresh client and fails closed if Redis is still unavailable.

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -322,12 +322,25 @@ export class RedisTokenBucketStore implements TokenBucketStore {
     let client = this.getClient();
     if (client.isReady) return client;
 
+    if (this.connectPromise) {
+      try {
+        return await withRedisTimeout(
+          this.connectPromise,
+          'redis rate-limit connect',
+          this.operationTimeoutMs,
+        );
+      } catch (error) {
+        this.resetClient(client);
+        throw error;
+      }
+    }
+
     if (client.isOpen) {
       this.resetClient(client);
       client = this.getClient();
     }
 
-    this.connectPromise ??= client
+    this.connectPromise = client
       .connect()
       .then(() => client)
       .catch((error: unknown) => {

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -1,6 +1,46 @@
-import { describe, expect, it } from 'vitest';
+import type { RedisClientType } from '@redis/client';
+import { describe, expect, it, vi } from 'vitest';
 
-import { hashRateLimitIdentity, InMemoryTokenBucketStore, RateLimiter } from '../src/rate-limit.ts';
+import {
+  hashRateLimitIdentity,
+  InMemoryTokenBucketStore,
+  RateLimiter,
+  RedisTokenBucketStore,
+} from '../src/rate-limit.ts';
+
+function createFakeRedisClient(options: {
+  isOpen?: boolean;
+  isReady?: boolean;
+  evalResult?: unknown;
+  evalError?: Error;
+}): RedisClientType {
+  let isOpen = options.isOpen ?? false;
+  let isReady = options.isReady ?? false;
+  const client = {
+    get isOpen() {
+      return isOpen;
+    },
+    get isReady() {
+      return isReady;
+    },
+    on: vi.fn(),
+    connect: vi.fn(async () => {
+      isOpen = true;
+      isReady = true;
+      return client;
+    }),
+    destroy: vi.fn(() => {
+      isOpen = false;
+      isReady = false;
+    }),
+    eval: vi.fn(async () => {
+      if (options.evalError) throw options.evalError;
+      return options.evalResult ?? [1, '9', 0, 360_000];
+    }),
+  };
+
+  return client as unknown as RedisClientType;
+}
 
 describe('RateLimiter', () => {
   it('allows the configured burst, rejects the next request, then refills over time', async () => {
@@ -39,5 +79,36 @@ describe('RateLimiter', () => {
     expect(hash).not.toContain(rawIp);
     expect(hash).toBe(hashRateLimitIdentity(rawIp, 'rate-limit-unit-test-secret'));
     expect(hash).not.toBe(hashRateLimitIdentity(rawIp, 'different-secret'));
+  });
+
+  it('recovers from an open but unready Redis client', async () => {
+    const staleClient = createFakeRedisClient({
+      isOpen: true,
+      isReady: false,
+      evalError: new Error('client is not ready'),
+    });
+    const freshClient = createFakeRedisClient({
+      evalResult: [1, '8', 0, 720_000],
+    });
+    const store = new RedisTokenBucketStore('redis://example.test:6379', staleClient, {
+      clientFactory: () => freshClient,
+    });
+
+    await expect(
+      store.consume({
+        key: 'squire:rate-limit:test',
+        capacity: 10,
+        refillTokens: 10,
+        refillIntervalMs: 3_600_000,
+        cost: 1,
+        nowMs: 0,
+      }),
+    ).resolves.toEqual({
+      allowed: true,
+      tokensRemaining: 8,
+      retryAfterMs: 0,
+      resetAfterMs: 720_000,
+    });
+    expect(staleClient.destroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -11,6 +11,7 @@ import {
 function createFakeRedisClient(options: {
   isOpen?: boolean;
   isReady?: boolean;
+  connectPromise?: Promise<unknown>;
   evalResult?: unknown;
   evalError?: Error;
 }): RedisClientType {
@@ -24,10 +25,11 @@ function createFakeRedisClient(options: {
       return isReady;
     },
     on: vi.fn(),
-    connect: vi.fn(async () => {
+    connect: vi.fn(() => {
+      if (options.connectPromise) return options.connectPromise;
       isOpen = true;
       isReady = true;
-      return client;
+      return Promise.resolve(client);
     }),
     destroy: vi.fn(() => {
       isOpen = false;
@@ -110,5 +112,26 @@ describe('RateLimiter', () => {
       resetAfterMs: 720_000,
     });
     expect(staleClient.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys pending Redis clients after a connect timeout', async () => {
+    const pendingClient = createFakeRedisClient({
+      connectPromise: new Promise(() => {}),
+    });
+    const store = new RedisTokenBucketStore('redis://example.test:6379', pendingClient, {
+      operationTimeoutMs: 1,
+    });
+
+    await expect(
+      store.consume({
+        key: 'squire:rate-limit:test',
+        capacity: 10,
+        refillTokens: 10,
+        refillIntervalMs: 3_600_000,
+        cost: 1,
+        nowMs: 0,
+      }),
+    ).rejects.toThrow('redis rate-limit connect timed out');
+    expect(pendingClient.destroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -8,6 +8,17 @@ import {
   RedisTokenBucketStore,
 } from '../src/rate-limit.ts';
 
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
 function createFakeRedisClient(options: {
   isOpen?: boolean;
   isReady?: boolean;
@@ -26,8 +37,13 @@ function createFakeRedisClient(options: {
     },
     on: vi.fn(),
     connect: vi.fn(() => {
-      if (options.connectPromise) return options.connectPromise;
       isOpen = true;
+      if (options.connectPromise) {
+        return options.connectPromise.then((value) => {
+          isReady = true;
+          return value;
+        });
+      }
       isReady = true;
       return Promise.resolve(client);
     }),
@@ -133,5 +149,39 @@ describe('RateLimiter', () => {
       }),
     ).rejects.toThrow('redis rate-limit connect timed out');
     expect(pendingClient.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses an in-flight Redis connect promise for concurrent callers', async () => {
+    const connect = createDeferred<unknown>();
+    const pendingClient = createFakeRedisClient({
+      connectPromise: connect.promise,
+    });
+    const store = new RedisTokenBucketStore('redis://example.test:6379', pendingClient);
+
+    const first = store.consume({
+      key: 'squire:rate-limit:first',
+      capacity: 10,
+      refillTokens: 10,
+      refillIntervalMs: 3_600_000,
+      cost: 1,
+      nowMs: 0,
+    });
+    const second = store.consume({
+      key: 'squire:rate-limit:second',
+      capacity: 10,
+      refillTokens: 10,
+      refillIntervalMs: 3_600_000,
+      cost: 1,
+      nowMs: 0,
+    });
+
+    expect(pendingClient.connect).toHaveBeenCalledTimes(1);
+    expect(pendingClient.destroy).not.toHaveBeenCalled();
+
+    connect.resolve(undefined);
+
+    await expect(first).resolves.toMatchObject({ allowed: true });
+    await expect(second).resolves.toMatchObject({ allowed: true });
+    expect(pendingClient.eval).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- recover the Redis-backed rate limiter when node-redis is open but no longer ready
- discard stale limiter clients after Redis errors so the next request can reconnect
- add a regression test for the stale-client Fly failure mode

## Validation
- gstack pre-landing review: clean
- npm test -- test/rate-limit.test.ts
- npm run check

Fixes SQR-52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support supplying a custom Redis client factory and deferring Redis connection until first use.
* **Bug Fixes**
  * Improved Redis error handling with automatic client reset/recovery, stricter connect timeouts, and reuse of in-flight connections to avoid duplicate reconnects.
* **Tests**
  * Added tests for client recovery, connect-timeout behavior, and concurrent connection handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->