### PR TITLE
feat(import): add game-aware importer config

### DIFF
--- a/src/ghs-utils.ts
+++ b/src/ghs-utils.ts
@@ -26,28 +26,67 @@ import { readFileSync, existsSync } from 'node:fs';
 import { basename, join, dirname, normalize } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseFragment, type DefaultTreeAdapterMap } from 'parse5';
+import {
+  DEFAULT_GAME_ID,
+  FROSTHAVEN_GAME_ID,
+  GLOOMHAVEN_2E_GAME_ID,
+  requireGameId,
+  type GameId,
+} from './game.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ─── GHS data paths ─────────────────────────────────────────────────────────
 
 const DEFAULT_GHS_GAME_DATA_SUBDIR = 'fh';
+const DEFAULT_GHS_SOURCE_DIR = join(__dirname, '..', 'data', 'gloomhavensecretariat');
+const GHS_GAME_DATA_SUBDIR_BY_GAME: Record<GameId, string> = {
+  [FROSTHAVEN_GAME_ID]: 'fh',
+  [GLOOMHAVEN_2E_GAME_ID]: 'gh2e',
+};
+const GHS_GAME_DATA_SUBDIRS = new Set(Object.values(GHS_GAME_DATA_SUBDIR_BY_GAME));
 
 interface ResolveGhsDataDirOptions {
   gameDataSubdir?: string;
   exists?: (path: string) => boolean;
 }
 
+export interface GhsImporterConfigInput {
+  game?: string;
+  sourceDir?: string;
+  exists?: (path: string) => boolean;
+}
+
+export interface GhsImporterConfig {
+  game: GameId;
+  sourceDir: string;
+  dataDir: string;
+  labelPath: string;
+  spoilerLabelPath: string;
+}
+
 function normalizeGhsGameDataSubdir(subdir: string): string {
   return subdir.replace(/^data[\\/]/, '');
 }
 
-function isDirectGhsGameDataDir(baseDir: string, gameDataSubdir: string): boolean {
+function ghsGameDataSubdirFor(game: GameId): string {
+  return GHS_GAME_DATA_SUBDIR_BY_GAME[game];
+}
+
+function resolveGhsGame(value: string | undefined): GameId {
+  if (value === undefined) return DEFAULT_GAME_ID;
+  return requireGameId(normalizeGhsGameDataSubdir(value));
+}
+
+function directGhsGameDataSubdir(baseDir: string): string | null {
   const normalizedBaseDir = normalize(baseDir);
-  return (
-    basename(normalizedBaseDir) === gameDataSubdir &&
-    basename(dirname(normalizedBaseDir)) === 'data'
-  );
+  const subdir = basename(normalizedBaseDir);
+  if (!GHS_GAME_DATA_SUBDIRS.has(subdir)) return null;
+  return basename(dirname(normalizedBaseDir)) === 'data' ? subdir : null;
+}
+
+function isDirectGhsGameDataDir(baseDir: string, gameDataSubdir: string): boolean {
+  return directGhsGameDataSubdir(baseDir) === gameDataSubdir;
 }
 
 /**
@@ -70,18 +109,41 @@ export function resolveGhsDataDir(baseDir: string, options: ResolveGhsDataDirOpt
   return candidate;
 }
 
-export const GHS_DATA_GAME = normalizeGhsGameDataSubdir(
-  process.env.GHS_DATA_GAME ?? DEFAULT_GHS_GAME_DATA_SUBDIR,
-);
+export function resolveGhsImporterConfig(input: GhsImporterConfigInput = {}): GhsImporterConfig {
+  const game = resolveGhsGame(input.game ?? process.env.GHS_DATA_GAME);
+  const gameDataSubdir = ghsGameDataSubdirFor(game);
+  const sourceDir = input.sourceDir ?? process.env.GHS_DATA_DIR ?? DEFAULT_GHS_SOURCE_DIR;
+  const directSubdir = directGhsGameDataSubdir(sourceDir);
 
-export const GHS_DATA_DIR = resolveGhsDataDir(
-  process.env.GHS_DATA_DIR ?? join(__dirname, '..', 'data', 'gloomhavensecretariat'),
-  { gameDataSubdir: GHS_DATA_GAME },
-);
+  if (directSubdir && directSubdir !== gameDataSubdir) {
+    throw new Error(
+      `GHS source directory ${sourceDir} uses data/${directSubdir}, which does not match requested game ${game} (expected data/${gameDataSubdir}).`,
+    );
+  }
 
-export const GHS_LABEL_PATH = join(GHS_DATA_DIR, 'label', 'en.json');
+  const dataDir = resolveGhsDataDir(sourceDir, {
+    gameDataSubdir,
+    exists: input.exists,
+  });
 
-export const GHS_SPOILER_LABEL_PATH = join(GHS_DATA_DIR, 'label', 'spoiler', 'en.json');
+  return {
+    game,
+    sourceDir,
+    dataDir,
+    labelPath: join(dataDir, 'label', 'en.json'),
+    spoilerLabelPath: join(dataDir, 'label', 'spoiler', 'en.json'),
+  };
+}
+
+const DEFAULT_GHS_IMPORTER_CONFIG = resolveGhsImporterConfig();
+
+export const GHS_DATA_GAME = ghsGameDataSubdirFor(DEFAULT_GHS_IMPORTER_CONFIG.game);
+
+export const GHS_DATA_DIR = DEFAULT_GHS_IMPORTER_CONFIG.dataDir;
+
+export const GHS_LABEL_PATH = DEFAULT_GHS_IMPORTER_CONFIG.labelPath;
+
+export const GHS_SPOILER_LABEL_PATH = DEFAULT_GHS_IMPORTER_CONFIG.spoilerLabelPath;
 
 // ─── GHS types ───────────────────────────────────────────────────────────────
 
@@ -248,12 +310,12 @@ function mergeLabels(a: LabelData, b: LabelData): LabelData {
  * Load and merge the base and spoiler English label files from GHS data.
  * Throws if label files are missing.
  */
-export function loadLabels(): LabelData {
-  if (!existsSync(GHS_LABEL_PATH) || !existsSync(GHS_SPOILER_LABEL_PATH)) {
+export function loadLabels(config: GhsImporterConfig = DEFAULT_GHS_IMPORTER_CONFIG): LabelData {
+  if (!existsSync(config.labelPath) || !existsSync(config.spoilerLabelPath)) {
     throw new Error('Missing GHS label data. Expected both base and spoiler English label files.');
   }
-  const baseLabels: LabelData = JSON.parse(readFileSync(GHS_LABEL_PATH, 'utf-8'));
-  const spoilerLabels: LabelData = JSON.parse(readFileSync(GHS_SPOILER_LABEL_PATH, 'utf-8'));
+  const baseLabels: LabelData = JSON.parse(readFileSync(config.labelPath, 'utf-8'));
+  const spoilerLabels: LabelData = JSON.parse(readFileSync(config.spoilerLabelPath, 'utf-8'));
   return mergeLabels(baseLabels, spoilerLabels);
 }
 

--- a/src/import-battle-goals.ts
+++ b/src/import-battle-goals.ts
@@ -12,10 +12,15 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { GHS_DATA_DIR, loadLabels, resolveGameTokens, type LabelData } from './ghs-utils.ts';
+import {
+  loadLabels,
+  resolveGameTokens,
+  resolveGhsImporterConfig,
+  type GhsImporterConfigInput,
+  type LabelData,
+} from './ghs-utils.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const GHS_BATTLE_GOALS_PATH = join(GHS_DATA_DIR, 'battle-goals.json');
 const OUTPUT_PATH = join(__dirname, '..', 'data', 'extracted', 'battle-goals.json');
 
 // ─── GHS source type ────────────────────────────────────────────────────────
@@ -56,15 +61,18 @@ export function convertBattleGoal(ghs: GhsBattleGoal, labels: LabelData): Extrac
 
 // ─── Main ───────────────────────────────────────────────────────────────────
 
-export function importBattleGoals(): ExtractedBattleGoal[] {
-  if (!existsSync(GHS_BATTLE_GOALS_PATH)) {
+export function importBattleGoals(configInput: GhsImporterConfigInput = {}): ExtractedBattleGoal[] {
+  const config = resolveGhsImporterConfig(configInput);
+  const ghsBattleGoalsPath = join(config.dataDir, 'battle-goals.json');
+
+  if (!existsSync(ghsBattleGoalsPath)) {
     throw new Error(
-      `GHS data not found at ${GHS_BATTLE_GOALS_PATH}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
+      `GHS data not found at ${ghsBattleGoalsPath}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
     );
   }
 
-  const labels = loadLabels();
-  const ghsData: GhsBattleGoal[] = JSON.parse(readFileSync(GHS_BATTLE_GOALS_PATH, 'utf-8'));
+  const labels = loadLabels(config);
+  const ghsData: GhsBattleGoal[] = JSON.parse(readFileSync(ghsBattleGoalsPath, 'utf-8'));
 
   const results: ExtractedBattleGoal[] = [];
 

--- a/src/import-buildings.ts
+++ b/src/import-buildings.ts
@@ -15,15 +15,15 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  GHS_DATA_DIR,
   kebabToTitle,
   resolveLabel,
   loadLabels,
+  resolveGhsImporterConfig,
+  type GhsImporterConfigInput,
   type LabelData,
 } from './ghs-utils.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const GHS_BUILDINGS_PATH = join(GHS_DATA_DIR, 'buildings.json');
 const OUTPUT_PATH = join(__dirname, '..', 'data', 'extracted', 'buildings.json');
 
 // ─── GHS building type ─────────────────────────────────────────────────────
@@ -203,15 +203,18 @@ export function convertBuilding(ghs: GhsBuilding, labels: LabelData): ExtractedB
 
 // ─── Main ──────────────────────────────────────────────────────────────────
 
-export function importBuildings(): ExtractedBuilding[] {
-  if (!existsSync(GHS_BUILDINGS_PATH)) {
+export function importBuildings(configInput: GhsImporterConfigInput = {}): ExtractedBuilding[] {
+  const config = resolveGhsImporterConfig(configInput);
+  const ghsBuildingsPath = join(config.dataDir, 'buildings.json');
+
+  if (!existsSync(ghsBuildingsPath)) {
     throw new Error(
-      `GHS buildings data not found at ${GHS_BUILDINGS_PATH}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
+      `GHS buildings data not found at ${ghsBuildingsPath}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
     );
   }
 
-  const labels = loadLabels();
-  const buildings: GhsBuilding[] = JSON.parse(readFileSync(GHS_BUILDINGS_PATH, 'utf-8'));
+  const labels = loadLabels(config);
+  const buildings: GhsBuilding[] = JSON.parse(readFileSync(ghsBuildingsPath, 'utf-8'));
   const results: ExtractedBuilding[] = [];
 
   for (const building of buildings) {

--- a/src/import-character-abilities.ts
+++ b/src/import-character-abilities.ts
@@ -14,17 +14,17 @@ import { join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  GHS_DATA_DIR,
   kebabToTitle,
   formatAction,
   loadLabels,
+  resolveGhsImporterConfig,
   type GhsAbility,
   type GhsDeck,
+  type GhsImporterConfigInput,
   type LabelData,
 } from './ghs-utils.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const GHS_DECK_DIR = join(GHS_DATA_DIR, 'character', 'deck');
 const OUTPUT_PATH = join(__dirname, '..', 'data', 'extracted', 'character-abilities.json');
 
 // ─── Our extracted format ────────────────────────────────────────────────────
@@ -78,21 +78,26 @@ export function convertAbility(
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
-export function importCharacterAbilities(): ExtractedCharacterAbility[] {
-  if (!existsSync(GHS_DECK_DIR)) {
+export function importCharacterAbilities(
+  configInput: GhsImporterConfigInput = {},
+): ExtractedCharacterAbility[] {
+  const config = resolveGhsImporterConfig(configInput);
+  const ghsDeckDir = join(config.dataDir, 'character', 'deck');
+
+  if (!existsSync(ghsDeckDir)) {
     throw new Error(
-      `GHS data not found at ${GHS_DECK_DIR}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
+      `GHS data not found at ${ghsDeckDir}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
     );
   }
 
-  const labels = loadLabels();
+  const labels = loadLabels(config);
   const allResults: ExtractedCharacterAbility[] = [];
 
-  for (const file of readdirSync(GHS_DECK_DIR).sort()) {
+  for (const file of readdirSync(ghsDeckDir).sort()) {
     if (!file.endsWith('.json')) continue;
 
     const characterName = basename(file, '.json');
-    const deck: GhsDeck = JSON.parse(readFileSync(join(GHS_DECK_DIR, file), 'utf-8'));
+    const deck: GhsDeck = JSON.parse(readFileSync(join(ghsDeckDir, file), 'utf-8'));
 
     for (const ability of deck.abilities) {
       const converted = convertAbility(ability, characterName, labels);

--- a/src/import-character-mats.ts
+++ b/src/import-character-mats.ts
@@ -14,17 +14,17 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  GHS_DATA_DIR,
   kebabToTitle,
   capitalize,
   loadLabels,
   resolveLabel,
   resolveGameTokens,
+  resolveGhsImporterConfig,
+  type GhsImporterConfigInput,
   type LabelData,
 } from './ghs-utils.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const GHS_CHARACTER_DIR = join(GHS_DATA_DIR, 'character');
 const OUTPUT_PATH = join(__dirname, '..', 'data', 'extracted', 'character-mats.json');
 
 // ─── GHS types ───────────────────────────────────────────────────────────────
@@ -281,20 +281,25 @@ export function convertCharacterMat(ghs: GhsCharacter, labels: LabelData): Extra
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
-export function importCharacterMats(): ExtractedCharacterMat[] {
-  if (!existsSync(GHS_CHARACTER_DIR)) {
+export function importCharacterMats(
+  configInput: GhsImporterConfigInput = {},
+): ExtractedCharacterMat[] {
+  const config = resolveGhsImporterConfig(configInput);
+  const ghsCharacterDir = join(config.dataDir, 'character');
+
+  if (!existsSync(ghsCharacterDir)) {
     throw new Error(
-      `GHS data not found at ${GHS_CHARACTER_DIR}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
+      `GHS data not found at ${ghsCharacterDir}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
     );
   }
 
-  const labels = loadLabels();
+  const labels = loadLabels(config);
   const allResults: ExtractedCharacterMat[] = [];
 
-  for (const file of readdirSync(GHS_CHARACTER_DIR).sort()) {
+  for (const file of readdirSync(ghsCharacterDir).sort()) {
     if (!file.endsWith('.json')) continue;
 
-    const ghs: GhsCharacter = JSON.parse(readFileSync(join(GHS_CHARACTER_DIR, file), 'utf-8'));
+    const ghs: GhsCharacter = JSON.parse(readFileSync(join(ghsCharacterDir, file), 'utf-8'));
     const record = convertCharacterMat(ghs, labels);
 
     const allText = [...record.perks, ...record.masteries];

--- a/src/import-events.ts
+++ b/src/import-events.ts
@@ -13,10 +13,14 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { GHS_DATA_DIR, resolveGameTokens, stripHtml } from './ghs-utils.ts';
+import {
+  resolveGameTokens,
+  resolveGhsImporterConfig,
+  stripHtml,
+  type GhsImporterConfigInput,
+} from './ghs-utils.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const GHS_EVENTS_PATH = join(GHS_DATA_DIR, 'events.json');
 const OUTPUT_PATH = join(__dirname, '..', 'data', 'extracted', 'events.json');
 
 // ─── GHS types (event-relevant subset) ──────────────────────────────────────
@@ -422,14 +426,17 @@ export function convertEvent(ghs: GhsEvent): ExtractedEvent {
 
 // ─── Main ───────────────────────────────────────────────────────────────────
 
-export function importEvents(): ExtractedEvent[] {
-  if (!existsSync(GHS_EVENTS_PATH)) {
+export function importEvents(configInput: GhsImporterConfigInput = {}): ExtractedEvent[] {
+  const config = resolveGhsImporterConfig(configInput);
+  const ghsEventsPath = join(config.dataDir, 'events.json');
+
+  if (!existsSync(ghsEventsPath)) {
     throw new Error(
-      `GHS event data not found at ${GHS_EVENTS_PATH}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
+      `GHS event data not found at ${ghsEventsPath}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
     );
   }
 
-  const events: GhsEvent[] = JSON.parse(readFileSync(GHS_EVENTS_PATH, 'utf-8'));
+  const events: GhsEvent[] = JSON.parse(readFileSync(ghsEventsPath, 'utf-8'));
   const results = events.map((e) => convertEvent(e));
 
   for (const event of results) {

--- a/src/import-items.ts
+++ b/src/import-items.ts
@@ -14,18 +14,18 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  GHS_DATA_DIR,
   capitalize,
   kebabToTitle,
   resolveLabel,
   formatAction,
   loadLabels,
+  resolveGhsImporterConfig,
   type GhsAction,
+  type GhsImporterConfigInput,
   type LabelData,
 } from './ghs-utils.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const GHS_ITEMS_PATH = join(GHS_DATA_DIR, 'items.json');
 const OUTPUT_PATH = join(__dirname, '..', 'data', 'extracted', 'items.json');
 
 // ─── GHS item type ──────────────────────────────────────────────────────────
@@ -160,15 +160,18 @@ export function convertItem(ghs: GhsItem, labels: LabelData): ExtractedItem {
 
 // ─── Main ───────────────────────────────────────────────────────────────────
 
-export function importItems(): ExtractedItem[] {
-  if (!existsSync(GHS_ITEMS_PATH)) {
+export function importItems(configInput: GhsImporterConfigInput = {}): ExtractedItem[] {
+  const config = resolveGhsImporterConfig(configInput);
+  const ghsItemsPath = join(config.dataDir, 'items.json');
+
+  if (!existsSync(ghsItemsPath)) {
     throw new Error(
-      `GHS items data not found at ${GHS_ITEMS_PATH}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
+      `GHS items data not found at ${ghsItemsPath}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
     );
   }
 
-  const labels = loadLabels();
-  const items: GhsItem[] = JSON.parse(readFileSync(GHS_ITEMS_PATH, 'utf-8'));
+  const labels = loadLabels(config);
+  const items: GhsItem[] = JSON.parse(readFileSync(ghsItemsPath, 'utf-8'));
   const results: ExtractedItem[] = [];
 
   for (const item of items) {

--- a/src/import-monster-abilities.ts
+++ b/src/import-monster-abilities.ts
@@ -14,17 +14,17 @@ import { join, dirname, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  GHS_DATA_DIR,
   kebabToTitle,
   formatAction,
   loadLabels,
+  resolveGhsImporterConfig,
   type GhsAbility,
   type GhsDeck,
+  type GhsImporterConfigInput,
   type LabelData,
 } from './ghs-utils.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const GHS_DECK_DIR = join(GHS_DATA_DIR, 'monster', 'deck');
 const OUTPUT_PATH = join(__dirname, '..', 'data', 'extracted', 'monster-abilities.json');
 
 // ─── Our extracted format ────────────────────────────────────────────────────
@@ -75,21 +75,26 @@ export function convertMonsterAbility(
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
-export function importMonsterAbilities(): ExtractedMonsterAbility[] {
-  if (!existsSync(GHS_DECK_DIR)) {
+export function importMonsterAbilities(
+  configInput: GhsImporterConfigInput = {},
+): ExtractedMonsterAbility[] {
+  const config = resolveGhsImporterConfig(configInput);
+  const ghsDeckDir = join(config.dataDir, 'monster', 'deck');
+
+  if (!existsSync(ghsDeckDir)) {
     throw new Error(
-      `GHS data not found at ${GHS_DECK_DIR}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
+      `GHS data not found at ${ghsDeckDir}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
     );
   }
 
-  const labels = loadLabels();
+  const labels = loadLabels(config);
   const allResults: ExtractedMonsterAbility[] = [];
 
-  for (const file of readdirSync(GHS_DECK_DIR).sort()) {
+  for (const file of readdirSync(ghsDeckDir).sort()) {
     if (!file.endsWith('.json')) continue;
 
     const deckName = basename(file, '.json');
-    const deck: GhsDeck = JSON.parse(readFileSync(join(GHS_DECK_DIR, file), 'utf-8'));
+    const deck: GhsDeck = JSON.parse(readFileSync(join(ghsDeckDir, file), 'utf-8'));
 
     // Sort by cardId so dedupe is deterministic — keep the lowest-ID copy.
     // Some decks omit cardId entirely (see SQR-62); treat missing as -Infinity

--- a/src/import-monster-stats.ts
+++ b/src/import-monster-stats.ts
@@ -13,16 +13,16 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  GHS_DATA_DIR,
   kebabToTitle,
   loadLabels,
   resolveLabel,
   resolveGameTokens,
+  resolveGhsImporterConfig,
+  type GhsImporterConfigInput,
   type LabelData,
 } from './ghs-utils.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const GHS_MONSTER_DIR = join(GHS_DATA_DIR, 'monster');
 const OUTPUT_PATH = join(__dirname, '..', 'data', 'extracted', 'monster-stats.json');
 
 // ─── GHS types ───────────────────────────────────────────────────────────────
@@ -165,22 +165,25 @@ export function convertMonster(ghs: GhsMonster, labels: LabelData): ExtractedMon
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
-export function importMonsterStats(): ExtractedMonster[] {
-  if (!existsSync(GHS_MONSTER_DIR)) {
+export function importMonsterStats(configInput: GhsImporterConfigInput = {}): ExtractedMonster[] {
+  const config = resolveGhsImporterConfig(configInput);
+  const ghsMonsterDir = join(config.dataDir, 'monster');
+
+  if (!existsSync(ghsMonsterDir)) {
     throw new Error(
-      `GHS data not found at ${GHS_MONSTER_DIR}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
+      `GHS data not found at ${ghsMonsterDir}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
     );
   }
 
-  const labels = loadLabels();
+  const labels = loadLabels(config);
   const allResults: ExtractedMonster[] = [];
 
-  for (const file of readdirSync(GHS_MONSTER_DIR).sort()) {
+  for (const file of readdirSync(ghsMonsterDir).sort()) {
     if (!file.endsWith('.json')) continue;
     // Skip scenario-specific and solo variants
     if (file.includes('scenario') || file.includes('solo')) continue;
 
-    const ghs: GhsMonster = JSON.parse(readFileSync(join(GHS_MONSTER_DIR, file), 'utf-8'));
+    const ghs: GhsMonster = JSON.parse(readFileSync(join(ghsMonsterDir, file), 'utf-8'));
     const records = convertMonster(ghs, labels);
 
     for (const record of records) {

--- a/src/import-personal-quests.ts
+++ b/src/import-personal-quests.ts
@@ -7,20 +7,21 @@
  * Output: data/extracted/personal-quests.json
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { gameDefinitionFor } from './game.ts';
 import {
-  GHS_DATA_DIR,
   resolveLabel,
   resolveGameTokens,
   loadLabels,
+  resolveGhsImporterConfig,
+  type GhsImporterConfigInput,
   type LabelData,
 } from './ghs-utils.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const GHS_PERSONAL_QUESTS_PATH = join(GHS_DATA_DIR, 'personal-quests.json');
 const OUTPUT_PATH = join(__dirname, '..', 'data', 'extracted', 'personal-quests.json');
 
 // ─── GHS types ──────────────────────────────────────────────────────────────
@@ -88,8 +89,12 @@ function resolveRequirementName(name: string, labels: LabelData): string {
  * Look up the quest title from labels. Falls back to "Personal Quest {cardId}"
  * if the label is missing.
  */
-function resolveQuestTitle(cardId: string, labels: LabelData): string {
-  const ref = `%data.personalQuest.fh.${cardId}.%`;
+function resolveQuestTitle(
+  cardId: string,
+  labels: LabelData,
+  gameLabelPrefix: string = 'fh',
+): string {
+  const ref = `%data.personalQuest.${gameLabelPrefix}.${cardId}.%`;
   const resolved = resolveLabel(ref, labels);
   if (resolved === ref) {
     return `Personal Quest ${cardId}`;
@@ -100,6 +105,7 @@ function resolveQuestTitle(cardId: string, labels: LabelData): string {
 export function convertPersonalQuest(
   ghs: GhsPersonalQuest,
   labels: LabelData,
+  gameLabelPrefix: string = 'fh',
 ): ExtractedPersonalQuest {
   const requirements: ExtractedRequirement[] = ghs.requirements.map((req) => {
     const description = resolveRequirementName(req.name, labels);
@@ -119,7 +125,7 @@ export function convertPersonalQuest(
   return {
     cardId: ghs.cardId,
     altId: ghs.altId,
-    name: resolveQuestTitle(ghs.cardId, labels),
+    name: resolveQuestTitle(ghs.cardId, labels, gameLabelPrefix),
     requirements,
     openEnvelope: ghs.openEnvelope,
     errata: ghs.errata ?? null,
@@ -129,14 +135,26 @@ export function convertPersonalQuest(
 
 // ─── Main ───────────────────────────────────────────────────────────────────
 
-export function importPersonalQuests(): ExtractedPersonalQuest[] {
-  const labels = loadLabels();
-  const quests: GhsPersonalQuest[] = JSON.parse(readFileSync(GHS_PERSONAL_QUESTS_PATH, 'utf-8'));
+export function importPersonalQuests(
+  configInput: GhsImporterConfigInput = {},
+): ExtractedPersonalQuest[] {
+  const config = resolveGhsImporterConfig(configInput);
+  const ghsPersonalQuestsPath = join(config.dataDir, 'personal-quests.json');
+
+  if (!existsSync(ghsPersonalQuestsPath)) {
+    throw new Error(
+      `GHS personal quest data not found at ${ghsPersonalQuestsPath}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
+    );
+  }
+
+  const labels = loadLabels(config);
+  const gameLabelPrefix = gameDefinitionFor(config.game).sourcePrefix;
+  const quests: GhsPersonalQuest[] = JSON.parse(readFileSync(ghsPersonalQuestsPath, 'utf-8'));
 
   const results: ExtractedPersonalQuest[] = [];
 
   for (const quest of quests) {
-    const converted = convertPersonalQuest(quest, labels);
+    const converted = convertPersonalQuest(quest, labels, gameLabelPrefix);
 
     // Verify all data/game tokens were resolved
     const allText = [

--- a/src/import-scenarios.ts
+++ b/src/import-scenarios.ts
@@ -14,18 +14,18 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
-  GHS_DATA_DIR,
   kebabToTitle,
   loadLabels,
   resolveLabel,
   resolveGameTokens,
+  resolveGhsImporterConfig,
+  type GhsImporterConfigInput,
   type LabelData,
 } from './ghs-utils.ts';
 
 import { resolveSectionRefs } from './import-buildings.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const GHS_SCENARIO_DIR = join(GHS_DATA_DIR, 'scenarios');
 const OUTPUT_PATH = join(__dirname, '..', 'data', 'extracted', 'scenarios.json');
 
 // ─── GHS types (scenario-relevant subset) ───────────────────────────────────
@@ -193,21 +193,24 @@ export function convertScenario(
 
 // ─── Main ───────────────────────────────────────────────────────────────────
 
-export function importScenarios(): ExtractedScenario[] {
-  if (!existsSync(GHS_SCENARIO_DIR)) {
+export function importScenarios(configInput: GhsImporterConfigInput = {}): ExtractedScenario[] {
+  const config = resolveGhsImporterConfig(configInput);
+  const ghsScenarioDir = join(config.dataDir, 'scenarios');
+
+  if (!existsSync(ghsScenarioDir)) {
     throw new Error(
-      `GHS scenario data not found at ${GHS_SCENARIO_DIR}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
+      `GHS scenario data not found at ${ghsScenarioDir}. Set GHS_DATA_DIR or clone GHS into data/gloomhavensecretariat/`,
     );
   }
 
-  const labels = loadLabels();
+  const labels = loadLabels(config);
   const allResults: ExtractedScenario[] = [];
 
-  for (const file of readdirSync(GHS_SCENARIO_DIR).sort()) {
+  for (const file of readdirSync(ghsScenarioDir).sort()) {
     if (!file.endsWith('.json')) continue;
 
     const filenameBasename = file.slice(0, -'.json'.length);
-    const scenario: GhsScenario = JSON.parse(readFileSync(join(GHS_SCENARIO_DIR, file), 'utf-8'));
+    const scenario: GhsScenario = JSON.parse(readFileSync(join(ghsScenarioDir, file), 'utf-8'));
 
     const converted = convertScenario(scenario, filenameBasename, labels);
 

--- a/src/server-start.ts
+++ b/src/server-start.ts
@@ -1,0 +1,84 @@
+import type { Server } from 'node:net';
+
+import type { ServerConfig } from './config.ts';
+import type { PortClaim, WorktreeRuntime } from './worktree-runtime.ts';
+
+type FetchHandler = (request: Request) => Response | Promise<Response>;
+
+type WorktreePortRuntime = Pick<
+  WorktreeRuntime,
+  'checkoutRoot' | 'checkoutSlug' | 'isMainCheckout'
+>;
+
+export interface StartHttpServerDeps {
+  appFetch: FetchHandler;
+  createAdaptorServer: (options: { fetch: FetchHandler }) => Server;
+  loadServerConfig: () => ServerConfig;
+  getWorktreeRuntime: () => WorktreePortRuntime;
+  claimWorktreePort: (runtime: WorktreePortRuntime) => Promise<PortClaim>;
+  startBootstrapLifecycle: () => void;
+  log?: (message: string) => void;
+}
+
+export async function startHttpServer({
+  appFetch,
+  createAdaptorServer,
+  loadServerConfig,
+  getWorktreeRuntime,
+  claimWorktreePort,
+  startBootstrapLifecycle,
+  log = console.log,
+}: StartHttpServerDeps): Promise<void> {
+  const config = loadServerConfig();
+  const configuredPort = config.port;
+  const runtime = getWorktreeRuntime();
+
+  if (configuredPort === undefined) {
+    while (true) {
+      const claim = await claimWorktreePort({
+        checkoutRoot: runtime.checkoutRoot,
+        checkoutSlug: runtime.checkoutSlug,
+        isMainCheckout: runtime.isMainCheckout,
+      });
+      const server = createAdaptorServer({ fetch: appFetch });
+      try {
+        await listen(server, claim.port, config.host);
+        server.once('close', () => {
+          void claim.release();
+        });
+        startBootstrapLifecycle();
+        log(`Squire server listening on port ${claim.port}`);
+        return;
+      } catch (error) {
+        await claim.release();
+        const errno = error as NodeJS.ErrnoException;
+        if (errno.code !== 'EADDRINUSE' || runtime.isMainCheckout) throw error;
+      }
+    }
+  }
+
+  const server = createAdaptorServer({ fetch: appFetch });
+  await listen(server, configuredPort, config.host);
+  startBootstrapLifecycle();
+  log(`Squire server listening on port ${configuredPort}`);
+}
+
+async function listen(server: Server, port: number, host?: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off('listening', onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    if (host) {
+      server.listen(port, host);
+    } else {
+      server.listen(port);
+    }
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,6 +51,7 @@ import type { CardType } from './schemas.ts';
 import { requireGameId } from './game.ts';
 import { z } from 'zod';
 import { createMcpServer } from './mcp.ts';
+import { startHttpServer } from './server-start.ts';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import {
   registerClient,
@@ -1647,62 +1648,14 @@ app.post('/api/ask', async (c) => {
 // ─── Server startup ──────────────────────────────────────────────────────────
 
 export async function startServer(): Promise<void> {
-  const config = loadServerConfig();
-  const configuredPort = config.port;
-  const runtime = getWorktreeRuntime();
   const { createAdaptorServer } = await import('@hono/node-server');
-
-  if (configuredPort === undefined) {
-    while (true) {
-      const claim = await claimWorktreePort({
-        checkoutRoot: runtime.checkoutRoot,
-        checkoutSlug: runtime.checkoutSlug,
-        isMainCheckout: runtime.isMainCheckout,
-      });
-      const server = createAdaptorServer({ fetch: app.fetch });
-      try {
-        await listen(server, claim.port, config.host);
-        server.once('close', () => {
-          void claim.release();
-        });
-        startBootstrapLifecycle();
-        console.log(`Squire server listening on port ${claim.port}`);
-        return;
-      } catch (error) {
-        await claim.release();
-        const errno = error as NodeJS.ErrnoException;
-        if (errno.code !== 'EADDRINUSE' || runtime.isMainCheckout) throw error;
-      }
-    }
-  }
-
-  const server = createAdaptorServer({ fetch: app.fetch });
-  await listen(server, configuredPort, config.host);
-  startBootstrapLifecycle();
-  console.log(`Squire server listening on port ${configuredPort}`);
-}
-
-async function listen(
-  server: import('node:net').Server,
-  port: number,
-  host?: string,
-): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const onError = (error: Error) => {
-      server.off('listening', onListening);
-      reject(error);
-    };
-    const onListening = () => {
-      server.off('error', onError);
-      resolve();
-    };
-    server.once('error', onError);
-    server.once('listening', onListening);
-    if (host) {
-      server.listen(port, host);
-    } else {
-      server.listen(port);
-    }
+  await startHttpServer({
+    appFetch: app.fetch,
+    createAdaptorServer,
+    loadServerConfig,
+    getWorktreeRuntime,
+    claimWorktreePort,
+    startBootstrapLifecycle,
   });
 }
 

--- a/test/ghs-utils.test.ts
+++ b/test/ghs-utils.test.ts
@@ -7,6 +7,7 @@ import {
   resolveGameTokens,
   formatAction,
   resolveGhsDataDir,
+  resolveGhsImporterConfig,
 } from '../src/ghs-utils.ts';
 
 // ─── GHS data path resolution ───────────────────────────────────────────────
@@ -61,6 +62,48 @@ describe('resolveGhsDataDir', () => {
         exists: () => false,
       }),
     ).toBe(join(root, 'data', 'gh2e'));
+  });
+});
+
+// ─── GHS importer configuration ─────────────────────────────────────────────
+
+describe('resolveGhsImporterConfig', () => {
+  it('maps game ids to GHS data subdirectories', () => {
+    const root = '/tmp/ghs';
+
+    expect(
+      resolveGhsImporterConfig({
+        game: 'frosthaven',
+        sourceDir: root,
+        exists: (path) => path === join(root, 'data', 'fh'),
+      }),
+    ).toMatchObject({
+      game: 'frosthaven',
+      sourceDir: root,
+      dataDir: join(root, 'data', 'fh'),
+    });
+
+    expect(
+      resolveGhsImporterConfig({
+        game: 'gh2',
+        sourceDir: root,
+        exists: (path) => path === join(root, 'data', 'gh2e'),
+      }),
+    ).toMatchObject({
+      game: 'gloomhaven-2e',
+      sourceDir: root,
+      dataDir: join(root, 'data', 'gh2e'),
+    });
+  });
+
+  it('rejects a direct source directory for the wrong game', () => {
+    expect(() =>
+      resolveGhsImporterConfig({
+        game: 'gh2',
+        sourceDir: '/tmp/ghs/data/fh',
+        exists: () => true,
+      }),
+    ).toThrow('does not match requested game');
   });
 });
 

--- a/test/import-items.test.ts
+++ b/test/import-items.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { convertItem, resolveNestedDataRefs } from '../src/import-items.ts';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { convertItem, importItems, resolveNestedDataRefs } from '../src/import-items.ts';
 import type { LabelData } from '../src/ghs-utils.ts';
 
 // ─── convertItem ────────────────────────────────────────────────────────────
@@ -277,6 +280,75 @@ describe('convertItem', () => {
 
     const result = convertItem(ghsItem, labels);
     expect(result.spent).toBe(false);
+  });
+});
+
+// ─── importItems ────────────────────────────────────────────────────────────
+
+function writeItemsFixture(
+  root: string,
+  subdir: 'fh' | 'gh2e',
+  labelKey: string,
+  name: string,
+  effect: string,
+): void {
+  const dataDir = join(root, 'data', subdir);
+  mkdirSync(join(dataDir, 'label', 'spoiler'), { recursive: true });
+  writeFileSync(
+    join(dataDir, 'label', 'en.json'),
+    JSON.stringify({ items: { [labelKey]: { '1': effect } } }),
+    'utf-8',
+  );
+  writeFileSync(join(dataDir, 'label', 'spoiler', 'en.json'), JSON.stringify({}), 'utf-8');
+  writeFileSync(
+    join(dataDir, 'items.json'),
+    JSON.stringify([
+      {
+        id: 1,
+        name,
+        count: 1,
+        edition: subdir === 'fh' ? 'fh' : 'gh2',
+        slot: 'head',
+        actions: [{ type: 'custom', value: `%data.items.${labelKey}.1%` }],
+      },
+    ]),
+    'utf-8',
+  );
+}
+
+describe('importItems', () => {
+  it('reads an explicit Frosthaven source directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'squire-ghs-fh-'));
+    try {
+      writeItemsFixture(root, 'fh', 'fh-1', 'FH Spyglass', 'Frosthaven item text');
+
+      const results = importItems({ game: 'frosthaven', sourceDir: root });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        name: 'FH Spyglass',
+        effect: 'Frosthaven item text',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reads an explicit GH2 source directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'squire-ghs-gh2-'));
+    try {
+      writeItemsFixture(root, 'gh2e', 'gh2-1', 'GH2 Boots', 'Gloomhaven 2E item text');
+
+      const results = importItems({ game: 'gh2', sourceDir: root });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({
+        name: 'GH2 Boots',
+        effect: 'Gloomhaven 2E item text',
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/start-server.test.ts
+++ b/test/start-server.test.ts
@@ -1,206 +1,133 @@
 import { EventEmitter } from 'node:events';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Server } from 'node:net';
+import { describe, expect, it, vi } from 'vitest';
+
+import { startHttpServer, type StartHttpServerDeps } from '../src/server-start.ts';
+import type { ServerConfig } from '../src/config.ts';
 
 class FakeServer extends EventEmitter {
-  listenCalls: number[] = [];
+  listenCalls: Array<{ port: number; host?: string }> = [];
+  private readonly listenError?: NodeJS.ErrnoException;
 
-  listen(port: number, _host?: string): this {
-    this.listenCalls.push(port);
+  constructor(listenError?: NodeJS.ErrnoException) {
+    super();
+    this.listenError = listenError;
+  }
+
+  listen(port: number, host?: string): this {
+    this.listenCalls.push({ port, host });
     queueMicrotask(() => {
-      this.emit('listening');
+      if (this.listenError) {
+        this.emit('error', this.listenError);
+      } else {
+        this.emit('listening');
+      }
     });
     return this;
   }
 }
 
-async function loadStartServer(options: {
-  configuredPort?: string;
-  configuredHost?: string;
-  claimedPort?: number;
-  bootstrapImpl?: () => unknown;
+function eaddrinuse(): NodeJS.ErrnoException {
+  const error = new Error('address in use') as NodeJS.ErrnoException;
+  error.code = 'EADDRINUSE';
+  return error;
+}
+
+function buildDeps(options: {
+  config: Pick<ServerConfig, 'port' | 'host'>;
+  servers: FakeServer[];
+  claimedPorts?: number[];
+  isMainCheckout?: boolean;
 }) {
-  vi.resetModules();
+  const releases = (options.claimedPorts ?? [4555]).map(() => vi.fn().mockResolvedValue(undefined));
+  let claimIndex = 0;
+  let serverIndex = 0;
 
-  if (options.configuredPort === undefined) {
-    vi.unstubAllEnvs();
-    delete process.env.PORT;
-  } else {
-    vi.stubEnv('PORT', options.configuredPort);
-  }
-  if (options.configuredHost === undefined) {
-    delete process.env.HOST;
-  } else {
-    vi.stubEnv('HOST', options.configuredHost);
-  }
-  vi.stubEnv('NODE_ENV', 'test');
-  vi.stubEnv('VITEST', 'true');
-
-  const fakeServer = new FakeServer();
-  const createAdaptorServer = vi.fn(() => fakeServer);
-  const claimRelease = vi.fn().mockResolvedValue(undefined);
-  const claimWorktreePort = vi.fn().mockResolvedValue({
-    port: options.claimedPort ?? 4555,
-    release: claimRelease,
-  });
-  const startBootstrapLifecycle = vi.fn(options.bootstrapImpl ?? (() => undefined));
-
-  vi.doMock('@hono/node-server', () => ({
-    createAdaptorServer,
-  }));
-  vi.doMock('../src/instrumentation.ts', () => ({}));
-  vi.doMock('../src/service.ts', () => ({
-    ask: vi.fn(),
-    ensureBootstrapStatus: vi.fn().mockResolvedValue({
-      lifecycle: 'boot_blocked',
-      ready: false,
-      bootstrapReady: false,
-      warmingUp: false,
-      indexSize: 0,
-      cardCount: 0,
-      ruleQueriesReady: false,
-      cardQueriesReady: false,
-      askReady: false,
-      missingBootstrapSteps: ['npm run index', 'npm run seed:cards'],
-      errors: [
-        'Embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        'No card data found in Postgres. Run `npm run seed:cards` first.',
-      ],
-      capabilities: {
-        rules: {
-          allowed: false,
-          reason: 'missing_index',
-          message:
-            'Embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        },
-        cards: {
-          allowed: false,
-          reason: 'missing_cards',
-          message: 'No card data found in Postgres. Run `npm run seed:cards` first.',
-        },
-        ask: {
-          allowed: false,
-          reason: 'missing_index',
-          message:
-            'Embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        },
-      },
+  const deps: StartHttpServerDeps = {
+    appFetch: vi.fn(async () => new Response('ok')),
+    createAdaptorServer: vi.fn(() => {
+      const server = options.servers[serverIndex];
+      serverIndex += 1;
+      return server as unknown as Server;
     }),
-    getBootstrapStatus: vi.fn().mockReturnValue({
-      lifecycle: 'boot_blocked',
-      ready: false,
-      bootstrapReady: false,
-      warmingUp: false,
-      indexSize: 0,
-      cardCount: 0,
-      ruleQueriesReady: false,
-      cardQueriesReady: false,
-      askReady: false,
-      missingBootstrapSteps: ['npm run index', 'npm run seed:cards'],
-      errors: [
-        'Embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        'No card data found in Postgres. Run `npm run seed:cards` first.',
-      ],
-      capabilities: {
-        rules: {
-          allowed: false,
-          reason: 'missing_index',
-          message:
-            'Embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        },
-        cards: {
-          allowed: false,
-          reason: 'missing_cards',
-          message: 'No card data found in Postgres. Run `npm run seed:cards` first.',
-        },
-        ask: {
-          allowed: false,
-          reason: 'missing_index',
-          message:
-            'Embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        },
-      },
-    }),
-    isReady: vi.fn().mockReturnValue(false),
-    startBootstrapLifecycle,
-  }));
-  vi.doMock('../src/db.ts', () => ({
+    loadServerConfig: vi.fn(() => ({
+      nodeEnv: 'test',
+      port: options.config.port,
+      host: options.config.host,
+    })),
     getWorktreeRuntime: vi.fn(() => ({
       checkoutRoot: '/tmp/squire',
       checkoutSlug: 'squire',
-      isMainCheckout: false,
+      isMainCheckout: options.isMainCheckout ?? false,
     })),
-    shutdownServerPool: vi.fn().mockResolvedValue(undefined),
-  }));
-  vi.doMock('../src/worktree-runtime.ts', () => ({
-    claimWorktreePort,
-  }));
-  vi.doMock('../src/tools.ts', () => ({
-    searchRules: vi.fn(),
-    searchCards: vi.fn(),
-    listCardTypes: vi.fn(),
-    listCards: vi.fn(),
-    getCard: vi.fn(),
-  }));
-  vi.doMock('../src/health.ts', () => ({
-    runReadinessChecks: vi.fn().mockResolvedValue({
-      status: 'ok',
-      db: { status: 'ok' },
-      vector: { status: 'ok' },
-      embedder: { status: 'ok' },
+    claimWorktreePort: vi.fn(async () => {
+      const index = claimIndex;
+      claimIndex += 1;
+      return {
+        port: options.claimedPorts?.[index] ?? 4555,
+        release: releases[index],
+      };
     }),
-  }));
-  vi.doMock('../src/auth.ts', () => ({
-    registerClient: vi.fn(),
-    createAuthorizationCode: vi.fn(),
-    exchangeAuthorizationCode: vi.fn(),
-    verifyAccessToken: vi.fn().mockResolvedValue({
-      token: 'stub',
-      clientId: 'stub-client',
-      scopes: [],
-      expiresAt: Math.floor(Date.now() / 1000) + 3600,
-    }),
-    getAuthProvider: vi.fn(),
-    resetAuthProvider: vi.fn(),
-    OAuthError: class OAuthError extends Error {},
-  }));
-
-  const mod = await import('../src/server.ts');
-  return {
-    startServer: mod.startServer,
-    fakeServer,
-    createAdaptorServer,
-    claimWorktreePort,
-    startBootstrapLifecycle,
+    startBootstrapLifecycle: vi.fn(),
+    log: vi.fn(),
   };
+
+  return { deps, releases };
 }
 
-describe.sequential('startServer', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  it('binds the configured port and the claimed worktree port', async () => {
-    const configured = await loadStartServer({
-      configuredPort: '4123',
+describe('startHttpServer', () => {
+  it('binds the configured port without claiming a worktree port', async () => {
+    const server = new FakeServer();
+    const { deps } = buildDeps({
+      config: { port: 4123, host: '127.0.0.1' },
+      servers: [server],
     });
 
-    await configured.startServer();
+    await startHttpServer(deps);
 
-    expect(configured.fakeServer.listenCalls).toContain(4123);
-    expect(configured.startBootstrapLifecycle).toHaveBeenCalled();
+    expect(deps.claimWorktreePort).not.toHaveBeenCalled();
+    expect(server.listenCalls).toEqual([{ port: 4123, host: '127.0.0.1' }]);
+    expect(deps.startBootstrapLifecycle).toHaveBeenCalledOnce();
+  });
 
-    const claimed = await loadStartServer({
-      claimedPort: 4555,
+  it('binds a claimed worktree port and releases it when the server closes', async () => {
+    const server = new FakeServer();
+    const { deps, releases } = buildDeps({
+      config: { port: undefined, host: undefined },
+      claimedPorts: [4555],
+      servers: [server],
     });
 
-    await claimed.startServer();
+    await startHttpServer(deps);
 
-    expect(claimed.claimWorktreePort).toHaveBeenCalled();
-    expect(claimed.fakeServer.listenCalls).toContain(4555);
-    expect(claimed.startBootstrapLifecycle).toHaveBeenCalled();
-  }, 30_000);
+    expect(deps.claimWorktreePort).toHaveBeenCalledWith({
+      checkoutRoot: '/tmp/squire',
+      checkoutSlug: 'squire',
+      isMainCheckout: false,
+    });
+    expect(server.listenCalls).toEqual([{ port: 4555, host: undefined }]);
+    expect(deps.startBootstrapLifecycle).toHaveBeenCalledOnce();
+
+    server.emit('close');
+
+    expect(releases[0]).toHaveBeenCalledOnce();
+  });
+
+  it('releases and retries a claimed worktree port that is already in use', async () => {
+    const busyServer = new FakeServer(eaddrinuse());
+    const retryServer = new FakeServer();
+    const { deps, releases } = buildDeps({
+      config: { port: undefined, host: undefined },
+      claimedPorts: [4555, 4556],
+      servers: [busyServer, retryServer],
+    });
+
+    await startHttpServer(deps);
+
+    expect(busyServer.listenCalls).toEqual([{ port: 4555, host: undefined }]);
+    expect(retryServer.listenCalls).toEqual([{ port: 4556, host: undefined }]);
+    expect(releases[0]).toHaveBeenCalledOnce();
+    expect(releases[1]).not.toHaveBeenCalled();
+    expect(deps.startBootstrapLifecycle).toHaveBeenCalledOnce();
+  });
 });

--- a/test/start-server.test.ts
+++ b/test/start-server.test.ts
@@ -202,5 +202,5 @@ describe.sequential('startServer', () => {
     expect(claimed.claimWorktreePort).toHaveBeenCalled();
     expect(claimed.fakeServer.listenCalls).toContain(4555);
     expect(claimed.startBootstrapLifecycle).toHaveBeenCalled();
-  }, 10_000);
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary
- add a shared GHS importer config resolver for game id, source directory, data directory, and label paths
- thread explicit importer config through GHS import entrypoints while preserving default Frosthaven behavior
- cover FH and GH2 fixture imports plus invalid game/source combinations
- isolate startup port-selection tests from the full server module import

Fixes SQR-195

## Tests
- npx vitest run test/ghs-utils.test.ts test/import-items.test.ts test/import-battle-goals.test.ts test/import-buildings.test.ts test/import-character-abilities.test.ts test/import-character-mats.test.ts test/import-events.test.ts test/import-monster-abilities.test.ts test/import-monster-stats.test.ts test/import-personal-quests.test.ts test/import-scenarios.test.ts
- npx vitest run test/start-server.test.ts
- npm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Importers now accept optional configuration to resolve data paths at runtime.
  * Centralized path resolution with improved multi-game and subdirectory support.
  * Server startup logic moved to a dedicated startup helper with robust port-claim/retry handling.

* **Bug Fixes**
  * Label loading now errors clearly when expected label files are missing.

* **Tests**
  * Added tests for configuration resolution and multi-game import scenarios.
  * Updated server startup tests to validate new port-claim/retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->