### PR TITLE
fix(agent): stop LangGraph loops after verified retrieval

### DIFF
--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -203,6 +203,11 @@ function langgraphRunTraceAttributes({
           'squire.agent.iterations': result.trajectory.iterations,
           'squire.agent.tool_call_count': result.trajectory.toolCalls.length,
           'squire.agent.stop_reason': result.trajectory.stopReason ?? 'unknown',
+          'squire.agent.input_tokens': result.trajectory.tokenUsage.inputTokens,
+          'squire.agent.output_tokens': result.trajectory.tokenUsage.outputTokens,
+          'squire.agent.cache_creation_input_tokens':
+            result.trajectory.tokenUsage.cacheCreationInputTokens,
+          'squire.agent.cache_read_input_tokens': result.trajectory.tokenUsage.cacheReadInputTokens,
         }
       : {}),
     'squire.agent.runtime': GRAPH_RUNTIME_PREFIX,

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -8,6 +8,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { Annotation, END, MemorySaver, START, StateGraph } from '@langchain/langgraph';
+import { SpanStatusCode, trace, type Attributes } from '@opentelemetry/api';
 import { randomUUID } from 'node:crypto';
 import {
   FORCE_SYNTHESIS_PROMPT,
@@ -33,6 +34,7 @@ import {
 } from './agent.ts';
 import type { AgentStreamEventMap, AskOptions, EmitFn } from './service.ts';
 import { requireGameId } from './game.ts';
+import { resolveSquireEnv } from './squire-env.ts';
 
 type Message = Anthropic.Message;
 type MessageParam = Anthropic.MessageParam;
@@ -46,6 +48,7 @@ const MAX_RULE_SEARCHES_BEFORE_SYNTHESIS = 3;
 const GRAPH_RUNTIME_PREFIX = 'langgraph';
 const FINAL_ANSWER_PROMPT =
   'Write the final answer now using only verified tool results in this run. Do not call tools. If the verified results are insufficient, say exactly what is missing instead of guessing.';
+const tracer = trace.getTracer('squire.agent');
 
 // LangGraph treats neighbors as discovery so returned refs must be opened or
 // searched before final_answer can use them.
@@ -103,6 +106,121 @@ function toolUseBlocks(message: Message | undefined) {
 
 function cloneUsage(usage: TokenUsage): TokenUsage {
   return { ...usage };
+}
+
+function jsonTraceAttribute(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function primitiveTraceAttribute(value: unknown): string | number | boolean {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+    ? value
+    : jsonTraceAttribute(value);
+}
+
+function langsmithUsageMetadata(usage: TokenUsage): Record<string, unknown> {
+  return {
+    input_tokens: usage.inputTokens,
+    output_tokens: usage.outputTokens,
+    total_tokens: usage.totalTokens,
+    input_token_details: {
+      cache_creation: usage.cacheCreationInputTokens,
+      cache_read: usage.cacheReadInputTokens,
+    },
+  };
+}
+
+function langgraphCorrelationMetadata(options: AskOptions | undefined): Record<string, string> {
+  const metadata: Record<string, string> = {
+    runtime: GRAPH_RUNTIME_PREFIX,
+    squireEnv: resolveSquireEnv(),
+  };
+  if (options?.requestId) metadata.requestId = options.requestId;
+  if (options?.conversationId) metadata.conversationId = options.conversationId;
+  if (options?.userMessageId) metadata.userMessageId = options.userMessageId;
+  if (options?.userId) metadata.userId = options.userId;
+  if (options?.campaignId) metadata.campaignId = options.campaignId;
+  if (options?.game) metadata.game = requireGameId(options.game);
+  return metadata;
+}
+
+function langgraphCorrelationAttributes(options: AskOptions | undefined): Attributes {
+  const attributes: Attributes = {
+    'squire.env': resolveSquireEnv(),
+  };
+  if (options?.requestId) attributes['squire.request_id'] = options.requestId;
+  if (options?.conversationId) attributes['squire.conversation_id'] = options.conversationId;
+  if (options?.userMessageId) attributes['squire.user_message_id'] = options.userMessageId;
+  if (options?.userId) attributes['squire.user_id'] = options.userId;
+  if (options?.campaignId) attributes['squire.campaign_id'] = options.campaignId;
+  if (options?.game) attributes['squire.game'] = requireGameId(options.game);
+  return attributes;
+}
+
+function langsmithMetadataAttributes(metadata: Record<string, unknown>): Attributes {
+  return Object.fromEntries(
+    Object.entries(metadata)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => [`langsmith.metadata.${key}`, primitiveTraceAttribute(value)]),
+  );
+}
+
+function langgraphTraceTags(model: string): string {
+  return [
+    'agent',
+    'runtime',
+    'anthropic',
+    GRAPH_RUNTIME_PREFIX,
+    model,
+    'redesigned',
+    `env:${resolveSquireEnv()}`,
+  ].join(', ');
+}
+
+function langgraphRunTraceAttributes({
+  question,
+  model,
+  options,
+  result,
+}: {
+  question: string;
+  model: string;
+  options?: AskOptions;
+  result?: AgentRunResult;
+}): Attributes {
+  return {
+    'langsmith.traceable': 'true',
+    'langsmith.span.kind': 'chain',
+    'langsmith.trace.name': 'squire.agent.langgraph',
+    'langsmith.span.tags': langgraphTraceTags(model),
+    'gen_ai.prompt': jsonTraceAttribute({ question }),
+    ...(result
+      ? {
+          'gen_ai.completion': jsonTraceAttribute({ finalAnswer: result.answer }),
+          'langsmith.usage_metadata': jsonTraceAttribute(
+            langsmithUsageMetadata(result.trajectory.tokenUsage),
+          ),
+          'squire.agent.iterations': result.trajectory.iterations,
+          'squire.agent.tool_call_count': result.trajectory.toolCalls.length,
+          'squire.agent.stop_reason': result.trajectory.stopReason ?? 'unknown',
+        }
+      : {}),
+    'squire.agent.runtime': GRAPH_RUNTIME_PREFIX,
+    'squire.agent.model': `${GRAPH_RUNTIME_PREFIX}:${model}`,
+    ...langsmithMetadataAttributes({
+      ...langgraphCorrelationMetadata(options),
+      model,
+      toolSurface: 'redesigned',
+      ...(result
+        ? {
+            iterations: result.trajectory.iterations,
+            toolCallCount: result.trajectory.toolCalls.length,
+            stopReason: result.trajectory.stopReason ?? 'unknown',
+          }
+        : {}),
+    }),
+    ...langgraphCorrelationAttributes(options),
+  };
 }
 
 function appendModelCall(
@@ -529,7 +647,7 @@ async function runLangGraphAgentLoop(
     .addEdge(START, 'plan_retrieval')
     .addEdge('execute_tools', 'verify_sources')
     .addConditionalEdges('verify_sources', (state: LangGraphStateValue) => {
-      if (state.forceSynthesis || state.iterations >= maxIterations) {
+      if (state.readyToAnswer || state.forceSynthesis || state.iterations >= maxIterations) {
         return 'final_answer';
       }
       return 'plan_retrieval';
@@ -537,12 +655,47 @@ async function runLangGraphAgentLoop(
     .addEdge('final_answer', END)
     .compile({ checkpointer: graphCheckpointer });
 
-  const finalState = await graph.invoke(createInitialState(question, options), {
-    configurable: { thread_id: threadIdFor(options) },
+  return tracer.startActiveSpan('squire.agent.langgraph.run', async (span) => {
+    try {
+      span.setAttributes(
+        langgraphRunTraceAttributes({
+          question,
+          model: config.model,
+          options,
+        }),
+      );
+      const finalState = await graph.invoke(createInitialState(question, options), {
+        configurable: { thread_id: threadIdFor(options) },
+      });
+      const result = {
+        answer: finalState.finalAnswer,
+        trajectory: trajectoryFromState(finalState, config.model),
+      };
+      span.setAttributes(
+        langgraphRunTraceAttributes({
+          question,
+          model: config.model,
+          options,
+          result,
+        }),
+      );
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      span.setAttributes({
+        'gen_ai.completion': jsonTraceAttribute({ error: message }),
+        ...langsmithMetadataAttributes({
+          ...langgraphCorrelationMetadata(options),
+          level: 'ERROR',
+          statusMessage: message,
+        }),
+        ...langgraphCorrelationAttributes(options),
+      });
+      span.recordException(error as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+      throw error;
+    } finally {
+      span.end();
+    }
   });
-
-  return {
-    answer: finalState.finalAnswer,
-    trajectory: trajectoryFromState(finalState, config.model),
-  };
 }

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -58,6 +58,12 @@ const DISCOVERY_ONLY_TOOL_NAMES = new Set([
   'resolve_entity',
   'neighbors',
 ]);
+const DIRECT_EVIDENCE_TOOL_NAMES = new Set([
+  'open_entity',
+  'get_card',
+  'get_scenario',
+  'get_section',
+]);
 const graphCheckpointer = new MemorySaver();
 
 const LangGraphState = Annotation.Root({
@@ -352,6 +358,10 @@ function hasAnswerableToolCalls(toolCalls: ToolTrajectoryStep[]): boolean {
   });
 }
 
+function hasDirectOpenedEvidence(toolCalls: ToolTrajectoryStep[]): boolean {
+  return toolCalls.some((call) => call.ok && DIRECT_EVIDENCE_TOOL_NAMES.has(call.name));
+}
+
 function shouldForceSynthesis(state: LangGraphStateValue, threshold: number): boolean {
   return state.broadRuleSearches >= threshold && !state.hasUsedNonRuleSearchTool;
 }
@@ -598,7 +608,7 @@ async function runLangGraphAgentLoop(
       };
     })
     .addNode('verify_sources', async (state: LangGraphStateValue) => {
-      const readyToAnswer = hasAnswerableToolCalls(state.toolCalls);
+      const readyToAnswer = hasDirectOpenedEvidence(state.toolCalls);
       await emitGraphDebug(emit, 'LangGraph verify_sources node completed.', {
         readyToAnswer,
         toolCallCount: state.toolCalls.length,
@@ -610,6 +620,21 @@ async function runLangGraphAgentLoop(
         readyToAnswer: state.readyToAnswer,
         stopReason: state.stopReason,
       });
+      const draftAnswer =
+        state.lastResponse && !hasToolUse(state.lastResponse)
+          ? textFromMessage(state.lastResponse)
+          : '';
+      if (draftAnswer) {
+        if (emit) {
+          await emit('text', { delta: draftAnswer });
+          await emit('done', {});
+        }
+        return {
+          finalAnswer: draftAnswer,
+          stopReason: state.stopReason as StopReason | null,
+        };
+      }
+
       const finalMessages: MessageParam[] = [
         ...state.messages,
         { role: 'user' as const, content: FINAL_ANSWER_PROMPT },

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -170,18 +170,14 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
   });
 
   it('runs a staged graph and emits answer text only from final_answer', async () => {
-    mockMessagesCreate.mockResolvedValueOnce(
-      toolUseResponse('search_knowledge', {
-        query: 'loot',
-        scope: ['rules_passage'],
-      }),
-    );
-    mockMessagesStream.mockReturnValueOnce(
-      mockStream(textResponse('Use loot abilities to pick up loot tokens.'), [
-        'Use loot abilities ',
-        'to pick up loot tokens.',
-      ]),
-    );
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'loot',
+          scope: ['rules_passage'],
+        }),
+      )
+      .mockResolvedValueOnce(textResponse('Use loot abilities to pick up loot tokens.'));
     const emitted: Array<[AgentStreamEventName, unknown]> = [];
 
     const result = await runLangGraphAgentLoopWithTrajectory('How does loot work?', {
@@ -195,15 +191,14 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
     expect(result.answer).toBe('Use loot abilities to pick up loot tokens.');
     expect(result.trajectory.model).toBe('langgraph:claude-sonnet-4-6');
     expect(result.trajectory.toolCalls).toHaveLength(1);
-    expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
+    expect(mockMessagesStream).not.toHaveBeenCalled();
     expect(mockMessagesCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: expect.arrayContaining([expect.objectContaining({ name: 'search_knowledge' })]),
       }),
     );
-    expect(mockMessagesStream).toHaveBeenCalledWith(
-      expect.not.objectContaining({ tools: expect.anything() }),
-    );
+    expect(mockMessagesStream).not.toHaveBeenCalled();
 
     const userVisibleEvents = emitted.filter(([event]) => event !== 'debug');
     expect(userVisibleEvents).toEqual([
@@ -213,8 +208,7 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
         { name: 'search_knowledge', input: { query: 'loot', scope: ['rules_passage'] } },
       ],
       ['tool_result', { name: 'search_knowledge', ok: true, sourceBooks: ['Rulebook'] }],
-      ['text', { delta: 'Use loot abilities ' }],
-      ['text', { delta: 'to pick up loot tokens.' }],
+      ['text', { delta: 'Use loot abilities to pick up loot tokens.' }],
       ['done', {}],
     ]);
   });
@@ -251,15 +245,14 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
   });
 
   it('adds LangSmith-native root trace attributes for production LangGraph runs', async () => {
-    mockMessagesCreate.mockResolvedValueOnce(
-      toolUseResponse('search_knowledge', {
-        query: 'loot',
-        scope: ['rules_passage'],
-      }),
-    );
-    mockMessagesStream.mockReturnValueOnce(
-      mockStream(textResponse('Use loot abilities to pick up loot tokens.')),
-    );
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('search_knowledge', {
+          query: 'loot',
+          scope: ['rules_passage'],
+        }),
+      )
+      .mockResolvedValueOnce(textResponse('Use loot abilities to pick up loot tokens.'));
 
     await runLangGraphAgentLoopWithTrajectory('How does loot work?', {
       emit: async () => undefined,
@@ -302,7 +295,7 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
       'squire.user_id': '7ba7b810-9dad-11d1-80b4-00c04fd430c8',
       'squire.game': 'frosthaven',
       'squire.agent.runtime': 'langgraph',
-      'squire.agent.iterations': 1,
+      'squire.agent.iterations': 2,
       'squire.agent.tool_call_count': 1,
       'squire.agent.stop_reason': 'end_turn',
       'squire.agent.input_tokens': 180,

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -119,7 +119,7 @@ function spanAttributes(name: string): Record<string, unknown> {
 
 function parseJsonAttribute(attributes: Record<string, unknown>, key: string): unknown {
   const value = attributes[key];
-  if (typeof value !== 'string') return value;
+  if (typeof value !== 'string') throw new Error(`Expected ${key} to be a JSON string attribute.`);
   return JSON.parse(value);
 }
 
@@ -305,6 +305,10 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
       'squire.agent.iterations': 1,
       'squire.agent.tool_call_count': 1,
       'squire.agent.stop_reason': 'end_turn',
+      'squire.agent.input_tokens': 180,
+      'squire.agent.output_tokens': 70,
+      'squire.agent.cache_creation_input_tokens': 0,
+      'squire.agent.cache_read_input_tokens': 0,
     });
     expect(attributes['langsmith.span.tags']).toBe(
       'agent, runtime, anthropic, langgraph, claude-sonnet-4-6, redesigned, env:test',

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -6,12 +6,49 @@ const {
   mockSearchKnowledge,
   mockNeighbors,
   mockOpenEntity,
+  mockStartedSpans,
+  mockStartActiveSpan,
 } = vi.hoisted(() => ({
   mockMessagesCreate: vi.fn(),
   mockMessagesStream: vi.fn(),
   mockSearchKnowledge: vi.fn(),
   mockNeighbors: vi.fn(),
   mockOpenEntity: vi.fn(),
+  mockStartedSpans: [] as Array<{ name: string; span: { attributes: Record<string, unknown> } }>,
+  mockStartActiveSpan: vi.fn((name: string, ...args: unknown[]) => {
+    const callback = args.find((arg) => typeof arg === 'function') as
+      | ((span: {
+          attributes: Record<string, unknown>;
+          setAttributes: (attributes: Record<string, unknown>) => void;
+          recordException: (error: unknown) => void;
+          setStatus: (status: unknown) => void;
+          end: () => void;
+        }) => unknown)
+      | undefined;
+    if (!callback) throw new Error(`No span callback for ${name}`);
+
+    const attributes: Record<string, unknown> = {};
+    const span = {
+      attributes,
+      setAttributes: (nextAttributes: Record<string, unknown>) => {
+        Object.assign(attributes, nextAttributes);
+      },
+      recordException: vi.fn(),
+      setStatus: vi.fn(),
+      end: vi.fn(),
+    };
+    mockStartedSpans.push({ name, span });
+    return callback(span);
+  }),
+}));
+
+vi.mock('@opentelemetry/api', () => ({
+  SpanStatusCode: { ERROR: 2 },
+  trace: {
+    getTracer: () => ({
+      startActiveSpan: mockStartActiveSpan,
+    }),
+  },
 }));
 
 vi.mock('@anthropic-ai/sdk', () => ({
@@ -74,9 +111,22 @@ function mockStream(finalMessage: Record<string, unknown>, textDeltas: string[] 
   };
 }
 
+function spanAttributes(name: string): Record<string, unknown> {
+  const record = mockStartedSpans.find((entry) => entry.name === name);
+  if (!record) throw new Error(`No span named ${name}`);
+  return record.span.attributes;
+}
+
+function parseJsonAttribute(attributes: Record<string, unknown>, key: string): unknown {
+  const value = attributes[key];
+  if (typeof value !== 'string') return value;
+  return JSON.parse(value);
+}
+
 describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    mockStartedSpans.length = 0;
     mockSearchKnowledge.mockResolvedValue({
       ok: true,
       query: 'loot',
@@ -126,9 +176,6 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
         scope: ['rules_passage'],
       }),
     );
-    mockMessagesCreate.mockResolvedValueOnce(
-      textResponse('I have enough evidence to answer from the rulebook result.'),
-    );
     mockMessagesStream.mockReturnValueOnce(
       mockStream(textResponse('Use loot abilities to pick up loot tokens.'), [
         'Use loot abilities ',
@@ -148,7 +195,7 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
     expect(result.answer).toBe('Use loot abilities to pick up loot tokens.');
     expect(result.trajectory.model).toBe('langgraph:claude-sonnet-4-6');
     expect(result.trajectory.toolCalls).toHaveLength(1);
-    expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
     expect(mockMessagesCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: expect.arrayContaining([expect.objectContaining({ name: 'search_knowledge' })]),
@@ -177,8 +224,7 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
       .mockResolvedValueOnce(toolUseResponse('neighbors', { ref: 'scenario:frosthaven/060' }))
       .mockResolvedValueOnce(
         toolUseResponse('open_entity', { ref: 'section:frosthaven/79.4' }, 'tool_open_section'),
-      )
-      .mockResolvedValueOnce(textResponse('I have the target section content.'));
+      );
     mockMessagesStream.mockReturnValueOnce(
       mockStream(textResponse('Section 79.4 unlocks Scenario 61.'), [
         'Section 79.4 unlocks ',
@@ -196,11 +242,72 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
     );
 
     expect(result.answer).toBe('Section 79.4 unlocks Scenario 61.');
-    expect(mockMessagesCreate).toHaveBeenCalledTimes(3);
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
     expect(mockOpenEntity).toHaveBeenCalledWith('section:frosthaven/79.4');
     expect(result.trajectory.toolCalls.map((call) => call.name)).toEqual([
       'neighbors',
       'open_entity',
     ]);
+  });
+
+  it('adds LangSmith-native root trace attributes for production LangGraph runs', async () => {
+    mockMessagesCreate.mockResolvedValueOnce(
+      toolUseResponse('search_knowledge', {
+        query: 'loot',
+        scope: ['rules_passage'],
+      }),
+    );
+    mockMessagesStream.mockReturnValueOnce(
+      mockStream(textResponse('Use loot abilities to pick up loot tokens.')),
+    );
+
+    await runLangGraphAgentLoopWithTrajectory('How does loot work?', {
+      emit: async () => undefined,
+      toolSurface: 'redesigned',
+      requestId: 'req-langgraph',
+      conversationId: '550e8400-e29b-41d4-a716-446655440000',
+      userMessageId: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      userId: '7ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      game: 'frosthaven',
+    });
+
+    const attributes = spanAttributes('squire.agent.langgraph.run');
+    expect(parseJsonAttribute(attributes, 'gen_ai.prompt')).toEqual({
+      question: 'How does loot work?',
+    });
+    expect(parseJsonAttribute(attributes, 'gen_ai.completion')).toEqual({
+      finalAnswer: 'Use loot abilities to pick up loot tokens.',
+    });
+    expect(parseJsonAttribute(attributes, 'langsmith.usage_metadata')).toEqual({
+      input_tokens: 180,
+      output_tokens: 70,
+      total_tokens: 250,
+      input_token_details: { cache_creation: 0, cache_read: 0 },
+    });
+    expect(attributes).toMatchObject({
+      'langsmith.traceable': 'true',
+      'langsmith.span.kind': 'chain',
+      'langsmith.trace.name': 'squire.agent.langgraph',
+      'langsmith.metadata.runtime': 'langgraph',
+      'langsmith.metadata.squireEnv': 'test',
+      'langsmith.metadata.requestId': 'req-langgraph',
+      'langsmith.metadata.conversationId': '550e8400-e29b-41d4-a716-446655440000',
+      'langsmith.metadata.userMessageId': '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      'langsmith.metadata.userId': '7ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      'langsmith.metadata.game': 'frosthaven',
+      'squire.env': 'test',
+      'squire.request_id': 'req-langgraph',
+      'squire.conversation_id': '550e8400-e29b-41d4-a716-446655440000',
+      'squire.user_message_id': '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      'squire.user_id': '7ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      'squire.game': 'frosthaven',
+      'squire.agent.runtime': 'langgraph',
+      'squire.agent.iterations': 1,
+      'squire.agent.tool_call_count': 1,
+      'squire.agent.stop_reason': 'end_turn',
+    });
+    expect(attributes['langsmith.span.tags']).toBe(
+      'agent, runtime, anthropic, langgraph, claude-sonnet-4-6, redesigned, env:test',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- route LangGraph runs to final_answer as soon as verifier has an answerable tool result
- add LangSmith-visible root span attributes for production LangGraph runs
- cover the recursion-limit regression and production trace metadata in agent-langgraph tests

## Root Cause
Production LangGraph runs reached the verifier with answerable retrieval results, but the verifier route ignored readyToAnswer and always returned to plan_retrieval unless forced synthesis or the iteration limit fired. Simple questions could therefore stream many tool events and eventually fail with LangGraph's recursion limit.

The LangGraph runtime also bypassed the old agent root span wrapper, so failed production graph runs did not create the expected LangSmith agent trace.

## Validation
- npm test -- --run test/agent-langgraph.test.ts
- npm run check

Follow-up hotfix for SQR-225 production LangGraph runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive tracing and observability for agent runs, capturing prompts, completions, errors, and usage metadata.

* **Improvements**
  * Agent routing can short-circuit to a draft final answer when evidence is directly available, enabling earlier finalization.

* **Tests**
  * Expanded tests to validate tracing attributes, execution flow, and tool-call ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->