### PR TITLE
v0.1.9: Show safe agent progress rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.9] - 2026-05-24
+
+### Added
+
+- Added browser-visible `tool-progress` SSE events so safe agent progress can render as compact metadata rows without becoming answer prose.
+- Added regression coverage for progress rows, final-answer-only `text-delta`, final HTML replacement, and consulted-source footer preservation.
+
 ## [0.1.8] - 2026-05-17
 
 ### Changed

--- a/docs/SSE_CONTRACT.md
+++ b/docs/SSE_CONTRACT.md
@@ -24,7 +24,13 @@ The browser consumes these SSE event names:
   - Payload: `{ "id": string, "label": string }`
 - `tool-result`
   - Marks a tool row complete or failed.
-  - Payload: `{ "id": string, "label": string, "ok": boolean }`
+  - Payload: `{ "id": string, "labels": string[], "ok": boolean }`
+- `tool-progress`
+  - Adds a compact, user-safe progress row for long tool work.
+  - Payload: `{ "id": string, "label": string, "message": string }`
+  - `label` is safe tool/source metadata such as `SECTION BOOK` or the
+    `REFERENCE` fallback. `message` is already filtered by the service as
+    user-safe progress text; it is rendered as metadata, never answer prose.
 - `done`
   - Marks the stream complete and clears the pending answer UI.
   - Payload: `{ "html": string, "consultedSources": string[] | null }`
@@ -60,8 +66,8 @@ For every successful stream:
    text and must not be sent as `text-delta`.
 2. The browser must receive exactly one terminal `done` event.
 3. Any `text-delta` events must arrive before `done`.
-4. Tool events may appear before completion, but they do not count as answer
-   text.
+4. Tool events and progress events may appear before completion, but they do
+   not count as answer text.
 5. The terminal `done` event carries the final server-rendered sanitized HTML
    fragment, which replaces the pending plain-text transcript in the browser.
 6. The terminal `done` event carries `consultedSources` (persisted tool
@@ -102,8 +108,8 @@ The conversation service emits Squire-owned internal events. These are typed in
   or raw retrieved fragments must not be emitted as `text`.
 - `tool_call`: a tool lookup or source traversal started.
 - `tool_result`: a tool lookup or source traversal completed.
-- `tool_progress`: optional user-safe progress from inside a long tool. This is
-  trace-only today and has no browser mapping.
+- `tool_progress`: optional user-safe progress from inside a long tool. Routes
+  that expose it must map it to browser `tool-progress`, not `text-delta`.
 - `debug`: diagnostic data for traces/logs. This is never browser-visible.
 - `done`: internal completion signal only. The route emits browser `done` after
   persistence so it can include sanitized HTML and persisted consulted sources.
@@ -118,7 +124,7 @@ The route, not the provider, owns the final browser ordering guarantees:
 - provider/internal `text` -> browser `text-delta`
 - provider/internal `tool_call` -> browser `tool-start`
 - provider/internal `tool_result` -> browser `tool-result`
-- internal `tool_progress` -> no browser event
+- internal `tool_progress` -> browser `tool-progress`
 - internal `debug` -> no browser event
 - provider/internal `done` is only a completion signal
 - browser `done` is emitted by the route with the final sanitized HTML derived
@@ -133,8 +139,8 @@ Regression tests should assert browser-visible behavior, not only persistence:
   `done.html` fragment
 - tool-planning text and raw tool output from intermediate model turns never
   appear in `text-delta`
-- `tool_progress` and `debug` do not appear in browser SSE unless this contract
-  is deliberately expanded
+- `tool_progress` appears only as browser `tool-progress`; `debug` never appears
+  in browser SSE
 - `text-delta` content remains inert plain text even when it contains hostile
   markup
 - `done.html` is sanitized before browser insertion

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.98.0",
         "@hono/node-server": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "engines": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1139,6 +1139,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
   // and persists the same sources. This handler just translates agent
   // events to wire events.
   return streamSSE(c, async (stream) => {
+    let progressSequence = 0;
     const assistantMessage = await streamAssistantTurn({
       conversationId: loaded.conversation.id,
       question: loaded.message.content,
@@ -1165,6 +1166,25 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
               // (REFERENCE fallback for utility/traversal tools) so the
               // tool-indicator UI doesn't need to know about nulls.
               label: toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL,
+            }),
+          });
+          return;
+        }
+
+        if (event === 'tool_progress') {
+          const payload = data as { message?: unknown; toolName?: string };
+          const message = typeof payload.message === 'string' ? payload.message.trim() : '';
+          if (message.length === 0) {
+            return;
+          }
+          const name = payload.toolName ?? 'tool';
+          progressSequence += 1;
+          await stream.writeSSE({
+            event: 'tool-progress',
+            data: JSON.stringify({
+              id: `${buildToolStatusId(name)}-progress-${progressSequence}`,
+              label: toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL,
+              message,
             }),
           });
           return;

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -352,6 +352,12 @@ function renderToolStatusRow(row, label, state) {
     return;
   }
 
+  if (state === 'progress') {
+    if (labelEl) labelEl.textContent = 'CHECKING';
+    stateEl.textContent = label || 'REFERENCE';
+    return;
+  }
+
   if (labelEl) labelEl.textContent = label || 'REFERENCE';
   stateEl.textContent = '';
 }
@@ -555,6 +561,21 @@ function attachPendingAnswerStream(answerEl) {
     toolPhaseStarted = true;
     var row = ensureToolStatusRow(toolsEl, toolEntries, payload.id);
     renderToolStatusRow(row, payload.label, 'running');
+  });
+
+  source.addEventListener('tool-progress', function (event) {
+    if (!toolsEl) return;
+    if (seenFirstDelta) {
+      clearToolStatusRows(toolsEl, toolEntries);
+      return;
+    }
+    var payload = JSON.parse(event.data || '{}');
+    if (!payload.message) return;
+    preToolBuffer = '';
+    toolPhaseStarted = true;
+    var row = ensureToolStatusRow(toolsEl, toolEntries, payload.id);
+    if (payload.label) row.dataset.toolLabel = payload.label;
+    renderToolStatusRow(row, payload.message, 'progress');
   });
 
   source.addEventListener('tool-result', function (event) {

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -1502,7 +1502,7 @@ describe('conversation web backend', () => {
     ]);
   });
 
-  it('does not expose trace-only progress or debug events as browser text-delta', async () => {
+  it('exposes safe progress as metadata without leaking debug events into answer text', async () => {
     mockAsk.mockImplementationOnce(async (_question, options) => {
       await options?.emit?.('tool_call', { name: 'follow_links' });
       await options?.emit?.('tool_progress', {
@@ -1549,15 +1549,24 @@ describe('conversation web backend', () => {
     const events = parseSse(await streamRes.text());
     expect(events.map((event) => event.event)).toEqual([
       'tool-start',
+      'tool-progress',
       'tool-result',
       'text-delta',
       'done',
     ]);
     expect(events).toContainEqual({
+      event: 'tool-progress',
+      data: {
+        id: 'follow_links-progress-1',
+        label: 'REFERENCE',
+        message: 'Tracing scenario 61 unlock links.',
+      },
+    });
+    expect(events).toContainEqual({
       event: 'text-delta',
       data: { delta: 'Scenario 61 is unlocked by the Locked Down branch.' },
     });
-    expect(JSON.stringify(events)).not.toMatch(/Tracing scenario 61|raw tool output|>>>/);
+    expect(JSON.stringify(events)).not.toMatch(/raw tool output|>>>/);
     expect(events.at(-1)).toEqual({
       event: 'done',
       data: expect.objectContaining({

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -416,6 +416,36 @@ describe('squire.js chat form retargeting', () => {
     expect(source.closed).toBe(true);
   });
 
+  it('renders progress rows outside answer prose and keeps done/footer behavior intact', () => {
+    const { contentEl, footerEl, source, toolsEl } = bootPendingTranscript();
+
+    source.emit('tool-start', { id: 'follow_links', label: 'REFERENCE' });
+    source.emit('tool-progress', {
+      id: 'follow_links-progress-1',
+      label: 'SECTION BOOK',
+      message: 'Found Locked Down',
+    });
+
+    expect(contentEl.querySelector('p')).toBeNull();
+    expect(toolsEl.children).toHaveLength(2);
+    const progressRow = toolsEl.children[1];
+    expect(progressRow.dataset.toolLabel).toBe('SECTION BOOK');
+    expect(progressRow.querySelector('.squire-answer__tool-label')?.textContent).toBe('CHECKING');
+    expect(progressRow.querySelector('.squire-answer__tool-state')?.textContent).toBe(
+      'Found Locked Down',
+    );
+
+    source.emit('tool-result', { id: 'follow_links', labels: ['SECTION BOOK'], ok: true });
+    source.emit('done', {
+      html: '<p>The section is <strong>Locked Down</strong>.</p>',
+    });
+
+    expect(contentEl.innerHTML).toBe('<p>The section is <strong>Locked Down</strong>.</p>');
+    expect(toolsEl.children).toHaveLength(0);
+    expect(footerEl.textContent).toBe('CONSULTED · SECTION BOOK');
+    expect(footerEl.hidden).toBe(false);
+  });
+
   // SQR-98: the consulted footer must reflect the actual tool calls this
   // turn made — never placeholder text, never stale data from a prior
   // turn. These tests cover the ok:false exclusion, dedup + insertion


### PR DESCRIPTION
## Summary
- map internal `tool_progress` stream events to browser-visible `tool-progress` metadata rows
- render progress rows in the pending answer tool area without appending them to `.squire-answer__content`
- update the SSE contract, release metadata, and regressions for final-answer-only text streaming plus footer preservation

## Tests
- npm test -- test/conversation.test.ts
- npm test -- test/web-ui-squire.regression-1.test.ts
- npm run check

Linear: SQR-236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 0.1.9

* **New Features**
  * Added progress event tracking for tool operations, displaying intermediate status updates separately from final answers during agent operations

* **Documentation**
  * Updated Server-Sent Events contract to document new progress event handling and clarify success-path invariants

* **Tests**
  * Added regression coverage for progress row rendering and final-answer update behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->