### PR TITLE
v0.1.10: Stream structured answer artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.10] - 2026-05-24
+
+### Added
+
+- Added structured `answer-artifact` SSE events for safe section quote blocks that render outside answer prose.
+- Added browser rendering for section artifacts using text-only DOM insertion, plus regressions for artifact SSE mapping, hostile text handling, and final answer replacement.
+
 ## [0.1.9] - 2026-05-24
 
 ### Added

--- a/docs/SSE_CONTRACT.md
+++ b/docs/SSE_CONTRACT.md
@@ -31,6 +31,13 @@ The browser consumes these SSE event names:
   - `label` is safe tool/source metadata such as `SECTION BOOK` or the
     `REFERENCE` fallback. `message` is already filtered by the service as
     user-safe progress text; it is rendered as metadata, never answer prose.
+- `answer-artifact`
+  - Adds a structured, user-safe artifact such as a quoted section block.
+  - Payload:
+    `{ "id": string, "kind": "section-quote", "title": string, "body": string, "sourceLabel": string | null, "ref": string | null }`
+  - The browser renders artifact fields with DOM text APIs, not `innerHTML`.
+    Artifact bodies are metadata/content blocks outside
+    `.squire-answer__content`; they are never appended as answer prose.
 - `done`
   - Marks the stream complete and clears the pending answer UI.
   - Payload: `{ "html": string, "consultedSources": string[] | null }`
@@ -66,8 +73,8 @@ For every successful stream:
    text and must not be sent as `text-delta`.
 2. The browser must receive exactly one terminal `done` event.
 3. Any `text-delta` events must arrive before `done`.
-4. Tool events and progress events may appear before completion, but they do
-   not count as answer text.
+4. Tool, progress, and artifact events may appear before completion, but they
+   do not count as answer text.
 5. The terminal `done` event carries the final server-rendered sanitized HTML
    fragment, which replaces the pending plain-text transcript in the browser.
 6. The terminal `done` event carries `consultedSources` (persisted tool
@@ -110,6 +117,9 @@ The conversation service emits Squire-owned internal events. These are typed in
 - `tool_result`: a tool lookup or source traversal completed.
 - `tool_progress`: optional user-safe progress from inside a long tool. Routes
   that expose it must map it to browser `tool-progress`, not `text-delta`.
+- `artifact`: optional user-safe structured content. Routes that expose it must
+  map it to browser `answer-artifact`, not `text-delta`, and the browser must
+  render fields as text rather than trusted HTML.
 - `debug`: diagnostic data for traces/logs. This is never browser-visible.
 - `done`: internal completion signal only. The route emits browser `done` after
   persistence so it can include sanitized HTML and persisted consulted sources.
@@ -125,6 +135,7 @@ The route, not the provider, owns the final browser ordering guarantees:
 - provider/internal `tool_call` -> browser `tool-start`
 - provider/internal `tool_result` -> browser `tool-result`
 - internal `tool_progress` -> browser `tool-progress`
+- internal `artifact` -> browser `answer-artifact`
 - internal `debug` -> no browser event
 - provider/internal `done` is only a completion signal
 - browser `done` is emitted by the route with the final sanitized HTML derived
@@ -141,6 +152,8 @@ Regression tests should assert browser-visible behavior, not only persistence:
   appear in `text-delta`
 - `tool_progress` appears only as browser `tool-progress`; `debug` never appears
   in browser SSE
+- structured artifacts appear only as browser `answer-artifact`, not
+  `text-delta`, and artifact DOM rendering treats artifact fields as text
 - `text-delta` content remains inert plain text even when it contains hostile
   markup
 - `done.html` is sanitized before browser insertion

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.98.0",
         "@hono/node-server": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "engines": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,7 @@ import {
   toolSourceLabel,
   TOOL_SOURCE_FALLBACK_LABEL,
   retrievalSourceLabelToFooterLabel,
+  isToolSourceLabel,
 } from './web-ui/consulted-footer.ts';
 import { claimWorktreePort } from './worktree-runtime.ts';
 import { searchRules, searchCards, listCardTypes, listCards, getCard } from './tools.ts';
@@ -1140,6 +1141,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
   // events to wire events.
   return streamSSE(c, async (stream) => {
     let progressSequence = 0;
+    let artifactSequence = 0;
     const assistantMessage = await streamAssistantTurn({
       conversationId: loaded.conversation.id,
       question: loaded.message.content,
@@ -1185,6 +1187,43 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
               id: `${buildToolStatusId(name)}-progress-${progressSequence}`,
               label: toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL,
               message,
+            }),
+          });
+          return;
+        }
+
+        if (event === 'artifact') {
+          const payload = data as {
+            kind?: unknown;
+            title?: unknown;
+            body?: unknown;
+            sourceLabel?: unknown;
+            ref?: unknown;
+          };
+          const title = typeof payload.title === 'string' ? payload.title.trim() : '';
+          const body = typeof payload.body === 'string' ? payload.body.trim() : '';
+          if (payload.kind !== 'section_quote' || title.length === 0 || body.length === 0) {
+            return;
+          }
+          const rawSourceLabel =
+            typeof payload.sourceLabel === 'string' ? payload.sourceLabel.trim() : '';
+          const sourceLabel =
+            rawSourceLabel.length === 0
+              ? null
+              : isToolSourceLabel(rawSourceLabel)
+                ? rawSourceLabel
+                : retrievalSourceLabelToFooterLabel(rawSourceLabel);
+          const ref = typeof payload.ref === 'string' ? payload.ref.trim() : '';
+          artifactSequence += 1;
+          await stream.writeSSE({
+            event: 'answer-artifact',
+            data: JSON.stringify({
+              id: `section-quote-${artifactSequence}`,
+              kind: 'section-quote',
+              title,
+              body,
+              sourceLabel,
+              ref: ref.length > 0 ? ref : null,
             }),
           });
           return;

--- a/src/service.ts
+++ b/src/service.ts
@@ -524,6 +524,14 @@ export interface AgentStreamEventMap {
   tool_result: { name: string; ok: boolean; sourceBooks?: string[] | undefined };
   /** User-safe progress from a long tool. Trace-only until explicitly mapped by a route. */
   tool_progress: { message: string; toolName?: string | undefined };
+  /** User-safe structured artifact content. Routes must render this outside answer prose. */
+  artifact: {
+    kind: 'section_quote';
+    title: string;
+    body: string;
+    sourceLabel?: string | undefined;
+    ref?: string | undefined;
+  };
   /** Diagnostic data for traces/logs. Never browser-visible. */
   debug: { message: string; data?: unknown };
   /** Internal completion signal. Browser `done` is emitted by the HTTP route after persistence. */

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -286,8 +286,9 @@ function renderPendingAnswerSkeleton(streamUrl: string): HtmlEscapedString {
     data-stream-state="pending"
     data-stream-url="${streamUrl}"
   >
-    <div class="squire-answer__content squire-markdown"></div>
     <div class="squire-answer__tools" aria-live="off"></div>
+    <div class="squire-answer__artifacts" aria-live="polite"></div>
+    <div class="squire-answer__content squire-markdown"></div>
     <div class="squire-answer__skeleton" aria-hidden="true">
       <div class="squire-answer__skeleton-dropcap"></div>
       <div class="squire-answer__skeleton-line squire-answer__skeleton-line--full"></div>

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -371,6 +371,46 @@ function clearToolStatusRows(toolsEl, toolEntries) {
   }
 }
 
+function renderAnswerArtifact(artifactsEl, artifactEntries, payload) {
+  if (!artifactsEl || !payload || payload.kind !== 'section-quote') return;
+  if (!payload.id || !payload.title || !payload.body) return;
+
+  var row = artifactEntries[payload.id];
+  if (!row) {
+    row = document.createElement('figure');
+    row.className = 'squire-answer__artifact';
+    row.dataset.artifactId = payload.id;
+
+    var heading = document.createElement('figcaption');
+    heading.className = 'squire-answer__artifact-title';
+    row.appendChild(heading);
+
+    var quote = document.createElement('blockquote');
+    quote.className = 'squire-answer__artifact-body squire-markdown';
+    row.appendChild(quote);
+
+    artifactEntries[payload.id] = row;
+    artifactsEl.appendChild(row);
+  }
+
+  var titleEl = row.querySelector('.squire-answer__artifact-title');
+  if (titleEl) {
+    titleEl.replaceChildren();
+    var titleText = document.createElement('span');
+    titleText.textContent = payload.title;
+    titleEl.appendChild(titleText);
+    if (payload.sourceLabel) {
+      var sourceEl = document.createElement('span');
+      sourceEl.className = 'squire-answer__artifact-source';
+      sourceEl.textContent = payload.sourceLabel;
+      titleEl.appendChild(sourceEl);
+    }
+  }
+
+  var bodyEl = row.querySelector('.squire-answer__artifact-body');
+  if (bodyEl) bodyEl.textContent = payload.body;
+}
+
 // SQR-108 / ADR 0012 D-3: pin-to-bottom helpers. Use page-level scroll
 // (the conversation page scrolls the document body — `.squire-frame` is
 // `min-height: 100vh` and the input dock sticky-pins to the viewport).
@@ -458,6 +498,7 @@ function attachPendingAnswerStream(answerEl) {
 
   var contentEl = answerEl.querySelector('.squire-answer__content');
   var toolsEl = answerEl.querySelector('.squire-answer__tools');
+  var artifactsEl = answerEl.querySelector('.squire-answer__artifacts');
   var skeletonEl = answerEl.querySelector('.squire-answer__skeleton');
   // SQR-98: the consulted footer now lives inside the answer element so
   // each turn owns its own provenance slot. Historical turns render the
@@ -468,6 +509,7 @@ function attachPendingAnswerStream(answerEl) {
   var preToolBuffer = '';
   var seenFirstDelta = false;
   var toolPhaseStarted = false;
+  var artifactEntries = {};
   // Ordered-dedup set of provenance labels collected from tool-result
   // events during this turn. `Map` preserves insertion order, which we
   // rely on so the footer reads "CONSULTED · RULEBOOK · CARD INDEX" in
@@ -608,6 +650,16 @@ function attachPendingAnswerStream(answerEl) {
     if (!toolsEl) return;
     var row = ensureToolStatusRow(toolsEl, toolEntries, payload.id);
     renderToolStatusRow(row, resultLabels[0] || null, payload.ok === false ? 'error' : 'running');
+  });
+
+  source.addEventListener('answer-artifact', function (event) {
+    if (!artifactsEl || seenFirstDelta) return;
+    var payload = JSON.parse(event.data || '{}');
+    preToolBuffer = '';
+    toolPhaseStarted = true;
+    renderAnswerArtifact(artifactsEl, artifactEntries, payload);
+    if (skeletonEl) skeletonEl.hidden = true;
+    if (pinToBottom) scrollToBottom();
   });
 
   source.addEventListener('done', function (event) {

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -1234,10 +1234,6 @@ template#squire-banner-fixtures {
   background: var(--surface-2);
 }
 
-.squire-answer__content:empty + .squire-answer__tools {
-  margin-top: 0;
-}
-
 .squire-answer__tools {
   display: grid;
   gap: 6px;
@@ -1275,6 +1271,48 @@ template#squire-banner-fixtures {
 
 .squire-answer__tool.is-error {
   color: var(--amber);
+}
+
+.squire-answer__artifacts {
+  display: grid;
+  gap: 10px;
+  margin: 0 0 18px;
+}
+
+.squire-answer__artifacts:empty {
+  display: none;
+}
+
+.squire-answer__artifact {
+  border-left: 2px solid var(--rule);
+  padding-left: 14px;
+  max-width: 100%;
+}
+
+.squire-answer__artifact-title {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--cream);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.squire-answer__artifact-source {
+  color: var(--sepia);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.squire-answer__artifact-source::before {
+  content: '·';
+  margin: 0 6px;
+  color: var(--sepia-dim);
+}
+
+.squire-answer__artifact-body {
+  margin: 0;
+  white-space: pre-wrap;
 }
 
 .squire-answer--pending .squire-answer__content {

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -1513,6 +1513,13 @@ describe('conversation web backend', () => {
         message: 'raw tool output',
         data: '>>> [Locked Down] >>> New Scenario: Life and Death 61',
       });
+      await options?.emit?.('artifact', {
+        kind: 'section_quote',
+        title: 'Locked Down',
+        body: 'New Scenario: Life and Death — 61',
+        sourceLabel: 'Section Book 62-81',
+        ref: 'section:frosthaven/67.1',
+      });
       await options?.emit?.('tool_result', {
         name: 'follow_links',
         ok: true,
@@ -1550,6 +1557,7 @@ describe('conversation web backend', () => {
     expect(events.map((event) => event.event)).toEqual([
       'tool-start',
       'tool-progress',
+      'answer-artifact',
       'tool-result',
       'text-delta',
       'done',
@@ -1560,6 +1568,17 @@ describe('conversation web backend', () => {
         id: 'follow_links-progress-1',
         label: 'REFERENCE',
         message: 'Tracing scenario 61 unlock links.',
+      },
+    });
+    expect(events).toContainEqual({
+      event: 'answer-artifact',
+      data: {
+        id: 'section-quote-1',
+        kind: 'section-quote',
+        title: 'Locked Down',
+        body: 'New Scenario: Life and Death — 61',
+        sourceLabel: 'SECTION BOOK',
+        ref: 'section:frosthaven/67.1',
       },
     });
     expect(events).toContainEqual({

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -536,6 +536,9 @@ describe('renderConversationTurnAppendFragment (SQR-108 / ADR 0012 E-3)', () => 
     );
     expect(body).toMatch(/<div[^>]*class="squire-answer__content squire-markdown"><\/div>/);
     expect(body).toMatch(/<div[^>]*class="squire-answer__tools"[^>]*aria-live="off"><\/div>/);
+    expect(body).toMatch(
+      /<div[^>]*class="squire-answer__artifacts"[^>]*aria-live="polite"><\/div>/,
+    );
     expect(body).toMatch(/class="squire-answer__skeleton"[^>]*aria-hidden="true"/);
     expect(body).toContain('squire-answer__skeleton-dropcap');
     expect(body).toContain('squire-answer__skeleton-line squire-answer__skeleton-line--full');

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -209,6 +209,8 @@ function bootPendingTranscript() {
   contentEl.classList.add('squire-answer__content');
   const toolsEl = new FakeElement('div');
   toolsEl.classList.add('squire-answer__tools');
+  const artifactsEl = new FakeElement('div');
+  artifactsEl.classList.add('squire-answer__artifacts');
   const skeletonEl = new FakeElement('div');
   skeletonEl.classList.add('squire-answer__skeleton');
 
@@ -217,8 +219,9 @@ function bootPendingTranscript() {
   // SQR-108 / ADR 0012: stream URL lives on the pending answer article,
   // not on the (now-deleted) `.squire-transcript--pending` wrapper.
   answerEl.setAttribute('data-stream-url', '/chat/stream');
-  answerEl.appendChild(contentEl);
   answerEl.appendChild(toolsEl);
+  answerEl.appendChild(artifactsEl);
+  answerEl.appendChild(contentEl);
   answerEl.appendChild(skeletonEl);
 
   const transcript = new FakeElement('section');
@@ -289,6 +292,7 @@ function bootPendingTranscript() {
 
   return {
     answerEl,
+    artifactsEl,
     contentEl,
     footerEl,
     form,
@@ -444,6 +448,45 @@ describe('squire.js chat form retargeting', () => {
     expect(toolsEl.children).toHaveLength(0);
     expect(footerEl.textContent).toBe('CONSULTED · SECTION BOOK');
     expect(footerEl.hidden).toBe(false);
+  });
+
+  it('renders section artifacts as text outside answer prose before final answer starts', () => {
+    const { artifactsEl, contentEl, source, toolsEl } = bootPendingTranscript();
+
+    source.emit('answer-artifact', {
+      id: 'section-quote-1',
+      kind: 'section-quote',
+      title: 'Locked Down',
+      body: '<img src=x onerror=alert(1)>\nNew Scenario: Life and Death — 61',
+      sourceLabel: 'SECTION BOOK',
+      ref: 'section:frosthaven/67.1',
+    });
+
+    expect(contentEl.querySelector('p')).toBeNull();
+    expect(toolsEl.children).toHaveLength(0);
+    expect(artifactsEl.children).toHaveLength(1);
+    const artifact = artifactsEl.children[0];
+    expect(artifact.querySelector('.squire-answer__artifact-title')?.textContent).toBe('');
+    expect(artifact.querySelector('.squire-answer__artifact-title')?.children[0]?.textContent).toBe(
+      'Locked Down',
+    );
+    expect(artifact.querySelector('.squire-answer__artifact-source')?.textContent).toBe(
+      'SECTION BOOK',
+    );
+    expect(artifact.querySelector('.squire-answer__artifact-body')?.textContent).toBe(
+      '<img src=x onerror=alert(1)>\nNew Scenario: Life and Death — 61',
+    );
+    expect(artifact.querySelector('.squire-answer__artifact-body')?.innerHTML).toBe('');
+
+    source.emit('text-delta', { delta: 'The section is Locked Down.' });
+    expect(artifactsEl.children).toHaveLength(1);
+    expect(contentEl.querySelector('p')?.textContent).toBe('The section is Locked Down.');
+
+    source.emit('done', {
+      html: '<p>The section is <strong>Locked Down</strong>.</p>',
+    });
+    expect(artifactsEl.children).toHaveLength(1);
+    expect(contentEl.innerHTML).toBe('<p>The section is <strong>Locked Down</strong>.</p>');
   });
 
   // SQR-98: the consulted footer must reflect the actual tool calls this


### PR DESCRIPTION
## Summary
- add an internal `artifact` event and browser `answer-artifact` SSE event for structured section quote blocks
- render artifacts outside `.squire-answer__content` using text-only DOM insertion
- update pending answer markup/styles, SSE docs, release metadata, and regressions for artifact translation/rendering

## Tests
- npm test -- test/conversation.test.ts
- npm test -- test/web-ui-squire.regression-1.test.ts
- npm test -- test/web-ui-layout.test.ts
- npm run check

Linear: SQR-237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for answer artifacts, enabling safe display of structured content (section quotes) with title, body, and optional source information streamed from the backend.
  * Artifacts render as plain text to ensure secure browser display.

* **UI Updates**
  * Redesigned answer layout with a dedicated artifacts section positioned before the main answer content.

* **Tests**
  * Expanded test coverage for artifact streaming and rendering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->