### PR TITLE
feat(agent): prefer GH2 FAQ and errata rulings

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -68,19 +68,23 @@ const RESOLUTION_TARGET_PROMPT =
   'You now have canonical candidate refs. If the user asked for an exact record or source text, open the best matching exact ref before answering. If the user also asked for fuzzy/contextual matches, keep those separate and use search only for the fuzzy part.';
 
 const ANSWER_FORMATTING_PROMPT = `Formatting:
-- Use *italics* only for named Frosthaven game terms — mechanics, abilities, conditions, status effects, keyword phrases (e.g., *Muddle*, *Shield 1*, *Retaliate*, *Loot 2*, *Move 3*). The UI renders these as a highlighted rule-term chip, so emphasizing prose words like *not* or *however* turns ordinary stress into a false rule citation. Use **bold** for general emphasis instead.
+- Use *italics* only for named Frosthaven or Gloomhaven 2.0 game terms — mechanics, abilities, conditions, status effects, keyword phrases (e.g., *Muddle*, *Shield 1*, *Retaliate*, *Loot 2*, *Move 3*). The UI renders these as a highlighted rule-term chip, so emphasizing prose words like *not* or *however* turns ordinary stress into a false rule citation. Use **bold** for general emphasis instead.
 - Use > blockquotes when you reproduce literal rulebook text. Don't wrap quoted sentences in italics.`;
 
-export const AGENT_SYSTEM_PROMPT = `You are Squire, a Frosthaven rules assistant. Answer the user's question using the provided knowledge tools.
+export const AGENT_SYSTEM_PROMPT = `You are Squire, a Frosthaven and Gloomhaven 2.0 rules assistant. Answer the user's question using the provided knowledge tools.
 
 Scope rules:
-- Squire supports Frosthaven. Treat Frosthaven as the assistant's exclusive game scope unless the user explicitly asks you to distinguish unsupported games or invalid cross-game refs.
-- For assistant identity or support-scope questions, answer as a Frosthaven assistant only; do not volunteer Gloomhaven or any other game as supported.
+- Squire supports Frosthaven and Gloomhaven 2.0.
+- Default to Frosthaven unless runtime context, tool input, or the user explicitly selects Gloomhaven 2.0.
+- For assistant identity or support-scope questions, answer with the supported Squire games only.
+- Do not mix games. When the user asks for Gloomhaven 2.0, pass the game qualifier to tools and use canonical gloomhaven-2e refs in citations and follow-up lookups.
 
 Grounding rules:
 - Use tools before answering factual rules, scenario, section, card, monster, item, or ability questions.
 - Treat tool results as the source of truth. Do not invent rules, stats, item numbers, section text, or scenario outcomes.
 - If the available data does not answer the question, say what is missing instead of guessing.
+- For Gloomhaven 2.0 current-rule questions, treat official FAQ and errata as current corrections and clarifications over printed rulebook text when relevant.
+- Cite FAQ or errata when you rely on it. Rulebook-only answers are allowed when no current-source clarification applies.
 - Resolve natural user language to refs when exact records are needed, then open or traverse those refs.
 - For scenario/section relationship questions, resolve the named scenario or section first, then open or traverse the canonical ref.
 - For named or numbered card-data records such as item 1, Spyglass, monsters, buildings, events, battle goals, personal quests, and character mats, resolve the record first and then open the exact canonical ref returned by resolve_entity.
@@ -101,14 +105,18 @@ Citations and answer shape:
 
 ${ANSWER_FORMATTING_PROMPT}`;
 
-export const LEGACY_AGENT_SYSTEM_PROMPT = `You are a knowledgeable Frosthaven rules assistant with access to tools \
+export const LEGACY_AGENT_SYSTEM_PROMPT = `You are a knowledgeable Frosthaven and Gloomhaven 2.0 rules assistant with access to tools \
 for searching the indexed rule sources and looking up card data. Use the tools to find relevant information before answering.
 
 Scope rules:
-- Squire supports Frosthaven. Treat Frosthaven as the assistant's exclusive game scope unless the user explicitly asks you to distinguish unsupported games or invalid cross-game refs.
-- For assistant identity or support-scope questions, answer as a Frosthaven assistant only; do not volunteer Gloomhaven or any other game as supported.
+- Squire supports Frosthaven and Gloomhaven 2.0.
+- Default to Frosthaven unless runtime context, tool input, or the user explicitly selects Gloomhaven 2.0.
+- For assistant identity or support-scope questions, answer with the supported Squire games only.
+- Do not mix games. When the user asks for Gloomhaven 2.0, pass the game qualifier to tools and use canonical gloomhaven-2e refs in citations and follow-up lookups.
 
 Guidelines:
+- For Gloomhaven 2.0 current-rule questions, treat official FAQ and errata as current corrections and clarifications over printed rulebook text when relevant.
+- Cite FAQ or errata when you rely on it. Rulebook-only answers are allowed when no current-source clarification applies.
 - Use inspect_sources and schema when you need to discover available kinds, filters, refs, or relations
 - Use resolve_entity to turn natural references into opener-ready scenario, section, card type, or card refs
 - Prefer search_knowledge for broad discovery across rules, scenarios, sections, and cards
@@ -212,7 +220,7 @@ export const AGENT_TOOLS = [
   {
     name: 'search_knowledge',
     description:
-      'Search rules passages, scenarios, sections, and cards. Results include openable refs, citations, source labels, and next refs.',
+      'Search rules passages, scenarios, sections, and cards. Results include openable refs, citations, source labels, and next refs. GH2 FAQ/errata hits are current corrections and clarifications when relevant.',
     input_schema: {
       type: 'object',
       properties: {
@@ -253,7 +261,7 @@ export const LEGACY_AGENT_TOOLS = [
   {
     name: 'search_rules',
     description:
-      'Search the indexed rule sources (rulebooks, FAQ, errata, scenario/section books, puzzle book) for passages relevant to a query.',
+      'Search the indexed rule sources (rulebooks, FAQ, errata, scenario/section books, puzzle book) for passages relevant to a query. GH2 FAQ/errata hits are current corrections and clarifications when relevant.',
     input_schema: {
       type: 'object',
       properties: {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -302,6 +302,77 @@ function normalizeToolOpts(opts?: ToolOpts): NormalizedToolOpts {
   return { ...opts, game: normalizeToolGame(opts?.game) };
 }
 
+const CURRENT_RULE_SOURCE_SCORE_WINDOW = 0.08;
+const CURRENT_RULE_SOURCE_EXTRA_CANDIDATES = 4;
+
+function currentRuleSourceCandidateLimit(requestedLimit: number, game: GameId): number {
+  if (game !== GLOOMHAVEN_2E_GAME_ID) return requestedLimit;
+  // Pull a small surplus so GH2 FAQ/errata just below the raw vector cutoff can
+  // still correct or clarify a printed-source hit with a similar score.
+  return Math.max(
+    requestedLimit,
+    Math.min(requestedLimit + CURRENT_RULE_SOURCE_EXTRA_CANDIDATES, 20),
+  );
+}
+
+function currentRuleSourceRank(sourceType: RuleSourceType): number {
+  if (sourceType === 'errata') return 0;
+  if (sourceType === 'faq') return 1;
+  return 2;
+}
+
+function isGh2RuleCitation(citation: KnowledgeCitation | undefined): citation is KnowledgeCitation {
+  return citation?.sourceRef.startsWith(`source:${GLOOMHAVEN_2E_GAME_ID}/`) ?? false;
+}
+
+function rankRuleHitsForCurrentSources(hits: ScoredEntry[], game: GameId): ScoredEntry[] {
+  return hits
+    .map((hit, index) => ({
+      hit,
+      index,
+      provenance: ruleSourceProvenance(hit.source, normalizeToolGame(hit.game ?? game)),
+    }))
+    .sort((a, b) => {
+      const scoreDelta = b.hit.score - a.hit.score;
+      const aCurrent = a.provenance.game === GLOOMHAVEN_2E_GAME_ID;
+      const bCurrent = b.provenance.game === GLOOMHAVEN_2E_GAME_ID;
+      const closeEnough = Math.abs(scoreDelta) <= CURRENT_RULE_SOURCE_SCORE_WINDOW;
+
+      if (aCurrent && bCurrent && closeEnough) {
+        const sourceRankDelta =
+          currentRuleSourceRank(a.provenance.sourceType) -
+          currentRuleSourceRank(b.provenance.sourceType);
+        if (sourceRankDelta !== 0) return sourceRankDelta;
+      }
+
+      if (scoreDelta !== 0) return scoreDelta;
+      return a.index - b.index;
+    })
+    .map(({ hit }) => hit);
+}
+
+function compareKnowledgeHits(a: KnowledgeSearchHit, b: KnowledgeSearchHit): number {
+  const scoreDelta = b.score - a.score;
+  const aCitation = a.citations[0];
+  const bCitation = b.citations[0];
+
+  if (
+    a.entity.kind === 'rules_passage' &&
+    b.entity.kind === 'rules_passage' &&
+    isGh2RuleCitation(aCitation) &&
+    isGh2RuleCitation(bCitation) &&
+    aCitation.sourceType &&
+    bCitation.sourceType &&
+    Math.abs(scoreDelta) <= CURRENT_RULE_SOURCE_SCORE_WINDOW
+  ) {
+    const sourceRankDelta =
+      currentRuleSourceRank(aCitation.sourceType) - currentRuleSourceRank(bCitation.sourceType);
+    if (sourceRankDelta !== 0) return sourceRankDelta;
+  }
+
+  return scoreDelta;
+}
+
 const CARD_KIND_ALIASES: Record<string, CardType[]> = {
   item: ['items'],
   items: ['items'],
@@ -854,15 +925,18 @@ async function linksFor(
 export async function searchRules(query: string, topK = 6, opts?: ToolOpts): Promise<RuleResult[]> {
   const queryEmbedding = await embed(query);
   const { game } = normalizeToolOpts(opts);
-  const hits: ScoredEntry[] = await search(queryEmbedding, topK, { game });
+  const candidateLimit = currentRuleSourceCandidateLimit(topK, game);
+  const hits: ScoredEntry[] = await search(queryEmbedding, candidateLimit, { game });
 
-  return hits.map((h) => ({
-    text: h.text,
-    source: h.source,
-    sourceLocator: ruleSourceLocator(h.chunkIndex),
-    score: h.score,
-    ...ruleSourceProvenance(h.source, h.game),
-  }));
+  return rankRuleHitsForCurrentSources(hits, game)
+    .slice(0, topK)
+    .map((h) => ({
+      text: h.text,
+      source: h.source,
+      sourceLocator: ruleSourceLocator(h.chunkIndex),
+      score: h.score,
+      ...ruleSourceProvenance(h.source, h.game),
+    }));
 }
 
 /**
@@ -1333,18 +1407,21 @@ export async function searchKnowledge(
 
   if (scope.includes('rules_passage')) {
     const queryEmbedding = await embed(query);
-    const rules = await search(queryEmbedding, perScope, { game });
+    const candidateLimit = currentRuleSourceCandidateLimit(perScope, game);
+    const rules = await search(queryEmbedding, candidateLimit, { game });
     hits.push(
-      ...rules.map((rule) => {
-        const entity = summarizeRule(rule, game);
-        return {
-          entity,
-          score: rule.score,
-          snippet: rule.text,
-          citations: citationForRule(rule, game),
-          nextRefs: [entity],
-        };
-      }),
+      ...rankRuleHitsForCurrentSources(rules, game)
+        .slice(0, perScope)
+        .map((rule) => {
+          const entity = summarizeRule(rule, game);
+          return {
+            entity,
+            score: rule.score,
+            snippet: rule.text,
+            citations: citationForRule(rule, game),
+            nextRefs: [entity],
+          };
+        }),
     );
   }
 
@@ -1412,7 +1489,7 @@ export async function searchKnowledge(
     );
   }
 
-  hits.sort((a, b) => b.score - a.score);
+  hits.sort(compareKnowledgeHits);
   return {
     ok: true,
     query,

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -366,12 +366,28 @@ describe('runAgentLoop', () => {
     );
   });
 
-  it('keeps assistant identity and support scope Frosthaven-only across tool surfaces', () => {
+  it('keeps assistant identity and support scope current for supported games', () => {
     for (const prompt of [AGENT_SYSTEM_PROMPT, LEGACY_AGENT_SYSTEM_PROMPT]) {
-      expect(prompt).toContain('exclusive game scope');
+      expect(prompt).toContain('Squire supports Frosthaven and Gloomhaven 2.0');
       expect(prompt).toContain('assistant identity or support-scope questions');
-      expect(prompt).toContain('do not volunteer Gloomhaven or any other game as supported');
+      expect(prompt).toContain(
+        'For Gloomhaven 2.0 current-rule questions, treat official FAQ and errata as current corrections and clarifications over printed rulebook text when relevant.',
+      );
+      expect(prompt).toContain('Cite FAQ or errata when you rely on it');
+      expect(prompt).toContain(
+        'Rulebook-only answers are allowed when no current-source clarification applies.',
+      );
     }
+  });
+
+  it('advertises GH2 FAQ and errata current-source behavior on both rule-search tools', () => {
+    const searchKnowledgeTool = AGENT_TOOLS.find((tool) => tool.name === 'search_knowledge');
+    const searchRulesTool = LEGACY_AGENT_TOOLS.find((tool) => tool.name === 'search_rules');
+
+    expect(searchKnowledgeTool?.description).toContain('GH2 FAQ/errata');
+    expect(searchKnowledgeTool?.description).toContain('current corrections');
+    expect(searchRulesTool?.description).toContain('GH2 FAQ/errata');
+    expect(searchRulesTool?.description).toContain('current corrections');
   });
 
   it('keeps the redesigned tools selectable for evals and follow-up work', async () => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -193,6 +193,116 @@ describe('searchRules', () => {
     ]);
   });
 
+  it('prefers relevant GH2 errata and FAQ hits over close printed rulebook hits', async () => {
+    mockSearch.mockResolvedValueOnce([
+      {
+        id: 'gh2-rule-book.pdf::10',
+        text: 'Printed rulebook answer.',
+        source: 'gh2-rule-book.pdf',
+        chunkIndex: 10,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.91,
+      },
+      {
+        id: 'gh2-faq.html::3',
+        text: 'FAQ clarification.',
+        source: 'gh2-faq.html',
+        chunkIndex: 3,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.88,
+      },
+      {
+        id: 'gh2-errata.html::0',
+        text: 'Errata correction.',
+        source: 'gh2-errata.html',
+        chunkIndex: 0,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.86,
+      },
+    ]);
+
+    const results = await searchRules('gh2 errata-sensitive question', 3, { game: 'gh2' });
+
+    expect(results.map((result) => result.sourceType)).toEqual(['errata', 'faq', 'rulebook']);
+  });
+
+  it('keeps a substantially stronger rulebook hit ahead of weak current-source hits', async () => {
+    mockSearch.mockResolvedValueOnce([
+      {
+        id: 'gh2-rule-book.pdf::10',
+        text: 'Printed rulebook answer.',
+        source: 'gh2-rule-book.pdf',
+        chunkIndex: 10,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.93,
+      },
+      {
+        id: 'gh2-errata.html::0',
+        text: 'Barely related errata correction.',
+        source: 'gh2-errata.html',
+        chunkIndex: 0,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.7,
+      },
+    ]);
+
+    const results = await searchRules('gh2 rulebook-only question', 2, { game: 'gh2' });
+
+    expect(results.map((result) => result.sourceType)).toEqual(['rulebook', 'errata']);
+  });
+
+  it('considers a small surplus of GH2 rule hits so close FAQ results can enter topK', async () => {
+    mockSearch.mockImplementationOnce(async (_v: number[], k = 6) =>
+      [
+        {
+          id: 'gh2-rule-book.pdf::10',
+          text: 'Printed rulebook answer.',
+          source: 'gh2-rule-book.pdf',
+          chunkIndex: 10,
+          game: GLOOMHAVEN_2E_GAME_ID,
+          score: 0.91,
+        },
+        {
+          id: 'gh2-scenario-book.pdf::0',
+          text: 'Close scenario-book context.',
+          source: 'gh2-scenario-book.pdf',
+          chunkIndex: 0,
+          game: GLOOMHAVEN_2E_GAME_ID,
+          score: 0.9,
+        },
+        {
+          id: 'gh2-faq.html::3',
+          text: 'FAQ clarification just outside the requested cutoff.',
+          source: 'gh2-faq.html',
+          chunkIndex: 3,
+          game: GLOOMHAVEN_2E_GAME_ID,
+          score: 0.88,
+        },
+      ].slice(0, k),
+    );
+
+    const results = await searchRules('gh2 faq-sensitive question', 2, { game: 'gh2' });
+
+    expect(results.map((result) => result.sourceType)).toEqual(['faq', 'rulebook']);
+  });
+
+  it('does not cap large GH2 searchRules topK requests while adding surplus candidates', async () => {
+    mockSearch.mockImplementationOnce(async (_v: number[], k = 6) =>
+      Array.from({ length: k }, (_, index) => ({
+        id: `gh2-rule-book.pdf::${index}`,
+        text: `Printed rulebook answer ${index}.`,
+        source: 'gh2-rule-book.pdf',
+        chunkIndex: index,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 1 - index / 100,
+      })),
+    );
+
+    const results = await searchRules('gh2 broad rulebook question', 25, { game: 'gh2' });
+
+    expect(results).toHaveLength(25);
+  });
+
   it('respects topK parameter', async () => {
     const results = await searchRules('loot action', 1);
     expect(results.length).toBe(1);
@@ -632,6 +742,49 @@ describe('searchKnowledge', () => {
         locator: 'passage 1',
         sourceUrl: 'https://cephalofairgames.github.io/gloomhaven2e-faq/#page_01',
       }),
+    ]);
+  });
+
+  it('prioritizes GH2 current rule sources in rules-passage knowledge search', async () => {
+    mockSearch.mockResolvedValueOnce([
+      {
+        id: 'gh2-rule-book.pdf::10',
+        text: 'Printed rulebook answer.',
+        source: 'gh2-rule-book.pdf',
+        chunkIndex: 10,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.91,
+      },
+      {
+        id: 'gh2-faq.html::3',
+        text: 'FAQ clarification.',
+        source: 'gh2-faq.html',
+        chunkIndex: 3,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.88,
+      },
+      {
+        id: 'gh2-errata.html::0',
+        text: 'Errata correction.',
+        source: 'gh2-errata.html',
+        chunkIndex: 0,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.86,
+      },
+    ]);
+
+    const result = await searchKnowledge('gh2 errata-sensitive question', {
+      scope: ['rules_passage'],
+      limit: 3,
+      game: 'gh2',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.results.map((hit) => hit.citations[0]?.sourceType)).toEqual([
+      'errata',
+      'faq',
+      'rulebook',
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Teach both agent prompts that Squire supports Frosthaven and Gloomhaven 2.0, with GH2 FAQ/errata treated as current corrections and clarifications when relevant.
- Rank GH2 FAQ/errata rule hits ahead of close printed-source hits in both legacy `search_rules` and redesigned `search_knowledge`.
- Pull a small surplus of GH2 rule candidates so near-cutoff FAQ/errata passages can still enter the returned results without capping large `topK` requests.

## Validation
- `npm run test -- test/tools.test.ts test/agent.test.ts`
- `npm run check`

Fixes SQR-192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gloomhaven 2.0 alongside existing Frosthaven support.
  * Enhanced rule search with improved relevance ranking that prioritizes Gloomhaven 2.0 FAQ and errata as current corrections.
  * Refined answer formatting with stricter guidance on styling named game terms and literal text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->