### PR TITLE
feat: add shared GH2 game id helpers

### DIFF
--- a/src/extracted-data.ts
+++ b/src/extracted-data.ts
@@ -16,6 +16,7 @@ import { getTableColumns, sql } from 'drizzle-orm';
 import type { PgTable } from 'drizzle-orm/pg-core';
 
 import { getDb } from './db.ts';
+import { DEFAULT_GAME_ID } from './game.ts';
 import {
   cardBattleGoals,
   cardBuildings,
@@ -184,7 +185,7 @@ function relaxedConditionSearchQuery(query: string): string | null {
 export async function load(type: CardType, opts: LoadOpts = {}): Promise<ExtractedRecord[]> {
   const { db } = getDb();
   const table = TYPE_TO_TABLE[type];
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
 
   const rows = await db.execute<Record<string, unknown>>(
     sql`SELECT ${visibleSelectList(table)} FROM ${table} WHERE game = ${game} ORDER BY source_id`,
@@ -206,7 +207,7 @@ export async function loadOne(
 ): Promise<ExtractedRecord | null> {
   const { db } = getDb();
   const table = TYPE_TO_TABLE[type];
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
 
   const rows = await db.execute<Record<string, unknown>>(
     sql`SELECT ${visibleSelectList(table)} FROM ${table}
@@ -229,7 +230,7 @@ export async function loadOne(
  */
 export async function countsByType(opts: LoadOpts = {}): Promise<Record<CardType, number>> {
   const { db } = getDb();
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
 
   const branches = TYPES.map(
     (type) => sql`
@@ -262,7 +263,7 @@ export async function searchExtractedRanked(
   opts: LoadOpts = {},
 ): Promise<Array<{ record: ExtractedRecord; score: number }>> {
   const { db } = getDb();
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
   const relaxedQuery = relaxedConditionSearchQuery(query);
   const queries = relaxedQuery ? [query, relaxedQuery] : [query];
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,0 +1,103 @@
+import { basename } from 'node:path';
+
+export const FROSTHAVEN_GAME_ID = 'frosthaven';
+export const GLOOMHAVEN_2E_GAME_ID = 'gloomhaven-2e';
+export const DEFAULT_GAME_ID = FROSTHAVEN_GAME_ID;
+
+export const SUPPORTED_GAME_IDS = [FROSTHAVEN_GAME_ID, GLOOMHAVEN_2E_GAME_ID] as const;
+
+export type GameId = (typeof SUPPORTED_GAME_IDS)[number];
+
+export interface GameDefinition {
+  id: GameId;
+  label: string;
+  default: boolean;
+  sourcePrefix: string;
+  aliases: string[];
+}
+
+export const SUPPORTED_GAMES: readonly GameDefinition[] = [
+  {
+    id: FROSTHAVEN_GAME_ID,
+    label: 'Frosthaven',
+    default: true,
+    sourcePrefix: 'fh',
+    aliases: ['fh', 'frost haven'],
+  },
+  {
+    id: GLOOMHAVEN_2E_GAME_ID,
+    label: 'Gloomhaven 2.0',
+    default: false,
+    sourcePrefix: 'gh2',
+    aliases: [
+      'gloomhaven-2',
+      'gloomhaven2',
+      'gloomhaven 2',
+      'gloomhaven 2.0',
+      'gloomhaven second edition',
+      'gloomhaven 2nd edition',
+      'gh2',
+      'gh2e',
+    ],
+  },
+];
+
+const GAME_IDS = new Set<string>(SUPPORTED_GAME_IDS);
+const GAME_BY_ID = new Map(SUPPORTED_GAMES.map((game) => [game.id, game]));
+const GAME_BY_ALIAS = new Map<string, GameId>();
+const GAME_BY_SOURCE_PREFIX = new Map(SUPPORTED_GAMES.map((game) => [game.sourcePrefix, game.id]));
+
+for (const game of SUPPORTED_GAMES) {
+  GAME_BY_ALIAS.set(normalizeAlias(game.id), game.id);
+  for (const alias of game.aliases) {
+    GAME_BY_ALIAS.set(normalizeAlias(alias), game.id);
+  }
+}
+
+function normalizeAlias(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, '-');
+}
+
+function supportedGameList(): string {
+  return SUPPORTED_GAME_IDS.map((id) => `"${id}"`).join(', ');
+}
+
+export function isGameId(value: string): value is GameId {
+  return GAME_IDS.has(value);
+}
+
+export function normalizeGameId(value: string): GameId | null {
+  return GAME_BY_ALIAS.get(normalizeAlias(value)) ?? null;
+}
+
+export function requireGameId(value: string): GameId {
+  const game = normalizeGameId(value);
+  if (game) return game;
+  throw new Error(
+    `Unsupported game id ${JSON.stringify(value)}. Expected one of ${supportedGameList()}.`,
+  );
+}
+
+export function gameDefinitionFor(game: GameId): GameDefinition {
+  const definition = GAME_BY_ID.get(game);
+  if (!definition) {
+    throw new Error(
+      `Unsupported game id ${JSON.stringify(game)}. Expected one of ${supportedGameList()}.`,
+    );
+  }
+  return definition;
+}
+
+export function gameIdFromSourceFilename(source: string): GameId {
+  const name = basename(source);
+  const prefix = name.toLowerCase().match(/^([a-z0-9]+)-/)?.[1];
+  const game = prefix ? GAME_BY_SOURCE_PREFIX.get(prefix) : undefined;
+  if (game) return game;
+  throw new Error(
+    `Cannot derive game id from source filename ${JSON.stringify(name)}. ` +
+      `Expected one of these prefixes: ${[...GAME_BY_SOURCE_PREFIX.keys()].join(', ')}.`,
+  );
+}

--- a/src/index-docs.ts
+++ b/src/index-docs.ts
@@ -19,6 +19,7 @@ import {
   getIndexedSourceHashes,
 } from './vector-store.ts';
 import type { IndexEntry } from './vector-store.ts';
+import { SUPPORTED_GAME_IDS, gameIdFromSourceFilename } from './game.ts';
 
 // Re-exported so seed / deployment workflows can reference the current value.
 export { EMBEDDING_VERSION } from './vector-store.ts';
@@ -224,25 +225,38 @@ async function extractText(pdfBytes: Buffer): Promise<string> {
 }
 
 export async function main(): Promise<void> {
-  const files = readdirSync(PDFS_DIR).filter((f) => f.endsWith('.pdf'));
+  const files = readdirSync(PDFS_DIR)
+    .filter((f) => f.endsWith('.pdf'))
+    .map((file) => ({ file, game: gameIdFromSourceFilename(file) }));
   console.log(`Found ${files.length} PDF(s) to index.`);
 
-  const indexedSourceHashes = await getIndexedSourceHashes();
-  const currentSources = new Set(files);
-  const removedSources = [...indexedSourceHashes.keys()].filter(
-    (source) => !currentSources.has(source),
-  );
-  if (removedSources.length > 0) {
-    const deleted = await deleteEntriesForSources(removedSources);
-    console.log(`Removed ${deleted} stale chunk(s) for ${removedSources.length} missing PDF(s).`);
+  const indexedSourceHashesByGame = new Map<string, Map<string, string | null>>();
+  for (const game of SUPPORTED_GAME_IDS) {
+    indexedSourceHashesByGame.set(game, await getIndexedSourceHashes(game));
+  }
+
+  for (const game of SUPPORTED_GAME_IDS) {
+    const indexedSourceHashes = indexedSourceHashesByGame.get(game) ?? new Map();
+    const currentSources = new Set(
+      files.filter((source) => source.game === game).map((source) => source.file),
+    );
+    const removedSources = [...indexedSourceHashes.keys()].filter(
+      (source) => !currentSources.has(source),
+    );
+    if (removedSources.length > 0) {
+      const deleted = await deleteEntriesForSources(removedSources, game);
+      console.log(
+        `Removed ${deleted} stale chunk(s) for ${removedSources.length} missing ${game} PDF(s).`,
+      );
+    }
   }
 
   const allNewEntries: IndexEntry[] = [];
 
-  for (const file of files) {
+  for (const { file, game } of files) {
     const pdfBytes = readFileSync(join(PDFS_DIR, file));
     const contentHash = computeContentHash(pdfBytes);
-    const indexedHash = indexedSourceHashes.get(file);
+    const indexedHash = indexedSourceHashesByGame.get(game)?.get(file);
 
     if (indexedHash === contentHash) {
       console.log(`  Skipping (unchanged): ${file}`);
@@ -250,7 +264,7 @@ export async function main(): Promise<void> {
     }
 
     if (indexedHash !== undefined) {
-      const deleted = await deleteEntriesForSources([file]);
+      const deleted = await deleteEntriesForSources([file], game);
       console.log(`  Re-indexing changed source: ${file} (${deleted} stale chunk(s) removed)`);
     }
 
@@ -270,6 +284,7 @@ export async function main(): Promise<void> {
           source: batch[j].source,
           chunkIndex: batch[j].chunkIndex,
           contentHash,
+          game,
           embedding: embeddings[j],
         });
       }

--- a/src/scenario-section-data.ts
+++ b/src/scenario-section-data.ts
@@ -8,6 +8,7 @@
 import { sql } from 'drizzle-orm';
 
 import { getDb } from './db.ts';
+import { DEFAULT_GAME_ID } from './game.ts';
 import {
   bookReferences,
   scenarioBookScenarios,
@@ -98,7 +99,7 @@ export async function findScenarios(
   opts: LoadOpts = {},
 ): Promise<ScenarioBookScenario[]> {
   const { db } = getDb();
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
   const normalized = query.trim();
   if (normalized.length === 0) return [];
   const lowered = normalized.toLowerCase();
@@ -148,7 +149,7 @@ export async function getScenario(
   opts: LoadOpts = {},
 ): Promise<ScenarioBookScenario | null> {
   const { db } = getDb();
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
 
   const rows = await db.execute<ScenarioBookScenario>(sql`
     SELECT
@@ -177,7 +178,7 @@ export async function getSection(
   opts: LoadOpts = {},
 ): Promise<SectionBookSection | null> {
   const { db } = getDb();
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
 
   const rows = await db.execute<SectionBookSection>(sql`
     SELECT
@@ -203,7 +204,7 @@ export async function searchSections(
   opts: LoadOpts = {},
 ): Promise<SectionBookSection[]> {
   const { db } = getDb();
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
   const normalized = query.trim();
   if (normalized.length === 0) return [];
   const likePattern = `%${normalized.toLowerCase()}%`;
@@ -237,7 +238,7 @@ export async function followReferences(
   opts: LoadOpts = {},
 ): Promise<BookReference[]> {
   const { db } = getDb();
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
   const referenceTypeClause = referenceType ? sql`AND link_type = ${referenceType}` : sql``;
 
   const rows = await db.execute<BookReference>(sql`
@@ -268,7 +269,7 @@ export async function findIncomingReferences(
   opts: LoadOpts = {},
 ): Promise<BookReference[]> {
   const { db } = getDb();
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
   const referenceTypeClause = referenceType ? sql`AND link_type = ${referenceType}` : sql``;
 
   const rows = await db.execute<BookReference>(sql`
@@ -296,7 +297,7 @@ export async function getScenarioSectionBooksBootstrapStatus(
   opts: LoadOpts = {},
 ): Promise<ScenarioSectionBooksBootstrapStatus> {
   const { db } = getDb();
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
 
   try {
     const rows = await db.execute<{

--- a/src/seed/seed-cards.ts
+++ b/src/seed/seed-cards.ts
@@ -27,6 +27,7 @@ import type { AnyPgColumn, PgTable } from 'drizzle-orm/pg-core';
 type CardTable = PgTable & { game: AnyPgColumn; sourceId: AnyPgColumn };
 
 import type { Db } from '../db.ts';
+import { DEFAULT_GAME_ID } from '../game.ts';
 import {
   cardBattleGoals,
   cardBuildings,
@@ -79,7 +80,7 @@ export interface SeedCardsResult {
  * Returns per-type counts so callers can print a summary.
  */
 export async function seedCards(db: Db, opts: SeedCardsOptions = {}): Promise<SeedCardsResult[]> {
-  const game = opts.game ?? 'frosthaven';
+  const game = opts.game ?? DEFAULT_GAME_ID;
   const types = opts.types ?? CARD_TYPES;
   const results: SeedCardsResult[] = [];
 

--- a/src/seed/seed-scenario-section-books.ts
+++ b/src/seed/seed-scenario-section-books.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 import { eq } from 'drizzle-orm';
 
 import type { Db } from '../db.ts';
+import { DEFAULT_GAME_ID, FROSTHAVEN_GAME_ID } from '../game.ts';
 import {
   bookReferences,
   scenarioBookScenarios,
@@ -48,8 +49,8 @@ export async function seedScenarioSectionBooks(
   db: Db,
   opts: SeedScenarioSectionBooksOptions = {},
 ): Promise<SeedScenarioSectionBooksResult[]> {
-  const game = opts.game ?? 'frosthaven';
-  if (game !== 'frosthaven') {
+  const game = opts.game ?? DEFAULT_GAME_ID;
+  if (game !== FROSTHAVEN_GAME_ID) {
     throw new Error(
       `seedScenarioSectionBooks currently supports only "frosthaven"; got ${JSON.stringify(game)}`,
     );

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -31,6 +31,7 @@ import {
   type BookReferenceType,
 } from './scenario-section-schemas.ts';
 import { DEFAULT_GAME_ID, SUPPORTED_GAMES, gameDefinitionFor, requireGameId } from './game.ts';
+import type { GameId } from './game.ts';
 
 // ─── Result types ────────────────────────────────────────────────────────────
 
@@ -249,6 +250,10 @@ interface ToolOpts {
   game?: string;
 }
 
+interface NormalizedToolOpts extends ToolOpts {
+  game: GameId;
+}
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /** Strip internal `_*` marker keys from a card record. */
@@ -266,6 +271,14 @@ const GAME_INFO = SUPPORTED_GAMES.map(({ id, label, default: isDefault }) => ({
   label,
   default: isDefault,
 }));
+
+function normalizeToolGame(game?: string): GameId {
+  return requireGameId(game ?? DEFAULT_GAME);
+}
+
+function normalizeToolOpts(opts?: ToolOpts): NormalizedToolOpts {
+  return { ...opts, game: normalizeToolGame(opts?.game) };
+}
 
 const CARD_KIND_ALIASES: Record<string, CardType[]> = {
   item: ['items'],
@@ -492,14 +505,15 @@ async function resolveCards(
 ): Promise<EntityCandidate[]> {
   if (query.trim() === '') return [];
 
-  const game = opts.game ?? DEFAULT_GAME;
+  const normalizedOpts = normalizeToolOpts(opts);
+  const game = normalizedOpts.game;
   const level = extractLevelQuery(query);
   const lowered = query.toLowerCase();
   const candidates: EntityCandidate[] = [];
   const exactItemNumber = cardTypes.includes('items') ? extractExactItemNumberQuery(query) : null;
 
   for (const type of cardTypes) {
-    const records = await load(type, opts);
+    const records = await load(type, normalizedOpts);
     for (const rawRecord of records) {
       const record = stripInternalKeys(rawRecord);
       if (level !== null && record.level !== level) continue;
@@ -553,7 +567,7 @@ async function resolveCards(
   }
 
   if (candidates.length === 0) {
-    const ranked = await searchExtractedRanked(query, limit, opts);
+    const ranked = await searchExtractedRanked(query, limit, normalizedOpts);
     for (const { record } of ranked) {
       if (!cardTypes.includes(record._type)) continue;
       const stripped = stripInternalKeys(record);
@@ -615,9 +629,11 @@ function gameQualifiedRef(
   ref: string,
   prefix: 'scenario' | 'section',
   fallbackGame = DEFAULT_GAME,
-): { game: string; ref: string } {
+): { game: GameId; ref: string } {
   const match = ref.match(new RegExp(`^${prefix}:([^/]+)/(.+)$`));
-  return match ? { game: match[1], ref: match[2] } : { game: fallbackGame, ref };
+  return match
+    ? { game: normalizeToolGame(match[1]), ref: match[2] }
+    : { game: normalizeToolGame(fallbackGame), ref };
 }
 
 function canonicalSectionRef(ref: string, game = DEFAULT_GAME): string {
@@ -718,18 +734,28 @@ function citationForCard(
 
 function parseRulesRef(
   ref: string,
-): { ok: true; game: string; source: string; chunkIndex: number } | { ok: false } {
+): { ok: true; game: GameId; source: string; chunkIndex: number } | { ok: false } {
   const match = ref.match(/^rules:([^/]+)\/(.+)#chunk=(\d+)$/);
   if (!match) return { ok: false };
-  return { ok: true, game: match[1], source: match[2], chunkIndex: Number(match[3]) };
+  return {
+    ok: true,
+    game: normalizeToolGame(match[1]),
+    source: match[2],
+    chunkIndex: Number(match[3]),
+  };
 }
 
 function parseCardRef(
   ref: string,
-): { ok: true; game: string; type: CardType; sourceId: string } | { ok: false } {
+): { ok: true; game: GameId; type: CardType; sourceId: string } | { ok: false } {
   const match = ref.match(/^card:([^/]+)\/([^/]+)\/(.+)$/);
   if (match && TYPES.includes(match[2] as CardType)) {
-    return { ok: true, game: match[1], type: match[2] as CardType, sourceId: match[3] };
+    return {
+      ok: true,
+      game: normalizeToolGame(match[1]),
+      type: match[2] as CardType,
+      sourceId: match[3],
+    };
   }
 
   const sourceIdMatch = ref.match(/^gloomhavensecretariat:([^/]+)\/(.+)$/);
@@ -775,8 +801,9 @@ async function linksFor(
   ref: string,
   opts?: ToolOpts,
 ): Promise<KnowledgeLink[]> {
-  const game = opts?.game ?? DEFAULT_GAME;
-  const links = await followLinks(kind, ref, undefined, opts);
+  const normalizedOpts = normalizeToolOpts(opts);
+  const game = normalizedOpts.game;
+  const links = await followLinks(kind, ref, undefined, normalizedOpts);
   return Promise.all(
     links.map(async (link) => ({
       relation: link.linkType,
@@ -799,7 +826,8 @@ async function linksFor(
  */
 export async function searchRules(query: string, topK = 6, opts?: ToolOpts): Promise<RuleResult[]> {
   const queryEmbedding = await embed(query);
-  const hits: ScoredEntry[] = await search(queryEmbedding, topK, { game: opts?.game });
+  const { game } = normalizeToolOpts(opts);
+  const hits: ScoredEntry[] = await search(queryEmbedding, topK, { game });
 
   return hits.map((h) => ({
     text: h.text,
@@ -814,7 +842,7 @@ export async function searchRules(query: string, topK = 6, opts?: ToolOpts): Pro
  * Returns structured results with card type, data, and `ts_rank` score.
  */
 export async function searchCards(query: string, topK = 6, opts?: ToolOpts): Promise<CardResult[]> {
-  const ranked = await searchExtractedRanked(query, topK, opts);
+  const ranked = await searchExtractedRanked(query, topK, normalizeToolOpts(opts));
   return ranked.map(({ record, score }) => {
     const { _type, ...rest } = record;
     return {
@@ -833,7 +861,7 @@ export async function searchCards(query: string, topK = 6, opts?: ToolOpts): Pro
  */
 export async function listCardTypes(opts?: ToolOpts): Promise<CardTypeInfo[]> {
   // Single UNION ALL of `count(*)` per type instead of N full-table scans.
-  const counts = await countsByType(opts);
+  const counts = await countsByType(normalizeToolOpts(opts));
   return TYPES.map((type) => ({ type, count: counts[type] }));
 }
 
@@ -846,7 +874,7 @@ export async function listCards(
   filter?: Record<string, unknown>,
   opts?: ToolOpts,
 ): Promise<Record<string, unknown>[]> {
-  let records = await load(type, opts);
+  let records = await load(type, normalizeToolOpts(opts));
 
   if (filter) {
     records = records.filter((record) =>
@@ -858,7 +886,7 @@ export async function listCards(
 }
 
 export async function inspectSources(opts?: ToolOpts): Promise<InspectSourcesResult> {
-  const game = requireGameId(opts?.game ?? DEFAULT_GAME);
+  const game = normalizeToolGame(opts?.game);
   const gameDefinition = gameDefinitionFor(game);
   const [cardCounts, scenarioSectionStatus] = await Promise.all([
     countsByType({ game }),
@@ -924,6 +952,7 @@ export async function resolveEntity(
   query: string,
   options: EntityResolutionOptions = {},
 ): Promise<EntityResolutionResult> {
+  const normalizedOptions = normalizeToolOpts(options);
   const validation = validateKinds(options.kinds);
   if (!validation.ok) {
     return {
@@ -935,7 +964,7 @@ export async function resolveEntity(
     };
   }
 
-  const game = options.game ?? DEFAULT_GAME;
+  const game = normalizedOptions.game;
   const limit = Math.min(Math.max(options.limit ?? 6, 1), 20);
   const candidates: EntityCandidate[] = [];
   const kinds = validation.kinds;
@@ -1001,7 +1030,7 @@ export async function resolveEntity(
 
   if (kinds.includes('card')) {
     candidates.push(
-      ...(await resolveCards(query, cardTypesForKinds(options.kinds), limit, { game })),
+      ...(await resolveCards(query, cardTypesForKinds(options.kinds), limit, normalizedOptions)),
     );
   }
 
@@ -1031,21 +1060,21 @@ export async function getCard(
 ): Promise<Record<string, unknown> | null> {
   // Indexed single-row lookup via `loadOne` — hits the `(game, source_id)`
   // unique index instead of loading every row and scanning client-side.
-  const match = await loadOne(type, id, opts);
+  const match = await loadOne(type, id, normalizeToolOpts(opts));
   if (!match) return null;
   return stripInternalKeys(match);
 }
 
 export async function findScenario(query: string, opts?: ToolOpts): Promise<ScenarioResult[]> {
-  return findScenarios(query, 6, opts);
+  return findScenarios(query, 6, normalizeToolOpts(opts));
 }
 
 export async function getScenario(ref: string, opts?: ToolOpts): Promise<ScenarioResult | null> {
-  return loadScenario(scenarioStorageRef(ref), opts);
+  return loadScenario(scenarioStorageRef(ref), normalizeToolOpts(opts));
 }
 
 export async function getSection(ref: string, opts?: ToolOpts): Promise<SectionResult | null> {
-  return loadSection(sectionStorageRef(ref), opts);
+  return loadSection(sectionStorageRef(ref), normalizeToolOpts(opts));
 }
 
 export async function searchSections(
@@ -1053,7 +1082,7 @@ export async function searchSections(
   limit = 6,
   opts?: ToolOpts,
 ): Promise<SectionResult[]> {
-  return loadSections(query, limit, opts);
+  return loadSections(query, limit, normalizeToolOpts(opts));
 }
 
 export async function followLinks(
@@ -1064,7 +1093,7 @@ export async function followLinks(
 ): Promise<ReferenceResult[]> {
   const normalizedRef =
     fromKind === 'scenario' ? scenarioStorageRef(fromRef) : sectionStorageRef(fromRef);
-  return loadReferences(fromKind, normalizedRef, linkType, opts);
+  return loadReferences(fromKind, normalizedRef, linkType, normalizeToolOpts(opts));
 }
 
 export async function incomingLinks(
@@ -1075,11 +1104,11 @@ export async function incomingLinks(
 ): Promise<ReferenceResult[]> {
   const normalizedRef =
     toKind === 'scenario' ? scenarioStorageRef(toRef) : sectionStorageRef(toRef);
-  return loadIncomingReferences(toKind, normalizedRef, linkType, opts);
+  return loadIncomingReferences(toKind, normalizedRef, linkType, normalizeToolOpts(opts));
 }
 
 export async function openEntity(ref: string, opts?: ToolOpts): Promise<KnowledgeOpenResult> {
-  const game = opts?.game ?? DEFAULT_GAME;
+  const game = normalizeToolGame(opts?.game);
 
   if (/^\d+$/.test(ref.trim())) {
     return {
@@ -1219,7 +1248,7 @@ export async function searchKnowledge(
   query: string,
   options: SearchKnowledgeOptions = {},
 ): Promise<KnowledgeSearchResult> {
-  const game = options.game ?? DEFAULT_GAME;
+  const game = normalizeToolGame(options.game);
   const scope = options.scope ?? ['rules_passage', 'scenario', 'section', 'card'];
   const limit = Math.min(Math.max(options.limit ?? 6, 1), 20);
   const allowed = new Set<KnowledgeEntityKind>(['rules_passage', 'scenario', 'section', 'card']);
@@ -1328,7 +1357,7 @@ export async function neighbors(
   ref: string,
   options: NeighborsOptions = {},
 ): Promise<KnowledgeNeighborsResult> {
-  const game = options.game ?? DEFAULT_GAME;
+  const game = normalizeToolGame(options.game);
   const relation = options.relation;
   if (relation && !BOOK_REFERENCE_TYPES.includes(relation)) {
     return {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -30,6 +30,7 @@ import {
   type BookRecordKind,
   type BookReferenceType,
 } from './scenario-section-schemas.ts';
+import { DEFAULT_GAME_ID, SUPPORTED_GAMES, gameDefinitionFor, requireGameId } from './game.ts';
 
 // ─── Result types ────────────────────────────────────────────────────────────
 
@@ -259,8 +260,12 @@ function stripInternalKeys(record: Record<string, unknown>): Record<string, unkn
   return out;
 }
 
-const DEFAULT_GAME = 'frosthaven';
-const GAME_INFO = { id: DEFAULT_GAME, label: 'Frosthaven', default: true };
+const DEFAULT_GAME = DEFAULT_GAME_ID;
+const GAME_INFO = SUPPORTED_GAMES.map(({ id, label, default: isDefault }) => ({
+  id,
+  label,
+  default: isDefault,
+}));
 
 const CARD_KIND_ALIASES: Record<string, CardType[]> = {
   item: ['items'],
@@ -853,7 +858,8 @@ export async function listCards(
 }
 
 export async function inspectSources(opts?: ToolOpts): Promise<InspectSourcesResult> {
-  const game = opts?.game ?? DEFAULT_GAME;
+  const game = requireGameId(opts?.game ?? DEFAULT_GAME);
+  const gameDefinition = gameDefinitionFor(game);
   const [cardCounts, scenarioSectionStatus] = await Promise.all([
     countsByType({ game }),
     getScenarioSectionBooksBootstrapStatus({ game }),
@@ -861,11 +867,11 @@ export async function inspectSources(opts?: ToolOpts): Promise<InspectSourcesRes
 
   return {
     ok: true,
-    games: [GAME_INFO],
+    games: GAME_INFO,
     sources: [
       {
         ref: `source:${game}/rulebook`,
-        label: 'Frosthaven Rulebook',
+        label: `${gameDefinition.label} Rulebook`,
         kinds: ['rules_passage'],
         searchable: true,
         openable: false,

--- a/src/vector-store.ts
+++ b/src/vector-store.ts
@@ -18,6 +18,7 @@ import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import { getDb } from './db.ts';
 import { embeddings as embeddingsTable } from './db/schema/core.ts';
+import { DEFAULT_GAME_ID } from './game.ts';
 
 export interface IndexEntry {
   id: string;
@@ -55,7 +56,7 @@ export interface SearchOptions {
  */
 export const EMBEDDING_VERSION = 'xenova-minilm-l6-v2.v1';
 
-const DEFAULT_GAME = 'frosthaven';
+const DEFAULT_GAME = DEFAULT_GAME_ID;
 
 /**
  * Ensure the HNSW cosine index exists on `embeddings.embedding`.

--- a/test/game.test.ts
+++ b/test/game.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FROSTHAVEN_GAME_ID,
+  GLOOMHAVEN_2E_GAME_ID,
+  gameIdFromSourceFilename,
+  normalizeGameId,
+  requireGameId,
+} from '../src/game.ts';
+
+describe('game id helpers', () => {
+  it('normalizes supported canonical ids', () => {
+    expect(normalizeGameId('frosthaven')).toBe(FROSTHAVEN_GAME_ID);
+    expect(normalizeGameId('gloomhaven-2e')).toBe(GLOOMHAVEN_2E_GAME_ID);
+  });
+
+  it('centralizes accepted aliases for Gloomhaven 2.0', () => {
+    const aliases = [
+      'gloomhaven-2',
+      'gloomhaven2',
+      'gloomhaven 2',
+      'gloomhaven 2.0',
+      'gloomhaven second edition',
+      'gloomhaven 2nd edition',
+      'gh2',
+      'gh2e',
+    ];
+
+    for (const alias of aliases) {
+      expect(normalizeGameId(alias), alias).toBe(GLOOMHAVEN_2E_GAME_ID);
+    }
+  });
+
+  it('returns null for unsupported aliases and throws clearly when required', () => {
+    expect(normalizeGameId('jaws of the lion')).toBeNull();
+    expect(() => requireGameId('jaws of the lion')).toThrow(
+      'Unsupported game id "jaws of the lion"',
+    );
+  });
+
+  it('derives the game id from deterministic source filename prefixes', () => {
+    expect(gameIdFromSourceFilename('fh-rule-book.pdf')).toBe(FROSTHAVEN_GAME_ID);
+    expect(gameIdFromSourceFilename('/tmp/data/pdfs/gh2-rule-book.pdf')).toBe(
+      GLOOMHAVEN_2E_GAME_ID,
+    );
+  });
+
+  it('rejects source filenames without a supported game prefix', () => {
+    expect(() => gameIdFromSourceFilename('rule-book.pdf')).toThrow(
+      'Cannot derive game id from source filename "rule-book.pdf"',
+    );
+  });
+});

--- a/test/index-docs.test.ts
+++ b/test/index-docs.test.ts
@@ -294,10 +294,14 @@ describe('main', () => {
 
   it('skips unchanged files already in the index', async () => {
     const pdfBytes = Buffer.from('same pdf bytes');
-    mockReaddirSync.mockReturnValue(['rulebook.pdf']);
+    mockReaddirSync.mockReturnValue(['fh-rulebook.pdf']);
     mockReadFileSync.mockReturnValue(pdfBytes);
-    mockGetIndexedSourceHashes.mockResolvedValue(
-      new Map([['rulebook.pdf', computeContentHash(pdfBytes)]]),
+    mockGetIndexedSourceHashes.mockImplementation((game: string) =>
+      Promise.resolve(
+        game === 'frosthaven'
+          ? new Map([['fh-rulebook.pdf', computeContentHash(pdfBytes)]])
+          : new Map<string, string | null>(),
+      ),
     );
 
     await main();
@@ -310,7 +314,7 @@ describe('main', () => {
 
   it('processes new PDF files', async () => {
     const longText = 'A'.repeat(900);
-    mockReaddirSync.mockReturnValue(['newfile.pdf']);
+    mockReaddirSync.mockReturnValue(['gh2-newfile.pdf']);
     mockReadFileSync.mockReturnValue(Buffer.from('pdf'));
     mockPdfParse.mockResolvedValue({ text: longText });
     mockGetIndexedSourceHashes.mockResolvedValue(new Map<string, string | null>());
@@ -324,43 +328,55 @@ describe('main', () => {
 
     const newEntries = mockAddEntries.mock.calls[0][0];
     expect(newEntries.length).toBeGreaterThan(0);
-    expect(newEntries[0].source).toBe('newfile.pdf');
+    expect(newEntries[0].source).toBe('gh2-newfile.pdf');
+    expect(newEntries[0].game).toBe('gloomhaven-2e');
     expect(newEntries[0].contentHash).toBe(computeContentHash(Buffer.from('pdf')));
     expect(newEntries[0].embedding).toEqual([0.1, 0.2]);
   });
 
   it('reindexes changed PDF files with the same filename', async () => {
     const longText = 'B'.repeat(900);
-    mockReaddirSync.mockReturnValue(['changed.pdf']);
+    mockReaddirSync.mockReturnValue(['fh-changed.pdf']);
     mockReadFileSync.mockReturnValue(Buffer.from('changed pdf bytes'));
     mockPdfParse.mockResolvedValue({ text: longText });
-    mockGetIndexedSourceHashes.mockResolvedValue(new Map([['changed.pdf', 'old-hash']]));
+    mockGetIndexedSourceHashes.mockImplementation((game: string) =>
+      Promise.resolve(
+        game === 'frosthaven'
+          ? new Map([['fh-changed.pdf', 'old-hash']])
+          : new Map<string, string | null>(),
+      ),
+    );
     mockEmbedBatch.mockResolvedValue([[0.3, 0.4]]);
 
     await main();
 
-    expect(mockDeleteEntriesForSources).toHaveBeenCalledWith(['changed.pdf']);
+    expect(mockDeleteEntriesForSources).toHaveBeenCalledWith(['fh-changed.pdf'], 'frosthaven');
     expect(mockPdfParse).toHaveBeenCalledOnce();
     expect(mockEmbedBatch).toHaveBeenCalledOnce();
     const newEntries = mockAddEntries.mock.calls[0][0];
-    expect(newEntries[0].source).toBe('changed.pdf');
+    expect(newEntries[0].source).toBe('fh-changed.pdf');
+    expect(newEntries[0].game).toBe('frosthaven');
     expect(newEntries[0].contentHash).toBe(computeContentHash(Buffer.from('changed pdf bytes')));
   });
 
   it('deletes embedding rows for PDFs that no longer exist', async () => {
-    mockReaddirSync.mockReturnValue(['kept.pdf']);
+    mockReaddirSync.mockReturnValue(['fh-kept.pdf']);
     const keptBytes = Buffer.from('kept pdf bytes');
     mockReadFileSync.mockReturnValue(keptBytes);
-    mockGetIndexedSourceHashes.mockResolvedValue(
-      new Map([
-        ['kept.pdf', computeContentHash(keptBytes)],
-        ['removed.pdf', 'removed-hash'],
-      ]),
+    mockGetIndexedSourceHashes.mockImplementation((game: string) =>
+      Promise.resolve(
+        game === 'frosthaven'
+          ? new Map([
+              ['fh-kept.pdf', computeContentHash(keptBytes)],
+              ['fh-removed.pdf', 'removed-hash'],
+            ])
+          : new Map<string, string | null>(),
+      ),
     );
 
     await main();
 
-    expect(mockDeleteEntriesForSources).toHaveBeenCalledWith(['removed.pdf']);
+    expect(mockDeleteEntriesForSources).toHaveBeenCalledWith(['fh-removed.pdf'], 'frosthaven');
     expect(mockPdfParse).not.toHaveBeenCalled();
     expect(mockEmbedBatch).not.toHaveBeenCalled();
     expect(mockAddEntries).not.toHaveBeenCalled();
@@ -376,8 +392,12 @@ describe('main', () => {
     ]);
     mockReadFileSync.mockImplementation((path) => Buffer.from(String(path)));
     mockPdfParse.mockResolvedValue({ text: longText });
-    mockGetIndexedSourceHashes.mockResolvedValue(
-      new Map([['fh-rule-book.pdf', computeContentHash(Buffer.from(rulebookPath))]]),
+    mockGetIndexedSourceHashes.mockImplementation((game: string) =>
+      Promise.resolve(
+        game === 'frosthaven'
+          ? new Map([['fh-rule-book.pdf', computeContentHash(Buffer.from(rulebookPath))]])
+          : new Map<string, string | null>(),
+      ),
     );
     mockEmbedBatch.mockResolvedValue([[0.1, 0.2]]);
 
@@ -389,6 +409,19 @@ describe('main', () => {
       'fh-scenario-book-42-61.pdf',
       'fh-section-book-62-81.pdf',
     ]);
+    expect(new Set(newEntries.map((entry: { game: string }) => entry.game))).toEqual(
+      new Set(['frosthaven']),
+    );
+  });
+
+  it('fails clearly for PDFs without a supported game prefix', async () => {
+    mockReaddirSync.mockReturnValue(['rule-book.pdf']);
+
+    await expect(main()).rejects.toThrow(
+      'Cannot derive game id from source filename "rule-book.pdf"',
+    );
+    expect(mockGetIndexedSourceHashes).not.toHaveBeenCalled();
+    expect(mockAddEntries).not.toHaveBeenCalled();
   });
 
   it('logs nothing new for empty docs directory', async () => {

--- a/test/seed/seed-scenario-section-books.test.ts
+++ b/test/seed/seed-scenario-section-books.test.ts
@@ -9,6 +9,7 @@ import {
   sectionBookSections,
   bookReferences,
 } from '../../src/db/schema/scenario-section-books.ts';
+import { GLOOMHAVEN_2E_GAME_ID } from '../../src/game.ts';
 import { seedScenarioSectionBooks } from '../../src/seed/seed-scenario-section-books.ts';
 import { ScenarioSectionBooksExtractSchema } from '../../src/scenario-section-schemas.ts';
 
@@ -110,7 +111,7 @@ describe('seedScenarioSectionBooks', () => {
   });
 
   it('rejects unsupported game seeds until the extract is game-aware', async () => {
-    await expect(seedScenarioSectionBooks(db, { game: 'gloomhaven-2' })).rejects.toThrow(
+    await expect(seedScenarioSectionBooks(db, { game: GLOOMHAVEN_2E_GAME_ID })).rejects.toThrow(
       'seedScenarioSectionBooks currently supports only "frosthaven"',
     );
   });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -148,12 +148,12 @@ describe('searchRules', () => {
     }
   });
 
-  it('threads opts.game through to the vector store', async () => {
+  it('normalizes opts.game before searching the vector store', async () => {
     mockSearch.mockClear();
-    await searchRules('loot', 3, { game: 'gloomhaven' });
+    await searchRules('loot', 3, { game: 'gh2' });
     expect(mockSearch).toHaveBeenCalledTimes(1);
     const callArgs = mockSearch.mock.calls[0];
-    expect(callArgs[2]).toEqual({ game: 'gloomhaven' });
+    expect(callArgs[2]).toEqual({ game: GLOOMHAVEN_2E_GAME_ID });
   });
 });
 
@@ -625,6 +625,26 @@ describe('knowledge discovery tools', () => {
             'monster-stats': expect.any(Number),
             'character-abilities': expect.any(Number),
           }),
+        }),
+      ]),
+    );
+  });
+
+  it('inspectSources accepts game aliases and reports canonical source refs', async () => {
+    const result = await inspectSources({ game: 'gh2' });
+
+    expect(result.ok).toBe(true);
+    expect(result.sources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ref: `source:${GLOOMHAVEN_2E_GAME_ID}/rulebook`,
+          label: 'Gloomhaven 2.0 Rulebook',
+        }),
+        expect.objectContaining({
+          ref: `source:${GLOOMHAVEN_2E_GAME_ID}/scenario-section-books`,
+        }),
+        expect.objectContaining({
+          ref: `source:${GLOOMHAVEN_2E_GAME_ID}/cards`,
         }),
       ]),
     );

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -56,6 +56,7 @@ import type {
 import { findScenarios } from '../src/scenario-section-data.ts';
 import { getDb } from '../src/db.ts';
 import { scenarioBookScenarios } from '../src/db/schema/scenario-section-books.ts';
+import { GLOOMHAVEN_2E_GAME_ID } from '../src/game.ts';
 
 import { setupTestDb, teardownTestDb } from './helpers/db.ts';
 
@@ -594,7 +595,10 @@ describe('knowledge discovery tools', () => {
 
     expect(result.ok).toBe(true);
     expect(result.defaultGame).toBe('frosthaven');
-    expect(result.games).toEqual([{ id: 'frosthaven', label: 'Frosthaven', default: true }]);
+    expect(result.games).toEqual([
+      { id: 'frosthaven', label: 'Frosthaven', default: true },
+      { id: GLOOMHAVEN_2E_GAME_ID, label: 'Gloomhaven 2.0', default: false },
+    ]);
     expect(result.sources).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/test/vector-store.test.ts
+++ b/test/vector-store.test.ts
@@ -20,6 +20,7 @@ import { sql } from 'drizzle-orm';
 import { beforeAll, beforeEach, afterAll, describe, expect, it } from 'vitest';
 
 import { embeddings as embeddingsTable } from '../src/db/schema/core.ts';
+import { GLOOMHAVEN_2E_GAME_ID } from '../src/game.ts';
 import {
   EMBEDDING_VERSION,
   addEntries,
@@ -120,11 +121,11 @@ describe('addEntries', () => {
         embedding: axisVector(0),
         source: 'gh2.pdf',
         chunkIndex: 0,
-        game: 'gloomhaven-2',
+        game: GLOOMHAVEN_2E_GAME_ID,
       },
     ]);
     const rows = await db.select().from(embeddingsTable);
-    expect(rows[0].game).toBe('gloomhaven-2');
+    expect(rows[0].game).toBe(GLOOMHAVEN_2E_GAME_ID);
   });
 
   it('handles an empty batch as a no-op', async () => {
@@ -158,11 +159,11 @@ describe('getIndexedSources', () => {
         embedding: axisVector(1),
         source: 'gh2.pdf',
         chunkIndex: 0,
-        game: 'gloomhaven-2',
+        game: GLOOMHAVEN_2E_GAME_ID,
       },
     ]);
     expect(await getIndexedSources('frosthaven')).toEqual(new Set(['fh.pdf']));
-    expect(await getIndexedSources('gloomhaven-2')).toEqual(new Set(['gh2.pdf']));
+    expect(await getIndexedSources(GLOOMHAVEN_2E_GAME_ID)).toEqual(new Set(['gh2.pdf']));
   });
 });
 
@@ -254,7 +255,7 @@ describe('deleteEntriesForSources', () => {
         embedding: axisVector(3),
         source: 'a.pdf',
         chunkIndex: 9,
-        game: 'gloomhaven-2',
+        game: GLOOMHAVEN_2E_GAME_ID,
       },
     ]);
 
@@ -269,7 +270,7 @@ describe('deleteEntriesForSources', () => {
     expect(remaining).toEqual(
       expect.arrayContaining([
         { id: 'b.pdf::0', game: 'frosthaven' },
-        { id: 'gh2-a.pdf::0', game: 'gloomhaven-2' },
+        { id: 'gh2-a.pdf::0', game: GLOOMHAVEN_2E_GAME_ID },
       ]),
     );
     expect(remaining).toHaveLength(2);
@@ -336,13 +337,13 @@ describe('search', () => {
         embedding: axisVector(0),
         source: 'gh2',
         chunkIndex: 0,
-        game: 'gloomhaven-2',
+        game: GLOOMHAVEN_2E_GAME_ID,
       },
     ]);
     const defaultHits = await search(axisVector(0), 10);
     expect(defaultHits.map((h) => h.id)).toEqual(['fh::0']);
 
-    const gh2Hits = await search(axisVector(0), 10, { game: 'gloomhaven-2' });
+    const gh2Hits = await search(axisVector(0), 10, { game: GLOOMHAVEN_2E_GAME_ID });
     expect(gh2Hits.map((h) => h.id)).toEqual(['gh2::0']);
   });
 


### PR DESCRIPTION
## Summary

- add shared game id metadata, alias normalization, and source-prefix derivation for Frosthaven and Gloomhaven 2.0
- use the shared default game id across indexing, vector/data access, seeders, and source inspection
- stamp indexed PDF chunks from `fh-*` and `gh2-*` filenames with the derived game id, and fail clearly for unsupported prefixes

## Review

- Pre-PR review against `origin/main`: no blockers found

## Validation

- `npm run check` passed: 83 files, 1208 tests
- End-to-end index smoke against local test DB:
  - temporary `fh-sqr-180-smoke.pdf` indexed as `game = "frosthaven"` with 5 chunks
  - temporary `gh2-sqr-180-smoke.pdf` indexed as `game = "gloomhaven-2e"` with 5 chunks
  - temporary PDFs and test DB smoke rows cleaned up after verification

Fixes SQR-180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class support for Gloomhaven 2E alongside Frosthaven and per-game selection across the product.
  * PDF indexing now organizes and indexes documents per game, and indexing fails with a clear error for unsupported filenames.

* **Improvements**
  * Centralized, game-aware defaults and normalization for consistent behavior across tools, search, seeding, and vector lookup.

* **Tests**
  * Expanded tests to cover game normalization, per-game indexing, and related workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->