### PR TITLE
fix: canonicalize GH2 entity refs

### DIFF
--- a/eval/dataset.json
+++ b/eval/dataset.json
@@ -330,7 +330,7 @@
       "requiredTools": ["resolve_entity", "open_entity"],
       "requiredToolKinds": ["resolution", "open"],
       "forbiddenTools": ["search_rules"],
-      "requiredRefs": ["section:frosthaven/67.1", "section:gloomhaven2/67.1"],
+      "requiredRefs": ["section:frosthaven/67.1", "section:gloomhaven-2e/67.1"],
       "maxToolCalls": 8,
       "notes": "This covers missing-data and invalid-ref behavior without letting the agent silently reuse Frosthaven data for another game."
     },

--- a/eval/schema.ts
+++ b/eval/schema.ts
@@ -149,10 +149,12 @@ export function validateRemoteDatasetShape(
 }
 
 export function normalizeTrajectoryRef(ref: string): string {
-  const qualifiedScenarioMatch = ref.match(/^scenario:([^/]+)\/(\d+)$/);
+  const qualifiedScenarioMatch = ref.match(/^scenario:([^/]+)\/([^/]+)$/);
   if (qualifiedScenarioMatch) {
     const game = normalizeGameId(qualifiedScenarioMatch[1]) ?? qualifiedScenarioMatch[1];
-    return `scenario:${game}/${qualifiedScenarioMatch[2].padStart(3, '0')}`;
+    const scenarioId = qualifiedScenarioMatch[2];
+    const canonicalScenarioId = /^\d+$/.test(scenarioId) ? scenarioId.padStart(3, '0') : scenarioId;
+    return `scenario:${game}/${canonicalScenarioId}`;
   }
 
   const scenarioMatch = ref.match(/^gloomhavensecretariat:scenario\/(\d+)$/);

--- a/eval/schema.ts
+++ b/eval/schema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { FROSTHAVEN_GAME_ID, normalizeGameId } from '../src/game.ts';
+
 const ToolKindSchema = z.enum(['discovery', 'resolution', 'search', 'open', 'traversal']);
 
 export const TrajectoryExpectationSchema = z
@@ -147,27 +149,41 @@ export function validateRemoteDatasetShape(
 }
 
 export function normalizeTrajectoryRef(ref: string): string {
-  const scenarioMatch = ref.match(
-    /^(?:scenario:frosthaven\/|gloomhavensecretariat:scenario\/)(\d+)$/,
-  );
+  const qualifiedScenarioMatch = ref.match(/^scenario:([^/]+)\/(\d+)$/);
+  if (qualifiedScenarioMatch) {
+    const game = normalizeGameId(qualifiedScenarioMatch[1]) ?? qualifiedScenarioMatch[1];
+    return `scenario:${game}/${qualifiedScenarioMatch[2].padStart(3, '0')}`;
+  }
+
+  const scenarioMatch = ref.match(/^gloomhavensecretariat:scenario\/(\d+)$/);
   if (scenarioMatch) {
-    return `scenario:frosthaven/${scenarioMatch[1].padStart(3, '0')}`;
+    return `scenario:${FROSTHAVEN_GAME_ID}/${scenarioMatch[1].padStart(3, '0')}`;
   }
 
-  const sectionMatch = ref.match(/^(?:section:frosthaven\/|section:)?(\d+\.\d+)$/);
+  const qualifiedSectionMatch = ref.match(/^section:([^/]+)\/(\d+\.\d+)$/);
+  if (qualifiedSectionMatch) {
+    const game = normalizeGameId(qualifiedSectionMatch[1]) ?? qualifiedSectionMatch[1];
+    return `section:${game}/${qualifiedSectionMatch[2]}`;
+  }
+
+  const sectionMatch = ref.match(/^(?:section:)?(\d+\.\d+)$/);
   if (sectionMatch) {
-    return `section:frosthaven/${sectionMatch[1]}`;
+    return `section:${FROSTHAVEN_GAME_ID}/${sectionMatch[1]}`;
   }
 
-  const cardMatch = ref.match(
-    /^(?:card:frosthaven\/([^/]+)\/)?gloomhavensecretariat:([^/]+)\/(.+)$/,
-  );
+  const qualifiedCardMatch = ref.match(/^card:([^/]+)\/([^/]+)\/(.+)$/);
+  if (qualifiedCardMatch) {
+    const game = normalizeGameId(qualifiedCardMatch[1]) ?? qualifiedCardMatch[1];
+    return `card:${game}/${qualifiedCardMatch[2]}/${qualifiedCardMatch[3]}`;
+  }
+
+  const cardMatch = ref.match(/^gloomhavensecretariat:([^/]+)\/(.+)$/);
   if (cardMatch) {
-    const explicitType = cardMatch[1];
-    const sourcePrefix = cardMatch[2];
-    const sourceRest = cardMatch[3];
-    const type = explicitType ?? CARD_TYPE_BY_SOURCE_PREFIX.get(sourcePrefix);
-    if (type) return `card:frosthaven/${type}/gloomhavensecretariat:${sourcePrefix}/${sourceRest}`;
+    const sourcePrefix = cardMatch[1];
+    const sourceRest = cardMatch[2];
+    const type = CARD_TYPE_BY_SOURCE_PREFIX.get(sourcePrefix);
+    if (type)
+      return `card:${FROSTHAVEN_GAME_ID}/${type}/gloomhavensecretariat:${sourcePrefix}/${sourceRest}`;
   }
 
   return ref;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -87,7 +87,7 @@ Grounding rules:
 - When an exact record has null or empty fields, state that the field is not available in the checked-in data. Do not recommend physical components, community knowledge, memory, or likely values as a substitute for missing tool data.
 - For building records, treat a cost object as known no-cost only when every numeric cost field is 0, including prosperity when present. If resources are 0 but prosperity is non-zero, say there is no resource cost but there is still a prosperity requirement.
 - If the user asks you to resolve something, call resolve_entity before opening or answering.
-- When the user gives an explicit game qualifier, preserve it in canonical refs such as section:gloomhaven2/67.1; never invent URI forms like gloomhaven2://section/67.1.
+- When the user gives an explicit game qualifier, normalize accepted aliases to canonical refs such as section:gloomhaven-2e/67.1; never invent URI forms like gloomhaven2://section/67.1.
 - Use neighbors for scenario/section traversal questions, including conclusions, read-now links, unlocks, next links, and related records. Open entities for record text after traversal identifies the target.
 - When neighbors returns the requested unlock, conclusion, read-now, next, or related target, open that target if text is needed, then answer. Do not search for a second path unless neighbors returns no relevant target.
 - For multi-hop traversal questions, open the starting record, then call neighbors for each hop; do not rely on open_entity links alone.

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -606,13 +606,13 @@ function validateKinds(
 }
 
 function sourceRefForPdf(game: string, source: string): string {
-  return `source:${game}/${source.replace(/\.pdf$/i, '')}`;
+  return `source:${normalizeToolGame(game)}/${source.replace(/\.pdf$/i, '')}`;
 }
 
 function canonicalScenarioRef(ref: string, game = DEFAULT_GAME): string {
   const match = ref.match(/(\d{1,3}[A-Z]?)$/i);
   const scenarioId = match ? match[1].padStart(3, '0') : ref;
-  return `scenario:${game}/${scenarioId}`;
+  return `scenario:${normalizeToolGame(game)}/${scenarioId}`;
 }
 
 function scenarioStorageRef(ref: string): string {
@@ -637,11 +637,11 @@ function gameQualifiedRef(
 }
 
 function canonicalSectionRef(ref: string, game = DEFAULT_GAME): string {
-  return `section:${game}/${sectionStorageRef(ref)}`;
+  return `section:${normalizeToolGame(game)}/${sectionStorageRef(ref)}`;
 }
 
 function canonicalCardRef(type: CardType, sourceId: string, game = DEFAULT_GAME): string {
-  return `card:${game}/${type}/${sourceId}`;
+  return `card:${normalizeToolGame(game)}/${type}/${sourceId}`;
 }
 
 function summarizeScenario(scenario: ScenarioResult, game = DEFAULT_GAME): KnowledgeEntitySummary {

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -55,7 +55,7 @@ describe('eval dataset', () => {
     const evalCase = cases.find((candidate) => candidate.id === 'traj-invalid-cross-game-ref');
 
     expect(evalCase?.finalAnswer?.grading).toMatch(/Gloomhaven 2 path is rejected/);
-    expect(evalCase?.trajectory?.requiredRefs).toContain('section:gloomhaven2/67.1');
+    expect(evalCase?.trajectory?.requiredRefs).toContain('section:gloomhaven-2e/67.1');
   });
 
   it('treats read-now chain traversal as a neighbors requirement', () => {

--- a/test/eval-trajectory.test.ts
+++ b/test/eval-trajectory.test.ts
@@ -57,6 +57,7 @@ describe('scoreTrajectory', () => {
         forbiddenToolKinds: [],
         requiredRefs: [
           'scenario:gloomhaven-2e/061',
+          'scenario:gloomhaven-2e/4A',
           'section:gloomhaven-2e/67.1',
           'card:gloomhaven-2e/items/gloomhavensecretariat:item/1',
         ],
@@ -66,7 +67,11 @@ describe('scoreTrajectory', () => {
         {
           name: 'open_entity',
           input: { ref: 'scenario:gloomhaven2/61' },
-          canonicalRefs: ['section:gh2/67.1', 'card:gh2e/items/gloomhavensecretariat:item/1'],
+          canonicalRefs: [
+            'scenario:gh2/4A',
+            'section:gh2/67.1',
+            'card:gh2e/items/gloomhavensecretariat:item/1',
+          ],
         },
       ],
     );

--- a/test/eval-trajectory.test.ts
+++ b/test/eval-trajectory.test.ts
@@ -48,6 +48,32 @@ describe('scoreTrajectory', () => {
     expect(result).toEqual({ pass: true, failures: [] });
   });
 
+  it('normalizes GH2 alias refs to canonical trajectory refs', () => {
+    const result = scoreTrajectory(
+      {
+        requiredTools: ['open_entity'],
+        requiredToolKinds: ['open'],
+        forbiddenTools: [],
+        forbiddenToolKinds: [],
+        requiredRefs: [
+          'scenario:gloomhaven-2e/061',
+          'section:gloomhaven-2e/67.1',
+          'card:gloomhaven-2e/items/gloomhavensecretariat:item/1',
+        ],
+        maxToolCalls: 2,
+      },
+      [
+        {
+          name: 'open_entity',
+          input: { ref: 'scenario:gloomhaven2/61' },
+          canonicalRefs: ['section:gh2/67.1', 'card:gh2e/items/gloomhavensecretariat:item/1'],
+        },
+      ],
+    );
+
+    expect(result).toEqual({ pass: true, failures: [] });
+  });
+
   it('matches exact card refs against opened GHS source IDs', () => {
     const result = scoreTrajectory(
       {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -87,6 +87,13 @@ const FAKE_RULE_HITS = [
   },
 ];
 
+const GH2_CANONICAL_SCENARIO_REF = 'gloomhavensecretariat:scenario/061';
+const GH2_CANONICAL_SCENARIO_NAME = 'GH2 Canonical Test Scenario';
+const GH2_CANONICAL_SECTION_REF = '67.1';
+const GH2_CANONICAL_SECTION_TEXT = 'GH2 canonical section marker text for ref normalization.';
+const GH2_CANONICAL_ITEM_SOURCE_ID = 'gloomhavensecretariat:item/gh2-canonical-test';
+const GH2_CANONICAL_ITEM_NAME = 'GH2 Canonical Test Blade';
+
 // `card_*` tables are seeded once per run by `test/helpers/global-setup.ts`.
 beforeAll(async () => {
   await setupTestDb();
@@ -314,6 +321,182 @@ describe('openEntity', () => {
     await expect(openEntity('61')).resolves.toMatchObject({
       ok: false,
       error: { code: 'ambiguous' },
+    });
+  });
+});
+
+describe('GH2 canonical entity refs', () => {
+  beforeAll(async () => {
+    const { db } = getDb();
+    await db.execute(sql`
+      DELETE FROM card_items
+      WHERE game = ${GLOOMHAVEN_2E_GAME_ID} AND source_id = ${GH2_CANONICAL_ITEM_SOURCE_ID}
+    `);
+    await db.execute(sql`
+      DELETE FROM section_book_sections
+      WHERE game = ${GLOOMHAVEN_2E_GAME_ID} AND ref = ${GH2_CANONICAL_SECTION_REF}
+    `);
+    await db.execute(sql`
+      DELETE FROM scenario_book_scenarios
+      WHERE game = ${GLOOMHAVEN_2E_GAME_ID} AND ref = ${GH2_CANONICAL_SCENARIO_REF}
+    `);
+    await db.execute(sql`
+      INSERT INTO scenario_book_scenarios (
+        game, ref, scenario_group, scenario_index, name, initial, source_pdf, source_page, raw_text, metadata
+      )
+      VALUES (
+        ${GLOOMHAVEN_2E_GAME_ID},
+        ${GH2_CANONICAL_SCENARIO_REF},
+        'test',
+        '61',
+        ${GH2_CANONICAL_SCENARIO_NAME},
+        false,
+        null,
+        null,
+        'GH2 canonical scenario marker text.',
+        '{}'::jsonb
+      )
+    `);
+    await db.execute(sql`
+      INSERT INTO section_book_sections (
+        game, ref, section_number, section_variant, source_pdf, source_page, text, metadata
+      )
+      VALUES (
+        ${GLOOMHAVEN_2E_GAME_ID},
+        ${GH2_CANONICAL_SECTION_REF},
+        67,
+        1,
+        'gh2-ghs-sections.json',
+        1,
+        ${GH2_CANONICAL_SECTION_TEXT},
+        '{}'::jsonb
+      )
+    `);
+    await db.execute(sql`
+      INSERT INTO card_items (
+        game, source_id, number, name, slot, cost, craft_cost, effect, uses, spent, lost
+      )
+      VALUES (
+        ${GLOOMHAVEN_2E_GAME_ID},
+        ${GH2_CANONICAL_ITEM_SOURCE_ID},
+        '001',
+        ${GH2_CANONICAL_ITEM_NAME},
+        'one hand',
+        10,
+        null,
+        'GH2 canonical item effect marker.',
+        null,
+        false,
+        false
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    const { db } = getDb();
+    await db.execute(sql`
+      DELETE FROM card_items
+      WHERE game = ${GLOOMHAVEN_2E_GAME_ID} AND source_id = ${GH2_CANONICAL_ITEM_SOURCE_ID}
+    `);
+    await db.execute(sql`
+      DELETE FROM section_book_sections
+      WHERE game = ${GLOOMHAVEN_2E_GAME_ID} AND ref = ${GH2_CANONICAL_SECTION_REF}
+    `);
+    await db.execute(sql`
+      DELETE FROM scenario_book_scenarios
+      WHERE game = ${GLOOMHAVEN_2E_GAME_ID} AND ref = ${GH2_CANONICAL_SCENARIO_REF}
+    `);
+  });
+
+  it('normalizes alias-qualified GH2 scenario refs to the canonical game id', async () => {
+    const result = await openEntity('scenario:gloomhaven2/061');
+
+    expect(result).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'scenario',
+        ref: `scenario:${GLOOMHAVEN_2E_GAME_ID}/061`,
+        title: GH2_CANONICAL_SCENARIO_NAME,
+      },
+    });
+  });
+
+  it('normalizes alias-qualified GH2 section refs to the canonical game id', async () => {
+    const result = await openEntity('section:gh2/67.1');
+
+    expect(result).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'section',
+        ref: `section:${GLOOMHAVEN_2E_GAME_ID}/67.1`,
+        data: {
+          text: GH2_CANONICAL_SECTION_TEXT,
+        },
+      },
+    });
+  });
+
+  it('normalizes alias-qualified GH2 card refs to the canonical game id', async () => {
+    const result = await openEntity(`card:gh2e/items/${GH2_CANONICAL_ITEM_SOURCE_ID}`);
+
+    expect(result).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'card',
+        ref: `card:${GLOOMHAVEN_2E_GAME_ID}/items/${GH2_CANONICAL_ITEM_SOURCE_ID}`,
+        title: GH2_CANONICAL_ITEM_NAME,
+        data: {
+          canonicalRef: `card:${GLOOMHAVEN_2E_GAME_ID}/items/${GH2_CANONICAL_ITEM_SOURCE_ID}`,
+          sourceId: GH2_CANONICAL_ITEM_SOURCE_ID,
+        },
+      },
+    });
+  });
+
+  it('keeps bare legacy section refs Frosthaven-only unless an active game is supplied', async () => {
+    const defaultResult = await openEntity(GH2_CANONICAL_SECTION_REF);
+    expect(defaultResult).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'section',
+        ref: 'section:frosthaven/67.1',
+      },
+    });
+    if (!defaultResult.ok) throw new Error(defaultResult.error.message);
+    expect(defaultResult.entity.data.text).not.toBe(GH2_CANONICAL_SECTION_TEXT);
+
+    const gh2Result = await openEntity(GH2_CANONICAL_SECTION_REF, { game: 'gh2' });
+    expect(gh2Result).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'section',
+        ref: `section:${GLOOMHAVEN_2E_GAME_ID}/67.1`,
+        data: {
+          text: GH2_CANONICAL_SECTION_TEXT,
+        },
+      },
+    });
+  });
+
+  it('keeps legacy scenario source IDs Frosthaven-only unless an active game is supplied', async () => {
+    const defaultResult = await openEntity(GH2_CANONICAL_SCENARIO_REF);
+    expect(defaultResult).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'scenario',
+        ref: 'scenario:frosthaven/061',
+        title: 'Life and Death',
+      },
+    });
+
+    const gh2Result = await openEntity(GH2_CANONICAL_SCENARIO_REF, { game: 'gloomhaven 2.0' });
+    expect(gh2Result).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'scenario',
+        ref: `scenario:${GLOOMHAVEN_2E_GAME_ID}/061`,
+        title: GH2_CANONICAL_SCENARIO_NAME,
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary
- normalize canonical source, scenario, section, and card refs through the shared game alias parser
- update trajectory scoring so GH2 alias refs match canonical `gloomhaven-2e` expectations
- add GH2 fixture-backed tests for canonical refs and Frosthaven-default legacy refs

## Verification
- `npm run check`

Fixes SQR-185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized game-qualified references so cross-game links and generated refs consistently use canonical game identifiers, preventing ambiguous or non-canonical references.
  * Updated agent grounding to prefer and emit canonical reference forms.

* **Tests**
  * Added and expanded tests to verify normalization of game-qualified scenario, section, and card references and end-to-end canonical handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->