### PR TITLE
fix(deploy): include rule source metadata manifest

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,11 @@
 .vscode/
 coverage/
 data/
+!data/
+data/*
+!data/rule-sources/
+data/rule-sources/*
+!data/rule-sources/metadata.json
 dist/
 docs/
 eval/

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update \
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=assets /app/dist ./dist
 COPY --chown=node:node package.json package-lock.json ./
+COPY --chown=node:node data/rule-sources/metadata.json ./data/rule-sources/metadata.json
 COPY --chown=node:node src ./src
 COPY --chown=node:node scripts ./scripts
 COPY --chown=node:node crontab ./crontab

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -346,7 +346,7 @@ _Historical note: an earlier version of Squire used the worldhaven repository pl
 | OAuth tokens / clients         | N/A (Phase 1)                                                  | Postgres                 |
 | Conversation history           | Postgres `conversations` + `messages`                          | Postgres                 |
 
-pgvector handles vector similarity search in the same database — no separate vector service at this scale. Source files are inputs to indexing, not deployed artifacts; PDFs live in `data/pdfs/`, HTML/text snapshots live in `data/rule-sources/`, and both are excluded from the production image.
+pgvector handles vector similarity search in the same database — no separate vector service at this scale. Source files are inputs to indexing, not deployed artifacts; PDFs live in `data/pdfs/`, HTML/text snapshots live in `data/rule-sources/`, and both are excluded from the production image. The small `data/rule-sources/metadata.json` provenance manifest is deployed with the app because runtime search responses use it to label sources and freshness.
 
 Production data updates are decoupled from image deploys. The weekly GHS refresh
 workflow opens reviewable PRs for `data/extracted/`; after those PRs merge,

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -35,6 +35,9 @@ describe('deployment configuration', () => {
     expect(dockerfile).toContain('supercronic-linux-amd64');
     expect(dockerfile).toContain('COPY --from=deps /app/node_modules ./node_modules');
     expect(dockerfile).toContain('COPY --from=assets /app/dist ./dist');
+    expect(dockerfile).toContain(
+      'COPY --chown=node:node data/rule-sources/metadata.json ./data/rule-sources/metadata.json',
+    );
     expect(dockerfile).toContain('COPY --chown=node:node src ./src');
     expect(dockerfile).toContain('COPY --chown=node:node scripts ./scripts');
     expect(dockerfile).toContain('COPY --chown=node:node crontab ./crontab');
@@ -128,6 +131,13 @@ describe('deployment configuration', () => {
     ]) {
       expect(dockerignore).toContain(ignoredPath);
     }
+
+    // The runtime app reads this provenance manifest directly, but the bulk
+    // rule-source snapshots and PDFs should stay out of production images.
+    expect(dockerignore).toContain('data/*');
+    expect(dockerignore).toContain('!data/rule-sources/');
+    expect(dockerignore).toContain('data/rule-sources/*');
+    expect(dockerignore).toContain('!data/rule-sources/metadata.json');
   });
 
   it('uses Fly release commands for migrate-before-cutover deploys', async () => {

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -134,6 +134,7 @@ describe('deployment configuration', () => {
 
     // The runtime app reads this provenance manifest directly, but the bulk
     // rule-source snapshots and PDFs should stay out of production images.
+    expect(dockerignore).toContain('!data/');
     expect(dockerignore).toContain('data/*');
     expect(dockerignore).toContain('!data/rule-sources/');
     expect(dockerignore).toContain('data/rule-sources/*');


### PR DESCRIPTION
## Summary
- include `data/rule-sources/metadata.json` in the production Docker image
- keep the rest of `data/` excluded from the Docker context
- add deployment contract coverage for the runtime manifest

## Verification
- `npm run test -- test/deployment-config.test.ts`
- `npm run check`
- `printf ... | docker build -f - -t squire-metadata-context-smoke .`

Refs SQR-190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined Docker build context to properly include source metadata in production deployments, enabling source identification and freshness indicators.

* **Documentation**
  * Updated architecture documentation to describe how source metadata is used in runtime search responses for labeling and freshness information.

* **Tests**
  * Added comprehensive validation tests for Docker deployment configuration and build context exclusion rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->