### PR TITLE
test(rules): add GH2 corpus regression seeds

### DIFF
--- a/test/fixtures/search-queries/gh2-rules.json
+++ b/test/fixtures/search-queries/gh2-rules.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "gh2-rule-scenario-level",
+    "query": "In Gloomhaven 2.0, how is the recommended scenario level calculated?",
+    "expectedSource": "gh2-rule-book.md",
+    "expectedSourceType": "rulebook",
+    "requiredPhrases": [
+      "At recommended difficulty",
+      "scenario level",
+      "average level of the characters divided by 2"
+    ],
+    "forbiddenSourcePrefixes": ["fh-"],
+    "evalSeed": {
+      "expected": "At recommended difficulty in Gloomhaven 2.0, the scenario level is the average level of the characters divided by 2.",
+      "grading": "Must answer for Gloomhaven 2.0/GH2, cite the rulebook source, and avoid any Frosthaven citation or Frosthaven-only framing."
+    }
+  },
+  {
+    "id": "gh2-faq-red-hex-aoe-targets",
+    "query": "In Gloomhaven 2.0, can I skip targets in a red hex AoE attack?",
+    "expectedSource": "gh2-faq.html",
+    "expectedSourceType": "faq",
+    "requiredPhrases": [
+      "Can I skip targets in a red hex AoE attack?",
+      "Yes",
+      "red hex AoE just determines the hexes where your potential targets are"
+    ],
+    "forbiddenSourcePrefixes": ["fh-"],
+    "evalSeed": {
+      "expected": "Yes. In Gloomhaven 2.0, a red hex AoE just determines the hexes where your potential targets are.",
+      "grading": "Must answer for Gloomhaven 2.0/GH2, cite the FAQ source, and avoid any Frosthaven citation or Frosthaven-only framing."
+    }
+  },
+  {
+    "id": "gh2-errata-campaign-sheet-section-29",
+    "query": "In Gloomhaven 2.0, the campaign sheet says to read section 29.5 after scenario 11 with 6 Demon Reputation. What is the current section?",
+    "expectedSource": "gh2-errata.html",
+    "expectedSourceType": "errata",
+    "requiredPhrases": [
+      "Read Section 29.5",
+      "should direct you to Section 29.1",
+      "There is no Section 29.5"
+    ],
+    "forbiddenSourcePrefixes": ["fh-"],
+    "evalSeed": {
+      "expected": "Use Section 29.1. The Gloomhaven 2.0 errata says the Campaign Sheet instruction to read Section 29.5 should direct you to Section 29.1, and that there is no Section 29.5.",
+      "grading": "Must answer for Gloomhaven 2.0/GH2, cite the errata source, state Section 29.1 instead of 29.5, and avoid any Frosthaven citation or Frosthaven-only framing."
+    }
+  }
+]

--- a/test/fixtures/search-queries/gh2-rules.json
+++ b/test/fixtures/search-queries/gh2-rules.json
@@ -27,7 +27,7 @@
     ],
     "forbiddenSourcePrefixes": ["fh-"],
     "evalSeed": {
-      "expected": "Yes. In Gloomhaven 2.0, a red hex AoE just determines the hexes where your potential targets are.",
+      "expected": "Can I skip targets in a red hex AoE attack? Yes. In Gloomhaven 2.0, a red hex AoE just determines the hexes where your potential targets are.",
       "grading": "Must answer for Gloomhaven 2.0/GH2, cite the FAQ source, and avoid any Frosthaven citation or Frosthaven-only framing."
     }
   },

--- a/test/gh2-corpus-regression.test.ts
+++ b/test/gh2-corpus-regression.test.ts
@@ -77,9 +77,10 @@ describe('GH2 corpus regression sample queries', () => {
 
   it('stores eval-seed expectations with source-citation grading requirements', () => {
     for (const sample of loadSampleQueries()) {
-      expect(normalizedText(sample.evalSeed.expected)).toContain(
-        normalizedText(sample.requiredPhrases.at(-1) ?? ''),
-      );
+      const normalizedExpected = normalizedText(sample.evalSeed.expected);
+      for (const phrase of sample.requiredPhrases) {
+        expect(normalizedExpected).toContain(normalizedText(phrase));
+      }
       expect(sample.evalSeed.grading).toMatch(/Gloomhaven 2\.0|GH2/);
       expect(sample.evalSeed.grading).toMatch(/cite|citation|source/i);
       expect(sample.evalSeed.grading).toMatch(new RegExp(sample.expectedSourceType, 'i'));

--- a/test/gh2-corpus-regression.test.ts
+++ b/test/gh2-corpus-regression.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { chunkText, htmlToIndexText } from '../src/index-docs.ts';
+import { GLOOMHAVEN_2E_GAME_ID } from '../src/game.ts';
+import { ruleSourceProvenance } from '../src/rule-source-provenance.ts';
+import type { RuleSourceType } from '../src/rule-source-provenance.ts';
+
+interface Gh2CorpusQuery {
+  id: string;
+  query: string;
+  expectedSource: string;
+  expectedSourceType: RuleSourceType;
+  requiredPhrases: string[];
+  forbiddenSourcePrefixes: string[];
+  evalSeed: {
+    expected: string;
+    grading: string;
+  };
+}
+
+const SAMPLE_QUERY_PATH = join(import.meta.dirname, 'fixtures', 'search-queries', 'gh2-rules.json');
+
+function loadSampleQueries(): Gh2CorpusQuery[] {
+  return JSON.parse(readFileSync(SAMPLE_QUERY_PATH, 'utf8')) as Gh2CorpusQuery[];
+}
+
+function sourceText(source: string): string {
+  const sourcePath = join(import.meta.dirname, '..', 'data', 'rule-sources', source);
+  const raw = readFileSync(sourcePath, 'utf8');
+  return source.endsWith('.html') ? htmlToIndexText(raw) : raw;
+}
+
+function normalizedText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+describe('GH2 corpus regression sample queries', () => {
+  it('covers rulebook, FAQ, and errata/current-rule source types', () => {
+    const sampleQueries = loadSampleQueries();
+
+    expect(sampleQueries.map((sample) => sample.expectedSourceType).sort()).toEqual([
+      'errata',
+      'faq',
+      'rulebook',
+    ]);
+    expect(sampleQueries.map((sample) => sample.id).sort()).toEqual([
+      'gh2-errata-campaign-sheet-section-29',
+      'gh2-faq-red-hex-aoe-targets',
+      'gh2-rule-scenario-level',
+    ]);
+  });
+
+  it('keeps each answerable source passage in an indexed chunk with GH2-only citations', () => {
+    for (const sample of loadSampleQueries()) {
+      const text = sourceText(sample.expectedSource);
+      const chunks = chunkText(text, sample.expectedSource);
+      const requiredPhrases = sample.requiredPhrases.map(normalizedText);
+      const matchingChunk = chunks.find((chunk) => {
+        const chunkText = normalizedText(chunk.text);
+        return requiredPhrases.every((phrase) => chunkText.includes(phrase));
+      });
+
+      expect(matchingChunk, `missing indexed chunk for ${sample.id}`).toBeDefined();
+      expect(sample.forbiddenSourcePrefixes).toContain('fh-');
+      expect(sample.expectedSource).not.toMatch(/^fh-/);
+
+      const provenance = ruleSourceProvenance(sample.expectedSource, GLOOMHAVEN_2E_GAME_ID);
+      expect(provenance.game).toBe(GLOOMHAVEN_2E_GAME_ID);
+      expect(provenance.sourceType).toBe(sample.expectedSourceType);
+      expect(provenance.sourceRef).toMatch(/^source:gloomhaven-2e\//);
+      expect(provenance.sourceRef).not.toContain('source:frosthaven/');
+    }
+  });
+
+  it('stores eval-seed expectations with source-citation grading requirements', () => {
+    for (const sample of loadSampleQueries()) {
+      expect(normalizedText(sample.evalSeed.expected)).toContain(
+        normalizedText(sample.requiredPhrases.at(-1) ?? ''),
+      );
+      expect(sample.evalSeed.grading).toMatch(/Gloomhaven 2\.0|GH2/);
+      expect(sample.evalSeed.grading).toMatch(/cite|citation|source/i);
+      expect(sample.evalSeed.grading).toMatch(new RegExp(sample.expectedSourceType, 'i'));
+      expect(sample.evalSeed.grading).toMatch(/avoid.*Frosthaven citation/i);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add GH2 sample queries covering one rulebook answer, one FAQ answer, and one errata/current-rule answer.
- Add a source-level corpus regression that chunks the checked-in GH2 snapshots and verifies answerable passages survive indexing boundaries.
- Assert GH2 provenance/citation metadata for each seed and require eval-seed grading to reject Frosthaven citations.

## Validation
- `npm run test -- test/gh2-corpus-regression.test.ts`
- `npm run check`

Fixes SQR-193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test suite for Gloomhaven 2.0 rule queries to verify search accuracy, source validation, and citation constraints.
  * Included sample scenarios (test fixtures) covering expected source types, required/forbidden phrases, and exact-answer evaluation checks aligned to GH2 rules and FAQs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->