### PR TITLE
feat(import): parameterize GHS data paths

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -7,6 +7,15 @@ name: Refresh extracted data
 
 on:
   workflow_dispatch:
+    inputs:
+      ghs_data_paths:
+        description: 'Space-separated GHS sparse checkout paths, e.g. data/fh or data/fh data/gh2e'
+        required: false
+        default: 'data/fh'
+      ghs_data_game:
+        description: 'GHS game data subdirectory to import from'
+        required: false
+        default: 'fh'
   schedule:
     # Weekly on Sundays at 06:00 UTC
     - cron: '0 6 * * 0'
@@ -22,6 +31,9 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    env:
+      GHS_DATA_PATHS: ${{ github.event.inputs.ghs_data_paths || 'data/fh' }}
+      GHS_DATA_GAME: ${{ github.event.inputs.ghs_data_game || 'fh' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -33,13 +45,14 @@ jobs:
 
       - run: npm ci
 
-      # Shallow-clone GHS with only the Frosthaven data subtree (~6 MB)
+      # Shallow-clone GHS with only the requested game data subtree(s).
       - name: Fetch GHS data
         run: |
           git clone --depth 1 --filter=blob:none --sparse \
             https://github.com/Lurkars/gloomhavensecretariat.git /tmp/ghs
           cd /tmp/ghs
-          git sparse-checkout set data/fh
+          read -r -a ghs_paths <<< "$GHS_DATA_PATHS"
+          git sparse-checkout set "${ghs_paths[@]}"
 
       # Run GHS imports (free — JSON parsing only)
       - name: Run GHS imports

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -603,13 +603,27 @@ the project and point the scripts at it via env var:
 ```bash
 git clone --depth 1 --filter=blob:none --sparse \
   https://github.com/Lurkars/gloomhavensecretariat.git ~/data/ghs
-cd ~/data/ghs && git sparse-checkout set data/fh
+cd ~/data/ghs
+
+# Frosthaven only
+git sparse-checkout set data/fh
+
+# Gloomhaven 2nd Edition only
+git sparse-checkout set data/gh2e
+
+# Both games in the same sparse checkout
+git sparse-checkout set data/fh data/gh2e
 ```
 
-Then run any import script:
+Then run any import script. `GHS_DATA_GAME` selects the GHS `data/<game>`
+subtree when `GHS_DATA_DIR` points at a checkout root; it defaults to `fh`:
 
 ```bash
+# Frosthaven
 GHS_DATA_DIR=~/data/ghs npx tsx src/import-monster-stats.ts
+
+# Gloomhaven 2nd Edition
+GHS_DATA_DIR=~/data/ghs GHS_DATA_GAME=gh2e npx tsx src/import-monster-stats.ts
 ```
 
 The clone lives outside the repo so it doesn't interfere with git or

--- a/src/ghs-utils.ts
+++ b/src/ghs-utils.ts
@@ -23,7 +23,7 @@
  */
 
 import { readFileSync, existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { basename, join, dirname, normalize } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseFragment, type DefaultTreeAdapterMap } from 'parse5';
 
@@ -43,7 +43,11 @@ function normalizeGhsGameDataSubdir(subdir: string): string {
 }
 
 function isDirectGhsGameDataDir(baseDir: string, gameDataSubdir: string): boolean {
-  return baseDir.endsWith(`${join('data', gameDataSubdir)}`);
+  const normalizedBaseDir = normalize(baseDir);
+  return (
+    basename(normalizedBaseDir) === gameDataSubdir &&
+    basename(dirname(normalizedBaseDir)) === 'data'
+  );
 }
 
 /**

--- a/src/ghs-utils.ts
+++ b/src/ghs-utils.ts
@@ -31,11 +31,49 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ─── GHS data paths ─────────────────────────────────────────────────────────
 
-export const GHS_DATA_DIR = process.env.GHS_DATA_DIR
-  ? existsSync(join(process.env.GHS_DATA_DIR, 'data', 'fh'))
-    ? join(process.env.GHS_DATA_DIR, 'data', 'fh')
-    : process.env.GHS_DATA_DIR
-  : join(__dirname, '..', 'data', 'gloomhavensecretariat', 'data', 'fh');
+const DEFAULT_GHS_GAME_DATA_SUBDIR = 'fh';
+
+interface ResolveGhsDataDirOptions {
+  gameDataSubdir?: string;
+  exists?: (path: string) => boolean;
+}
+
+function normalizeGhsGameDataSubdir(subdir: string): string {
+  return subdir.replace(/^data[\\/]/, '');
+}
+
+function isDirectGhsGameDataDir(baseDir: string, gameDataSubdir: string): boolean {
+  return baseDir.endsWith(`${join('data', gameDataSubdir)}`);
+}
+
+/**
+ * Resolve either a GHS checkout root (`.../gloomhavensecretariat`) or a direct
+ * game data directory (`.../data/fh`, `.../data/gh2e`) to the importable folder.
+ */
+export function resolveGhsDataDir(baseDir: string, options: ResolveGhsDataDirOptions = {}): string {
+  const gameDataSubdir = normalizeGhsGameDataSubdir(
+    options.gameDataSubdir ?? DEFAULT_GHS_GAME_DATA_SUBDIR,
+  );
+
+  if (isDirectGhsGameDataDir(baseDir, gameDataSubdir)) return baseDir;
+
+  const candidate = join(baseDir, 'data', gameDataSubdir);
+  const exists = options.exists ?? existsSync;
+  if (exists(candidate)) return candidate;
+  if (exists(join(baseDir, 'label', 'en.json')) || exists(join(baseDir, 'items.json'))) {
+    return baseDir;
+  }
+  return candidate;
+}
+
+export const GHS_DATA_GAME = normalizeGhsGameDataSubdir(
+  process.env.GHS_DATA_GAME ?? DEFAULT_GHS_GAME_DATA_SUBDIR,
+);
+
+export const GHS_DATA_DIR = resolveGhsDataDir(
+  process.env.GHS_DATA_DIR ?? join(__dirname, '..', 'data', 'gloomhavensecretariat'),
+  { gameDataSubdir: GHS_DATA_GAME },
+);
 
 export const GHS_LABEL_PATH = join(GHS_DATA_DIR, 'label', 'en.json');
 

--- a/test/ghs-utils.test.ts
+++ b/test/ghs-utils.test.ts
@@ -1,11 +1,58 @@
 import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
 import {
   kebabToTitle,
   stripHtml,
   resolveLabel,
   resolveGameTokens,
   formatAction,
+  resolveGhsDataDir,
 } from '../src/ghs-utils.ts';
+
+// ─── GHS data path resolution ───────────────────────────────────────────────
+
+describe('resolveGhsDataDir', () => {
+  it('defaults to the Frosthaven subtree when given a GHS checkout root', () => {
+    const root = '/tmp/ghs';
+
+    expect(resolveGhsDataDir(root, { exists: (path) => path === join(root, 'data', 'fh') })).toBe(
+      join(root, 'data', 'fh'),
+    );
+  });
+
+  it('selects the GH2 subtree when requested', () => {
+    const root = '/tmp/ghs';
+
+    expect(
+      resolveGhsDataDir(root, {
+        gameDataSubdir: 'gh2e',
+        exists: (path) => path === join(root, 'data', 'gh2e'),
+      }),
+    ).toBe(join(root, 'data', 'gh2e'));
+  });
+
+  it('keeps accepting a direct game data directory', () => {
+    const direct = '/tmp/ghs/data/gh2e';
+
+    expect(
+      resolveGhsDataDir(direct, {
+        gameDataSubdir: 'gh2e',
+        exists: () => false,
+      }),
+    ).toBe(direct);
+  });
+
+  it('keeps the requested subtree in the resolved path when it has not been checked out', () => {
+    const root = '/tmp/ghs';
+
+    expect(
+      resolveGhsDataDir(root, {
+        gameDataSubdir: 'gh2e',
+        exists: () => false,
+      }),
+    ).toBe(join(root, 'data', 'gh2e'));
+  });
+});
 
 // ─── kebabToTitle ────────────────────────────────────────────────────────────
 

--- a/test/ghs-utils.test.ts
+++ b/test/ghs-utils.test.ts
@@ -42,6 +42,16 @@ describe('resolveGhsDataDir', () => {
     ).toBe(direct);
   });
 
+  it('does not treat path suffix text as a direct game data directory', () => {
+    const root = '/tmp/notdata/fh';
+
+    expect(
+      resolveGhsDataDir(root, {
+        exists: () => false,
+      }),
+    ).toBe(join(root, 'data', 'fh'));
+  });
+
   it('keeps the requested subtree in the resolved path when it has not been checked out', () => {
     const root = '/tmp/ghs';
 


### PR DESCRIPTION
## Summary
- add shared GHS data directory resolution for checkout roots and direct game data directories
- preserve Frosthaven as the default while allowing `GHS_DATA_GAME=gh2e`
- make the refresh workflow sparse-checkout paths configurable for FH-only, GH2-only, or both-game local data
- document the local commands and cover path resolution with unit tests

## Verification
- `npm run check`
- `npm run lint:actions`

Fixes SQR-194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data refresh workflow now accepts configurable paths/game selection to import different game data sources without workflow edits.
  * Import tooling now resolves and accepts root or subtree data directories for multiple game variants.

* **Documentation**
  * Development guide updated with step-by-step local import instructions and examples for different game variants.

* **Tests**
  * Added tests covering directory-resolution behavior for multiple game data layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->