### PR TITLE
fix(agent): suppress streamed scratch text before tool use

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -976,10 +976,19 @@ async function callClaude(
   const stream = requestOptions
     ? client.messages.stream(paramsWithTools, requestOptions)
     : client.messages.stream(paramsWithTools);
+  // Text emitted by a response that ends in tool_use is planning scratch, not answer prose.
+  const textDeltas: string[] = [];
   stream.on('text', (delta) => {
-    void emit('text', { delta });
+    textDeltas.push(delta);
   });
-  return stream.finalMessage();
+  const finalMessage = await stream.finalMessage();
+  const hasToolUse = finalMessage.content.some((block) => block.type === 'tool_use');
+  if (!hasToolUse) {
+    for (const delta of textDeltas) {
+      await emit('text', { delta });
+    }
+  }
+  return finalMessage;
 }
 
 /**

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -1581,5 +1581,8 @@ describe('runAgentLoop with emit (streaming)', () => {
 
     const result = await runAgentLoop('test', { emit, toolSurface: 'legacy' });
     expect(result).toBe('Read section 67.1.');
+    expect(
+      emit.mock.calls.filter(([event]) => event === 'text').map(([, payload]) => payload),
+    ).toEqual([{ delta: 'Read section 67.1.' }]);
   });
 });


### PR DESCRIPTION
## Summary
- buffer provider text deltas inside `callClaude()` until the final message is available
- suppress buffered text when that message contains `tool_use`, so planning scratch does not render as assistant prose
- assert the streaming event payload only contains the final user-facing answer

## Review
- No blocking findings in the pre-landing review.
- Intentional tradeoff: final answer text is emitted after the provider message completes, which avoids scratch leakage before tool calls.

## Verification
- `npm run check`

Fixes SQR-222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where intermediate AI reasoning text was incorrectly emitted as final output when tool calls were involved. Now only the final answer text is emitted in such cases.

* **Tests**
  * Improved test coverage to verify that intermediate text is properly suppressed when tool calls are planned.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->