### PR TITLE
Enable Fly proxy WebSockets for production data workflows

### DIFF
--- a/.github/workflows/production-reindex-pdfs.yml
+++ b/.github/workflows/production-reindex-pdfs.yml
@@ -61,6 +61,7 @@ jobs:
           proxied_url="$(node -e 'const url = new URL(process.env.PRODUCTION_DATABASE_URL); url.hostname = "127.0.0.1"; url.port = "15432"; console.log(url.toString())')"
           echo "::add-mask::$proxied_url"
           echo "DATABASE_URL=$proxied_url" >> "$GITHUB_ENV"
+          flyctl wireguard websockets enable
           flyctl proxy 15432:5432 "$remote_host" --app maz-squire > /tmp/fly-postgres-proxy.log 2>&1 &
           echo "$!" > /tmp/fly-postgres-proxy.pid
           for _ in {1..20}; do

--- a/.github/workflows/production-seed-cards.yml
+++ b/.github/workflows/production-seed-cards.yml
@@ -52,6 +52,7 @@ jobs:
           proxied_url="$(node -e 'const url = new URL(process.env.PRODUCTION_DATABASE_URL); url.hostname = "127.0.0.1"; url.port = "15432"; console.log(url.toString())')"
           echo "::add-mask::$proxied_url"
           echo "DATABASE_URL=$proxied_url" >> "$GITHUB_ENV"
+          flyctl wireguard websockets enable
           flyctl proxy 15432:5432 "$remote_host" --app maz-squire > /tmp/fly-postgres-proxy.log 2>&1 &
           echo "$!" > /tmp/fly-postgres-proxy.pid
           for _ in {1..20}; do

--- a/.github/workflows/production-seed-scenario-section-books.yml
+++ b/.github/workflows/production-seed-scenario-section-books.yml
@@ -57,6 +57,7 @@ jobs:
           proxied_url="$(node -e 'const url = new URL(process.env.PRODUCTION_DATABASE_URL); url.hostname = "127.0.0.1"; url.port = "15432"; console.log(url.toString())')"
           echo "::add-mask::$proxied_url"
           echo "DATABASE_URL=$proxied_url" >> "$GITHUB_ENV"
+          flyctl wireguard websockets enable
           flyctl proxy 15432:5432 "$remote_host" --app maz-squire > /tmp/fly-postgres-proxy.log 2>&1 &
           echo "$!" > /tmp/fly-postgres-proxy.pid
           for _ in {1..20}; do

--- a/test/production-data-workflows.test.ts
+++ b/test/production-data-workflows.test.ts
@@ -99,6 +99,7 @@ describe('production data lifecycle workflows', () => {
     expect(workflow).toContain('NODE_ENV: production');
     expect(workflow).toContain('SQUIRE_ENV: production');
     expect(workflow).toContain('superfly/flyctl-actions/setup-flyctl');
+    expect(workflow).toContain('flyctl wireguard websockets enable');
     expect(workflow).toContain('flyctl proxy 15432:5432 "$remote_host" --app maz-squire');
     expect(workflow).toContain('echo "::add-mask::$proxied_url"');
     expect(workflow).toContain('run: npm run production-data:verify-db-url');


### PR DESCRIPTION
## Summary
- enable Fly WireGuard-over-WebSockets before opening the production DB proxy
- keep the existing masked proxy URL and production URL guard behavior

## Validation
- npm run check
- npm test -- --run test/production-data-workflows.test.ts
- npm run lint:actions

Follow-up to #408 after production workflow dispatch showed GitHub-hosted runners timing out on Fly private DNS over the default tunnel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production data workflows to enable WireGuard websockets for improved database proxy connectivity during scheduled maintenance operations.

* **Tests**
  * Added validation to verify WireGuard websocket configuration in production workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->