### PR TITLE
fix(auth): avoid Redis idle timeout errors

### DIFF
--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -58,7 +58,6 @@ const DEFAULT_KEY_PREFIX = 'squire:rate-limit';
 const TEST_IDENTITY_SECRET = 'squire-test-rate-limit-identity-secret';
 const DEV_IDENTITY_SECRET = 'squire-development-rate-limit-identity-secret';
 const REDIS_OPERATION_TIMEOUT_MS = 2_000;
-const REDIS_SOCKET_TIMEOUT_MS = 10_000;
 
 export const REGISTER_CLIENT_RATE_LIMIT_POLICY: RateLimitPolicy = {
   name: 'oauth_register_ip',
@@ -290,7 +289,6 @@ export class RedisRateLimitStore extends FlexibleRateLimitStore {
           url,
           socket: {
             connectTimeout: operationTimeoutMs,
-            socketTimeout: REDIS_SOCKET_TIMEOUT_MS,
           },
         }));
     const redisClient = client ?? clientFactory();


### PR DESCRIPTION
## Summary
- remove the node-redis idle socket timeout from the rate limiter client
- keep connectTimeout and the app-level limiter operation timeout in place

## Validation
- npm run check
- production follow-up from SQR-52: rate probe returned 400 for allowed malformed requests and 429 after the register limit, but logs showed rate_limit_redis_error about 10 seconds after idle; this PR removes that idle-timeout source

Follow-up to #400 / SQR-52.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Redis client timeout configuration by consolidating socket settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->