### PR TITLE
feat(tools): thread active game through knowledge tools

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -38,6 +38,7 @@ import {
   type BookRecordKind,
 } from './scenario-section-schemas.ts';
 import { resolveSquireEnv } from './squire-env.ts';
+import { requireGameId } from './game.ts';
 
 type MessageParam = Anthropic.MessageParam;
 type Tool = Anthropic.Tool;
@@ -132,6 +133,11 @@ Guidelines:
 
 ${ANSWER_FORMATTING_PROMPT}`;
 
+const GAME_INPUT_SCHEMA = {
+  type: 'string',
+  description: 'Active game id or alias, such as "frosthaven" or "gh2".',
+} as const;
+
 // `as const satisfies readonly Tool[]` lets us derive `AgentToolName` below
 // as a literal union of the tool names. That union is what powers the
 // compile-time drift guard on `TOOL_SOURCE_LABELS` in
@@ -145,7 +151,9 @@ export const AGENT_TOOLS = [
       'Discover available Frosthaven knowledge sources, entity kinds, relation kinds, and live record counts before choosing a lookup tool.',
     input_schema: {
       type: 'object',
-      properties: {},
+      properties: {
+        game: GAME_INPUT_SCHEMA,
+      },
     },
   },
   {
@@ -183,6 +191,7 @@ export const AGENT_TOOLS = [
           description: 'Maximum candidates (1-20, default 6)',
           default: 6,
         },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['query'],
     },
@@ -195,6 +204,7 @@ export const AGENT_TOOLS = [
       type: 'object',
       properties: {
         ref: { type: 'string', description: 'Canonical inspectable ref' },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['ref'],
     },
@@ -213,6 +223,7 @@ export const AGENT_TOOLS = [
           description: 'Optional searchable kind filter',
         },
         limit: { type: 'integer', description: 'Global result limit (default 6)', default: 6 },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['query'],
     },
@@ -231,6 +242,7 @@ export const AGENT_TOOLS = [
           description: 'Optional relation filter like "conclusion" or "section_link"',
         },
         limit: { type: 'integer', description: 'Maximum neighbors (default 20)', default: 20 },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['ref'],
     },
@@ -247,6 +259,7 @@ export const LEGACY_AGENT_TOOLS = [
       properties: {
         query: { type: 'string', description: 'Search query' },
         topK: { type: 'integer', description: 'Number of results (default 6)', default: 6 },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['query'],
     },
@@ -259,6 +272,7 @@ export const LEGACY_AGENT_TOOLS = [
       properties: {
         query: { type: 'string', description: 'Search query' },
         topK: { type: 'integer', description: 'Number of results (default 6)', default: 6 },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['query'],
     },
@@ -268,7 +282,9 @@ export const LEGACY_AGENT_TOOLS = [
     description: 'List all available card types with record counts.',
     input_schema: {
       type: 'object',
-      properties: {},
+      properties: {
+        game: GAME_INPUT_SCHEMA,
+      },
     },
   },
   {
@@ -286,6 +302,7 @@ export const LEGACY_AGENT_TOOLS = [
           type: 'object',
           description: 'Optional field/value filters (AND logic)',
         },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['type'],
     },
@@ -306,6 +323,7 @@ export const LEGACY_AGENT_TOOLS = [
           description:
             'Canonical sourceId (e.g. "gloomhavensecretariat:item/1"). Case-sensitive. Use list_cards or search_cards to discover sourceIds.',
         },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['type', 'id'],
     },
@@ -318,6 +336,7 @@ export const LEGACY_AGENT_TOOLS = [
       type: 'object',
       properties: {
         query: { type: 'string', description: 'Scenario query' },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['query'],
     },
@@ -333,6 +352,7 @@ export const LEGACY_AGENT_TOOLS = [
           description:
             'Canonical scenario ref like "gloomhavensecretariat:scenario/061". Use find_scenario if you only know the number or name.',
         },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['ref'],
     },
@@ -344,6 +364,7 @@ export const LEGACY_AGENT_TOOLS = [
       type: 'object',
       properties: {
         ref: { type: 'string', description: 'Section ref like "90.2"' },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['ref'],
     },
@@ -369,6 +390,7 @@ export const LEGACY_AGENT_TOOLS = [
           enum: [...BOOK_REFERENCE_TYPES],
           description: 'Optional link-type filter like "conclusion" or "section_link"',
         },
+        game: GAME_INPUT_SCHEMA,
       },
       required: ['fromKind', 'fromRef'],
     },
@@ -396,6 +418,11 @@ export interface ToolCallResult {
   content: string;
   /** Distinct provenance labels for dynamic result sources. */
   sourceBooks?: string[];
+}
+
+export interface ToolExecutionContext {
+  /** Active game from runtime context. Explicit tool input overrides this. */
+  game?: string;
 }
 
 export interface TokenUsage {
@@ -596,6 +623,7 @@ function agentCorrelationMetadata(options: AskOptions | undefined): Record<strin
   if (options?.userMessageId) metadata.userMessageId = options.userMessageId;
   if (options?.userId) metadata.userId = options.userId;
   if (options?.campaignId) metadata.campaignId = options.campaignId;
+  if (options?.game) metadata.game = requireGameId(options.game);
   return metadata;
 }
 
@@ -608,6 +636,7 @@ function agentCorrelationAttributes(options: AskOptions | undefined): Attributes
   if (options?.userMessageId) attributes['squire.user_message_id'] = options.userMessageId;
   if (options?.userId) attributes['squire.user_id'] = options.userId;
   if (options?.campaignId) attributes['squire.campaign_id'] = options.campaignId;
+  if (options?.game) attributes['squire.game'] = requireGameId(options.game);
   return attributes;
 }
 
@@ -742,6 +771,15 @@ function isNonRuleSearchTool(toolName: string, input: Record<string, unknown>): 
   return !isBroadRuleSearchTool(toolName, input);
 }
 
+function gameOptsForToolInput(
+  input: Record<string, unknown>,
+  context?: ToolExecutionContext,
+): { game: string } | undefined {
+  const explicit = typeof input.game === 'string' ? input.game : undefined;
+  const game = explicit ?? context?.game;
+  return game === undefined ? undefined : { game };
+}
+
 /**
  * Execute a single tool call and return the result content plus any per-result
  * provenance metadata. Dynamic search/open tools return distinct source labels
@@ -751,10 +789,13 @@ function isNonRuleSearchTool(toolName: string, input: Record<string, unknown>): 
 export async function executeToolCall(
   name: string,
   input: Record<string, unknown>,
+  context?: ToolExecutionContext,
 ): Promise<ToolCallResult> {
+  const gameOpts = gameOptsForToolInput(input, context);
   switch (name) {
     case 'inspect_sources': {
-      return { content: JSON.stringify(await inspectSources(), null, 2) };
+      const result = gameOpts ? await inspectSources(gameOpts) : await inspectSources();
+      return { content: JSON.stringify(result, null, 2) };
     }
     case 'schema': {
       return { content: JSON.stringify(getSchema(input.kind as string), null, 2) };
@@ -768,6 +809,7 @@ export async function executeToolCall(
           await resolveEntity(input.query as string, {
             kinds,
             limit: input.limit as number | undefined,
+            ...gameOpts,
           }),
           null,
           2,
@@ -775,10 +817,11 @@ export async function executeToolCall(
       };
     }
     case 'search_rules': {
-      const results = await searchRules(
-        input.query as string,
-        (input.topK as number | undefined) ?? 6,
-      );
+      const query = input.query as string;
+      const topK = (input.topK as number | undefined) ?? 6;
+      const results = gameOpts
+        ? await searchRules(query, topK, gameOpts)
+        : await searchRules(query, topK);
       const seen = new Set<string>();
       const sourceBooks: string[] = [];
       for (const r of results) {
@@ -796,10 +839,11 @@ export async function executeToolCall(
       };
     }
     case 'search_cards': {
-      const results = await searchCards(
-        input.query as string,
-        (input.topK as number | undefined) ?? 6,
-      );
+      const query = input.query as string;
+      const topK = (input.topK as number | undefined) ?? 6;
+      const results = gameOpts
+        ? await searchCards(query, topK, gameOpts)
+        : await searchCards(query, topK);
       return { content: JSON.stringify(results, null, 2) };
     }
     case 'search_knowledge': {
@@ -807,6 +851,7 @@ export async function executeToolCall(
       const result = await searchKnowledge(input.query as string, {
         scope,
         limit: (input.limit as number | undefined) ?? 6,
+        ...gameOpts,
       });
       return {
         content: JSON.stringify(result, null, 2),
@@ -814,7 +859,9 @@ export async function executeToolCall(
       };
     }
     case 'open_entity': {
-      const result = await openEntity(input.ref as string);
+      const result = gameOpts
+        ? await openEntity(input.ref as string, gameOpts)
+        : await openEntity(input.ref as string);
       return {
         content: JSON.stringify(result, null, 2),
         sourceBooks: sourceLabelsFromResult(result),
@@ -824,36 +871,48 @@ export async function executeToolCall(
       const result = await neighbors(input.ref as string, {
         relation: input.relation as (typeof BOOK_REFERENCE_TYPES)[number] | undefined,
         limit: (input.limit as number | undefined) ?? 20,
+        ...gameOpts,
       });
       return { content: JSON.stringify(result, null, 2) };
     }
     case 'list_card_types': {
-      return { content: JSON.stringify(await listCardTypes(), null, 2) };
+      const result = gameOpts ? await listCardTypes(gameOpts) : await listCardTypes();
+      return { content: JSON.stringify(result, null, 2) };
     }
     case 'list_cards': {
       const filter =
         input.filter && typeof input.filter === 'object' && !Array.isArray(input.filter)
           ? (input.filter as Record<string, unknown>)
           : undefined;
-      const cards = await listCards(input.type as CardType, filter);
+      const cards = gameOpts
+        ? await listCards(input.type as CardType, filter, gameOpts)
+        : await listCards(input.type as CardType, filter);
       return { content: JSON.stringify(cards, null, 2) };
     }
     case 'get_card': {
-      const card = await getCard(input.type as CardType, input.id as string);
+      const card = gameOpts
+        ? await getCard(input.type as CardType, input.id as string, gameOpts)
+        : await getCard(input.type as CardType, input.id as string);
       if (!card) return { content: `Card not found: ${input.type}/${input.id}` };
       return { content: JSON.stringify(card, null, 2) };
     }
     case 'find_scenario': {
-      const scenarios = await findScenario(input.query as string);
+      const scenarios = gameOpts
+        ? await findScenario(input.query as string, gameOpts)
+        : await findScenario(input.query as string);
       return { content: JSON.stringify(scenarios, null, 2) };
     }
     case 'get_scenario': {
-      const scenario = await getScenario(input.ref as string);
+      const scenario = gameOpts
+        ? await getScenario(input.ref as string, gameOpts)
+        : await getScenario(input.ref as string);
       if (!scenario) return { content: `Scenario not found: ${input.ref}` };
       return { content: JSON.stringify(scenario, null, 2) };
     }
     case 'get_section': {
-      const section = await getSection(input.ref as string);
+      const section = gameOpts
+        ? await getSection(input.ref as string, gameOpts)
+        : await getSection(input.ref as string);
       if (!section) return { content: `Section not found: ${input.ref}` };
       return { content: JSON.stringify(section, null, 2) };
     }
@@ -862,6 +921,7 @@ export async function executeToolCall(
         input.fromKind as BookRecordKind,
         input.fromRef as string,
         input.linkType as (typeof BOOK_REFERENCE_TYPES)[number] | undefined,
+        ...(gameOpts ? [gameOpts] : []),
       );
       return { content: JSON.stringify(links, null, 2) };
     }
@@ -1078,6 +1138,7 @@ async function runAgentLoopInternal(
   const history = options?.history;
   const emit = options?.emit;
   const toolSurface = options?.toolSurface;
+  const activeGame = options?.game === undefined ? undefined : requireGameId(options.game);
   const truncatedHistory = history ? history.slice(-MAX_HISTORY_TURNS) : [];
   const model = config.model ?? AGENT_MODEL;
   const maxIterations = config.toolLoopLimit ?? MAX_AGENT_ITERATIONS;
@@ -1280,6 +1341,7 @@ async function runAgentLoopInternal(
                 const result = await executeToolCall(
                   block.name,
                   block.input as Record<string, unknown>,
+                  { game: activeGame },
                 );
                 const { summary, canonicalRefs } = summarizeToolOutput(result.content);
                 span.setAttributes({

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -31,6 +31,15 @@ import {
   type BookRecordKind,
 } from './scenario-section-schemas.ts';
 
+const gameSchema = z
+  .string()
+  .optional()
+  .describe('Active game id or alias, such as "frosthaven" or "gh2"');
+
+function gameOpts(game?: string): { game: string } | undefined {
+  return game === undefined ? undefined : { game };
+}
+
 export function createMcpServer(): McpServer {
   const server = new McpServer({
     name: 'squire',
@@ -44,9 +53,13 @@ export function createMcpServer(): McpServer {
     {
       description:
         'Discover available Frosthaven knowledge sources, entity kinds, relation kinds, and live record counts before choosing a lookup tool.',
+      inputSchema: {
+        game: gameSchema,
+      },
     },
-    async () => {
-      const result = await inspectSources();
+    async ({ game }) => {
+      const opts = gameOpts(game);
+      const result = opts ? await inspectSources(opts) : await inspectSources();
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     },
   );
@@ -84,10 +97,11 @@ export function createMcpServer(): McpServer {
           .optional()
           .describe('Optional kind filters returned by inspect_sources, plus common aliases'),
         limit: z.number().int().min(1).max(20).default(6).describe('Maximum candidates'),
+        game: gameSchema,
       },
     },
-    async ({ query, kinds, limit }) => {
-      const result = await resolveEntity(query, { kinds, limit });
+    async ({ query, kinds, limit, game }) => {
+      const result = await resolveEntity(query, { kinds, limit, ...gameOpts(game) });
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     },
   );
@@ -102,10 +116,12 @@ export function createMcpServer(): McpServer {
       inputSchema: {
         query: z.string().describe('Search query'),
         topK: z.number().int().min(1).max(100).default(6).describe('Number of results'),
+        game: gameSchema,
       },
     },
-    async ({ query, topK }) => {
-      const results = await searchRules(query, topK);
+    async ({ query, topK, game }) => {
+      const opts = gameOpts(game);
+      const results = opts ? await searchRules(query, topK, opts) : await searchRules(query, topK);
       return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
     },
   );
@@ -119,10 +135,12 @@ export function createMcpServer(): McpServer {
       inputSchema: {
         query: z.string().describe('Search query'),
         topK: z.number().int().min(1).max(100).default(6).describe('Number of results'),
+        game: gameSchema,
       },
     },
-    async ({ query, topK }) => {
-      const results = await searchCards(query, topK);
+    async ({ query, topK, game }) => {
+      const opts = gameOpts(game);
+      const results = opts ? await searchCards(query, topK, opts) : await searchCards(query, topK);
       return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
     },
   );
@@ -133,9 +151,13 @@ export function createMcpServer(): McpServer {
     'list_card_types',
     {
       description: 'List all available card types with record counts.',
+      inputSchema: {
+        game: gameSchema,
+      },
     },
-    async () => {
-      const types = await listCardTypes();
+    async ({ game }) => {
+      const opts = gameOpts(game);
+      const types = opts ? await listCardTypes(opts) : await listCardTypes();
       return { content: [{ type: 'text', text: JSON.stringify(types, null, 2) }] };
     },
   );
@@ -152,9 +174,10 @@ export function createMcpServer(): McpServer {
           .string()
           .optional()
           .describe('Optional JSON filter object (AND logic), e.g. {"name":"Algox Archer"}'),
+        game: gameSchema,
       },
     },
-    async ({ type, filter }) => {
+    async ({ type, filter, game }) => {
       let parsed: Record<string, unknown> | undefined;
       if (filter) {
         try {
@@ -166,7 +189,10 @@ export function createMcpServer(): McpServer {
           };
         }
       }
-      const cards = await listCards(type as CardType, parsed);
+      const opts = gameOpts(game);
+      const cards = opts
+        ? await listCards(type as CardType, parsed, opts)
+        : await listCards(type as CardType, parsed);
       return { content: [{ type: 'text', text: JSON.stringify(cards, null, 2) }] };
     },
   );
@@ -184,10 +210,14 @@ export function createMcpServer(): McpServer {
           .describe(
             'Canonical sourceId (e.g. "gloomhavensecretariat:item/1"). Case-sensitive. Use list_cards or search_cards to discover sourceIds.',
           ),
+        game: gameSchema,
       },
     },
-    async ({ type, id }) => {
-      const card = await getCard(type as CardType, id);
+    async ({ type, id, game }) => {
+      const opts = gameOpts(game);
+      const card = opts
+        ? await getCard(type as CardType, id, opts)
+        : await getCard(type as CardType, id);
       if (!card) {
         return {
           content: [{ type: 'text', text: `Card not found: ${type}/${id}` }],
@@ -205,10 +235,12 @@ export function createMcpServer(): McpServer {
         'Resolve a scenario query like "scenario 61" or "Life and Death" to matching scenario records.',
       inputSchema: {
         query: z.string().describe('Scenario query'),
+        game: gameSchema,
       },
     },
-    async ({ query }) => {
-      const scenarios = await findScenario(query);
+    async ({ query, game }) => {
+      const opts = gameOpts(game);
+      const scenarios = opts ? await findScenario(query, opts) : await findScenario(query);
       return { content: [{ type: 'text', text: JSON.stringify(scenarios, null, 2) }] };
     },
   );
@@ -223,10 +255,12 @@ export function createMcpServer(): McpServer {
           .describe(
             'Canonical scenario ref like "gloomhavensecretariat:scenario/061". Use find_scenario if you only know the number or name.',
           ),
+        game: gameSchema,
       },
     },
-    async ({ ref }) => {
-      const scenario = await getScenario(ref);
+    async ({ ref, game }) => {
+      const opts = gameOpts(game);
+      const scenario = opts ? await getScenario(ref, opts) : await getScenario(ref);
       if (!scenario) {
         return {
           content: [{ type: 'text', text: `Scenario not found: ${ref}` }],
@@ -243,10 +277,12 @@ export function createMcpServer(): McpServer {
       description: 'Fetch an exact section record by section ref like "90.2".',
       inputSchema: {
         ref: z.string().describe('Section ref like "90.2"'),
+        game: gameSchema,
       },
     },
-    async ({ ref }) => {
-      const section = await getSection(ref);
+    async ({ ref, game }) => {
+      const opts = gameOpts(game);
+      const section = opts ? await getSection(ref, opts) : await getSection(ref);
       if (!section) {
         return {
           content: [{ type: 'text', text: `Section not found: ${ref}` }],
@@ -269,10 +305,14 @@ export function createMcpServer(): McpServer {
           .enum(BOOK_REFERENCE_TYPES)
           .optional()
           .describe('Optional link-type filter like "conclusion" or "section_link"'),
+        game: gameSchema,
       },
     },
-    async ({ fromKind, fromRef, linkType }) => {
-      const links = await followLinks(fromKind as BookRecordKind, fromRef, linkType);
+    async ({ fromKind, fromRef, linkType, game }) => {
+      const opts = gameOpts(game);
+      const links = opts
+        ? await followLinks(fromKind as BookRecordKind, fromRef, linkType, opts)
+        : await followLinks(fromKind as BookRecordKind, fromRef, linkType);
       return { content: [{ type: 'text', text: JSON.stringify(links, null, 2) }] };
     },
   );
@@ -284,10 +324,12 @@ export function createMcpServer(): McpServer {
         'Open one exact Squire entity by canonical ref: rules passage, scenario, section, or card.',
       inputSchema: {
         ref: z.string().describe('Canonical inspectable ref'),
+        game: gameSchema,
       },
     },
-    async ({ ref }) => {
-      const result = await openEntity(ref);
+    async ({ ref, game }) => {
+      const opts = gameOpts(game);
+      const result = opts ? await openEntity(ref, opts) : await openEntity(ref);
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         isError: !result.ok,
@@ -306,10 +348,11 @@ export function createMcpServer(): McpServer {
           .optional()
           .describe('Optional searchable kind filter'),
         limit: z.number().int().min(1).max(20).default(6).describe('Global result limit'),
+        game: gameSchema,
       },
     },
-    async ({ query, scope, limit }) => {
-      const result = await searchKnowledge(query, { scope, limit });
+    async ({ query, scope, limit, game }) => {
+      const result = await searchKnowledge(query, { scope, limit, ...gameOpts(game) });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         isError: !result.ok,
@@ -325,10 +368,11 @@ export function createMcpServer(): McpServer {
         ref: z.string().describe('Canonical traversable ref'),
         relation: z.enum(BOOK_REFERENCE_TYPES).optional().describe('Optional relation filter'),
         limit: z.number().int().min(1).max(50).default(20).describe('Maximum neighbors'),
+        game: gameSchema,
       },
     },
-    async ({ ref, relation, limit }) => {
-      const result = await neighbors(ref, { relation, limit });
+    async ({ ref, relation, limit, game }) => {
+      const result = await neighbors(ref, { relation, limit, ...gameOpts(game) });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         isError: !result.ok,

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,6 +47,7 @@ import {
 import { claimWorktreePort } from './worktree-runtime.ts';
 import { searchRules, searchCards, listCardTypes, listCards, getCard } from './tools.ts';
 import type { CardType } from './schemas.ts';
+import { requireGameId } from './game.ts';
 import { z } from 'zod';
 import { createMcpServer } from './mcp.ts';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
@@ -1382,6 +1383,23 @@ function parseTopK(raw: string | undefined): number {
   return n;
 }
 
+function gameOptsFromValue(game: string | undefined): { game: string } | undefined {
+  if (game === undefined) return undefined;
+  requireGameId(game);
+  return { game };
+}
+
+function gameOptsFromQuery(
+  c: Context,
+): { ok: true; opts?: { game: string } } | { ok: false; response: Response } {
+  try {
+    return { ok: true, opts: gameOptsFromValue(c.req.query('game')) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, response: c.json(jsonError(message, 400), 400) };
+  }
+}
+
 async function bootstrapErrorResponse(
   c: Context,
   scope: 'rules' | 'cards' | 'ask',
@@ -1424,7 +1442,11 @@ app.get('/api/search/rules', async (c) => {
   if (bootstrapError) return bootstrapError;
 
   const topK = parseTopK(c.req.query('topK'));
-  const results = await searchRules(q, topK);
+  const gameOpts = gameOptsFromQuery(c);
+  if (!gameOpts.ok) return gameOpts.response;
+  const results = gameOpts.opts
+    ? await searchRules(q, topK, gameOpts.opts)
+    : await searchRules(q, topK);
   return c.json({ results });
 });
 
@@ -1436,21 +1458,29 @@ app.get('/api/search/cards', async (c) => {
   if (bootstrapError) return bootstrapError;
 
   const topK = parseTopK(c.req.query('topK'));
-  const results = await searchCards(q, topK);
+  const gameOpts = gameOptsFromQuery(c);
+  if (!gameOpts.ok) return gameOpts.response;
+  const results = gameOpts.opts
+    ? await searchCards(q, topK, gameOpts.opts)
+    : await searchCards(q, topK);
   return c.json({ results });
 });
 
 // ─── Card discovery and lookup endpoints ─────────────────────────────────────
 
 app.get('/api/card-types', requireBootstrapCapability('cards'), async (c) => {
-  const types = await listCardTypes();
+  const gameOpts = gameOptsFromQuery(c);
+  if (!gameOpts.ok) return gameOpts.response;
+  const types = gameOpts.opts ? await listCardTypes(gameOpts.opts) : await listCardTypes();
   return c.json({ types });
 });
 
 app.get('/api/cards/:type/:id', requireBootstrapCapability('cards'), async (c) => {
   const type = c.req.param('type') as CardType;
   const id = decodeURIComponent(c.req.param('id'));
-  const card = await getCard(type, id);
+  const gameOpts = gameOptsFromQuery(c);
+  if (!gameOpts.ok) return gameOpts.response;
+  const card = gameOpts.opts ? await getCard(type, id, gameOpts.opts) : await getCard(type, id);
   if (!card) return c.json(jsonError('Card not found', 404), 404);
   return c.json({ card });
 });
@@ -1476,7 +1506,11 @@ app.get('/api/cards', async (c) => {
   const bootstrapError = await ensureBootstrapCapability(c, 'cards');
   if (bootstrapError) return bootstrapError;
 
-  const cards = await listCards(type as CardType, filter);
+  const gameOpts = gameOptsFromQuery(c);
+  if (!gameOpts.ok) return gameOpts.response;
+  const cards = gameOpts.opts
+    ? await listCards(type as CardType, filter, gameOpts.opts)
+    : await listCards(type as CardType, filter);
   return c.json({ cards });
 });
 
@@ -1496,6 +1530,7 @@ const AskRequestSchema = z.object({
   campaignId: z.string().uuid().optional(),
   userId: z.string().uuid().optional(),
   toolSurface: z.enum(['redesigned', 'legacy']).optional(),
+  game: z.string().optional(),
 });
 
 app.post('/api/ask', async (c) => {
@@ -1517,6 +1552,12 @@ app.post('/api/ask', async (c) => {
   if (bootstrapError) return bootstrapError;
 
   const { question, ...options } = result.data;
+  try {
+    gameOptsFromValue(options.game);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return c.json(jsonError(message, 400), 400);
+  }
   delete options.userId;
   try {
     await ensureAskBudgetAvailable(null);

--- a/src/service.ts
+++ b/src/service.ts
@@ -523,6 +523,8 @@ export interface AskOptions {
    * report. `redesigned` remains selectable for the follow-up retrieval work.
    */
   toolSurface?: 'redesigned' | 'legacy';
+  /** Active game id or alias for knowledge-tool routing. Defaults to Frosthaven when omitted. */
+  game?: string;
   /** Campaign UUID — reserved for future campaign context loading. */
   campaignId?: string;
   /** User UUID — reserved for future player context loading. */

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -1205,9 +1205,18 @@ describe('executeToolCall', () => {
   });
 
   it('dispatches search_rules', async () => {
-    const result = await executeToolCall('search_rules', { query: 'loot', topK: 3 });
-    expect(mockSearchRules).toHaveBeenCalledWith('loot', 3);
+    const result = await executeToolCall(
+      'search_rules',
+      { query: 'loot', topK: 3 },
+      { game: 'gh2' },
+    );
+    expect(mockSearchRules).toHaveBeenCalledWith('loot', 3, { game: 'gh2' });
     expect(JSON.parse(result.content)).toHaveLength(1);
+  });
+
+  it('lets explicit tool game override the runtime active game', async () => {
+    await executeToolCall('search_rules', { query: 'loot', game: 'frosthaven' }, { game: 'gh2' });
+    expect(mockSearchRules).toHaveBeenCalledWith('loot', 6, { game: 'frosthaven' });
   });
 
   it('search_rules populates sourceBooks from per-result sourceLabel', async () => {
@@ -1238,8 +1247,8 @@ describe('executeToolCall', () => {
   });
 
   it('dispatches search_cards', async () => {
-    const result = await executeToolCall('search_cards', { query: 'boots' });
-    expect(mockSearchCards).toHaveBeenCalledWith('boots', 6);
+    const result = await executeToolCall('search_cards', { query: 'boots' }, { game: 'gh2' });
+    expect(mockSearchCards).toHaveBeenCalledWith('boots', 6, { game: 'gh2' });
     expect(JSON.parse(result.content)).toHaveLength(1);
   });
 
@@ -1265,14 +1274,19 @@ describe('executeToolCall', () => {
         },
       ],
     });
-    const result = await executeToolCall('search_knowledge', {
-      query: 'loot',
-      scope: ['rules_passage'],
-      limit: 3,
-    });
+    const result = await executeToolCall(
+      'search_knowledge',
+      {
+        query: 'loot',
+        scope: ['rules_passage'],
+        limit: 3,
+      },
+      { game: 'gh2' },
+    );
     expect(mockSearchKnowledge).toHaveBeenCalledWith('loot', {
       scope: ['rules_passage'],
       limit: 3,
+      game: 'gh2',
     });
     expect(result.sourceBooks).toEqual(['Rulebook', 'Card Index']);
   });
@@ -1297,21 +1311,25 @@ describe('executeToolCall', () => {
       links: [],
       related: [],
     });
-    const result = await executeToolCall('open_entity', { ref: 'section:frosthaven/67.1' });
-    expect(mockOpenEntity).toHaveBeenCalledWith('section:frosthaven/67.1');
+    const result = await executeToolCall(
+      'open_entity',
+      { ref: 'section:frosthaven/67.1' },
+      { game: 'gh2' },
+    );
+    expect(mockOpenEntity).toHaveBeenCalledWith('section:frosthaven/67.1', { game: 'gh2' });
     expect(JSON.parse(result.content).entity.ref).toBe('section:frosthaven/67.1');
     expect(result.sourceBooks).toEqual(['Section Book 62-81']);
   });
 
   it('dispatches list_card_types', async () => {
-    const result = await executeToolCall('list_card_types', {});
-    expect(mockListCardTypes).toHaveBeenCalled();
+    const result = await executeToolCall('list_card_types', {}, { game: 'gh2' });
+    expect(mockListCardTypes).toHaveBeenCalledWith({ game: 'gh2' });
     expect(JSON.parse(result.content)).toEqual([{ type: 'items', count: 5 }]);
   });
 
   it('dispatches inspect_sources', async () => {
-    const result = await executeToolCall('inspect_sources', {});
-    expect(mockInspectSources).toHaveBeenCalled();
+    const result = await executeToolCall('inspect_sources', {}, { game: 'gh2' });
+    expect(mockInspectSources).toHaveBeenCalledWith({ game: 'gh2' });
     expect(JSON.parse(result.content)).toEqual({
       ok: true,
       sources: [],
@@ -1327,14 +1345,19 @@ describe('executeToolCall', () => {
   });
 
   it('dispatches resolve_entity', async () => {
-    const result = await executeToolCall('resolve_entity', {
-      query: 'Spyglass',
-      kinds: ['card'],
-      limit: 3,
-    });
+    const result = await executeToolCall(
+      'resolve_entity',
+      {
+        query: 'Spyglass',
+        kinds: ['card'],
+        limit: 3,
+      },
+      { game: 'gh2' },
+    );
     expect(mockResolveEntity).toHaveBeenCalledWith('Spyglass', {
       kinds: ['card'],
       limit: 3,
+      game: 'gh2',
     });
     expect(JSON.parse(result.content)).toEqual({
       ok: true,
@@ -1344,8 +1367,14 @@ describe('executeToolCall', () => {
   });
 
   it('dispatches get_card', async () => {
-    const result = await executeToolCall('get_card', { type: 'items', id: 'Test Item' });
-    expect(mockGetCard).toHaveBeenCalledWith('items', 'Test Item');
+    const result = await executeToolCall(
+      'get_card',
+      { type: 'items', id: 'Test Item' },
+      {
+        game: 'gh2',
+      },
+    );
+    expect(mockGetCard).toHaveBeenCalledWith('items', 'Test Item', { game: 'gh2' });
     expect(JSON.parse(result.content)).toEqual({ name: 'Test Item' });
   });
 
@@ -1356,48 +1385,70 @@ describe('executeToolCall', () => {
   });
 
   it('dispatches find_scenario', async () => {
-    const result = await executeToolCall('find_scenario', { query: 'scenario 61' });
-    expect(mockFindScenario).toHaveBeenCalledWith('scenario 61');
+    const result = await executeToolCall(
+      'find_scenario',
+      { query: 'scenario 61' },
+      {
+        game: 'gh2',
+      },
+    );
+    expect(mockFindScenario).toHaveBeenCalledWith('scenario 61', { game: 'gh2' });
     expect(JSON.parse(result.content)).toEqual([{ ref: 'gloomhavensecretariat:scenario/061' }]);
   });
 
   it('dispatches get_scenario', async () => {
-    const result = await executeToolCall('get_scenario', {
-      ref: 'gloomhavensecretariat:scenario/061',
+    const result = await executeToolCall(
+      'get_scenario',
+      {
+        ref: 'gloomhavensecretariat:scenario/061',
+      },
+      { game: 'gh2' },
+    );
+    expect(mockGetScenario).toHaveBeenCalledWith('gloomhavensecretariat:scenario/061', {
+      game: 'gh2',
     });
-    expect(mockGetScenario).toHaveBeenCalledWith('gloomhavensecretariat:scenario/061');
     expect(JSON.parse(result.content)).toEqual({ ref: 'gloomhavensecretariat:scenario/061' });
   });
 
   it('dispatches get_section', async () => {
-    const result = await executeToolCall('get_section', { ref: '67.1' });
-    expect(mockGetSection).toHaveBeenCalledWith('67.1');
+    const result = await executeToolCall('get_section', { ref: '67.1' }, { game: 'gh2' });
+    expect(mockGetSection).toHaveBeenCalledWith('67.1', { game: 'gh2' });
     expect(JSON.parse(result.content)).toEqual({ ref: '67.1' });
   });
 
   it('dispatches follow_links', async () => {
-    const result = await executeToolCall('follow_links', {
-      fromKind: 'scenario',
-      fromRef: 'gloomhavensecretariat:scenario/061',
-      linkType: 'conclusion',
-    });
+    const result = await executeToolCall(
+      'follow_links',
+      {
+        fromKind: 'scenario',
+        fromRef: 'gloomhavensecretariat:scenario/061',
+        linkType: 'conclusion',
+      },
+      { game: 'gh2' },
+    );
     expect(mockFollowLinks).toHaveBeenCalledWith(
       'scenario',
       'gloomhavensecretariat:scenario/061',
       'conclusion',
+      { game: 'gh2' },
     );
     expect(JSON.parse(result.content)).toEqual([{ toRef: '67.1' }]);
   });
 
   it('dispatches neighbors', async () => {
-    const result = await executeToolCall('neighbors', {
-      ref: 'scenario:frosthaven/061',
-      relation: 'conclusion',
-      limit: 5,
-    });
+    const result = await executeToolCall(
+      'neighbors',
+      {
+        ref: 'scenario:frosthaven/061',
+        relation: 'conclusion',
+        limit: 5,
+      },
+      { game: 'gh2' },
+    );
     expect(mockNeighbors).toHaveBeenCalledWith('scenario:frosthaven/061', {
       relation: 'conclusion',
       limit: 5,
+      game: 'gh2',
     });
     expect(JSON.parse(result.content)).toEqual({
       ok: true,

--- a/test/eval-openai-schema.test.ts
+++ b/test/eval-openai-schema.test.ts
@@ -92,14 +92,15 @@ describe('OpenAI strict tool schema renderer', () => {
       }
     >;
 
-    expect(byName.search_rules.required).toEqual(['query', 'topK']);
+    expect(byName.search_rules.required).toEqual(['query', 'topK', 'game']);
     expect(byName.search_rules.properties.topK.type).toEqual(['integer', 'null']);
-    expect(byName.search_cards.required).toEqual(['query', 'topK']);
-    expect(byName.search_knowledge.required).toEqual(['query', 'scope', 'limit']);
-    expect(byName.resolve_entity.required).toEqual(['query', 'kinds', 'limit']);
-    expect(byName.neighbors.required).toEqual(['ref', 'relation', 'limit']);
+    expect(byName.search_rules.properties.game.type).toEqual(['string', 'null']);
+    expect(byName.search_cards.required).toEqual(['query', 'topK', 'game']);
+    expect(byName.search_knowledge.required).toEqual(['query', 'scope', 'limit', 'game']);
+    expect(byName.resolve_entity.required).toEqual(['query', 'kinds', 'limit', 'game']);
+    expect(byName.neighbors.required).toEqual(['ref', 'relation', 'limit', 'game']);
     expect(byName.neighbors.properties.relation.enum).toContain(null);
-    expect(byName.list_cards.required).toEqual(['type', 'filter']);
+    expect(byName.list_cards.required).toEqual(['type', 'filter', 'game']);
     expect(byName.list_cards.properties.filter.type).toEqual(['object', 'null']);
     expect(byName.list_cards.properties.filter.additionalProperties).toBe(false);
     expect(byName.list_cards.properties.filter.required).toEqual(
@@ -111,7 +112,7 @@ describe('OpenAI strict tool schema renderer', () => {
       'boolean',
       'null',
     ]);
-    expect(byName.follow_links.required).toEqual(['fromKind', 'fromRef', 'linkType']);
+    expect(byName.follow_links.required).toEqual(['fromKind', 'fromRef', 'linkType', 'game']);
     expect(byName.follow_links.properties.linkType.enum).toContain(null);
   });
 
@@ -120,6 +121,7 @@ describe('OpenAI strict tool schema renderer', () => {
       normalizeOpenAiToolInput('search_rules', {
         query: 'loot',
         topK: null,
+        game: null,
       }),
     ).toEqual({ query: 'loot' });
 

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -190,6 +190,11 @@ describe('MCP tool registration', () => {
     expect(mockInspectSources).toHaveBeenCalledWith();
 
     await expect(
+      client.callTool({ name: 'inspect_sources', arguments: { game: 'gh2' } }),
+    ).resolves.toBeDefined();
+    expect(mockInspectSources).toHaveBeenLastCalledWith({ game: 'gh2' });
+
+    await expect(
       client.callTool({ name: 'schema', arguments: { kind: 'item' } }),
     ).resolves.toBeDefined();
     expect(mockGetSchema).toHaveBeenCalledWith('item');
@@ -197,12 +202,13 @@ describe('MCP tool registration', () => {
     await expect(
       client.callTool({
         name: 'resolve_entity',
-        arguments: { query: 'Spyglass', kinds: ['card'], limit: 3 },
+        arguments: { query: 'Spyglass', kinds: ['card'], limit: 3, game: 'gh2' },
       }),
     ).resolves.toBeDefined();
     expect(mockResolveEntity).toHaveBeenCalledWith('Spyglass', {
       kinds: ['card'],
       limit: 3,
+      game: 'gh2',
     });
   });
 
@@ -210,57 +216,75 @@ describe('MCP tool registration', () => {
     const client = await connectClient();
 
     await expect(
-      client.callTool({ name: 'find_scenario', arguments: { query: 'scenario 61' } }),
+      client.callTool({
+        name: 'find_scenario',
+        arguments: { query: 'scenario 61', game: 'gh2' },
+      }),
     ).resolves.toBeDefined();
-    expect(mockFindScenario).toHaveBeenCalledWith('scenario 61');
+    expect(mockFindScenario).toHaveBeenCalledWith('scenario 61', { game: 'gh2' });
 
     await expect(
       client.callTool({
         name: 'get_scenario',
-        arguments: { ref: 'gloomhavensecretariat:scenario/061' },
+        arguments: { ref: 'gloomhavensecretariat:scenario/061', game: 'gh2' },
       }),
     ).resolves.toBeDefined();
-    expect(mockGetScenario).toHaveBeenCalledWith('gloomhavensecretariat:scenario/061');
+    expect(mockGetScenario).toHaveBeenCalledWith('gloomhavensecretariat:scenario/061', {
+      game: 'gh2',
+    });
 
     await expect(
-      client.callTool({ name: 'get_section', arguments: { ref: '67.1' } }),
+      client.callTool({ name: 'get_section', arguments: { ref: '67.1', game: 'gh2' } }),
     ).resolves.toBeDefined();
-    expect(mockGetSection).toHaveBeenCalledWith('67.1');
+    expect(mockGetSection).toHaveBeenCalledWith('67.1', { game: 'gh2' });
 
     await expect(
       client.callTool({
         name: 'follow_links',
-        arguments: { fromKind: 'scenario', fromRef: 'gloomhavensecretariat:scenario/061' },
+        arguments: {
+          fromKind: 'scenario',
+          fromRef: 'gloomhavensecretariat:scenario/061',
+          game: 'gh2',
+        },
       }),
     ).resolves.toBeDefined();
     expect(mockFollowLinks).toHaveBeenCalledWith(
       'scenario',
       'gloomhavensecretariat:scenario/061',
       undefined,
+      { game: 'gh2' },
     );
 
     await expect(
-      client.callTool({ name: 'open_entity', arguments: { ref: 'section:frosthaven/67.1' } }),
+      client.callTool({
+        name: 'open_entity',
+        arguments: { ref: 'section:frosthaven/67.1', game: 'gh2' },
+      }),
     ).resolves.toBeDefined();
-    expect(mockOpenEntity).toHaveBeenCalledWith('section:frosthaven/67.1');
+    expect(mockOpenEntity).toHaveBeenCalledWith('section:frosthaven/67.1', { game: 'gh2' });
 
     await expect(
-      client.callTool({ name: 'search_knowledge', arguments: { query: 'loot', limit: 3 } }),
+      client.callTool({
+        name: 'search_knowledge',
+        arguments: { query: 'loot', limit: 3, game: 'gh2' },
+      }),
     ).resolves.toBeDefined();
     expect(mockSearchKnowledge).toHaveBeenCalledWith('loot', {
       scope: undefined,
       limit: 3,
+      game: 'gh2',
     });
 
     await expect(
       client.callTool({
         name: 'neighbors',
-        arguments: { ref: 'scenario:frosthaven/061', relation: 'conclusion' },
+        arguments: { ref: 'scenario:frosthaven/061', relation: 'conclusion', game: 'gh2' },
       }),
     ).resolves.toBeDefined();
     expect(mockNeighbors).toHaveBeenCalledWith('scenario:frosthaven/061', {
       relation: 'conclusion',
       limit: 20,
+      game: 'gh2',
     });
   });
 });
@@ -275,8 +299,11 @@ describe('search_rules tool', () => {
 
   it('calls searchRules and returns results', async () => {
     const client = await connectClient();
-    const result = await client.callTool({ name: 'search_rules', arguments: { query: 'loot' } });
-    expect(mockSearchRules).toHaveBeenCalledWith('loot', 6);
+    const result = await client.callTool({
+      name: 'search_rules',
+      arguments: { query: 'loot', game: 'gh2' },
+    });
+    expect(mockSearchRules).toHaveBeenCalledWith('loot', 6, { game: 'gh2' });
     const content = getTextContent(result);
     expect(content).toHaveLength(1);
     expect(content[0].text).toContain('Loot');
@@ -301,9 +328,9 @@ describe('search_cards tool', () => {
     const client = await connectClient();
     const result = await client.callTool({
       name: 'search_cards',
-      arguments: { query: 'algox archer' },
+      arguments: { query: 'algox archer', game: 'gh2' },
     });
-    expect(mockSearchCards).toHaveBeenCalledWith('algox archer', 6);
+    expect(mockSearchCards).toHaveBeenCalledWith('algox archer', 6, { game: 'gh2' });
     const content = getTextContent(result);
     expect(content).toHaveLength(1);
     expect(content[0].text).toContain('Algox Archer');
@@ -321,8 +348,11 @@ describe('list_card_types tool', () => {
 
   it('returns card types', async () => {
     const client = await connectClient();
-    const result = await client.callTool({ name: 'list_card_types', arguments: {} });
-    expect(mockListCardTypes).toHaveBeenCalled();
+    const result = await client.callTool({
+      name: 'list_card_types',
+      arguments: { game: 'gh2' },
+    });
+    expect(mockListCardTypes).toHaveBeenCalledWith({ game: 'gh2' });
     const content = getTextContent(result);
     expect(content).toHaveLength(1);
     const text = content[0].text;
@@ -341,18 +371,22 @@ describe('list_cards tool', () => {
     const client = await connectClient();
     await client.callTool({
       name: 'list_cards',
-      arguments: { type: 'monster-stats' },
+      arguments: { type: 'monster-stats', game: 'gh2' },
     });
-    expect(mockListCards).toHaveBeenCalledWith('monster-stats', undefined);
+    expect(mockListCards).toHaveBeenCalledWith('monster-stats', undefined, { game: 'gh2' });
   });
 
   it('passes filter when provided', async () => {
     const client = await connectClient();
     await client.callTool({
       name: 'list_cards',
-      arguments: { type: 'monster-stats', filter: '{"name":"Algox Archer"}' },
+      arguments: { type: 'monster-stats', filter: '{"name":"Algox Archer"}', game: 'gh2' },
     });
-    expect(mockListCards).toHaveBeenCalledWith('monster-stats', { name: 'Algox Archer' });
+    expect(mockListCards).toHaveBeenCalledWith(
+      'monster-stats',
+      { name: 'Algox Archer' },
+      { game: 'gh2' },
+    );
   });
 });
 
@@ -366,9 +400,9 @@ describe('get_card tool', () => {
     const client = await connectClient();
     const result = await client.callTool({
       name: 'get_card',
-      arguments: { type: 'monster-stats', id: 'Algox Archer' },
+      arguments: { type: 'monster-stats', id: 'Algox Archer', game: 'gh2' },
     });
-    expect(mockGetCard).toHaveBeenCalledWith('monster-stats', 'Algox Archer');
+    expect(mockGetCard).toHaveBeenCalledWith('monster-stats', 'Algox Archer', { game: 'gh2' });
     const content = getTextContent(result);
     expect(content).toHaveLength(1);
     expect(content[0].text).toContain('Algox Archer');

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -252,13 +252,21 @@ describe('GET /api/search/rules', () => {
   });
 
   it('passes query and topK to searchRules', async () => {
-    await app.request('/api/search/rules?q=loot&topK=3', { headers: await auth() });
-    expect(mockSearchRules).toHaveBeenCalledWith('loot', 3);
+    await app.request('/api/search/rules?q=loot&topK=3&game=gh2', { headers: await auth() });
+    expect(mockSearchRules).toHaveBeenCalledWith('loot', 3, { game: 'gh2' });
   });
 
   it('defaults topK to 6', async () => {
     await app.request('/api/search/rules?q=loot', { headers: await auth() });
     expect(mockSearchRules).toHaveBeenCalledWith('loot', 6);
+  });
+
+  it('returns 400 for unsupported game ids before searching rules', async () => {
+    const res = await app.request('/api/search/rules?q=loot&game=no-such-game', {
+      headers: await auth(),
+    });
+    expect(res.status).toBe(400);
+    expect(mockSearchRules).not.toHaveBeenCalled();
   });
 
   it('returns 400 when q is missing', async () => {
@@ -346,8 +354,8 @@ describe('GET /api/search/cards', () => {
   });
 
   it('passes query and topK to searchCards', async () => {
-    await app.request('/api/search/cards?q=algox&topK=4', { headers: await auth() });
-    expect(mockSearchCards).toHaveBeenCalledWith('algox', 4);
+    await app.request('/api/search/cards?q=algox&topK=4&game=gh2', { headers: await auth() });
+    expect(mockSearchCards).toHaveBeenCalledWith('algox', 4, { game: 'gh2' });
   });
 
   it('defaults topK to 6', async () => {
@@ -419,12 +427,13 @@ describe('GET /api/card-types', () => {
   });
 
   it('returns all card types', async () => {
-    const res = await app.request('/api/card-types', { headers: await auth() });
+    const res = await app.request('/api/card-types?game=gh2', { headers: await auth() });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.types).toHaveLength(2);
     expect(body.types[0]).toHaveProperty('type');
     expect(body.types[0]).toHaveProperty('count');
+    expect(mockListCardTypes).toHaveBeenCalledWith({ game: 'gh2' });
   });
 });
 
@@ -440,11 +449,13 @@ describe('GET /api/cards', () => {
   });
 
   it('returns cards of a given type', async () => {
-    const res = await app.request('/api/cards?type=monster-stats', { headers: await auth() });
+    const res = await app.request('/api/cards?type=monster-stats&game=gh2', {
+      headers: await auth(),
+    });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.cards).toHaveLength(1);
-    expect(mockListCards).toHaveBeenCalledWith('monster-stats', undefined);
+    expect(mockListCards).toHaveBeenCalledWith('monster-stats', undefined, { game: 'gh2' });
   });
 
   it('returns 400 when type is missing', async () => {
@@ -461,8 +472,14 @@ describe('GET /api/cards', () => {
 
   it('passes filter as parsed JSON', async () => {
     const filter = encodeURIComponent(JSON.stringify({ name: 'Algox Archer' }));
-    await app.request(`/api/cards?type=monster-stats&filter=${filter}`, { headers: await auth() });
-    expect(mockListCards).toHaveBeenCalledWith('monster-stats', { name: 'Algox Archer' });
+    await app.request(`/api/cards?type=monster-stats&filter=${filter}&game=gh2`, {
+      headers: await auth(),
+    });
+    expect(mockListCards).toHaveBeenCalledWith(
+      'monster-stats',
+      { name: 'Algox Archer' },
+      { game: 'gh2' },
+    );
   });
 
   it('returns 400 for invalid filter JSON', async () => {
@@ -485,13 +502,13 @@ describe('GET /api/cards/:type/:id', () => {
   });
 
   it('returns a card by type and id', async () => {
-    const res = await app.request('/api/cards/monster-stats/Algox%20Archer', {
+    const res = await app.request('/api/cards/monster-stats/Algox%20Archer?game=gh2', {
       headers: await auth(),
     });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.card).toHaveProperty('name', 'Algox Archer');
-    expect(mockGetCard).toHaveBeenCalledWith('monster-stats', 'Algox Archer');
+    expect(mockGetCard).toHaveBeenCalledWith('monster-stats', 'Algox Archer', { game: 'gh2' });
   });
 
   it('returns 404 when card is not found', async () => {
@@ -676,6 +693,25 @@ describe('POST /api/ask', () => {
       'What is loot?',
       expect.objectContaining({ toolSurface: 'legacy' }),
     );
+  });
+
+  it('passes active game to ask()', async () => {
+    await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'What is loot?', game: 'gh2' }),
+    });
+    expect(mockAsk).toHaveBeenCalledWith('What is loot?', expect.objectContaining({ game: 'gh2' }));
+  });
+
+  it('returns 400 for unsupported ask game ids', async () => {
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'test', game: 'no-such-game' }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockAsk).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid toolSurface', async () => {

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -407,6 +407,7 @@ describe('ask', () => {
       history: [{ role: 'user' as const, content: 'What is loot?' }],
       campaignId: '550e8400-e29b-41d4-a716-446655440000',
       userId: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      game: 'gh2',
     };
     await ask('Follow-up', options);
     expect(mockRunAgentLoopWithTrajectory).toHaveBeenCalledWith('Follow-up', options);


### PR DESCRIPTION
## Summary
- Add active game input to agent, MCP, and REST knowledge-tool surfaces
- Thread runtime `AskOptions.game` through agent tool execution while allowing explicit tool input to override it
- Validate unsupported REST and ask game input before running lookups
- Update OpenAI strict tool schema tests for nullable `game`

## Validation
- Pre-Landing Review: No issues found
- `npm run db:migrate:test`
- `npx vitest run eval-openai-schema`
- `npx vitest run test/vector-store.test.ts`
- `npm run check`

Fixes SQR-184


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional game parameter support to search, card discovery, and knowledge tools, enabling users to specify and maintain a game context across operations.
  * Content and card discovery endpoints now accept game parameters for game-specific filtering and results.
  * Implemented game parameter validation with appropriate error handling for unsupported game values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->