### PR TITLE
fix(loaders): make extracted data loaders game-aware by default (SQR-182)

### DIFF
--- a/src/extracted-data.ts
+++ b/src/extracted-data.ts
@@ -16,7 +16,7 @@ import { getTableColumns, sql } from 'drizzle-orm';
 import type { PgTable } from 'drizzle-orm/pg-core';
 
 import { getDb } from './db.ts';
-import { DEFAULT_GAME_ID } from './game.ts';
+import { type GameLoadOpts, resolveGameId } from './game.ts';
 import {
   cardBattleGoals,
   cardBuildings,
@@ -50,10 +50,7 @@ interface ExtractedRecord extends Record<string, unknown> {
   _type: CardType;
 }
 
-interface LoadOpts {
-  /** Campaign variant. Defaults to 'frosthaven'. Reserved for Phase 2. */
-  game?: string;
-}
+export type LoadOpts = GameLoadOpts;
 
 // ─── Table registry ──────────────────────────────────────────────────────────
 
@@ -185,7 +182,7 @@ function relaxedConditionSearchQuery(query: string): string | null {
 export async function load(type: CardType, opts: LoadOpts = {}): Promise<ExtractedRecord[]> {
   const { db } = getDb();
   const table = TYPE_TO_TABLE[type];
-  const game = opts.game ?? DEFAULT_GAME_ID;
+  const game = resolveGameId(opts);
 
   const rows = await db.execute<Record<string, unknown>>(
     sql`SELECT ${visibleSelectList(table)} FROM ${table} WHERE game = ${game} ORDER BY source_id`,
@@ -207,7 +204,7 @@ export async function loadOne(
 ): Promise<ExtractedRecord | null> {
   const { db } = getDb();
   const table = TYPE_TO_TABLE[type];
-  const game = opts.game ?? DEFAULT_GAME_ID;
+  const game = resolveGameId(opts);
 
   const rows = await db.execute<Record<string, unknown>>(
     sql`SELECT ${visibleSelectList(table)} FROM ${table}
@@ -230,7 +227,7 @@ export async function loadOne(
  */
 export async function countsByType(opts: LoadOpts = {}): Promise<Record<CardType, number>> {
   const { db } = getDb();
-  const game = opts.game ?? DEFAULT_GAME_ID;
+  const game = resolveGameId(opts);
 
   const branches = TYPES.map(
     (type) => sql`
@@ -263,7 +260,7 @@ export async function searchExtractedRanked(
   opts: LoadOpts = {},
 ): Promise<Array<{ record: ExtractedRecord; score: number }>> {
   const { db } = getDb();
-  const game = opts.game ?? DEFAULT_GAME_ID;
+  const game = resolveGameId(opts);
   const relaxedQuery = relaxedConditionSearchQuery(query);
   const queries = relaxedQuery ? [query, relaxedQuery] : [query];
 
@@ -541,7 +538,7 @@ export function formatExtracted(records: ExtractedRecord[]): string {
 /**
  * Record counts across all 10 card tables. Single round-trip via a CTE.
  */
-export async function extractedStats(): Promise<string> {
-  const counts = await countsByType();
+export async function extractedStats(opts: LoadOpts = {}): Promise<string> {
+  const counts = await countsByType(opts);
   return TYPES.map((t) => `${t}: ${counts[t]}`).join(', ');
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -88,7 +88,7 @@ export interface GameLoadOpts {
 
 /** Resolve the active game for DB-backed loaders. Validates explicit ids. */
 export function resolveGameId(opts: GameLoadOpts = {}): GameId {
-  return opts.game ? requireGameId(opts.game) : DEFAULT_GAME_ID;
+  return opts.game !== undefined ? requireGameId(opts.game) : DEFAULT_GAME_ID;
 }
 
 export function gameDefinitionFor(game: GameId): GameDefinition {

--- a/src/game.ts
+++ b/src/game.ts
@@ -81,6 +81,16 @@ export function requireGameId(value: string): GameId {
   );
 }
 
+export interface GameLoadOpts {
+  /** Active game. Defaults to Frosthaven when omitted. */
+  game?: string;
+}
+
+/** Resolve the active game for DB-backed loaders. Validates explicit ids. */
+export function resolveGameId(opts: GameLoadOpts = {}): GameId {
+  return opts.game ? requireGameId(opts.game) : DEFAULT_GAME_ID;
+}
+
 export function gameDefinitionFor(game: GameId): GameDefinition {
   const definition = GAME_BY_ID.get(game);
   if (!definition) {

--- a/src/scenario-section-data.ts
+++ b/src/scenario-section-data.ts
@@ -8,7 +8,7 @@
 import { sql } from 'drizzle-orm';
 
 import { getDb } from './db.ts';
-import { DEFAULT_GAME_ID } from './game.ts';
+import { type GameLoadOpts, resolveGameId } from './game.ts';
 import {
   bookReferences,
   scenarioBookScenarios,
@@ -54,9 +54,7 @@ export interface BookReference extends Record<string, unknown> {
   sequence: number;
 }
 
-interface LoadOpts {
-  game?: string;
-}
+export type LoadOpts = GameLoadOpts;
 
 export interface ScenarioSectionBooksBootstrapStatus {
   ready: boolean;
@@ -99,7 +97,7 @@ export async function findScenarios(
   opts: LoadOpts = {},
 ): Promise<ScenarioBookScenario[]> {
   const { db } = getDb();
-  const game = opts.game ?? DEFAULT_GAME_ID;
+  const game = resolveGameId(opts);
   const normalized = query.trim();
   if (normalized.length === 0) return [];
   const lowered = normalized.toLowerCase();
@@ -149,7 +147,7 @@ export async function getScenario(
   opts: LoadOpts = {},
 ): Promise<ScenarioBookScenario | null> {
   const { db } = getDb();
-  const game = opts.game ?? DEFAULT_GAME_ID;
+  const game = resolveGameId(opts);
 
   const rows = await db.execute<ScenarioBookScenario>(sql`
     SELECT
@@ -178,7 +176,7 @@ export async function getSection(
   opts: LoadOpts = {},
 ): Promise<SectionBookSection | null> {
   const { db } = getDb();
-  const game = opts.game ?? DEFAULT_GAME_ID;
+  const game = resolveGameId(opts);
 
   const rows = await db.execute<SectionBookSection>(sql`
     SELECT
@@ -204,7 +202,7 @@ export async function searchSections(
   opts: LoadOpts = {},
 ): Promise<SectionBookSection[]> {
   const { db } = getDb();
-  const game = opts.game ?? DEFAULT_GAME_ID;
+  const game = resolveGameId(opts);
   const normalized = query.trim();
   if (normalized.length === 0) return [];
   const likePattern = `%${normalized.toLowerCase()}%`;
@@ -238,7 +236,7 @@ export async function followReferences(
   opts: LoadOpts = {},
 ): Promise<BookReference[]> {
   const { db } = getDb();
-  const game = opts.game ?? DEFAULT_GAME_ID;
+  const game = resolveGameId(opts);
   const referenceTypeClause = referenceType ? sql`AND link_type = ${referenceType}` : sql``;
 
   const rows = await db.execute<BookReference>(sql`
@@ -269,7 +267,7 @@ export async function findIncomingReferences(
   opts: LoadOpts = {},
 ): Promise<BookReference[]> {
   const { db } = getDb();
-  const game = opts.game ?? DEFAULT_GAME_ID;
+  const game = resolveGameId(opts);
   const referenceTypeClause = referenceType ? sql`AND link_type = ${referenceType}` : sql``;
 
   const rows = await db.execute<BookReference>(sql`
@@ -297,7 +295,7 @@ export async function getScenarioSectionBooksBootstrapStatus(
   opts: LoadOpts = {},
 ): Promise<ScenarioSectionBooksBootstrapStatus> {
   const { db } = getDb();
-  const game = opts.game ?? DEFAULT_GAME_ID;
+  const game = resolveGameId(opts);
 
   try {
     const rows = await db.execute<{

--- a/test/extracted-data.test.ts
+++ b/test/extracted-data.test.ts
@@ -13,6 +13,7 @@
  * Tests here are read-only against that shared seed, so we don't truncate
  * between files.
  */
+import { sql } from 'drizzle-orm';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -28,6 +29,7 @@ import {
   searchExtracted,
   searchExtractedRanked,
 } from '../src/extracted-data.ts';
+import { FROSTHAVEN_GAME_ID, GLOOMHAVEN_2E_GAME_ID } from '../src/game.ts';
 import type { CardType } from '../src/schemas.ts';
 
 import { setupTestDb, teardownTestDb } from './helpers/db.ts';
@@ -105,9 +107,10 @@ describe('load', () => {
     }
   });
 
-  it('returns an empty array for an unknown game', async () => {
-    const rows = await load('items', { game: 'no-such-game' });
-    expect(rows).toEqual([]);
+  it('rejects unknown game ids', async () => {
+    await expect(load('items', { game: 'no-such-game' })).rejects.toThrow(
+      'Unsupported game id "no-such-game"',
+    );
   });
 });
 
@@ -334,6 +337,72 @@ describe('extractedStats', () => {
     for (const t of TYPES) {
       expect(summary).toContain(`${t}:`);
     }
+  });
+});
+
+const GH2_ISOLATION_SOURCE_ID = 'gh2:test/isolation-monster';
+const GH2_ISOLATION_NAME = 'Zephyrix Gh2IsolationMarker';
+
+describe('game isolation', () => {
+  beforeAll(async () => {
+    const db = await setupTestDb();
+    await db.execute(sql`
+      INSERT INTO card_monster_stats (game, source_id, name, level_range, normal, elite, immunities)
+      VALUES (
+        ${GLOOMHAVEN_2E_GAME_ID},
+        ${GH2_ISOLATION_SOURCE_ID},
+        ${GH2_ISOLATION_NAME},
+        '0-3',
+        ${JSON.stringify({ 0: { hp: 1, move: 1, attack: 1 } })}::jsonb,
+        ${JSON.stringify({ 0: { hp: 2, move: 2, attack: 2 } })}::jsonb,
+        ARRAY[]::text[]
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    const db = await setupTestDb();
+    await db.execute(sql`
+      DELETE FROM card_monster_stats
+      WHERE game = ${GLOOMHAVEN_2E_GAME_ID} AND source_id = ${GH2_ISOLATION_SOURCE_ID}
+    `);
+  });
+
+  it('defaults to Frosthaven rows when game is omitted', async () => {
+    const row = await loadOne('monster-stats', GH2_ISOLATION_SOURCE_ID);
+    expect(row).toBeNull();
+  });
+
+  it('does not return GH2 rows from Frosthaven load/search/count APIs', async () => {
+    const loaded = await load('monster-stats', { game: FROSTHAVEN_GAME_ID });
+    expect(loaded.some((row) => row.sourceId === GH2_ISOLATION_SOURCE_ID)).toBe(false);
+
+    const searched = await searchExtracted(GH2_ISOLATION_NAME, 6, { game: FROSTHAVEN_GAME_ID });
+    expect(searched).toEqual([]);
+
+    const counts = await countsByType({ game: FROSTHAVEN_GAME_ID });
+    const gh2Counts = await countsByType({ game: GLOOMHAVEN_2E_GAME_ID });
+    expect(counts['monster-stats']).toBeGreaterThan(0);
+    expect(gh2Counts['monster-stats']).toBe(1);
+  });
+
+  it('returns GH2 rows only for explicit Gloomhaven 2.0 queries', async () => {
+    const row = await loadOne('monster-stats', GH2_ISOLATION_SOURCE_ID, {
+      game: GLOOMHAVEN_2E_GAME_ID,
+    });
+    expect(row).toMatchObject({
+      _type: 'monster-stats',
+      sourceId: GH2_ISOLATION_SOURCE_ID,
+      name: GH2_ISOLATION_NAME,
+    });
+
+    const searched = await searchExtracted(GH2_ISOLATION_NAME, 6, {
+      game: GLOOMHAVEN_2E_GAME_ID,
+    });
+    expect(searched[0]?.sourceId).toBe(GH2_ISOLATION_SOURCE_ID);
+
+    const summary = await extractedStats({ game: GLOOMHAVEN_2E_GAME_ID });
+    expect(summary).toContain('monster-stats: 1');
   });
 });
 

--- a/test/game.test.ts
+++ b/test/game.test.ts
@@ -59,5 +59,6 @@ describe('game id helpers', () => {
     expect(() => resolveGameId({ game: 'no-such-game' })).toThrow(
       'Unsupported game id "no-such-game"',
     );
+    expect(() => resolveGameId({ game: '' })).toThrow('Unsupported game id ""');
   });
 });

--- a/test/game.test.ts
+++ b/test/game.test.ts
@@ -6,6 +6,7 @@ import {
   gameIdFromSourceFilename,
   normalizeGameId,
   requireGameId,
+  resolveGameId,
 } from '../src/game.ts';
 
 describe('game id helpers', () => {
@@ -48,6 +49,15 @@ describe('game id helpers', () => {
   it('rejects source filenames without a supported game prefix', () => {
     expect(() => gameIdFromSourceFilename('rule-book.pdf')).toThrow(
       'Cannot derive game id from source filename "rule-book.pdf"',
+    );
+  });
+
+  it('resolveGameId defaults to Frosthaven and validates explicit ids', () => {
+    expect(resolveGameId()).toBe(FROSTHAVEN_GAME_ID);
+    expect(resolveGameId({})).toBe(FROSTHAVEN_GAME_ID);
+    expect(resolveGameId({ game: 'gh2' })).toBe(GLOOMHAVEN_2E_GAME_ID);
+    expect(() => resolveGameId({ game: 'no-such-game' })).toThrow(
+      'Unsupported game id "no-such-game"',
     );
   });
 });

--- a/test/helpers/test-slices.ts
+++ b/test/helpers/test-slices.ts
@@ -12,6 +12,7 @@ export const DB_BACKED_TEST_FILES = [
   'test/dev-login.test.ts',
   'test/extracted-data.test.ts',
   'test/llm-budget.test.ts',
+  'test/scenario-section-data.test.ts',
   'test/seed/seed-cards.test.ts',
   'test/seed/seed-dev-user.test.ts',
   'test/seed/seed-scenario-section-books.test.ts',

--- a/test/scenario-section-data.test.ts
+++ b/test/scenario-section-data.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Integration tests for `src/scenario-section-data.ts`.
+ *
+ * Scenario/section book tables are seeded once per run by
+ * `test/helpers/global-setup.ts`. These tests add minimal GH2 fixture rows
+ * to prove game-scoped queries do not leak across campaigns.
+ */
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { FROSTHAVEN_GAME_ID, GLOOMHAVEN_2E_GAME_ID } from '../src/game.ts';
+import {
+  findScenarios,
+  getScenario,
+  getScenarioSectionBooksBootstrapStatus,
+  getSection,
+  searchSections,
+} from '../src/scenario-section-data.ts';
+
+import { setupTestDb, teardownTestDb } from './helpers/db.ts';
+
+const GH2_SCENARIO_REF = 'gh2:test/isolation-scenario';
+const GH2_SCENARIO_NAME = 'GH2 Isolation Test Scenario';
+const GH2_SECTION_REF = 'gh2:test/isolation-section';
+const GH2_SECTION_TEXT = 'GH2 isolation section marker text for search.';
+
+beforeAll(async () => {
+  await setupTestDb();
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+describe('game isolation', () => {
+  beforeAll(async () => {
+    const db = await setupTestDb();
+    await db.execute(sql`
+      INSERT INTO scenario_book_scenarios (
+        game, ref, scenario_group, scenario_index, name, initial, metadata
+      )
+      VALUES (
+        ${GLOOMHAVEN_2E_GAME_ID},
+        ${GH2_SCENARIO_REF},
+        'test',
+        '999',
+        ${GH2_SCENARIO_NAME},
+        false,
+        '{}'::jsonb
+      )
+    `);
+    await db.execute(sql`
+      INSERT INTO section_book_sections (
+        game, ref, section_number, section_variant, source_pdf, source_page, text, metadata
+      )
+      VALUES (
+        ${GLOOMHAVEN_2E_GAME_ID},
+        ${GH2_SECTION_REF},
+        999,
+        1,
+        'gh2-test.pdf',
+        1,
+        ${GH2_SECTION_TEXT},
+        '{}'::jsonb
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    const db = await setupTestDb();
+    await db.execute(sql`
+      DELETE FROM section_book_sections
+      WHERE game = ${GLOOMHAVEN_2E_GAME_ID} AND ref = ${GH2_SECTION_REF}
+    `);
+    await db.execute(sql`
+      DELETE FROM scenario_book_scenarios
+      WHERE game = ${GLOOMHAVEN_2E_GAME_ID} AND ref = ${GH2_SCENARIO_REF}
+    `);
+  });
+
+  it('defaults to Frosthaven when game is omitted', async () => {
+    expect(await getScenario(GH2_SCENARIO_REF)).toBeNull();
+    expect(await getSection(GH2_SECTION_REF)).toBeNull();
+  });
+
+  it('does not return GH2 rows from Frosthaven scenario/section queries', async () => {
+    const scenarios = await findScenarios(GH2_SCENARIO_NAME, 6, { game: FROSTHAVEN_GAME_ID });
+    expect(scenarios).toEqual([]);
+
+    const sections = await searchSections('GH2 isolation section marker', 6, {
+      game: FROSTHAVEN_GAME_ID,
+    });
+    expect(sections).toEqual([]);
+  });
+
+  it('returns GH2 rows only for explicit Gloomhaven 2.0 queries', async () => {
+    const scenario = await getScenario(GH2_SCENARIO_REF, { game: GLOOMHAVEN_2E_GAME_ID });
+    expect(scenario).toMatchObject({ ref: GH2_SCENARIO_REF, name: GH2_SCENARIO_NAME });
+
+    const section = await getSection(GH2_SECTION_REF, { game: GLOOMHAVEN_2E_GAME_ID });
+    expect(section).toMatchObject({ ref: GH2_SECTION_REF, text: GH2_SECTION_TEXT });
+
+    const scenarios = await findScenarios('999', 6, { game: GLOOMHAVEN_2E_GAME_ID });
+    expect(scenarios.some((row) => row.ref === GH2_SCENARIO_REF)).toBe(true);
+  });
+
+  it('scopes bootstrap counts to the requested game', async () => {
+    const frosthaven = await getScenarioSectionBooksBootstrapStatus({ game: FROSTHAVEN_GAME_ID });
+    const gh2 = await getScenarioSectionBooksBootstrapStatus({ game: GLOOMHAVEN_2E_GAME_ID });
+
+    expect(frosthaven.scenarioCount).toBeGreaterThan(gh2.scenarioCount);
+    expect(gh2.scenarioCount).toBe(1);
+    expect(gh2.sectionCount).toBe(1);
+    expect(gh2.linkCount).toBe(0);
+    expect(gh2.ready).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `resolveGameId()` in `src/game.ts` so DB-backed loaders validate explicit game ids and default to Frosthaven when omitted.
- Route `extracted-data.ts` and `scenario-section-data.ts` through `resolveGameId()` for load, search, count, and bootstrap APIs.
- `extractedStats()` now accepts optional game scoping (previously always Frosthaven-only).
- Unknown game ids throw instead of silently returning empty results.

## Test plan

- [x] `npm run check` (typecheck, lint, format, 1217 tests)
- [x] `resolveGameId()` unit tests
- [x] Cross-game isolation tests for extracted data and scenario/section APIs

Fixes SQR-182

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game isolation so queries return data only for the selected game by default.
  * Validation added for game selection with clearer errors when an unsupported game id is provided.

* **New Features**
  * Consistent resolution of the active game option across loading, counting, and search operations.

* **Tests**
  * Added integration and DB-backed tests to verify game-scoped behavior and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->