### PR TITLE
feat(knowledge): expose GH2 rule source provenance

### DIFF
--- a/data/rule-sources/metadata.json
+++ b/data/rule-sources/metadata.json
@@ -16,6 +16,7 @@
     "sourceType": "faq",
     "sourceUrl": "https://cephalofairgames.github.io/gloomhaven2e-faq/",
     "capturedAt": "2026-05-24",
+    "sourceLastUpdated": "2026-04-19",
     "refreshNotes": "Official Gloomhaven: Second Edition FAQ HTML snapshot. The page showed Last Updated 2026-04-19 when captured. Use for retrieval and citation indexing only; do not use for model training."
   },
   {
@@ -25,6 +26,7 @@
     "sourceType": "errata",
     "sourceUrl": "https://cephalofairgames.github.io/gloomhaven2e-faq/#page_01",
     "capturedAt": "2026-05-24",
+    "sourceLastUpdated": "2026-04-19",
     "refreshNotes": "Errata-only HTML snapshot extracted from section 1.0 Errata of the official FAQ. Refresh from the current FAQ unless Cephalofair publishes a separate official errata file."
   }
 ]

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -511,11 +511,15 @@ in `data/rule-sources/`. Filenames must start with a supported game prefix
 (`fh-` or `gh2-`) so indexing can derive the `game` value. The
 `data/rule-sources/metadata.json` manifest records each non-GHS source's stable
 id, file path, game, source type, official URL, capture date, and refresh notes.
-When an official PDF is image-based, the metadata can also point at the
-normalized OCR snapshot used for indexing. To refresh an official source,
-replace the stable file in place, update the matching metadata record, refresh
-any normalized snapshot, and rerun `npm run index`; unchanged sources are
-skipped and changed sources are re-indexed by content hash.
+FAQ and errata snapshots should also include the official source's
+`sourceLastUpdated` date when the upstream page publishes one. Runtime rule
+search and citation results derive their game, source type, source label,
+locator, URL, and freshness fields from this manifest without changing the
+embedding row keys. When an official PDF is image-based, the metadata can also
+point at the normalized OCR snapshot used for indexing. To refresh an official
+source, replace the stable file in place, update the matching metadata record,
+refresh any normalized snapshot, and rerun `npm run index`; unchanged sources
+are skipped and changed sources are re-indexed by content hash.
 
 The current GH2 rulebook snapshot is the Apple Vision baseline, generated on
 macOS with:

--- a/src/retrieval-source.ts
+++ b/src/retrieval-source.ts
@@ -1,5 +1,3 @@
-const SOURCE_SUFFIX = /\.(pdf|html?|md|txt)$/i;
-
 /**
  * Human-readable label for an indexed rule source.
  *
@@ -8,19 +6,4 @@ const SOURCE_SUFFIX = /\.(pdf|html?|md|txt)$/i;
  * This helper exists for tool/API/UI display so retrieval results clearly
  * distinguish rulebooks, FAQ snapshots, errata, and scenario/section books.
  */
-export function formatRetrievalSourceLabel(source: string): string {
-  const basename = source.replace(SOURCE_SUFFIX, '');
-
-  if (/-rule-book$/i.test(basename)) return 'Rulebook';
-  if (/-puzzle-book$/i.test(basename)) return 'Puzzle Book';
-  if (/-faq$/i.test(basename)) return 'FAQ';
-  if (/-errata$/i.test(basename)) return 'Errata';
-
-  const scenarioMatch = basename.match(/-scenario-book-(.+)$/i);
-  if (scenarioMatch) return `Scenario Book ${scenarioMatch[1]}`;
-
-  const sectionMatch = basename.match(/-section-book-(.+)$/i);
-  if (sectionMatch) return `Section Book ${sectionMatch[1]}`;
-
-  return basename;
-}
+export { formatRetrievalSourceLabel } from './rule-source-provenance.ts';

--- a/src/rule-source-provenance.ts
+++ b/src/rule-source-provenance.ts
@@ -78,12 +78,17 @@ function readMetadata(): RuleSourceMetadata[] {
   return JSON.parse(raw) as RuleSourceMetadata[];
 }
 
-const METADATA_BY_INDEXED_BASENAME = new Map<string, RuleSourceMetadata>();
+const METADATA_BY_GAME_AND_BASENAME = new Map<string, RuleSourceMetadata>();
+
+function metadataKey(game: GameId, file: string): string {
+  return `${game}:${basename(file)}`;
+}
+
 for (const source of readMetadata()) {
   for (const file of [source.file, source.normalizedFile].filter(
     (value): value is string => typeof value === 'string',
   )) {
-    METADATA_BY_INDEXED_BASENAME.set(basename(file), source);
+    METADATA_BY_GAME_AND_BASENAME.set(metadataKey(source.game, file), source);
   }
 }
 
@@ -96,15 +101,15 @@ export function ruleSourceLocator(chunkIndex: number): string {
 }
 
 export function ruleSourceProvenance(source: string, game: GameId): RuleSourceProvenance {
-  const metadata = METADATA_BY_INDEXED_BASENAME.get(basename(source));
+  const metadata = METADATA_BY_GAME_AND_BASENAME.get(metadataKey(game, source));
   const sourceType = metadata?.sourceType ?? inferSourceType(source);
   const sourceRefId = metadata?.id ?? sourceStem(source);
 
   return {
-    game: metadata?.game ?? game,
+    game,
     sourceType,
     sourceLabel: formatSourceLabel(source),
-    sourceRef: `source:${metadata?.game ?? game}/${sourceRefId}`,
+    sourceRef: `source:${game}/${sourceRefId}`,
     sourceUrl: metadata?.sourceUrl,
     freshness: metadata
       ? {

--- a/src/rule-source-provenance.ts
+++ b/src/rule-source-provenance.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from 'node:fs';
+import { basename, extname } from 'node:path';
+
+import type { GameId } from './game.ts';
+
+export type RuleSourceType =
+  | 'rulebook'
+  | 'faq'
+  | 'errata'
+  | 'puzzle_book'
+  | 'scenario_book'
+  | 'section_book'
+  | 'unknown';
+
+export interface RuleSourceFreshness {
+  capturedAt: string;
+  sourceLastUpdated?: string;
+}
+
+interface RuleSourceMetadata {
+  id: string;
+  file: string;
+  normalizedFile?: string;
+  game: GameId;
+  sourceType: RuleSourceType;
+  sourceUrl: string;
+  capturedAt: string;
+  sourceLastUpdated?: string;
+  refreshNotes: string;
+}
+
+export interface RuleSourceProvenance {
+  game: GameId;
+  sourceType: RuleSourceType;
+  sourceLabel: string;
+  sourceRef: string;
+  sourceUrl?: string;
+  freshness?: RuleSourceFreshness;
+}
+
+const SOURCE_SUFFIX = /\.(pdf|html?|md|txt)$/i;
+
+function sourceStem(source: string): string {
+  const extension = extname(source);
+  return extension ? source.slice(0, -extension.length) : source;
+}
+
+function formatSourceLabel(source: string): string {
+  const stem = sourceStem(source);
+
+  if (/-rule-book$/i.test(stem)) return 'Rulebook';
+  if (/-puzzle-book$/i.test(stem)) return 'Puzzle Book';
+  if (/-faq$/i.test(stem)) return 'FAQ';
+  if (/-errata$/i.test(stem)) return 'Errata';
+
+  const scenarioMatch = stem.match(/-scenario-book-(.+)$/i);
+  if (scenarioMatch) return `Scenario Book ${scenarioMatch[1]}`;
+
+  const sectionMatch = stem.match(/-section-book-(.+)$/i);
+  if (sectionMatch) return `Section Book ${sectionMatch[1]}`;
+
+  return stem;
+}
+
+function inferSourceType(source: string): RuleSourceType {
+  const stem = sourceStem(source);
+  if (/-rule-book$/i.test(stem)) return 'rulebook';
+  if (/-puzzle-book$/i.test(stem)) return 'puzzle_book';
+  if (/-faq$/i.test(stem)) return 'faq';
+  if (/-errata$/i.test(stem)) return 'errata';
+  if (/-scenario-book-/i.test(stem)) return 'scenario_book';
+  if (/-section-book-/i.test(stem)) return 'section_book';
+  return 'unknown';
+}
+
+function readMetadata(): RuleSourceMetadata[] {
+  const raw = readFileSync(new URL('../data/rule-sources/metadata.json', import.meta.url), 'utf8');
+  return JSON.parse(raw) as RuleSourceMetadata[];
+}
+
+const METADATA_BY_INDEXED_BASENAME = new Map<string, RuleSourceMetadata>();
+for (const source of readMetadata()) {
+  for (const file of [source.file, source.normalizedFile].filter(
+    (value): value is string => typeof value === 'string',
+  )) {
+    METADATA_BY_INDEXED_BASENAME.set(basename(file), source);
+  }
+}
+
+export function formatRetrievalSourceLabel(source: string): string {
+  return formatSourceLabel(source.replace(SOURCE_SUFFIX, ''));
+}
+
+export function ruleSourceLocator(chunkIndex: number): string {
+  return `passage ${chunkIndex + 1}`;
+}
+
+export function ruleSourceProvenance(source: string, game: GameId): RuleSourceProvenance {
+  const metadata = METADATA_BY_INDEXED_BASENAME.get(basename(source));
+  const sourceType = metadata?.sourceType ?? inferSourceType(source);
+  const sourceRefId = metadata?.id ?? sourceStem(source);
+
+  return {
+    game: metadata?.game ?? game,
+    sourceType,
+    sourceLabel: formatSourceLabel(source),
+    sourceRef: `source:${metadata?.game ?? game}/${sourceRefId}`,
+    sourceUrl: metadata?.sourceUrl,
+    freshness: metadata
+      ? {
+          capturedAt: metadata.capturedAt,
+          ...(metadata.sourceLastUpdated ? { sourceLastUpdated: metadata.sourceLastUpdated } : {}),
+        }
+      : undefined,
+  };
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -195,7 +195,7 @@ export interface KnowledgeEntitySummary {
 
 export interface KnowledgeCitation {
   sourceRef: string;
-  sourceType?: string;
+  sourceType?: RuleSourceType;
   sourceLabel: string;
   locator: string;
   sourceUrl?: string;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -5,6 +5,12 @@
 
 import { embed } from './embedder.ts';
 import { formatRetrievalSourceLabel } from './retrieval-source.ts';
+import {
+  ruleSourceLocator,
+  ruleSourceProvenance,
+  type RuleSourceFreshness,
+  type RuleSourceType,
+} from './rule-source-provenance.ts';
 import { getEntryBySourceChunk, search } from './vector-store.ts';
 import type { ScoredEntry } from './vector-store.ts';
 import {
@@ -43,8 +49,14 @@ import type { GameId } from './game.ts';
 
 export interface RuleResult {
   text: string;
+  game: GameId;
   source: string;
+  sourceRef: string;
+  sourceUrl?: string;
+  sourceType: RuleSourceType;
   sourceLabel: string;
+  sourceLocator: string;
+  freshness?: RuleSourceFreshness;
   score: number;
 }
 
@@ -109,8 +121,9 @@ export interface SourceInfo {
   searchable: boolean;
   openable: boolean;
   relations: string[];
+  sourceType?: RuleSourceType;
   counts?: Record<string, number>;
-  freshness?: Record<string, string | number>;
+  freshness?: RuleSourceFreshness;
 }
 
 export type KnowledgeKind = 'rules_passage' | 'scenario' | 'section' | 'card_type' | 'card';
@@ -182,8 +195,11 @@ export interface KnowledgeEntitySummary {
 
 export interface KnowledgeCitation {
   sourceRef: string;
+  sourceType?: string;
   sourceLabel: string;
   locator: string;
+  sourceUrl?: string;
+  freshness?: RuleSourceFreshness;
 }
 
 export interface KnowledgeLink {
@@ -671,11 +687,12 @@ function summarizeSection(section: SectionResult, game = DEFAULT_GAME): Knowledg
 }
 
 function summarizeRule(hit: ScoredEntry, game = DEFAULT_GAME): KnowledgeEntitySummary {
+  const provenance = ruleSourceProvenance(hit.source, normalizeToolGame(game));
   return {
     kind: 'rules_passage',
     ref: `rules:${game}/${hit.source}#chunk=${hit.chunkIndex}`,
-    title: `${formatRetrievalSourceLabel(hit.source)} passage ${hit.chunkIndex + 1}`,
-    sourceLabel: formatRetrievalSourceLabel(hit.source),
+    title: `${provenance.sourceLabel} ${ruleSourceLocator(hit.chunkIndex)}`,
+    sourceLabel: provenance.sourceLabel,
   };
 }
 
@@ -715,11 +732,15 @@ function citationForSection(section: SectionResult, game = DEFAULT_GAME): Knowle
 }
 
 function citationForRule(hit: ScoredEntry, game = DEFAULT_GAME): KnowledgeCitation[] {
+  const provenance = ruleSourceProvenance(hit.source, normalizeToolGame(game));
   return [
     {
-      sourceRef: sourceRefForPdf(game, hit.source),
-      sourceLabel: formatRetrievalSourceLabel(hit.source),
-      locator: `chunk ${hit.chunkIndex}`,
+      sourceRef: provenance.sourceRef,
+      sourceType: provenance.sourceType,
+      sourceLabel: provenance.sourceLabel,
+      locator: ruleSourceLocator(hit.chunkIndex),
+      ...(provenance.sourceUrl ? { sourceUrl: provenance.sourceUrl } : {}),
+      ...(provenance.freshness ? { freshness: provenance.freshness } : {}),
     },
   ];
 }
@@ -838,8 +859,9 @@ export async function searchRules(query: string, topK = 6, opts?: ToolOpts): Pro
   return hits.map((h) => ({
     text: h.text,
     source: h.source,
-    sourceLabel: formatRetrievalSourceLabel(h.source),
+    sourceLocator: ruleSourceLocator(h.chunkIndex),
     score: h.score,
+    ...ruleSourceProvenance(h.source, h.game),
   }));
 }
 
@@ -894,6 +916,7 @@ export async function listCards(
 export async function inspectSources(opts?: ToolOpts): Promise<InspectSourcesResult> {
   const game = normalizeToolGame(opts?.game);
   const gameDefinition = gameDefinitionFor(game);
+  const rulebook = ruleSourceProvenance(`${gameDefinition.sourcePrefix}-rule-book.pdf`, game);
   const [cardCounts, scenarioSectionStatus] = await Promise.all([
     countsByType({ game }),
     getScenarioSectionBooksBootstrapStatus({ game }),
@@ -906,10 +929,14 @@ export async function inspectSources(opts?: ToolOpts): Promise<InspectSourcesRes
       searchable: true,
       openable: false,
       relations: [],
+      sourceType: rulebook.sourceType,
+      ...(rulebook.freshness ? { freshness: rulebook.freshness } : {}),
     },
   ];
 
   if (game === GLOOMHAVEN_2E_GAME_ID) {
+    const faq = ruleSourceProvenance('gh2-faq.html', game);
+    const errata = ruleSourceProvenance('gh2-errata.html', game);
     sources.push(
       {
         ref: `source:${game}/faq`,
@@ -918,6 +945,8 @@ export async function inspectSources(opts?: ToolOpts): Promise<InspectSourcesRes
         searchable: true,
         openable: false,
         relations: [],
+        sourceType: faq.sourceType,
+        ...(faq.freshness ? { freshness: faq.freshness } : {}),
       },
       {
         ref: `source:${game}/errata`,
@@ -926,6 +955,8 @@ export async function inspectSources(opts?: ToolOpts): Promise<InspectSourcesRes
         searchable: true,
         openable: false,
         relations: [],
+        sourceType: errata.sourceType,
+        ...(errata.freshness ? { freshness: errata.freshness } : {}),
       },
     );
   }
@@ -1161,14 +1192,20 @@ export async function openEntity(ref: string, opts?: ToolOpts): Promise<Knowledg
       return { ok: false, error: { code: 'not_found', message: `Rule passage not found: ${ref}` } };
     }
     const entity = summarizeRule(hit, ruleRef.game);
+    const provenance = ruleSourceProvenance(hit.source, ruleRef.game);
     return {
       ok: true,
       entity: {
         ...entity,
         data: {
           text: hit.text,
+          game: hit.game,
           source: hit.source,
+          sourceType: provenance.sourceType,
+          sourceLabel: provenance.sourceLabel,
+          sourceLocator: ruleSourceLocator(hit.chunkIndex),
           chunkIndex: hit.chunkIndex,
+          ...(provenance.freshness ? { freshness: provenance.freshness } : {}),
         },
       },
       citations: citationForRule(hit, ruleRef.game),

--- a/test/retrieval-source.test.ts
+++ b/test/retrieval-source.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import { FROSTHAVEN_GAME_ID, GLOOMHAVEN_2E_GAME_ID } from '../src/game.ts';
 import { formatRetrievalSourceLabel } from '../src/retrieval-source.ts';
+import { ruleSourceProvenance } from '../src/rule-source-provenance.ts';
 
 describe('formatRetrievalSourceLabel', () => {
   it('labels indexed PDF and HTML rule sources', () => {
@@ -11,5 +13,26 @@ describe('formatRetrievalSourceLabel', () => {
     expect(formatRetrievalSourceLabel('gh2-errata.html')).toBe('Errata');
     expect(formatRetrievalSourceLabel('gh2-errata.txt')).toBe('Errata');
     expect(formatRetrievalSourceLabel('fh-scenario-book-42-61.pdf')).toBe('Scenario Book 42-61');
+  });
+});
+
+describe('ruleSourceProvenance', () => {
+  it('keys manifest metadata by game and basename', () => {
+    expect(ruleSourceProvenance('gh2-faq.html', GLOOMHAVEN_2E_GAME_ID)).toMatchObject({
+      game: GLOOMHAVEN_2E_GAME_ID,
+      sourceRef: `source:${GLOOMHAVEN_2E_GAME_ID}/gh2-faq`,
+      sourceType: 'faq',
+      freshness: {
+        capturedAt: '2026-05-24',
+        sourceLastUpdated: '2026-04-19',
+      },
+    });
+
+    expect(ruleSourceProvenance('gh2-faq.html', FROSTHAVEN_GAME_ID)).toMatchObject({
+      game: FROSTHAVEN_GAME_ID,
+      sourceRef: `source:${FROSTHAVEN_GAME_ID}/gh2-faq`,
+      sourceType: 'faq',
+      freshness: undefined,
+    });
   });
 });

--- a/test/rule-source-metadata.test.ts
+++ b/test/rule-source-metadata.test.ts
@@ -11,6 +11,7 @@ interface RuleSourceMetadata {
   sourceType: string;
   sourceUrl: string;
   capturedAt: string;
+  sourceLastUpdated?: string;
   refreshNotes: string;
 }
 
@@ -42,6 +43,7 @@ describe('GH2 rule source metadata', () => {
           game: 'gloomhaven-2e',
           sourceType: 'faq',
           sourceUrl: 'https://cephalofairgames.github.io/gloomhaven2e-faq/',
+          sourceLastUpdated: '2026-04-19',
         }),
         expect.objectContaining({
           id: 'gh2-errata',
@@ -49,6 +51,7 @@ describe('GH2 rule source metadata', () => {
           game: 'gloomhaven-2e',
           sourceType: 'errata',
           sourceUrl: 'https://cephalofairgames.github.io/gloomhaven2e-faq/#page_01',
+          sourceLastUpdated: '2026-04-19',
         }),
       ]),
     );

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -117,21 +117,79 @@ describe('searchRules', () => {
     const results: RuleResult[] = await searchRules('loot action');
     expect(results.length).toBeGreaterThan(0);
     expect(results[0]).toHaveProperty('text');
+    expect(results[0]).toHaveProperty('game');
     expect(results[0]).toHaveProperty('source');
+    expect(results[0]).toHaveProperty('sourceRef');
+    expect(results[0]).toHaveProperty('sourceType');
     expect(results[0]).toHaveProperty('sourceLabel');
+    expect(results[0]).toHaveProperty('sourceLocator');
     expect(results[0]).toHaveProperty('score');
     expect(typeof results[0].text).toBe('string');
+    expect(typeof results[0].game).toBe('string');
     expect(typeof results[0].source).toBe('string');
+    expect(typeof results[0].sourceRef).toBe('string');
+    expect(typeof results[0].sourceType).toBe('string');
     expect(typeof results[0].sourceLabel).toBe('string');
+    expect(typeof results[0].sourceLocator).toBe('string');
     expect(typeof results[0].score).toBe('number');
   });
 
-  it('adds source labels that distinguish rulebook, scenario, and section books', async () => {
+  it('adds source provenance that distinguishes rulebook, scenario, and section books', async () => {
     const results = await searchRules('scenario 61');
-    expect(results.map((r) => [r.source, r.sourceLabel])).toEqual([
-      ['fh-rule-book.pdf', 'Rulebook'],
-      ['fh-scenario-book-42-61.pdf', 'Scenario Book 42-61'],
-      ['fh-section-book-62-81.pdf', 'Section Book 62-81'],
+    expect(results.map((r) => [r.source, r.sourceType, r.sourceLabel, r.sourceLocator])).toEqual([
+      ['fh-rule-book.pdf', 'rulebook', 'Rulebook', 'passage 1'],
+      ['fh-scenario-book-42-61.pdf', 'scenario_book', 'Scenario Book 42-61', 'passage 2'],
+      ['fh-section-book-62-81.pdf', 'section_book', 'Section Book 62-81', 'passage 3'],
+    ]);
+  });
+
+  it('adds captured freshness metadata for GH2 FAQ and errata sources', async () => {
+    mockSearch.mockResolvedValueOnce([
+      {
+        id: 'gh2-faq.html::3',
+        text: 'FAQ answer.',
+        source: 'gh2-faq.html',
+        chunkIndex: 3,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.8,
+      },
+      {
+        id: 'gh2-errata.html::0',
+        text: 'Errata answer.',
+        source: 'gh2-errata.html',
+        chunkIndex: 0,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.7,
+      },
+    ]);
+
+    const results = await searchRules('gh2 faq errata', 2, { game: 'gh2' });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        game: GLOOMHAVEN_2E_GAME_ID,
+        sourceRef: `source:${GLOOMHAVEN_2E_GAME_ID}/gh2-faq`,
+        sourceUrl: 'https://cephalofairgames.github.io/gloomhaven2e-faq/',
+        sourceType: 'faq',
+        sourceLabel: 'FAQ',
+        sourceLocator: 'passage 4',
+        freshness: expect.objectContaining({
+          capturedAt: '2026-05-24',
+          sourceLastUpdated: '2026-04-19',
+        }),
+      }),
+      expect.objectContaining({
+        game: GLOOMHAVEN_2E_GAME_ID,
+        sourceRef: `source:${GLOOMHAVEN_2E_GAME_ID}/gh2-errata`,
+        sourceUrl: 'https://cephalofairgames.github.io/gloomhaven2e-faq/#page_01',
+        sourceType: 'errata',
+        sourceLabel: 'Errata',
+        sourceLocator: 'passage 1',
+        freshness: expect.objectContaining({
+          capturedAt: '2026-05-24',
+          sourceLastUpdated: '2026-04-19',
+        }),
+      }),
     ]);
   });
 
@@ -290,6 +348,13 @@ describe('openEntity', () => {
       sourceLabel: 'Rulebook',
     });
     expect(result.entity.data.text).toContain('Loot action');
+    expect(result.citations).toEqual([
+      expect.objectContaining({
+        sourceType: 'rulebook',
+        sourceLabel: 'Rulebook',
+        locator: 'passage 1',
+      }),
+    ]);
   });
 
   it('returns structured not_found and invalid_ref failures', async () => {
@@ -522,6 +587,52 @@ describe('searchKnowledge', () => {
       citations: expect.any(Array),
       nextRefs: expect.any(Array),
     });
+  });
+
+  it('carries typed GH2 rule-source citations for FAQ and errata hits', async () => {
+    mockSearch.mockResolvedValueOnce([
+      {
+        id: 'gh2-faq.html::3',
+        text: 'FAQ answer.',
+        source: 'gh2-faq.html',
+        chunkIndex: 3,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.8,
+      },
+      {
+        id: 'gh2-errata.html::0',
+        text: 'Errata answer.',
+        source: 'gh2-errata.html',
+        chunkIndex: 0,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.7,
+      },
+    ]);
+
+    const result = await searchKnowledge('gh2 faq errata', {
+      scope: ['rules_passage'],
+      limit: 2,
+      game: 'gh2',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.results.map((hit) => hit.citations[0])).toEqual([
+      expect.objectContaining({
+        sourceRef: `source:${GLOOMHAVEN_2E_GAME_ID}/gh2-faq`,
+        sourceType: 'faq',
+        sourceLabel: 'FAQ',
+        locator: 'passage 4',
+        sourceUrl: 'https://cephalofairgames.github.io/gloomhaven2e-faq/',
+      }),
+      expect.objectContaining({
+        sourceRef: `source:${GLOOMHAVEN_2E_GAME_ID}/gh2-errata`,
+        sourceType: 'errata',
+        sourceLabel: 'Errata',
+        locator: 'passage 1',
+        sourceUrl: 'https://cephalofairgames.github.io/gloomhaven2e-faq/#page_01',
+      }),
+    ]);
   });
 
   it('returns an empty successful result set for no-result searches', async () => {
@@ -828,12 +939,20 @@ describe('knowledge discovery tools', () => {
           label: 'Gloomhaven 2.0 FAQ',
           kinds: ['rules_passage'],
           searchable: true,
+          freshness: expect.objectContaining({
+            capturedAt: '2026-05-24',
+            sourceLastUpdated: '2026-04-19',
+          }),
         }),
         expect.objectContaining({
           ref: `source:${GLOOMHAVEN_2E_GAME_ID}/errata`,
           label: 'Gloomhaven 2.0 Errata',
           kinds: ['rules_passage'],
           searchable: true,
+          freshness: expect.objectContaining({
+            capturedAt: '2026-05-24',
+            sourceLastUpdated: '2026-04-19',
+          }),
         }),
         expect.objectContaining({
           ref: `source:${GLOOMHAVEN_2E_GAME_ID}/scenario-section-books`,


### PR DESCRIPTION
## Summary
- add a rule-source provenance helper backed by `data/rule-sources/metadata.json`
- expose game, source ref, source type, source label, locator, URL, and freshness metadata on rule search results and rule citations
- add GH2 FAQ/errata `sourceLastUpdated` metadata and document the source manifest contract

## Validation
- `npm run check` (88 files, 1250 tests)

Fixes SQR-190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results and citations now include richer provenance: source type, stable source reference, source URL (when available), passage locators, and freshness metadata.
  * Entity views and source inspection now surface provenance-derived labels, locators, and freshness info.

* **Documentation**
  * Data-management guidance updated: FAQ/errata snapshots must record upstream last-updated dates and follow the documented refresh procedure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->