### PR TITLE
feat(auth): rate limit Google OAuth routes

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -78,6 +78,10 @@ planned as a custom implementation inside the Hono server.
   non-local hosts still use the configured redirect URI
 - Rate limit client registration (10/hour per trusted client IP) through the
   Redis/Valkey-backed app limiter from SQR-52 / ADR 0018
+- Rate limit Google OAuth web login initiation and callback routes
+  (`/auth/google/start` at 10/minute and `/auth/google/callback` at 20/minute
+  per trusted client IP) through the same Redis/Valkey-backed limiter; denials
+  are structured logs, not `oauth_audit_log` rows
 - **Long-lived access tokens (30-day default)** stored as SHA-256 hashes at rest.
   Long-lived tokens are a deliberate developer-experience choice for MCP and API
   clients — short-lived tokens with refresh rotation force every client (Claude

--- a/docs/runbooks/production-operations.md
+++ b/docs/runbooks/production-operations.md
@@ -58,6 +58,11 @@ Rate-limit denials return 429 with `Retry-After` and emit structured security
 log events with a hashed identity. They do not write `oauth_audit_log` rows;
 that table is for durable auth lifecycle state changes.
 
+`GET /auth/google/start` is limited to 10 requests per minute per trusted
+client IP. `GET /auth/google/callback` is limited to 20 requests per minute per
+trusted client IP. Denials use the same `Retry-After` response and structured
+log shape as registration, and do not write `oauth_audit_log` rows.
+
 `/mcp` is limited to 120 requests per minute per authenticated token user when
 available, otherwise per OAuth client id. Unauthenticated or malformed requests
 fall back to the trusted client IP resolver, then a shared `unknown` bucket if no

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -65,6 +65,18 @@ export const REGISTER_CLIENT_RATE_LIMIT_POLICY: RateLimitPolicy = {
   windowMs: 60 * 60 * 1000,
 };
 
+export const GOOGLE_OAUTH_START_RATE_LIMIT_POLICY: RateLimitPolicy = {
+  name: 'google_oauth_start_ip',
+  limit: 10,
+  windowMs: 60 * 1000,
+};
+
+export const GOOGLE_OAUTH_CALLBACK_RATE_LIMIT_POLICY: RateLimitPolicy = {
+  name: 'google_oauth_callback_ip',
+  limit: 20,
+  windowMs: 60 * 1000,
+};
+
 export const MCP_REQUEST_RATE_LIMIT_POLICY: RateLimitPolicy = {
   name: 'mcp_request',
   limit: 120,

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,9 +29,12 @@ import { originSharedSecretMiddleware } from './origin-lock.ts';
 import { resolveTrustedClientIp } from './http/trusted-client-ip.ts';
 import { LlmBudgetExceededError } from './llm-budget.ts';
 import {
+  GOOGLE_OAUTH_CALLBACK_RATE_LIMIT_POLICY,
+  GOOGLE_OAUTH_START_RATE_LIMIT_POLICY,
   getDefaultRateLimiter,
   MCP_REQUEST_RATE_LIMIT_POLICY,
   REGISTER_CLIENT_RATE_LIMIT_POLICY,
+  type RateLimitPolicy,
   type RateLimitDecision,
 } from './rate-limit.ts';
 import { errorLogFields, writeSecurityLog } from './security-log.ts';
@@ -176,6 +179,11 @@ async function checkRegisterRateLimit(c: Context): Promise<RateLimitDecision> {
   });
 }
 
+async function checkIpRateLimit(c: Context, policy: RateLimitPolicy): Promise<RateLimitDecision> {
+  const identity = resolveTrustedClientIp(c.req) ?? 'unknown';
+  return getDefaultRateLimiter().consume({ policy, identity });
+}
+
 function rateLimitedResponse(c: Context, decision: RateLimitDecision) {
   const retryAfterSeconds = Math.max(1, decision.retryAfterSeconds);
   writeSecurityLog({
@@ -203,6 +211,33 @@ function rateLimitedResponse(c: Context, decision: RateLimitDecision) {
   );
 }
 
+function googleOAuthRateLimitedResponse(c: Context, decision: RateLimitDecision, route: string) {
+  const retryAfterSeconds = Math.max(1, decision.retryAfterSeconds);
+  writeSecurityLog({
+    event: 'rate_limit_rejected',
+    fields: {
+      route,
+      method: 'GET',
+      policy: decision.policy.name,
+      limit: decision.policy.limit,
+      window_ms: decision.policy.windowMs,
+      identity_hash: decision.identityHash,
+      retry_after_seconds: retryAfterSeconds,
+      reset_after_seconds: decision.resetAfterSeconds,
+    },
+  });
+
+  c.header('Retry-After', String(retryAfterSeconds));
+  return c.json(
+    {
+      error: 'rate_limited',
+      error_description: 'Too many sign-in attempts. Try again later.',
+      retry_after_seconds: retryAfterSeconds,
+    },
+    429,
+  );
+}
+
 function rateLimitUnavailableResponse(c: Context, error: unknown) {
   writeSecurityLog({
     event: 'rate_limit_unavailable',
@@ -219,6 +254,32 @@ function rateLimitUnavailableResponse(c: Context, error: unknown) {
     {
       error: 'temporarily_unavailable',
       error_description: 'Registration is temporarily unavailable. Try again later.',
+    },
+    503,
+  );
+}
+
+function googleOAuthRateLimitUnavailableResponse(
+  c: Context,
+  error: unknown,
+  route: string,
+  policy: RateLimitPolicy,
+) {
+  writeSecurityLog({
+    event: 'rate_limit_unavailable',
+    level: 'error',
+    fields: {
+      route,
+      method: 'GET',
+      policy: policy.name,
+      ...errorLogFields(error),
+    },
+  });
+
+  return c.json(
+    {
+      error: 'temporarily_unavailable',
+      error_description: 'Sign-in is temporarily unavailable. Try again later.',
     },
     503,
   );
@@ -650,6 +711,19 @@ app.post('/token', async (c) => {
 const PKCE_COOKIE_NAME = 'squire_oauth_pkce';
 
 app.get('/auth/google/start', async (c) => {
+  let rateLimit: RateLimitDecision;
+  try {
+    rateLimit = await checkIpRateLimit(c, GOOGLE_OAUTH_START_RATE_LIMIT_POLICY);
+  } catch (error) {
+    return googleOAuthRateLimitUnavailableResponse(
+      c,
+      error,
+      '/auth/google/start',
+      GOOGLE_OAUTH_START_RATE_LIMIT_POLICY,
+    );
+  }
+  if (!rateLimit.allowed) return googleOAuthRateLimitedResponse(c, rateLimit, '/auth/google/start');
+
   const state = generateState();
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = computeCodeChallenge(codeVerifier);
@@ -670,6 +744,21 @@ app.get('/auth/google/start', async (c) => {
 });
 
 app.get('/auth/google/callback', async (c) => {
+  let rateLimit: RateLimitDecision;
+  try {
+    rateLimit = await checkIpRateLimit(c, GOOGLE_OAUTH_CALLBACK_RATE_LIMIT_POLICY);
+  } catch (error) {
+    return googleOAuthRateLimitUnavailableResponse(
+      c,
+      error,
+      '/auth/google/callback',
+      GOOGLE_OAUTH_CALLBACK_RATE_LIMIT_POLICY,
+    );
+  }
+  if (!rateLimit.allowed) {
+    return googleOAuthRateLimitedResponse(c, rateLimit, '/auth/google/callback');
+  }
+
   // Check for error from Google (e.g., user clicked Cancel)
   const error = c.req.query('error');
   if (error) {

--- a/test/auth-google.test.ts
+++ b/test/auth-google.test.ts
@@ -27,7 +27,7 @@
  * google-auth-library boundary; everything else hits the real test database.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setupTestDb, resetTestDb, teardownTestDb } from './helpers/db.ts';
 
@@ -72,6 +72,12 @@ import { shutdownServerPool, getDb } from '../src/db.ts';
 import { sessions, users } from '../src/db/schema/core.ts';
 import { oauthAuditLog } from '../src/db/schema/auth.ts';
 import * as auditModule from '../src/auth/audit.ts';
+import {
+  InMemoryTokenBucketStore,
+  RateLimiter,
+  resetRateLimiterForTesting,
+  setRateLimiterForTesting,
+} from '../src/rate-limit.ts';
 import { eq, sql } from 'drizzle-orm';
 // google.ts types used indirectly via the server routes
 
@@ -113,6 +119,35 @@ function mockGoogleUnverifiedEmail(user = TEST_USER) {
       name: user.name,
       picture: user.picture,
     }),
+  });
+}
+
+function enableInMemoryGoogleOAuthLimiter() {
+  setRateLimiterForTesting(
+    new RateLimiter(new InMemoryTokenBucketStore(), {
+      identitySecret: 'auth-google-rate-limit-test-secret',
+      nowMs: () => 2_000_000,
+    }),
+  );
+}
+
+function googleStartFromIp(ip: string, headers: Record<string, string> = {}) {
+  return app.request('http://localhost:3000/auth/google/start', {
+    redirect: 'manual',
+    headers: {
+      'X-Forwarded-For': ip,
+      ...headers,
+    },
+  });
+}
+
+function googleCallbackFromIp(ip: string, index: number, headers: Record<string, string> = {}) {
+  return app.request(`http://localhost:3000/auth/google/callback?state=only-state-${index}`, {
+    redirect: 'manual',
+    headers: {
+      'X-Forwarded-For': ip,
+      ...headers,
+    },
   });
 }
 
@@ -185,6 +220,10 @@ beforeEach(async () => {
   // Default: allow the test user's email via env var
   process.env.SQUIRE_ALLOWED_EMAILS = TEST_USER.email;
   delete process.env.ORIGIN_SHARED_SECRET;
+});
+
+afterEach(() => {
+  resetRateLimiterForTesting();
 });
 
 afterAll(async () => {
@@ -302,6 +341,141 @@ describe('Google OAuth callback', () => {
     expect(redirectUrl.searchParams.get('redirect_uri')).toBe(
       'http://localhost:3000/auth/google/callback',
     );
+  });
+
+  it('1e. rate limits the 11th Google OAuth start request from one resolved IP', async () => {
+    enableInMemoryGoogleOAuthLimiter();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      for (let i = 0; i < 10; i += 1) {
+        const res = await googleStartFromIp('198.51.100.80');
+        expect(res.status).toBe(302);
+      }
+
+      const limited = await googleStartFromIp('198.51.100.80');
+      expect(limited.status).toBe(429);
+      expect(limited.headers.get('retry-after')).toBe('6');
+      await expect(limited.json()).resolves.toMatchObject({
+        error: 'rate_limited',
+        retry_after_seconds: 6,
+      });
+
+      const logLine = warn.mock.calls
+        .map((call) => String(call[0]))
+        .find((line) => line.includes('"event":"rate_limit_rejected"'));
+      expect(logLine).toBeTruthy();
+      expect(logLine).not.toContain('198.51.100.80');
+
+      const event = JSON.parse(logLine!);
+      expect(event).toMatchObject({
+        level: 'warn',
+        event: 'rate_limit_rejected',
+        route: '/auth/google/start',
+        method: 'GET',
+        policy: 'google_oauth_start_ip',
+        limit: 10,
+        window_ms: 60_000,
+        retry_after_seconds: 6,
+      });
+      expect(event.identity_hash).toMatch(/^[A-Za-z0-9_-]{32}$/);
+
+      const { db } = getDb('server');
+      const auditRows = await db.select().from(oauthAuditLog);
+      expect(auditRows).toHaveLength(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('1f. rate limits the 21st Google OAuth callback request from one resolved IP', async () => {
+    enableInMemoryGoogleOAuthLimiter();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      for (let i = 0; i < 20; i += 1) {
+        const res = await googleCallbackFromIp('198.51.100.81', i);
+        expect(res.status).toBe(302);
+        expect(res.headers.get('location')).toBe('/login?error=Missing+code+or+state+parameter.');
+      }
+
+      const limited = await googleCallbackFromIp('198.51.100.81', 21);
+      expect(limited.status).toBe(429);
+      expect(limited.headers.get('retry-after')).toBe('3');
+      await expect(limited.json()).resolves.toMatchObject({
+        error: 'rate_limited',
+        retry_after_seconds: 3,
+      });
+
+      const logLine = warn.mock.calls
+        .map((call) => String(call[0]))
+        .find((line) => line.includes('"event":"rate_limit_rejected"'));
+      expect(logLine).toBeTruthy();
+      expect(logLine).not.toContain('198.51.100.81');
+
+      const event = JSON.parse(logLine!);
+      expect(event).toMatchObject({
+        level: 'warn',
+        event: 'rate_limit_rejected',
+        route: '/auth/google/callback',
+        method: 'GET',
+        policy: 'google_oauth_callback_ip',
+        limit: 20,
+        window_ms: 60_000,
+        retry_after_seconds: 3,
+      });
+      expect(event.identity_hash).toMatch(/^[A-Za-z0-9_-]{32}$/);
+
+      const { db } = getDb('server');
+      const auditRows = await db.select().from(oauthAuditLog);
+      expect(auditRows).toHaveLength(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('1g. keeps Google OAuth start and callback buckets independent per IP and route', async () => {
+    enableInMemoryGoogleOAuthLimiter();
+
+    for (let i = 0; i < 10; i += 1) {
+      const startRes = await googleStartFromIp('198.51.100.82');
+      expect(startRes.status).toBe(302);
+    }
+
+    const otherStartIp = await googleStartFromIp('198.51.100.83');
+    expect(otherStartIp.status).toBe(302);
+
+    const sameIpCallback = await googleCallbackFromIp('198.51.100.82', 0);
+    expect(sameIpCallback.status).toBe(302);
+  });
+
+  it('1h. keys Google OAuth start limits by trusted CloudFront/Fly client IP', async () => {
+    enableInMemoryGoogleOAuthLimiter();
+    const originSecret = 'cloudfront-origin-secret'.repeat(2);
+    process.env.ORIGIN_SHARED_SECRET = originSecret;
+
+    const trustedHeaders = {
+      'X-Origin-Secret': originSecret,
+      'X-Forwarded-For': '192.0.2.99, 198.51.100.84, 203.0.113.20',
+    };
+    const spoofedHeaders = {
+      'X-Origin-Secret': originSecret,
+      'X-Forwarded-For': '192.0.2.100, 198.51.100.84, 203.0.113.21',
+    };
+
+    for (let i = 0; i < 10; i += 1) {
+      const res = await app.request('http://localhost:3000/auth/google/start', {
+        redirect: 'manual',
+        headers: trustedHeaders,
+      });
+      expect(res.status).toBe(302);
+    }
+
+    const sameTrustedClient = await app.request('http://localhost:3000/auth/google/start', {
+      redirect: 'manual',
+      headers: spoofedHeaders,
+    });
+    expect(sameTrustedClient.status).toBe(429);
   });
 });
 


### PR DESCRIPTION
## Summary
- add shared rate-limit policies for Google OAuth start and callback routes
- enforce per-trusted-IP limits before PKCE generation or callback work
- emit structured, PII-safe denial logs and keep rate-limit denials out of `oauth_audit_log`
- document the OAuth route limits in security and production operations docs

## Validation
- `npm test -- test/auth-google.test.ts` (red before implementation, green after)
- `npm test -- test/rate-limit.test.ts`
- `npm test -- test/deployment-operations-docs.test.ts`
- `npm run check`

Fixes SQR-76


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rate limiting to Google OAuth endpoints: 10 requests/minute for login initiation and 20 requests/minute for callback processing, per IP address. Rate-limited requests return HTTP 429 with retry guidance.

* **Documentation**
  * Updated security and operations documentation with OAuth rate-limiting configuration and response behavior.

* **Tests**
  * Added test coverage for OAuth rate-limiting functionality across multiple IP scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->