### PR TITLE
test: avoid postgres secret fixture literal

### DIFF
--- a/test/production-data-workflows.test.ts
+++ b/test/production-data-workflows.test.ts
@@ -8,6 +8,16 @@ async function readProjectFile(path: string): Promise<string> {
   return readFile(new URL(`../${path}`, import.meta.url), 'utf8');
 }
 
+function postgresFixtureUrl(options: { host: string; database?: string; port?: number }): string {
+  const url = new URL('postgres://fixture.invalid');
+  url.username = 'squire';
+  url.password = 'fixture-password';
+  url.hostname = options.host;
+  if (options.port !== undefined) url.port = String(options.port);
+  if (options.database !== undefined) url.pathname = `/${options.database}`;
+  return url.toString();
+}
+
 describe('production data lifecycle workflows', () => {
   it('defines package scripts for production data URL verification and sanity checks', async () => {
     const packageJson = JSON.parse(await readProjectFile('package.json')) as {
@@ -28,24 +38,36 @@ describe('production data lifecycle workflows', () => {
   it('rejects missing local and obvious dev/test production database URLs', () => {
     expect(() => assertProductionDatabaseUrl('')).toThrow(/PRODUCTION_DATABASE_URL/);
     expect(() =>
-      assertProductionDatabaseUrl('postgres://squire:squire@localhost:5432/fly-db'),
+      assertProductionDatabaseUrl(
+        postgresFixtureUrl({ host: 'localhost', port: 5432, database: 'fly-db' }),
+      ),
     ).toThrow(/local database/);
     expect(() =>
-      assertProductionDatabaseUrl('postgres://squire:squire@127.0.0.1:5432/fly-db'),
+      assertProductionDatabaseUrl(
+        postgresFixtureUrl({ host: '127.0.0.1', port: 5432, database: 'fly-db' }),
+      ),
     ).toThrow(/local database/);
-    expect(() => assertProductionDatabaseUrl('postgres://squire:squire@db.internal')).toThrow(
+    expect(() => assertProductionDatabaseUrl(postgresFixtureUrl({ host: 'db.internal' }))).toThrow(
       /explicit database name/,
     );
     expect(() =>
-      assertProductionDatabaseUrl('postgres://squire:squire@db.internal:5432/squire_test'),
+      assertProductionDatabaseUrl(
+        postgresFixtureUrl({ host: 'db.internal', port: 5432, database: 'squire_test' }),
+      ),
     ).toThrow(/dev\/test database/);
     expect(() =>
-      assertProductionDatabaseUrl('postgres://squire:squire@db.internal:5432/squire_dev'),
+      assertProductionDatabaseUrl(
+        postgresFixtureUrl({ host: 'db.internal', port: 5432, database: 'squire_dev' }),
+      ),
     ).toThrow(/dev\/test database/);
 
     expect(() =>
       assertProductionDatabaseUrl(
-        'postgres://squire:secret@top2.nearest.of.maz-squire-db:5432/fly-db',
+        postgresFixtureUrl({
+          host: 'top2.nearest.of.maz-squire-db',
+          port: 5432,
+          database: 'fly-db',
+        }),
       ),
     ).not.toThrow();
   });

--- a/test/production-data-workflows.test.ts
+++ b/test/production-data-workflows.test.ts
@@ -77,8 +77,16 @@ describe('production data lifecycle workflows', () => {
   });
 
   it('allows a local Fly proxy connection only when the production target URL is separate', () => {
-    const productionUrl = 'postgres://squire:secret@pgbouncer.internal:5432/fly-db';
-    const proxyUrl = 'postgres://squire:secret@127.0.0.1:15432/fly-db';
+    const productionUrl = postgresFixtureUrl({
+      host: 'pgbouncer.internal',
+      port: 5432,
+      database: 'fly-db',
+    });
+    const proxyUrl = postgresFixtureUrl({
+      host: '127.0.0.1',
+      port: 15432,
+      database: 'fly-db',
+    });
 
     expect(() => assertProductionDatabaseUrl(proxyUrl)).toThrow(/local database/);
     expect(
@@ -101,7 +109,11 @@ describe('production data lifecycle workflows', () => {
     ).toBe(productionUrl);
     expect(() =>
       getProductionDatabaseConnectionUrl({
-        DATABASE_URL: 'postgres://squire:secret@staging.internal:5432/fly-db',
+        DATABASE_URL: postgresFixtureUrl({
+          host: 'staging.internal',
+          port: 5432,
+          database: 'fly-db',
+        }),
         PRODUCTION_DATABASE_URL: productionUrl,
       }),
     ).toThrow(/local Fly proxy/);


### PR DESCRIPTION
## Summary
- replace hard-coded Postgres credential URLs in production data workflow tests with generated fixture URLs
- keep the same production URL guard coverage without committing secret-shaped strings

## Verification
- npx vitest run ./test/production-data-workflows.test.ts --sequence.shuffle=false
- npm run check

Refs GitHub secret scanning alert #1: https://github.com/maz-org/squire/security/secret-scanning/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for database URL validation with additional fixture variants.
  * Improved test helper utilities for consistent test data construction.
  * Updated staging database configuration assertions to align with new test infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->