### PR TITLE
v0.1.8 test: restore safe Vitest parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.8] - 2026-05-17
+
+### Changed
+
+- Split the normal Vitest suite into a parallel isolated slice and a serial DB-backed slice so PR CI can recover safe file parallelism without adding per-worker databases.
+- Added explicit unit, DB, split, and serial coverage commands, with development docs describing when to use each path.
+
 ## [0.1.7] - 2026-05-06
 
 ### Changed

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -444,8 +444,12 @@ worktree sync can be slow and may need network access for embeddings.
 ## Testing
 
 ```bash
-npm test              # Fast suite, run once
+npm test              # Fast split suite: parallel unit slice plus serial DB slice
+npm run test:unit     # Isolated tests with Vitest file parallelism enabled
+npm run test:db       # DB-backed tests serially against the checkout test DB
+npm run test:split    # Unit slice plus DB slice via Vitest projects
 npm run test:coverage # Fast coverage suite used by normal PR CI
+npm run test:coverage:serial # Previous serial coverage path, useful for comparison
 npm run test:slow:pdf # Real scenario/section PDF extraction check
 npm run test:full     # Fast suite plus real scenario/section PDF extraction
 npm run test:watch    # Watch mode
@@ -465,10 +469,19 @@ config) to catch order-dependent tests. Normal PR CI runs the fast coverage
 suite and does not reparse the full scenario/section PDF set. The checked-in
 scenario/section extract has fast regression coverage; `npm run test:slow:pdf`
 and the scheduled/manual CI path run the real PDF parser when that parser or
-source PDFs need verification. The pre-commit hook is intentionally cheap: it
-runs the conditional agent parity check above plus `lint-staged` on staged
-files. There is no pre-push hook. Use `npm run check` as the canonical local
-gate before `/ship` or any manual push you expect to survive CI.
+source PDFs need verification.
+
+SQR-148 added an explicit test split for measuring safe parallelism:
+`test/helpers/test-slices.ts` lists the DB-backed test files that use the
+checkout-local test database. `npm run test:unit` excludes those files and can
+use Vitest file parallelism; `npm run test:db` keeps them serial against that
+database. `npm run test:coverage` runs both slices as Vitest projects so
+coverage can still be measured from one command.
+
+The pre-commit hook is intentionally cheap: it runs the conditional agent
+parity check above plus `lint-staged` on staged files. There is no pre-push
+hook. Use `npm run check` as the canonical local gate before `/ship` or any
+manual push you expect to survive CI.
 
 **Prettier covers everything CI checks.** CI runs `prettier --check src/ test/`
 which walks those directories and formats _every_ file type Prettier knows

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.96.0",
         "@hono/node-server": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "engines": {
@@ -25,8 +25,12 @@
     "serve": "node src/server.ts",
     "eval": "node eval/run.ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --exclude test/import-scenario-section-books.test.ts",
-    "test:coverage": "vitest run --coverage --exclude test/import-scenario-section-books.test.ts",
+    "test": "vitest run --config vitest.split.config.ts",
+    "test:unit": "vitest run --config vitest.unit.config.ts",
+    "test:db": "vitest run --config vitest.db.config.ts",
+    "test:split": "vitest run --config vitest.split.config.ts",
+    "test:coverage": "vitest run --coverage --config vitest.split.config.ts",
+    "test:coverage:serial": "vitest run --coverage --exclude test/import-scenario-section-books.test.ts",
     "test:slow:pdf": "vitest run test/import-scenario-section-books.test.ts",
     "test:full": "vitest run",
     "test:coverage:full": "vitest run --coverage",

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -64,16 +64,20 @@ describe('deployment configuration', () => {
     expect(packageJson.scripts?.['lint:actions']).toBe('actionlint');
   });
 
-  it('splits fast PR tests from explicit slow PDF extraction tests', async () => {
+  it('splits fast PR tests from DB-backed and slow PDF extraction tests', async () => {
     const packageJson = JSON.parse(await readProjectFile('package.json')) as {
       scripts?: Record<string, string>;
     };
     const workflow = await readProjectFile('.github/workflows/ci.yml');
 
-    expect(packageJson.scripts?.test).toBe(
-      'vitest run --exclude test/import-scenario-section-books.test.ts',
-    );
+    expect(packageJson.scripts?.test).toBe('vitest run --config vitest.split.config.ts');
+    expect(packageJson.scripts?.['test:unit']).toBe('vitest run --config vitest.unit.config.ts');
+    expect(packageJson.scripts?.['test:db']).toBe('vitest run --config vitest.db.config.ts');
+    expect(packageJson.scripts?.['test:split']).toBe('vitest run --config vitest.split.config.ts');
     expect(packageJson.scripts?.['test:coverage']).toBe(
+      'vitest run --coverage --config vitest.split.config.ts',
+    );
+    expect(packageJson.scripts?.['test:coverage:serial']).toBe(
       'vitest run --coverage --exclude test/import-scenario-section-books.test.ts',
     );
     expect(packageJson.scripts?.['test:slow:pdf']).toBe(

--- a/test/helpers/test-slices.ts
+++ b/test/helpers/test-slices.ts
@@ -1,0 +1,23 @@
+/**
+ * Test files that share mutable Postgres state through test/helpers/db.ts.
+ *
+ * These stay in the serial DB slice. The unit slice excludes them so Vitest can
+ * parallelize isolated tests without reintroducing shared-DB truncation races.
+ */
+export const DB_BACKED_TEST_FILES = [
+  'test/auth-google.test.ts',
+  'test/auth-provider.test.ts',
+  'test/auth-restart.test.ts',
+  'test/conversation.test.ts',
+  'test/dev-login.test.ts',
+  'test/extracted-data.test.ts',
+  'test/seed/seed-cards.test.ts',
+  'test/seed/seed-dev-user.test.ts',
+  'test/seed/seed-scenario-section-books.test.ts',
+  'test/server-oauth.test.ts',
+  'test/session-repository.test.ts',
+  'test/tools.test.ts',
+  'test/vector-store.test.ts',
+];
+
+export const SLOW_PDF_TEST_FILES = ['test/import-scenario-section-books.test.ts'];

--- a/test/helpers/test-slices.ts
+++ b/test/helpers/test-slices.ts
@@ -20,4 +20,12 @@ export const DB_BACKED_TEST_FILES = [
   'test/vector-store.test.ts',
 ];
 
+/**
+ * Tests that perform the real scenario/section PDF extraction path.
+ *
+ * SLOW_PDF_TEST_FILES stays out of the normal PR suite because it does heavier
+ * file/PDF processing than the regression fixtures. Run these explicitly with
+ * `npm run test:slow:pdf`; CI runs them from the scheduled/manual slow-test
+ * path when source PDFs or parser behavior need verification.
+ */
 export const SLOW_PDF_TEST_FILES = ['test/import-scenario-section-books.test.ts'];

--- a/vitest.db.config.ts
+++ b/vitest.db.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+import { DB_BACKED_TEST_FILES } from './test/helpers/test-slices.ts';
+
+export default defineConfig({
+  test: {
+    env: { SQUIRE_DEV_LOGIN: '1' },
+    include: DB_BACKED_TEST_FILES,
+    globalSetup: ['./test/helpers/global-setup.ts'],
+    setupFiles: ['./test/helpers/vitest-eslint-setup.js'],
+    sequence: { shuffle: true },
+    fileParallelism: false,
+  },
+});

--- a/vitest.split.config.ts
+++ b/vitest.split.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, configDefaults } from 'vitest/config';
+
+import { DB_BACKED_TEST_FILES, SLOW_PDF_TEST_FILES } from './test/helpers/test-slices.ts';
+
+const shared = {
+  env: { SQUIRE_DEV_LOGIN: '1' },
+  setupFiles: ['./test/helpers/vitest-eslint-setup.js'],
+  sequence: { shuffle: true },
+};
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/types/**'],
+      thresholds: {
+        lines: 60,
+        functions: 60,
+        branches: 60,
+        statements: 60,
+      },
+    },
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          ...shared,
+          exclude: [
+            ...configDefaults.exclude,
+            'data/**',
+            '.claude/worktrees/**',
+            ...DB_BACKED_TEST_FILES,
+            ...SLOW_PDF_TEST_FILES,
+          ],
+          fileParallelism: true,
+        },
+      },
+      {
+        test: {
+          name: 'db',
+          ...shared,
+          include: DB_BACKED_TEST_FILES,
+          globalSetup: ['./test/helpers/global-setup.ts'],
+          fileParallelism: false,
+        },
+      },
+    ],
+  },
+});

--- a/vitest.split.config.ts
+++ b/vitest.split.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
             'data/**',
             '.claude/worktrees/**',
             ...DB_BACKED_TEST_FILES,
+            // Kept on the dedicated slow path: `npm run test:slow:pdf`.
             ...SLOW_PDF_TEST_FILES,
           ],
           fileParallelism: true,

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, configDefaults } from 'vitest/config';
+
+import { DB_BACKED_TEST_FILES, SLOW_PDF_TEST_FILES } from './test/helpers/test-slices.ts';
+
+export default defineConfig({
+  test: {
+    env: { SQUIRE_DEV_LOGIN: '1' },
+    exclude: [
+      ...configDefaults.exclude,
+      'data/**',
+      '.claude/worktrees/**',
+      ...DB_BACKED_TEST_FILES,
+      ...SLOW_PDF_TEST_FILES,
+    ],
+    setupFiles: ['./test/helpers/vitest-eslint-setup.js'],
+    sequence: { shuffle: true },
+    fileParallelism: true,
+  },
+});


### PR DESCRIPTION
## Summary

- Split the normal Vitest path into a parallel isolated unit project and a serial DB-backed project.
- Added explicit `test:unit`, `test:db`, `test:split`, and `test:coverage:serial` scripts while keeping CI on `npm run test:coverage`.
- Documented the split and bumped the package/changelog to `0.1.8`.

## Pre-Landing Review

No blockers found. Fixed one stale docs reference before committing: the docs now point to `npm run test:coverage`, not the earlier temporary split command name.

## Test plan

- `npm run db:migrate:test`
- `npm run check`
- `npm run test:coverage -- --reporter=dot`
- `npm run check` after commit

## Measured result

On the pre-merge base, serial coverage took 53.79s and split coverage took 35.35s. After merging current `origin/main`, split coverage passed in 37.52s with 80 files and 1169 tests.

Closes SQR-148.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added granular test commands for unit, DB-backed, split, and serial coverage runs to improve test workflow flexibility.

* **Documentation**
  * Expanded development guide testing section with step-by-step usage and guidance on when to use each test path.

* **Chores**
  * Version bumped to 0.1.8.
  * Reorganized test execution to isolate DB-backed tests, enable parallel unit runs, and provide clearer coverage options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->