### PR TITLE
test(agent): lock down stream hygiene contract

### DIFF
--- a/docs/SSE_CONTRACT.md
+++ b/docs/SSE_CONTRACT.md
@@ -47,13 +47,17 @@ The browser consumes these SSE event names:
   - Replaces the pending answer UI with an error banner.
   - Payload: `{ "kind": string, "message": string, "recoverable": boolean }`
 
+The browser does not consume provider-native stream chunks directly. Any new
+internal event must be mapped here before it can become browser-visible.
+
 ## Required success-path invariants
 
 For every successful stream:
 
 1. The browser may receive zero or more `text-delta` events before completion.
    If present, their concatenation represents the plain-text incremental
-   answer.
+   answer. Planning narration, raw tool output, and debug data are never answer
+   text and must not be sent as `text-delta`.
 2. The browser must receive exactly one terminal `done` event.
 3. Any `text-delta` events must arrive before `done`.
 4. Tool events may appear before completion, but they do not count as answer
@@ -89,17 +93,33 @@ turns are not transparently retried after `ask()` starts. The browser may have
 already received partial text or tool events, so the safe terminal state is one
 recoverable error event plus one persisted assistant failure row.
 
+## Internal event vocabulary
+
+The conversation service emits Squire-owned internal events. These are typed in
+`src/service.ts` and are intentionally narrower than provider stream events:
+
+- `text`: final answer prose only. Tool-planning text such as "Let me search"
+  or raw retrieved fragments must not be emitted as `text`.
+- `tool_call`: a tool lookup or source traversal started.
+- `tool_result`: a tool lookup or source traversal completed.
+- `tool_progress`: optional user-safe progress from inside a long tool. This is
+  trace-only today and has no browser mapping.
+- `debug`: diagnostic data for traces/logs. This is never browser-visible.
+- `done`: internal completion signal only. The route emits browser `done` after
+  persistence so it can include sanitized HTML and persisted consulted sources.
+
 ## Translation rules
 
-The conversation service emits internal events like `text`, `tool_call`,
-`tool_result`, and `done`. The HTTP stream route is responsible for translating
-those into the browser contract above.
+The HTTP stream route is responsible for translating internal events into the
+browser contract above.
 
 The route, not the provider, owns the final browser ordering guarantees:
 
 - provider/internal `text` -> browser `text-delta`
 - provider/internal `tool_call` -> browser `tool-start`
 - provider/internal `tool_result` -> browser `tool-result`
+- internal `tool_progress` -> no browser event
+- internal `debug` -> no browser event
 - provider/internal `done` is only a completion signal
 - browser `done` is emitted by the route with the final sanitized HTML derived
   from the persisted assistant message and the persisted `consultedSources`
@@ -111,6 +131,10 @@ Regression tests should assert browser-visible behavior, not only persistence:
 
 - successful streams without incremental text still end with a visible
   `done.html` fragment
+- tool-planning text and raw tool output from intermediate model turns never
+  appear in `text-delta`
+- `tool_progress` and `debug` do not appear in browser SSE unless this contract
+  is deliberately expanded
 - `text-delta` content remains inert plain text even when it contains hostile
   markup
 - `done.html` is sanitized before browser insertion

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm';
 
-import { ask, type HistoryMessage } from '../service.ts';
+import { ask, type HistoryMessage, type EmitFn } from '../service.ts';
 import { getDb } from '../db.ts';
 import * as ConversationRepository from '../db/repositories/conversation-repository.ts';
 import * as MessageRepository from '../db/repositories/message-repository.ts';
@@ -52,7 +52,7 @@ async function generateAssistantReply(
   history: HistoryMessage[],
   userId: string,
   correlation: { conversationId: string; userMessageId: string; requestId?: string },
-  emit: (event: string, data: unknown) => Promise<void>,
+  emit: EmitFn,
   options: { retryOnTransportError: boolean; onRetry?: () => void } = {
     retryOnTransportError: true,
   },
@@ -94,7 +94,7 @@ async function persistAssistantOutcome(input: {
   userId: string;
   currentUserMessageId: string;
   requestId?: string;
-  onEvent?: (event: string, data: unknown) => Promise<void>;
+  onEvent?: EmitFn;
   failureMessage?: string;
 }): Promise<ConversationMessage> {
   const priorMessages = await MessageRepository.listByConversationId(input.conversationId, {
@@ -112,7 +112,7 @@ async function persistAssistantOutcome(input: {
   // chokepoint — any path that produces an assistant message (streaming or
   // not) now persists sources.
   const capturedSources: string[] = [];
-  const captureOnEvent = async (event: string, data: unknown) => {
+  const captureOnEvent: EmitFn = async (event, data) => {
     if (event === 'tool_result') {
       const payload = data as { name?: string; ok?: boolean; sourceBooks?: string[] };
       // Require explicit ok === true. Absence-of-failure (ok undefined) is
@@ -313,7 +313,7 @@ export async function streamAssistantTurn(input: {
   userId: string;
   currentUserMessageId: string;
   requestId?: string;
-  onEvent: (event: string, data: unknown) => Promise<void>;
+  onEvent: EmitFn;
   failureMessage?: string;
 }): Promise<ConversationMessage> {
   return persistAssistantOutcome({

--- a/src/service.ts
+++ b/src/service.ts
@@ -514,7 +514,27 @@ export interface HistoryMessage {
   content: string;
 }
 
-export type EmitFn = (event: string, data: unknown) => Promise<void>;
+export interface AgentStreamEventMap {
+  /** Final answer prose only. Tool-planning text must not be emitted here. */
+  text: { delta: string };
+  /** A tool lookup or source traversal started. */
+  tool_call: { name: string; input?: unknown };
+  /** A tool lookup or source traversal completed. */
+  tool_result: { name: string; ok: boolean; sourceBooks?: string[] | undefined };
+  /** User-safe progress from a long tool. Trace-only until explicitly mapped by a route. */
+  tool_progress: { message: string; toolName?: string | undefined };
+  /** Diagnostic data for traces/logs. Never browser-visible. */
+  debug: { message: string; data?: unknown };
+  /** Internal completion signal. Browser `done` is emitted by the HTTP route after persistence. */
+  done: Record<string, never>;
+}
+
+export type AgentStreamEventName = keyof AgentStreamEventMap;
+
+export type EmitFn = <EventName extends AgentStreamEventName>(
+  event: EventName,
+  data: AgentStreamEventMap[EventName],
+) => Promise<void>;
 
 export interface AskOptions {
   history?: HistoryMessage[];
@@ -535,7 +555,7 @@ export interface AskOptions {
   conversationId?: string;
   /** Persisted user-message UUID for trace/log correlation. */
   userMessageId?: string;
-  /** SSE emit callback. When provided, the agent streams text deltas and tool events. */
+  /** Internal stream callback. Browser SSE translation happens in src/server.ts. */
   emit?: EmitFn;
   /** Internal route hint: `/api/ask` already rejected exhausted budgets before SSE starts. */
   budgetPrechecked?: boolean;

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -1585,4 +1585,64 @@ describe('runAgentLoop with emit (streaming)', () => {
       emit.mock.calls.filter(([event]) => event === 'text').map(([, payload]) => payload),
     ).toEqual([{ delta: 'Read section 67.1.' }]);
   });
+
+  it('keeps multi-hop traversal planning text out of streamed answer events', async () => {
+    const findScenarioMsg = textAndToolUseResponse(
+      'Let me find scenario 61 first.',
+      'find_scenario',
+      {
+        query: 'scenario 61',
+      },
+      'tool_find_scenario',
+    );
+    const followLinksMsg = textAndToolUseResponse(
+      'The scenario data does not list what unlocks it. I will trace section links.',
+      'follow_links',
+      {
+        fromKind: 'scenario',
+        fromRef: 'gloomhavensecretariat:scenario/061',
+        linkType: 'unlock',
+      },
+      'tool_follow_links',
+    );
+    const getSectionMsg = textAndToolUseResponse(
+      'I found a raw section-book fragment: >>> [Locked Down] >>> New Scenario: Life and Death 61.',
+      'get_section',
+      {
+        ref: '67.1',
+      },
+      'tool_get_section',
+    );
+    const finalMsg = textResponse('The unlock text is in [Locked Down].');
+    mockMessagesStream
+      .mockReturnValueOnce(mockStream(findScenarioMsg, ['Let me ', 'find scenario 61 first.']))
+      .mockReturnValueOnce(
+        mockStream(followLinksMsg, [
+          'The scenario data does not list what unlocks it. ',
+          'I will trace section links.',
+        ]),
+      )
+      .mockReturnValueOnce(
+        mockStream(getSectionMsg, [
+          'I found a raw section-book fragment: ',
+          '>>> [Locked Down] >>> New Scenario: Life and Death 61.',
+        ]),
+      )
+      .mockReturnValueOnce(mockStream(finalMsg, ['The unlock text is in [Locked Down].']));
+    const emit = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runAgentLoop('what unlocks scenario 61?', {
+      emit,
+      toolSurface: 'legacy',
+    });
+
+    expect(result).toBe('The unlock text is in [Locked Down].');
+    const textDeltas = emit.mock.calls
+      .filter(([event]) => event === 'text')
+      .map(([, payload]) => (payload as { delta: string }).delta);
+    expect(textDeltas).toEqual(['The unlock text is in [Locked Down].']);
+    expect(textDeltas.join('')).not.toMatch(/Let me|scenario data|raw section-book fragment|>>>/);
+    expect(emit.mock.calls.filter(([event]) => event === 'tool_call')).toHaveLength(3);
+    expect(emit.mock.calls.filter(([event]) => event === 'tool_result')).toHaveLength(3);
+  });
 });

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -1502,6 +1502,71 @@ describe('conversation web backend', () => {
     ]);
   });
 
+  it('does not expose trace-only progress or debug events as browser text-delta', async () => {
+    mockAsk.mockImplementationOnce(async (_question, options) => {
+      await options?.emit?.('tool_call', { name: 'follow_links' });
+      await options?.emit?.('tool_progress', {
+        message: 'Tracing scenario 61 unlock links.',
+        toolName: 'follow_links',
+      });
+      await options?.emit?.('debug', {
+        message: 'raw tool output',
+        data: '>>> [Locked Down] >>> New Scenario: Life and Death 61',
+      });
+      await options?.emit?.('tool_result', {
+        name: 'follow_links',
+        ok: true,
+        sourceBooks: ['Section Book'],
+      });
+      await options?.emit?.('text', {
+        delta: 'Scenario 61 is unlocked by the Locked Down branch.',
+      });
+      await options?.emit?.('done', {});
+      return 'Scenario 61 is unlocked by the Locked Down branch.';
+    });
+
+    const auth = await createAuthContext();
+
+    const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'hx-request': 'true',
+      },
+      body: formBody({
+        question: 'What unlocks scenario 61?',
+        idempotencyKey: 'idem-stream-hygiene',
+      }),
+    });
+
+    const body = await createRes.text();
+    const streamUrl = body.match(/data-stream-url="([^"]+)"/)?.[1];
+    expect(streamUrl).toBeTruthy();
+
+    const streamRes = await requestWithAuth(auth, `http://localhost:3000${streamUrl}`);
+    expect(streamRes.status).toBe(200);
+    const events = parseSse(await streamRes.text());
+    expect(events.map((event) => event.event)).toEqual([
+      'tool-start',
+      'tool-result',
+      'text-delta',
+      'done',
+    ]);
+    expect(events).toContainEqual({
+      event: 'text-delta',
+      data: { delta: 'Scenario 61 is unlocked by the Locked Down branch.' },
+    });
+    expect(JSON.stringify(events)).not.toMatch(/Tracing scenario 61|raw tool output|>>>/);
+    expect(events.at(-1)).toEqual({
+      event: 'done',
+      data: expect.objectContaining({
+        html: '<p>Scenario 61 is unlocked by the Locked Down branch.</p>\n',
+        consultedSources: ['SECTION BOOK'],
+      }),
+    });
+  });
+
   it('reuses one tool-status id when the same tool runs multiple times in one answer', async () => {
     mockAsk.mockImplementationOnce(async (_question, options) => {
       await options?.emit?.('tool_call', { name: 'search_rules' });


### PR DESCRIPTION
## Summary
- define a typed internal agent stream event vocabulary so `text` means final answer prose only
- document that browser `text-delta` never carries planning narration, raw tool output, `tool_progress`, or `debug`
- add agent and browser SSE regressions for multi-hop traversal scratch leakage and trace-only events

## Review
- Pre-landing review found no blocking issues.
- Scope check clean: changed files are limited to the stream event contract, SSE docs, and regression coverage.

## Verification
- `npx vitest run --config vitest.unit.config.ts test/agent.test.ts -t "runAgentLoop with emit"`
- `npx vitest run --config vitest.db.config.ts test/conversation.test.ts -t "trace-only progress"`
- `npm run typecheck`
- `npm run check`

Fixes SQR-223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the streaming event contract to explicitly define which internal events map to browser-visible output and which remain internal-only.

* **Tests**
  * Added tests verifying that internal planning narration and debug content do not appear in user-visible chat text during multi-step tool interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->