### PR TITLE
feat(agent): add eval-gated LangGraph runner

### DIFF
--- a/docs/plans/agent-streaming-runtime-fuller-vision.md
+++ b/docs/plans/agent-streaming-runtime-fuller-vision.md
@@ -1,0 +1,394 @@
+# LangGraph, Deep Agents, and Squire Fuller Vision
+
+Date: 2026-05-24
+
+Status: planning artifact. This is the long-term vision paired with
+[agent-streaming-runtime-practical-path.md](./agent-streaming-runtime-practical-path.md).
+It is not a commitment to move Squire's production runtime now.
+
+## Purpose
+
+Explain how LangGraph and Deep Agents could fit Squire if the practical streaming
+project proves the runtime model is useful.
+
+The short version:
+
+- LangGraph is the execution model: graph nodes, stream modes, state updates,
+  tool events, resumable runs, and interrupts.
+- Deep Agents is an opinionated harness on top: planning, todo tracking,
+  subagents, memory, filesystem-style context, permissions, and human approval.
+- Squire remains the product: Frosthaven/GH2 tools, data, auth, web UI, MCP,
+  REST, conversation history, citations, and table-side UX.
+
+The current standalone project is not finished until the practical path includes
+three concrete UX pieces: an explicit final-answer node, browser-visible
+progress rows, and structured artifact events.
+
+## Product Thesis
+
+Squire should not become a framework demo. It should become a rules and strategy
+assistant that shows the right layer of work to the player:
+
+- factual lookups should feel fast and clean
+- source discovery should be visible but quiet
+- long strategy tasks should show progress without dumping internal reasoning
+- campaign-affecting actions should pause for confirmation
+- failed lookup paths should help debugging without polluting the answer
+
+LangGraph and Deep Agents matter only if they help Squire separate those layers.
+
+## Current Baseline
+
+The production baseline stays:
+
+```text
+Browser / REST / MCP
+  -> Squire Hono app
+    -> Squire auth and conversation service
+      -> ask(question, options)
+        -> current Claude SDK runner
+          -> Squire tools
+            -> Squire Postgres + pgvector + canonical game data
+```
+
+ADR 0015 already keeps LangChain, LangGraph, Deep Agents, and LangSmith at the
+intelligence boundary behind `/api/ask`. The LangSmith deployment report also
+keeps remote Agent Server out of Phase 1.
+
+The fuller vision keeps those ownership boundaries unless a new ADR changes
+them.
+
+## Target Runtime Shape
+
+```text
+Squire web, REST, MCP, future channels
+  -> ask service
+    -> AgentRuntime interface
+      -> Claude SDK runner
+      -> LangGraph local runner
+      -> Deep Agents runner for complex tasks
+      -> future remote agent adapter if justified
+    -> Squire tool registry
+      -> search/open/traverse cards and books
+      -> future campaign and character tools
+    -> Squire state
+      -> conversations
+      -> users and sessions
+      -> campaign and character data
+      -> trace ids and eval records
+```
+
+Every runner must return the same Squire-level result:
+
+```text
+answer: final assistant answer
+trajectory: tool calls, model calls, state summaries, token usage
+events: typed internal event stream
+sources: consulted source labels
+trace: links or ids for debugging
+```
+
+## LangGraph Role
+
+LangGraph is the first serious runtime candidate because it directly addresses
+the streaming problem.
+
+Expected uses:
+
+- split retrieval, traversal, validation, and final answer into named nodes
+- stream only final-answer node tokens into answer prose
+- stream tool lifecycle events into metadata rows
+- store graph state updates for debugging and evals
+- add human approval interrupts later
+- add resumable runs when Squire needs durable work
+
+Possible graph for normal rules Q&A:
+
+```text
+START
+  -> classify_or_resolve
+  -> retrieve_or_traverse
+  -> source_check
+  -> final_answer
+  -> END
+```
+
+Possible graph for scenario/section traversal:
+
+```text
+START
+  -> resolve_start_record
+  -> traverse_neighbors
+  -> open_target_records
+  -> verify_answerable
+  -> final_answer
+  -> END
+```
+
+Possible graph for recommendations:
+
+```text
+START
+  -> load_character_context
+  -> load_available_cards_or_items
+  -> fetch_guides_if_needed
+  -> compare_options
+  -> final_recommendation
+  -> END
+```
+
+## Deep Agents Role
+
+Deep Agents should not be the first fix for chat streaming. It becomes relevant
+when Squire's tasks are long, decomposed, and context-heavy.
+
+Best-fit future tasks:
+
+- card selection at level-up
+- inventory optimization
+- pre-combat hand selection
+- long-term build planning
+- build-guide reading and comparison
+- campaign audits
+- scheduled recommendation jobs
+- multi-step "prepare my party for scenario X" tasks
+
+Deep Agents capabilities that fit Squire later:
+
+- task planning for multi-step recommendation work
+- subagents for independent research tracks
+- memory scoped by user, campaign, and purpose
+- human approval before spoiler reveals or campaign writes
+- filesystem-style context for long guide excerpts or generated reports
+- permissions for tools that read vs write campaign state
+
+Where Deep Agents should not own state:
+
+- web sessions
+- Google OAuth
+- Squire API bearer tokens
+- canonical game data
+- campaign ownership checks
+- final persisted conversation transcript
+
+## Deep Agents Task Model
+
+A future recommendation run could look like this:
+
+```text
+Deep Agent supervisor
+  -> writes task list
+  -> subagent: rules/source verifier
+  -> subagent: card and item data checker
+  -> subagent: build-guide reader
+  -> supervisor compares findings
+  -> final answer writer emits structured recommendation
+  -> optional approval interrupt before campaign write
+```
+
+The user sees:
+
+```text
+CONSULTING - CHARACTER STATE
+CONSULTING - ITEM DATA
+CHECKING - BUILD GUIDE
+READY - COMPARISON
+
+Recommendation prose and tables
+```
+
+The user does not see:
+
+- private task notes
+- failed subagent branches
+- raw guide chunks unless quoted intentionally
+- model reasoning
+- unsafe memory contents
+
+## Event Model Vision
+
+Squire should own one internal event vocabulary across all runners:
+
+| Event              | Meaning                                                | Browser use                   |
+| ------------------ | ------------------------------------------------------ | ----------------------------- |
+| `answer_text`      | Final answer prose only                                | `text-delta`                  |
+| `tool_started`     | A Squire tool started                                  | `tool-start`                  |
+| `tool_progress`    | Safe lookup progress                                   | metadata row                  |
+| `tool_finished`    | A Squire tool finished                                 | `tool-result`                 |
+| `source_found`     | A source candidate is available                        | source/status chip            |
+| `artifact_started` | A table, card comparison, quote block, or report began | structured UI                 |
+| `artifact_delta`   | Structured artifact content                            | structured UI                 |
+| `approval_needed`  | User must confirm before continuing                    | future approval UI            |
+| `debug`            | Trace-only detail                                      | never browser-visible         |
+| `done`             | Terminal success                                       | final `done.html` replacement |
+| `error`            | Terminal failure                                       | error banner                  |
+
+Browser SSE can keep its current stable names for now. The internal vocabulary
+lets Squire adapt LangGraph and Deep Agents streams without leaking framework
+events into the UI.
+
+## State Ownership
+
+Squire-owned state:
+
+- users
+- sessions
+- conversations
+- message rows
+- consulted source labels
+- campaign and character records
+- canonical book and card data
+- authorization rules
+- final rendered answers
+
+Runtime-owned state, if adopted:
+
+- in-run graph checkpoints
+- retry state for the active run
+- task plans
+- subagent scratch context
+- run traces
+
+Runtime-owned state can become product state only after a new ADR defines:
+
+- user isolation
+- campaign isolation
+- retention and deletion
+- trace visibility
+- prompt-injection boundaries
+- migration and export paths
+
+## LangSmith and Remote Runtime
+
+Remote LangSmith Agent Server is a later option, not part of the practical path.
+
+It becomes interesting if Squire needs:
+
+- runs that survive app restarts
+- background queue workers
+- scheduled or cron agent work
+- remote graph composition
+- managed checkpointers
+- production interrupt/resume flows
+
+Even then, the browser should call Squire, not LangSmith:
+
+```text
+Browser
+  -> Squire Hono app
+    -> Squire auth and state checks
+      -> outbound remote agent call
+        -> remote stream chunks
+      -> Squire event adapter
+    -> browser SSE
+```
+
+## Security and Privacy Rules
+
+- Never forward browser cookies or Google session tokens to LangGraph,
+  LangSmith, or Deep Agents.
+- Use service-level credentials for remote runtime calls.
+- Pass Squire user and campaign ids as scoped metadata only when needed.
+- Do not use local filesystem or shell backends in the production web server.
+- Do not let shared memory affect answers unless it is scoped by user, campaign,
+  game, and purpose.
+- Treat build guides and external content as untrusted.
+- Treat tool results as source data, not as instructions.
+- Keep final answer sanitization in Squire.
+
+## Evaluation Strategy
+
+The runtime earns adoption only by measured results.
+
+Compare every candidate runner on:
+
+- final answer correctness
+- trajectory correctness
+- stream hygiene
+- citation/source correctness
+- latency
+- token usage
+- cost
+- trace clarity
+- implementation complexity
+- failure handling
+
+Stream hygiene gets its own score:
+
+- no planning text in answer body
+- no raw tool JSON in answer body
+- no raw markdown artifacts during live stream unless final-answer text intends it
+- safe progress rows are visible without becoming answer prose
+- retrieved or quoted content can travel as structured artifacts
+- no hidden failed lookup path presented as a fact
+- final answer starts with the answer, not with the search story
+
+## Adoption Ladder
+
+1. Current-stack stream gating.
+2. Stream-hygiene event contract with regression coverage.
+3. Browser-visible progress rows.
+4. Structured artifact events.
+5. Local LangGraph eval runner with an explicit final-answer node.
+6. Compare current runner vs LangGraph in the full eval matrix.
+7. Hidden-flag LangGraph web runner for local QA.
+8. Production canary for a small allowlisted path, only after evals pass.
+9. Deep Agents eval runner for recommendation-style tasks.
+10. Deep Agents hidden path for long-running recommendations.
+11. Optional remote LangSmith Agent Server only after durable-run needs appear.
+
+Each step needs a report. Moving from one step to the next is a decision, not an
+automatic consequence of the previous step working.
+
+## What Would Make This Worth It
+
+LangGraph is worth keeping if it makes Squire's streams cleaner and traces easier
+to debug without harming answer quality or latency.
+
+Deep Agents is worth keeping if future recommendation tasks become easier to
+express, test, and debug as decomposed runs than as one hand-owned loop.
+
+Remote LangSmith is worth revisiting if Squire needs durable background agent
+work that does not fit the current web request lifecycle.
+
+## What Would Kill It
+
+- The current-stack fix solves the UX problem and LangGraph adds complexity
+  without eval wins.
+- LangGraph traces are harder to map to existing Langfuse reports.
+- Runtime adapters duplicate too much of Squire's tool loop.
+- Deep Agents planning makes simple Q&A slower or noisier.
+- Remote runtime state creates unclear user/campaign ownership.
+- Stream adapters leak framework details into browser UX.
+
+## Future Issue Set
+
+The current standalone project already owns the stream-hygiene, progress,
+artifact, LangGraph prototype, comparison, and decision issues:
+
+- SQR-222: current-runner stream gating.
+- SQR-223: stream-hygiene event contract and regression coverage.
+- SQR-224: local LangGraph runner with an explicit final-answer node.
+- SQR-236: browser-visible agent progress rows.
+- SQR-237: structured answer artifact stream events.
+- SQR-225: current runner vs LangGraph comparison.
+- SQR-226: adoption decision and architecture-doc update.
+
+Later issues should be created only as the ladder advances:
+
+1. Add optional hidden-flag web runner for local browser QA.
+2. Prototype Deep Agents for one recommendation-style eval task.
+3. Add user/campaign-scoped memory threat model.
+4. Define approval interrupts for spoiler and campaign-write actions.
+5. Reopen remote LangSmith Agent Server only when durable runs are needed.
+
+## Long-Term Decision Boundary
+
+The product goal is not "use LangGraph" or "use Deep Agents." The product goal
+is a Squire that can show clean answers, expose useful source progress, handle
+longer strategy work, and keep user/campaign state under Squire's control.
+
+Do not call the current project complete while the final-answer-node,
+progress-row, or structured-artifact pieces are missing.
+
+LangGraph and Deep Agents fit only where they serve that goal.

--- a/docs/plans/agent-streaming-runtime-practical-path.md
+++ b/docs/plans/agent-streaming-runtime-practical-path.md
@@ -1,0 +1,399 @@
+# Agent Streaming Runtime Practical Path
+
+Date: 2026-05-24
+
+Status: planning artifact for a standalone Linear project. This work is
+outside the main Squire product phase initiatives.
+
+Related docs:
+
+- [docs/SSE_CONTRACT.md](../SSE_CONTRACT.md)
+- [docs/ARCHITECTURE.md](../ARCHITECTURE.md)
+- [docs/adr/0015-langchain-deep-agents-intelligence-layer.md](../adr/0015-langchain-deep-agents-intelligence-layer.md)
+- [docs/plans/sqr-161-langsmith-deployment-agent-runtime-report.md](./sqr-161-langsmith-deployment-agent-runtime-report.md)
+- [docs/plans/agent-streaming-runtime-fuller-vision.md](./agent-streaming-runtime-fuller-vision.md)
+
+## Goal
+
+Fix the chat-streaming UX problem shown in the May 10 screenshots, then test a
+minimal LangGraph runner behind Squire's current `ask()` boundary.
+
+The user-visible failure is clear: Squire streams the agent's work-in-progress
+text as if it were answer prose. The browser shows "Let me search..." reasoning,
+failed retrieval attempts, raw markdown, awkward token joins, and partial source
+fragments before the final answer. The final answer eventually becomes usable,
+but the live reading experience looks like the agent thinking out loud.
+
+The practical path has two steps:
+
+1. Fix the current stack so model text from tool-planning turns never reaches
+   the answer body.
+2. Add an eval-gated LangGraph runner that separates final-answer token streams
+   from tool, progress, state, and debug streams.
+
+The project is not complete with answer-body hygiene alone. The target UX also
+requires browser-visible progress rows, structured artifact events, and an
+explicit final-answer node in the LangGraph runner.
+
+## Office-Hours Synthesis
+
+Goal: make Squire feel trustworthy at the table while preserving the option to
+learn from LangGraph and Deep Agents.
+
+Narrowest useful wedge: gate current streaming so only final-answer text reaches
+`.squire-answer__content`. Tool-planning text should either be hidden or mapped
+to compact status events.
+
+What not to build first: a remote LangSmith Agent Server, a Deep Agents
+production rewrite, a new chat UI, or campaign-state approval flows. Those are
+future options, not the fix for the screenshots.
+
+Best practical bet: fix the leak in the current Claude SDK loop, then run a
+small LangGraph adapter behind a feature flag and compare it against evals.
+
+## Existing System
+
+Squire already has the right ownership split:
+
+- The Hono server owns web routes, auth, and browser SSE.
+- The conversation service owns persisted turns, failure rows, provenance
+  capture, and final rendering.
+- The `ask()` service boundary delegates to the knowledge agent.
+- The knowledge agent owns tool planning, source lookup, and final answer
+  synthesis.
+- The browser consumes a stable event vocabulary: `text-delta`, `tool-start`,
+  `tool-result`, `done`, and `error`.
+
+The current agent loop already distinguishes saved final answer text from
+scratch text. In `src/agent.ts`, text from a response with tool use is not saved
+as the final answer. The bug is narrower: `callClaude()` streams every provider
+text delta immediately when `emit` is present, before the caller knows whether
+that response will end in `tool_use`.
+
+Current behavior:
+
+```text
+Claude streaming text delta
+  -> emit("text")
+    -> conversation service
+      -> browser text-delta
+        -> live answer body
+```
+
+Needed behavior:
+
+```text
+Claude streaming text delta from a tool-planning turn
+  -> buffer or discard
+    -> no browser answer text
+
+Claude streaming text delta from a final-answer turn
+  -> emit("text")
+    -> browser text-delta
+```
+
+## Scope
+
+### In Scope
+
+- Stop leaking model scratch text into the browser answer body.
+- Preserve the existing final `done.html` replacement and sanitization path.
+- Preserve the existing `consultedSources` footer behavior.
+- Add internal progress events that can render as quiet browser-visible tool
+  metadata.
+- Add structured artifact events for user-safe retrieved content, such as a
+  quoted section block.
+- Add regression tests using the scenario-61 unlock flow or an equivalent
+  fixture where the model first narrates a tool lookup.
+- Add a LangGraph runner behind `ask()` as an eval-only or feature-flagged path.
+- Map LangGraph stream modes into Squire internal events.
+- Compare the LangGraph runner to the current Claude SDK runner on final answer
+  quality, trajectory quality, latency, cost, trace clarity, and stream hygiene.
+
+### Not in Scope
+
+- Replacing Squire's Hono app, auth, Postgres store, or web conversation model.
+- Exposing LangGraph or LangSmith streams directly to the browser.
+- Moving production traffic to LangGraph without eval results and a later ADR.
+- Adding remote LangSmith Agent Server.
+- Adding Deep Agents to production web chat.
+- Redesigning the visual chat surface.
+- Persisting partial assistant answer text in Postgres.
+- Adding campaign writes, spoiler approvals, or long-term memory.
+
+## Plan-CEO Review
+
+The 10-star version is not "Squire uses LangGraph." It is "Squire never shows
+the wrong layer of the agent run to the user." Framework adoption is only useful
+if it improves that outcome.
+
+Hold scope for the first project:
+
+- Fix the live UX leak first.
+- Keep the runtime experiment behind `ask()`.
+- Do not attach this project to Phase 1 or Phase 2.
+- Do not let it block GH2 table-readiness or other phase work.
+
+Selective expansion worth including: measure stream hygiene explicitly. A runner
+can have correct final answers and still fail the UX bar if it streams planning
+text into the answer body.
+
+## Plan-Eng Review
+
+### Architecture
+
+Use a runner interface at the intelligence boundary:
+
+```text
+Browser SSE
+  -> Hono stream route
+    -> conversation service
+      -> ask(question, options)
+        -> agent runner
+          -> current Claude SDK runner
+          -> optional LangGraph runner
+        -> Squire tools
+          -> Postgres + pgvector + GHS/book data
+```
+
+The browser must not know which runner produced the answer. Every runner emits
+Squire internal events, and the existing web layer maps those to browser SSE.
+
+### Stream Event Rules
+
+Add a stricter internal rule:
+
+- `text` means final answer prose only.
+- `tool_call` means a source or lookup step started.
+- `tool_result` means a source or lookup step completed.
+- `tool_progress` means user-safe progress from inside a long tool or lookup.
+- `artifact` means structured, sanitized answer-adjacent content such as a
+  retrieved quote block.
+- `debug` means trace-only, never browser-visible.
+
+This rule matters more than the runner. The current loop and the LangGraph
+runner must both satisfy it.
+
+### Minimal Current-Stack Fix
+
+There are two viable implementation choices:
+
+1. Disable provider text streaming during tool-enabled turns. Keep showing tool
+   events, then rely on `done.html` for the final answer. This is simplest but
+   loses token streaming for final answers unless a second no-tool synthesis call
+   is made.
+2. Buffer provider text per model response. If the final provider message ends
+   with `tool_use`, discard the buffered text or convert it to progress. If it
+   ends as final answer text, flush the buffer and subsequent deltas as answer
+   text.
+
+Recommendation: implement buffering. It preserves final-answer streaming while
+removing planning text. It also mirrors what LangGraph will make explicit later:
+tokens are only answer tokens after the producing node is known.
+
+### Minimal LangGraph Runner
+
+Build a local LangGraph graph with enough structure to prove stream routing:
+
+```text
+START
+  -> model_or_tool_choice
+      -> execute_tools
+      -> model_or_tool_choice
+  -> final_answer
+  -> END
+```
+
+Stream mapping:
+
+| LangGraph stream | Squire use                                                |
+| ---------------- | --------------------------------------------------------- |
+| `messages`       | Emit `text` only when `metadata.langgraph_node` is final. |
+| `tools`          | Emit `tool_call` and `tool_result`.                       |
+| `custom`         | Emit `tool_progress` or structured artifacts.             |
+| `updates`        | Store in trajectory and traces.                           |
+| `values`         | Trace/debug only unless a test needs state snapshots.     |
+| `debug`          | Trace/debug only, never browser-visible.                  |
+
+The first LangGraph runner can reuse existing Squire tools and the existing
+system prompt. It does not need memory, interrupts, subagents, or remote
+deployment.
+
+### Data Flow
+
+```text
+User asks question
+  -> POST writes user message and pending answer shell
+  -> GET /chat/:conversationId/messages/:messageId/stream
+  -> conversation service calls ask(..., emit)
+  -> selected runner emits internal events
+  -> conversation service captures consulted sources
+  -> Hono route translates to browser SSE
+  -> final assistant row is persisted once
+  -> done event swaps final sanitized HTML into the pending answer
+```
+
+### Failure Modes
+
+- A provider stream emits text then ends in `tool_use`.
+  - Expected: no answer-body text is emitted from that turn.
+- A provider stream emits final text after several tool turns.
+  - Expected: final text appears as answer prose, then `done.html` replaces it.
+- Tool result contains source labels but no final answer arrives.
+  - Expected: error row persists, footer stays hidden or reflects only completed
+    successful source use according to the existing contract.
+- LangGraph emits tokens from a non-final node.
+  - Expected: tokens are ignored for browser prose and recorded only in trace.
+- LangGraph emits duplicate tool events through multiple stream modes.
+  - Expected: adapter de-duplicates by tool call id.
+- SSE disconnects mid-run.
+  - Expected in this project: current reliability policy still applies. Durable
+    resume is a later project unless this work explicitly adds event-log replay.
+
+### Test Plan
+
+Unit tests:
+
+- `runAgentLoop` does not emit `text` for a response that ends in `tool_use`.
+- Final no-tool model text still emits answer text.
+- Buffered tool-planning text is discarded or converted only to safe progress.
+- `tool_call` and `tool_result` still emit in order.
+- Consulted source capture still stores successful tool labels.
+- Structured artifact events are never emitted as answer prose.
+
+Conversation tests:
+
+- Browser SSE never receives `text-delta` for "Let me search" scratch text.
+- Browser SSE can receive user-safe progress rows without appending them to
+  `.squire-answer__content`.
+- Browser SSE can receive structured artifacts through a sanitized non-text-delta
+  path.
+- Existing `done.html` final replacement still renders sanitized markdown.
+- Error path still persists one failure row and emits exactly one terminal event.
+
+Web UI tests:
+
+- Tool/progress rows appear as metadata, not answer prose.
+- Skeleton clears only when answer prose begins or final HTML arrives.
+- The input dock remains disabled during one active stream and re-enabled after
+  `done` or `error`.
+
+Eval tests:
+
+- Add or reuse a scenario traversal case similar to "what is the text of the
+  section that unlocks scenario 61?"
+- Add a stream-hygiene assertion: no final answer stream may include phrases
+  like "Let me search", "I found", or raw tool-result framing before the final
+  answer node.
+- Compare current runner and LangGraph runner on trajectory and final answer.
+
+Manual QA:
+
+- Run the scenario-61 unlock prompt locally in the browser.
+- Verify the live stream shows compact lookup status, then clean answer text.
+- Verify the final transcript reload matches the completed streamed answer.
+
+### Performance
+
+The current-stack fix should not add another model call. Buffering may delay the
+first visible answer token until the first final-answer response is identified,
+which is acceptable because it removes misleading text.
+
+The LangGraph runner must report:
+
+- time to first user-visible event
+- time to first final-answer token
+- total latency
+- model calls
+- tool calls
+- token usage
+- cost estimate when available
+
+### Implementation Tasks
+
+1. Add regression coverage for scratch-text leakage in the current runner.
+2. Change the current Claude streaming path so text from tool-use responses is
+   not emitted as answer prose.
+3. Add `tool_progress` to the internal event type and browser mapper so
+   user-safe status rows can appear outside answer prose.
+4. Add structured artifact events for retrieved/quoted content, with browser
+   sanitization and non-text-delta rendering.
+5. Add stream-hygiene assertions to conversation or agent tests.
+6. Add a runner selector behind `ask()` if a clean selector does not already
+   exist for eval/runtime variants.
+7. Implement the minimal LangGraph runner behind an eval-only flag, with an
+   explicit final-answer node.
+8. Map LangGraph stream modes into Squire internal events.
+9. Add eval matrix rows for current vs LangGraph runner.
+10. Write a comparison report and decide whether LangGraph should stay eval-only,
+    ship behind a hidden flag, or be dropped.
+
+### Worktree Parallelization
+
+Sequential implementation is safest for the current-stack fix because it touches
+`src/agent.ts`, streaming tests, and conversation tests.
+
+The LangGraph runner can run in parallel after the internal event contract is
+clear:
+
+| Lane | Work                                              | Depends on                       |
+| ---- | ------------------------------------------------- | -------------------------------- |
+| A    | Current runner stream gating and regression tests | None                             |
+| B    | Browser-visible progress rows                     | Internal event contract from A   |
+| C    | Structured artifact events                        | Internal event contract from A   |
+| D    | LangGraph runner adapter and eval rows            | Internal event contract from A-C |
+
+## Linear Scope Boundary
+
+The current issue split is:
+
+- SQR-222: fix current-runner scratch-text leakage.
+- SQR-223: lock the stream-hygiene event contract in tests.
+- SQR-224: prototype a minimal LangGraph runner with an explicit final-answer
+  node.
+- SQR-236: add browser-visible agent progress rows.
+- SQR-237: add structured answer artifact stream events.
+- SQR-225: compare current runner and LangGraph runner against the full UX bar.
+- SQR-226: make the adoption decision and update durable architecture docs.
+
+SQR-225 and SQR-226 must stay blocked while SQR-224, SQR-236, or SQR-237 remain
+unfinished. The project should not be marked complete until those UX pieces are
+shipped or a later explicit decision removes them from scope.
+
+## Acceptance Criteria
+
+- The May 10 screenshot failure cannot reproduce in local browser QA.
+- Tool-planning text never appears in `.squire-answer__content`.
+- Final answer text still streams when the model is actually answering.
+- `done.html` remains the authoritative final rendered answer.
+- Existing consulted-source footer behavior is preserved.
+- LangGraph runner is available for eval comparison but not production default.
+- The LangGraph runner has an explicit final-answer node, and only that node's
+  message stream can become answer body text.
+- Browser-visible progress rows render for safe tool/custom events without
+  becoming answer prose.
+- Structured artifacts can carry retrieved/quoted content without using
+  `text-delta`.
+- Eval report clearly states whether LangGraph improves stream hygiene, answer
+  quality, trace clarity, latency, and implementation clarity.
+
+## Open Questions
+
+- Should the current-stack fix discard scratch text entirely, or convert a small
+  allowlisted subset into progress labels?
+- Should the LangGraph runner use the current legacy tool surface first, or the
+  redesigned self-describing tool contract first?
+- Should stream-hygiene evals be hard failures in CI, or report-only while the
+  runner is experimental?
+
+## Decision Record
+
+- Use Squire-owned app, auth, conversation, and data state.
+- Use LangGraph only behind `ask()` for the practical path.
+- Treat browser-visible progress rows and structured artifact events as required
+  project scope, not optional polish.
+- Require the LangGraph prototype to include an explicit final-answer node.
+- Keep Deep Agents out of the practical-path implementation unless a later eval
+  task needs it as a comparison runner.
+- Keep this project outside phase initiatives.
+- Promote durable decisions from this plan into ADRs after implementation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@hono/node-server": "^2.0.3",
         "@langchain/anthropic": "^1.4.0",
         "@langchain/core": "^1.1.44",
+        "@langchain/langgraph": "^1.3.2",
         "@langfuse/client": "^5.3.0",
         "@langfuse/otel": "^5.3.0",
         "@langfuse/tracing": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@hono/node-server": "^2.0.3",
     "@langchain/anthropic": "^1.4.0",
     "@langchain/core": "^1.1.44",
+    "@langchain/langgraph": "^1.3.2",
     "@langfuse/client": "^5.3.0",
     "@langfuse/otel": "^5.3.0",
     "@langfuse/tracing": "^5.3.0",

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -1,0 +1,84 @@
+/**
+ * Minimal local LangGraph adapter for Squire's existing agent loop.
+ *
+ * SQR-224 intentionally keeps Squire's tools, prompts, persistence, and browser
+ * SSE contract owned by the app. LangGraph is only introduced behind `ask()` to
+ * prove node-scoped stream routing: non-final graph work can emit tool/debug
+ * events, while answer text is emitted only from the explicit `final_answer`
+ * node.
+ */
+
+import { Annotation, END, START, StateGraph } from '@langchain/langgraph';
+import { runAgentLoopWithTrajectory, type AgentRunResult } from './agent.ts';
+import type { AgentStreamEventMap, AgentStreamEventName, AskOptions, EmitFn } from './service.ts';
+
+const LangGraphState = Annotation.Root({
+  question: Annotation<string>(),
+  result: Annotation<AgentRunResult | undefined>(),
+});
+
+type LangGraphStateValue = typeof LangGraphState.State;
+
+function createNonFinalNodeEmitter(emit: EmitFn): EmitFn {
+  return async <EventName extends AgentStreamEventName>(
+    event: EventName,
+    data: AgentStreamEventMap[EventName],
+  ) => {
+    if (event === 'text' || event === 'done') return;
+    await emit(event, data);
+  };
+}
+
+function markLangGraphTrajectory(result: AgentRunResult): AgentRunResult {
+  return {
+    answer: result.answer,
+    trajectory: {
+      ...result.trajectory,
+      model: `langgraph:${result.trajectory.model}`,
+    },
+  };
+}
+
+function requireResult(state: LangGraphStateValue): AgentRunResult {
+  if (!state.result) {
+    throw new Error('LangGraph final_answer node ran before agent_loop produced a result.');
+  }
+  return state.result;
+}
+
+export async function runLangGraphAgentLoopWithTrajectory(
+  question: string,
+  options?: AskOptions,
+): Promise<AgentRunResult> {
+  const { emit } = options ?? {};
+  const currentRunnerOptions = { ...(options ?? {}) };
+  delete currentRunnerOptions.runner;
+  const currentOptions =
+    Object.keys(currentRunnerOptions).length > 0 || emit
+      ? {
+          ...currentRunnerOptions,
+          ...(emit ? { emit: createNonFinalNodeEmitter(emit) } : {}),
+        }
+      : undefined;
+
+  const graph = new StateGraph(LangGraphState)
+    .addNode('agent_loop', async (state: LangGraphStateValue) => {
+      const result = await runAgentLoopWithTrajectory(state.question, currentOptions);
+      return { result: markLangGraphTrajectory(result) };
+    })
+    .addNode('final_answer', async (state: LangGraphStateValue) => {
+      const result = requireResult(state);
+      if (emit) {
+        await emit('text', { delta: result.answer });
+        await emit('done', {});
+      }
+      return {};
+    })
+    .addEdge(START, 'agent_loop')
+    .addEdge('agent_loop', 'final_answer')
+    .addEdge('final_answer', END)
+    .compile();
+
+  const finalState = await graph.invoke({ question });
+  return requireResult(finalState);
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -12,6 +12,7 @@ import {
 } from './vector-store.ts';
 import { listCardTypes } from './tools.ts';
 import { runAgentLoopWithTrajectory } from './agent.ts';
+import { runLangGraphAgentLoopWithTrajectory } from './agent-langgraph.ts';
 import { assertLlmBudgetAvailable, recordLlmUsage } from './llm-budget.ts';
 import { errorLogFields, writeSecurityLog } from './security-log.ts';
 import {
@@ -555,6 +556,8 @@ export interface AskOptions {
   conversationId?: string;
   /** Persisted user-message UUID for trace/log correlation. */
   userMessageId?: string;
+  /** Hidden/eval-only runner selector. Production browser traffic defaults to `current`. */
+  runner?: 'current' | 'langgraph';
   /** Internal stream callback. Browser SSE translation happens in src/server.ts. */
   emit?: EmitFn;
   /** Internal route hint: `/api/ask` already rejected exhausted budgets before SSE starts. */
@@ -572,15 +575,16 @@ export async function ensureAskBudgetAvailable(userId?: string | null): Promise<
  */
 export async function ask(question: string, options?: AskOptions): Promise<string> {
   if (!isReady()) await initialize();
-  const { budgetPrechecked, ...agentOptions } = options ?? {};
+  const { budgetPrechecked, runner = 'current', ...agentOptions } = options ?? {};
   const userId = options?.userId ?? null;
   if (!budgetPrechecked) {
     await ensureAskBudgetAvailable(userId);
   }
-  const result = await runAgentLoopWithTrajectory(
-    question,
-    Object.keys(agentOptions).length > 0 ? agentOptions : undefined,
-  );
+  const runnerOptions = Object.keys(agentOptions).length > 0 ? agentOptions : undefined;
+  const result =
+    runner === 'langgraph'
+      ? await runLangGraphAgentLoopWithTrajectory(question, runnerOptions)
+      : await runAgentLoopWithTrajectory(question, runnerOptions);
   try {
     await recordLlmUsage({
       userId,

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockRunAgentLoopWithTrajectory } = vi.hoisted(() => ({
+  mockRunAgentLoopWithTrajectory: vi.fn(),
+}));
+
+vi.mock('../src/agent.ts', () => ({
+  runAgentLoopWithTrajectory: mockRunAgentLoopWithTrajectory,
+}));
+
+import { runLangGraphAgentLoopWithTrajectory } from '../src/agent-langgraph.ts';
+import type { AgentStreamEventName } from '../src/service.ts';
+
+describe('runLangGraphAgentLoopWithTrajectory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunAgentLoopWithTrajectory.mockImplementation(async (_question, options) => {
+      await options.emit('tool_call', { name: 'find_scenario', input: { query: '61' } });
+      await options.emit('text', { delta: 'Let me find scenario 61 first.' });
+      await options.emit('debug', { message: 'agent_loop state update' });
+      await options.emit('tool_result', {
+        name: 'find_scenario',
+        ok: true,
+        sourceBooks: ['Scenario Book'],
+      });
+      await options.emit('done', {});
+      return {
+        answer: 'Scenario 61 is unlocked by Locked Down.',
+        trajectory: {
+          toolCalls: [],
+          modelCalls: [],
+          finalAnswer: 'Scenario 61 is unlocked by Locked Down.',
+          tokenUsage: {
+            inputTokens: 10,
+            outputTokens: 5,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            totalTokens: 15,
+          },
+          model: 'claude-sonnet-4-6',
+          iterations: 1,
+          stopReason: 'end_turn',
+        },
+      };
+    });
+  });
+
+  it('only emits text from the explicit final_answer node', async () => {
+    const emitted: Array<[AgentStreamEventName, unknown]> = [];
+
+    const result = await runLangGraphAgentLoopWithTrajectory('What unlocks scenario 61?', {
+      emit: async (event, data) => {
+        emitted.push([event, data]);
+      },
+      toolSurface: 'legacy',
+    });
+
+    expect(result.answer).toBe('Scenario 61 is unlocked by Locked Down.');
+    expect(mockRunAgentLoopWithTrajectory).toHaveBeenCalledWith('What unlocks scenario 61?', {
+      emit: expect.any(Function),
+      toolSurface: 'legacy',
+    });
+    expect(emitted).toEqual([
+      ['tool_call', { name: 'find_scenario', input: { query: '61' } }],
+      ['debug', { message: 'agent_loop state update' }],
+      ['tool_result', { name: 'find_scenario', ok: true, sourceBooks: ['Scenario Book'] }],
+      ['text', { delta: 'Scenario 61 is unlocked by Locked Down.' }],
+      ['done', {}],
+    ]);
+  });
+});

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const {
   mockRunAgentLoopWithTrajectory,
+  mockRunLangGraphAgentLoopWithTrajectory,
   mockAssertLlmBudgetAvailable,
   mockRecordLlmUsage,
   mockWriteSecurityLog,
@@ -14,6 +15,7 @@ const {
   mockGetScenarioSectionBooksBootstrapStatus,
 } = vi.hoisted(() => ({
   mockRunAgentLoopWithTrajectory: vi.fn(),
+  mockRunLangGraphAgentLoopWithTrajectory: vi.fn(),
   mockAssertLlmBudgetAvailable: vi.fn(),
   mockRecordLlmUsage: vi.fn(),
   mockWriteSecurityLog: vi.fn(),
@@ -26,6 +28,10 @@ const {
 
 vi.mock('../src/agent.ts', () => ({
   runAgentLoopWithTrajectory: mockRunAgentLoopWithTrajectory,
+}));
+
+vi.mock('../src/agent-langgraph.ts', () => ({
+  runLangGraphAgentLoopWithTrajectory: mockRunLangGraphAgentLoopWithTrajectory,
 }));
 
 vi.mock('../src/llm-budget.ts', () => ({
@@ -343,6 +349,24 @@ describe('ask', () => {
         stopReason: 'end_turn',
       },
     });
+    mockRunLangGraphAgentLoopWithTrajectory.mockResolvedValue({
+      answer: 'LangGraph answer.',
+      trajectory: {
+        toolCalls: [],
+        modelCalls: [],
+        finalAnswer: 'LangGraph answer.',
+        tokenUsage: {
+          inputTokens: 20,
+          outputTokens: 10,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          totalTokens: 30,
+        },
+        model: 'langgraph:claude-sdk',
+        iterations: 1,
+        stopReason: 'end_turn',
+      },
+    });
   });
 
   it('checks the budget before delegating to the agent loop', async () => {
@@ -411,6 +435,27 @@ describe('ask', () => {
     };
     await ask('Follow-up', options);
     expect(mockRunAgentLoopWithTrajectory).toHaveBeenCalledWith('Follow-up', options);
+  });
+
+  it('routes opt-in LangGraph runs behind ask without changing the default runner', async () => {
+    await initialize();
+    const emit = vi.fn().mockResolvedValue(undefined);
+
+    const result = await ask('What unlocks scenario 61?', {
+      emit,
+      runner: 'langgraph',
+      userId: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+    });
+
+    expect(result).toBe('LangGraph answer.');
+    expect(mockRunAgentLoopWithTrajectory).not.toHaveBeenCalled();
+    expect(mockRunLangGraphAgentLoopWithTrajectory).toHaveBeenCalledWith(
+      'What unlocks scenario 61?',
+      {
+        emit,
+        userId: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      },
+    );
   });
 
   it('initializes lazily when asked before warmup', async () => {


### PR DESCRIPTION
## Summary
- add an opt-in LangGraph runner path behind ask() while keeping the current runner as default
- route non-final graph work through non-answer events and emit answer text only from an explicit final_answer node
- add stream-boundary regression coverage plus the project planning specs/scope audit updates

Fixes SQR-224

## Verification
- npm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an alternative agent runtime with improved streaming behavior to prevent intermediate processing steps from appearing as final answers.

* **Chores**
  * Added LangGraph framework dependency to support new agent runtime infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->