### PR TITLE
feat(vector-store): enforce game-scoped embedding isolation

### DIFF
--- a/src/db/migrations/20260522110000_embeddings_game_source_chunk_idx/migration.sql
+++ b/src/db/migrations/20260522110000_embeddings_game_source_chunk_idx/migration.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS "embeddings_source_chunk_idx";
+--> statement-breakpoint
+CREATE UNIQUE INDEX "embeddings_game_source_chunk_idx" ON "embeddings" USING btree ("game","source","chunk_index");

--- a/src/db/schema/core.ts
+++ b/src/db/schema/core.ts
@@ -73,7 +73,7 @@ export const embeddings = pgTable(
     contentHash: text('content_hash'),
   },
   (t) => [
-    uniqueIndex('embeddings_source_chunk_idx').on(t.source, t.chunkIndex),
+    uniqueIndex('embeddings_game_source_chunk_idx').on(t.game, t.source, t.chunkIndex),
     index('embeddings_game_idx').on(t.game),
     // HNSW index is added in the migration (raw SQL) — Drizzle's index builder
     // doesn't expose pgvector operator classes yet. Placeholder reference here

--- a/src/vector-store.ts
+++ b/src/vector-store.ts
@@ -18,7 +18,8 @@ import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import { getDb } from './db.ts';
 import { embeddings as embeddingsTable } from './db/schema/core.ts';
-import { DEFAULT_GAME_ID } from './game.ts';
+import { DEFAULT_GAME_ID, requireGameId } from './game.ts';
+import type { GameId } from './game.ts';
 
 export interface IndexEntry {
   id: string;
@@ -32,7 +33,7 @@ export interface IndexEntry {
    * column default. Phase 2 starts populating this per-row from the PDF
    * filename prefix in `index-docs.ts`.
    */
-  game?: string;
+  game?: GameId;
 }
 
 export interface ScoredEntry {
@@ -40,13 +41,13 @@ export interface ScoredEntry {
   text: string;
   source: string;
   chunkIndex: number;
-  game: string;
+  game: GameId;
   score: number;
 }
 
 export interface SearchOptions {
   /** Game filter. Defaults to `'frosthaven'`. */
-  game?: string;
+  game?: GameId | string;
 }
 
 /**
@@ -57,6 +58,11 @@ export interface SearchOptions {
 export const EMBEDDING_VERSION = 'xenova-minilm-l6-v2.v1';
 
 const DEFAULT_GAME = DEFAULT_GAME_ID;
+
+function resolveGame(game?: GameId | string): GameId {
+  if (game === undefined) return DEFAULT_GAME;
+  return requireGameId(game);
+}
 
 /**
  * Ensure the HNSW cosine index exists on `embeddings.embedding`.
@@ -80,10 +86,11 @@ export async function ensureHnswIndex(): Promise<void> {
 /**
  * Upsert indexed-book chunk embeddings into the `embeddings` table.
  *
- * Idempotent: uses `ON CONFLICT (source, chunk_index) DO NOTHING`, so
+ * Idempotent: uses `ON CONFLICT (game, source, chunk_index) DO NOTHING`, so
  * reindexing the same PDF twice is a no-op. If chunking changes for an
  * existing PDF, delete rows for that source first (`DELETE FROM embeddings
- * WHERE source = $1`) and reindex — see the tech spec's diff-vs-rebuild table.
+ * WHERE game = $1 AND source = $2`) and reindex — see the tech spec's
+ * diff-vs-rebuild table.
  *
  * Every row is stamped with the current `EMBEDDING_VERSION` as a drift guard.
  */
@@ -108,13 +115,13 @@ export async function addEntries(entries: IndexEntry[]): Promise<void> {
             chunkIndex: e.chunkIndex,
             text: e.text,
             embedding: e.embedding,
-            game: e.game ?? DEFAULT_GAME,
+            game: resolveGame(e.game),
             embeddingVersion: EMBEDDING_VERSION,
             contentHash: e.contentHash,
           })),
         )
         .onConflictDoNothing({
-          target: [embeddingsTable.source, embeddingsTable.chunkIndex],
+          target: [embeddingsTable.game, embeddingsTable.source, embeddingsTable.chunkIndex],
         });
     }
   });
@@ -124,11 +131,14 @@ export async function addEntries(entries: IndexEntry[]): Promise<void> {
  * Return the set of `source` values already present in the embeddings table.
  * Used by `index-docs.ts` to skip PDFs that are already indexed.
  */
-export async function getIndexedSources(game: string = DEFAULT_GAME): Promise<Set<string>> {
+export async function getIndexedSources(
+  game: GameId | string = DEFAULT_GAME,
+): Promise<Set<string>> {
+  const resolvedGame = resolveGame(game);
   try {
     const { db } = getDb('server');
     const rows = await db.execute<{ source: string }>(
-      sql`SELECT DISTINCT source FROM embeddings WHERE game = ${game}`,
+      sql`SELECT DISTINCT source FROM embeddings WHERE game = ${resolvedGame}`,
     );
     return new Set(rows.rows.map((r) => r.source));
   } catch (err) {
@@ -144,8 +154,9 @@ export async function getIndexedSources(game: string = DEFAULT_GAME): Promise<Se
  * current checked-in PDF bytes.
  */
 export async function getIndexedSourceHashes(
-  game: string = DEFAULT_GAME,
+  game: GameId | string = DEFAULT_GAME,
 ): Promise<Map<string, string | null>> {
+  const resolvedGame = resolveGame(game);
   try {
     const { db } = getDb('server');
     const rows = await db.execute<{ source: string; content_hash: string | null }>(sql`
@@ -157,7 +168,7 @@ export async function getIndexedSourceHashes(
           ELSE NULL
         END AS content_hash
       FROM embeddings
-      WHERE game = ${game}
+      WHERE game = ${resolvedGame}
       GROUP BY source
     `);
     return new Map(rows.rows.map((r) => [r.source, r.content_hash]));
@@ -168,15 +179,16 @@ export async function getIndexedSourceHashes(
 
 export async function deleteEntriesForSources(
   sources: string[],
-  game: string = DEFAULT_GAME,
+  game: GameId | string = DEFAULT_GAME,
 ): Promise<number> {
   if (sources.length === 0) return 0;
 
+  const resolvedGame = resolveGame(game);
   try {
     const { db } = getDb('server');
     const rows = await db
       .delete(embeddingsTable)
-      .where(and(eq(embeddingsTable.game, game), inArray(embeddingsTable.source, sources)))
+      .where(and(eq(embeddingsTable.game, resolvedGame), inArray(embeddingsTable.source, sources)))
       .returning({ id: embeddingsTable.id });
     return rows.length;
   } catch (err) {
@@ -196,7 +208,7 @@ export async function search(
   k = 8,
   opts: SearchOptions = {},
 ): Promise<ScoredEntry[]> {
-  const game = opts.game ?? DEFAULT_GAME;
+  const game = resolveGame(opts.game);
   const vectorLiteral = `[${queryEmbedding.join(',')}]`;
 
   try {
@@ -206,7 +218,7 @@ export async function search(
       source: string;
       chunk_index: number;
       text: string;
-      game: string;
+      game: GameId;
       score: number;
     }>(sql`
       SELECT
@@ -241,7 +253,7 @@ export async function getEntryBySourceChunk(
   chunkIndex: number,
   opts: SearchOptions = {},
 ): Promise<ScoredEntry | null> {
-  const game = opts.game ?? DEFAULT_GAME;
+  const game = resolveGame(opts.game);
 
   try {
     const { db } = getDb('server');
@@ -250,7 +262,7 @@ export async function getEntryBySourceChunk(
       source: string;
       chunk_index: number;
       text: string;
-      game: string;
+      game: GameId;
     }>(sql`
       SELECT id, source, chunk_index, text, game
       FROM embeddings

--- a/test/vector-store.test.ts
+++ b/test/vector-store.test.ts
@@ -25,6 +25,7 @@ import {
   EMBEDDING_VERSION,
   addEntries,
   deleteEntriesForSources,
+  getEntryBySourceChunk,
   getIndexedSourceHashes,
   getIndexedSources,
   search,
@@ -95,7 +96,7 @@ describe('addEntries', () => {
     expect(rows[0].contentHash).toBe('sha256:test-hash');
   });
 
-  it('is idempotent on (source, chunk_index) — second insert is a no-op', async () => {
+  it('is idempotent on (game, source, chunk_index) — second insert is a no-op', async () => {
     const entry: IndexEntry = {
       id: 'fake.pdf::0',
       text: 'v1',
@@ -126,6 +127,24 @@ describe('addEntries', () => {
     ]);
     const rows = await db.select().from(embeddingsTable);
     expect(rows[0].game).toBe(GLOOMHAVEN_2E_GAME_ID);
+  });
+
+  it('allows the same source and chunk index in different games', async () => {
+    const sharedSource = 'rule-book.pdf';
+    const entry = {
+      text: 'shared chunk text',
+      embedding: axisVector(0),
+      source: sharedSource,
+      chunkIndex: 0,
+    };
+    await addEntries([
+      { ...entry, id: 'fh::0', game: 'frosthaven' },
+      { ...entry, id: 'gh2::0', game: GLOOMHAVEN_2E_GAME_ID },
+    ]);
+
+    const rows = await db.select().from(embeddingsTable);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.game).sort()).toEqual(['frosthaven', GLOOMHAVEN_2E_GAME_ID]);
   });
 
   it('handles an empty batch as a no-op', async () => {
@@ -322,29 +341,48 @@ describe('search', () => {
     expect(results).toEqual([]);
   });
 
-  it('defaults to game=frosthaven and filters out other games', async () => {
+  it('defaults to game=frosthaven and filters out other games for the same query', async () => {
+    const sharedText = 'When a monster dies, place a loot token.';
     await addEntries([
       {
         id: 'fh::0',
-        text: 'fh',
+        text: sharedText,
         embedding: axisVector(0),
-        source: 'fh',
+        source: 'fh-rule-book.pdf',
         chunkIndex: 0,
       },
       {
         id: 'gh2::0',
-        text: 'gh2',
+        text: sharedText,
         embedding: axisVector(0),
-        source: 'gh2',
+        source: 'gh2-rule-book.pdf',
         chunkIndex: 0,
         game: GLOOMHAVEN_2E_GAME_ID,
       },
     ]);
-    const defaultHits = await search(axisVector(0), 10);
-    expect(defaultHits.map((h) => h.id)).toEqual(['fh::0']);
 
-    const gh2Hits = await search(axisVector(0), 10, { game: GLOOMHAVEN_2E_GAME_ID });
-    expect(gh2Hits.map((h) => h.id)).toEqual(['gh2::0']);
+    const query = axisVector(0);
+    const defaultHits = await search(query, 10);
+    expect(defaultHits).toHaveLength(1);
+    expect(defaultHits[0]).toMatchObject({
+      id: 'fh::0',
+      source: 'fh-rule-book.pdf',
+      game: 'frosthaven',
+    });
+
+    const gh2Hits = await search(query, 10, { game: GLOOMHAVEN_2E_GAME_ID });
+    expect(gh2Hits).toHaveLength(1);
+    expect(gh2Hits[0]).toMatchObject({
+      id: 'gh2::0',
+      source: 'gh2-rule-book.pdf',
+      game: GLOOMHAVEN_2E_GAME_ID,
+    });
+  });
+
+  it('rejects unsupported game filters', async () => {
+    await expect(search(axisVector(0), 1, { game: 'jaws-of-the-lion' })).rejects.toThrow(
+      /Unsupported game id/,
+    );
   });
 
   it('can retrieve scenario-book and section-book sources as nearest matches', async () => {
@@ -379,6 +417,38 @@ describe('search', () => {
     const sectionHits = await search(axisVector(2), 1);
     expect(sectionHits).toHaveLength(1);
     expect(sectionHits[0].source).toBe('fh-section-book-62-81.pdf');
+  });
+});
+
+describe('getEntryBySourceChunk', () => {
+  it('returns the chunk for the requested game only', async () => {
+    const source = 'rule-book.pdf';
+    await addEntries([
+      {
+        id: 'fh::0',
+        text: 'Frosthaven rules',
+        embedding: axisVector(0),
+        source,
+        chunkIndex: 0,
+      },
+      {
+        id: 'gh2::0',
+        text: 'GH2 rules',
+        embedding: axisVector(0),
+        source,
+        chunkIndex: 0,
+        game: GLOOMHAVEN_2E_GAME_ID,
+      },
+    ]);
+
+    expect(await getEntryBySourceChunk(source, 0)).toMatchObject({
+      text: 'Frosthaven rules',
+      game: 'frosthaven',
+    });
+    expect(await getEntryBySourceChunk(source, 0, { game: GLOOMHAVEN_2E_GAME_ID })).toMatchObject({
+      text: 'GH2 rules',
+      game: GLOOMHAVEN_2E_GAME_ID,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Change embedding uniqueness from `(source, chunk_index)` to `(game, source, chunk_index)` via schema + migration
- Validate `game` on vector-store index/search/delete paths using `requireGameId`
- Add FH/GH2 isolation tests: same query, same source/chunk, different games stay separate

Fixes SQR-183

## Test plan
- [x] `npm run check`
- [x] `npm run db:migrate:test`
- [x] `npm run test:db -- test/vector-store.test.ts`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data isolation between games to prevent cross-game data contamination.
  * Enhanced validation for game identifiers with clearer error messages for unsupported inputs.
  * Corrected storage to properly scope indexed entries per game instance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->