### PR TITLE
fix: parse GHS label HTML as text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "langchain": "^1.4.0",
         "langsmith": "^0.7.1",
         "markdown-it": "^14.1.1",
+        "parse5": "^8.0.1",
         "pdf-parse": "^1.1.1",
         "pg": "^8.20.0",
         "tailwindcss": "^4.2.4",
@@ -8129,6 +8130,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "langchain": "^1.4.0",
     "langsmith": "^0.7.1",
     "markdown-it": "^14.1.1",
+    "parse5": "^8.0.1",
     "pdf-parse": "^1.1.1",
     "pg": "^8.20.0",
     "tailwindcss": "^4.2.4",

--- a/src/ghs-utils.ts
+++ b/src/ghs-utils.ts
@@ -25,6 +25,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseFragment, type DefaultTreeAdapterMap } from 'parse5';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -99,30 +100,37 @@ export function kebabToTitle(name: string): string {
 // ─── HTML stripping ─────────────────────────────────────────────────────────
 
 /**
- * Strip HTML tags from GHS text. Converts `<br>` to spaces, removes all
- * other tags, and collapses whitespace.
+ * Extract plain text from GHS label HTML fragments. GHS uses simple markup as
+ * data, so parse the fragment instead of trying to maintain tag-scanner rules.
  */
 export function stripHtml(text: string): string {
-  let stripped = '';
+  const fragment = parseFragment(text);
+  const parts: string[] = [];
 
-  for (let i = 0; i < text.length; i += 1) {
-    const char = text[i];
-    if (char !== '<') {
-      stripped += char;
-      continue;
+  function appendText(node: DefaultTreeAdapterMap['node']): void {
+    if (node.nodeName === '#text' && 'value' in node) {
+      parts.push(node.value);
+      return;
     }
 
-    const closeIndex = text.indexOf('>', i + 1);
-    if (closeIndex === -1) break;
+    if (node.nodeName === 'br') {
+      parts.push(' ');
+      return;
+    }
 
-    const tagContent = text.slice(i + 1, closeIndex).trim();
-    const tagName = tagContent.replace(/\/$/, '').trim().split(/\s+/, 1)[0]?.toLowerCase();
-    if (tagName === 'br') stripped += ' ';
+    if (node.nodeName === 'script' || node.nodeName === 'style') return;
 
-    i = closeIndex;
+    if ('content' in node) appendChildren(node.content.childNodes);
+    if ('childNodes' in node) appendChildren(node.childNodes);
   }
 
-  return stripped.replace(/  +/g, ' ').trim();
+  function appendChildren(nodes: DefaultTreeAdapterMap['childNode'][]): void {
+    for (const node of nodes) appendText(node);
+  }
+
+  appendChildren(fragment.childNodes);
+
+  return parts.join('').replace(/\s+/g, ' ').trim();
 }
 
 // ─── Game token resolution ───────────────────────────────────────────────────

--- a/test/ghs-utils.test.ts
+++ b/test/ghs-utils.test.ts
@@ -30,8 +30,22 @@ describe('stripHtml', () => {
     expect(stripHtml('Attack <b>3</b><br/>Then move <i>2</i>')).toBe('Attack 3 Then move 2');
   });
 
+  it('preserves text inside nested formatting tags', () => {
+    expect(stripHtml('Gain <strong><i>Advantage</i></strong> on the next attack')).toBe(
+      'Gain Advantage on the next attack',
+    );
+  });
+
   it('drops unterminated tag fragments', () => {
     expect(stripHtml('Attack 3 <script')).toBe('Attack 3');
+  });
+
+  it('keeps text inside malformed formatting fragments', () => {
+    expect(stripHtml('Attack <strong>3')).toBe('Attack 3');
+  });
+
+  it('drops script and style contents from parsed fragments', () => {
+    expect(stripHtml('Attack <script>alert(1)</script><style>.x{}</style> 3')).toBe('Attack 3');
   });
 });
 
@@ -93,6 +107,25 @@ describe('resolveLabel', () => {
   it('resolves a %data.custom.fh...% reference', () => {
     const result = resolveLabel('%data.custom.fh.drifter.abilities.1.1%', labels);
     expect(result).toBe('On your next six melee attacks, add +2 Attack.');
+  });
+
+  it('resolves labels through plain-text HTML extraction before game tokens', () => {
+    const htmlLabels = {
+      custom: {
+        fh: {
+          drifter: {
+            abilities: {
+              '1': {
+                '2': '<strong>Move</strong><br><i>+1%game.action.attack%</i>',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = resolveLabel('%data.custom.fh.drifter.abilities.1.2%', htmlLabels);
+    expect(result).toBe('Move +1 Attack');
   });
 
   it('returns the original string when path is not found', () => {


### PR DESCRIPTION
## Summary

- Replaces the hand-written GHS HTML tag scanner with `parse5` fragment parsing.
- Keeps GHS label output plain text while preserving formatting-tag text and `<br>` spacing.
- Drops script/style contents and covers malformed fragments plus `resolveLabel` integration.

## Pre-landing review

No blockers found. The security boundary now relies on an HTML fragment parser rather than regex/scanner parsing, and the old tag-scanning loop is removed.

## Test plan

- `npm run test:unit -- test/ghs-utils.test.ts --reporter=dot`
- `npm run test:unit -- test/ghs-utils.test.ts test/import-battle-goals.test.ts test/import-buildings.test.ts test/import-character-abilities.test.ts test/import-character-mats.test.ts test/import-events.test.ts test/import-items.test.ts test/import-monster-abilities.test.ts test/import-monster-stats.test.ts test/import-personal-quests.test.ts test/import-scenarios.test.ts --reporter=dot`
- `npm run check`
- `npm audit --omit=dev` showed the existing 5 moderate `@xenova/transformers` / `protobufjs` chain findings; `parse5` was not in the audit findings.

Fixes SQR-171.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML text extraction to properly handle nested formatting tags, malformed tags, and remove script/style content.

* **Tests**
  * Added comprehensive test coverage for HTML text extraction edge cases and label resolution with embedded HTML content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->