### PR TITLE
fix(config): enable production LangSmith tracing

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -203,6 +203,7 @@ SQUIRE_ALLOWED_EMAILS=your-email@example.com
 LANGSMITH_ENDPOINT=https://api.smith.langchain.com
 LANGSMITH_PROJECT=...
 LANGSMITH_API_KEY=...
+LANGSMITH_TRACING=true
 
 # Optional locally; production requires REDIS_URL for app-level rate limits.
 # REDIS_URL=redis://localhost:6379

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -33,6 +33,7 @@ SQUIRE_ALLOWED_EMAILS=your-email@example.com
 # LangSmith observability
 LANGSMITH_API_KEY=...
 LANGSMITH_PROJECT=squire-evals
+LANGSMITH_TRACING=true
 # LANGSMITH_ENDPOINT=https://api.smith.langchain.com
 # LANGSMITH_WORKSPACE_ID=...
 

--- a/docs/runbooks/production-operations.md
+++ b/docs/runbooks/production-operations.md
@@ -83,6 +83,7 @@ app-runtime secrets and settings belong in Fly:
 - `SQUIRE_ENV=production`
 - `LANGSMITH_API_KEY` (optional tracing; absence must not block startup)
 - `LANGSMITH_PROJECT` (optional tracing; defaults to `squire-production`)
+- `LANGSMITH_TRACING=true` (required when LangSmith credentials are set)
 - `LANGSMITH_ENDPOINT` (optional; defaults to LangSmith Cloud)
 - `LANGSMITH_WORKSPACE_ID` (when required by the API key)
 - `ORIGIN_SHARED_SECRET`

--- a/fly.toml
+++ b/fly.toml
@@ -12,6 +12,7 @@ NODE_ENV = "production"
 SQUIRE_ENV = "production"
 PORT = "8080"
 HOST = "0.0.0.0"
+LANGSMITH_TRACING = "true"
 
 [processes]
 app = "node src/server.ts"

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,11 @@ function hasEnabledLangSmithTracing(env: Env): boolean {
 }
 
 function hasLangSmithCredentials(env: Env): boolean {
-  return hasText(env.LANGSMITH_API_KEY) || hasText(env.LANGSMITH_PROJECT);
+  return (
+    hasText(env.LANGSMITH_API_KEY) ||
+    hasText(env.LANGCHAIN_API_KEY) ||
+    hasText(env.LANGSMITH_PROJECT)
+  );
 }
 
 function validateUrl(

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,19 @@ function hasText(value: string | undefined): boolean {
   return value !== undefined && value.trim().length > 0;
 }
 
+function hasEnabledLangSmithTracing(env: Env): boolean {
+  return (
+    env.LANGSMITH_TRACING === 'true' ||
+    env.LANGCHAIN_TRACING === 'true' ||
+    env.LANGSMITH_TRACING_V2 === 'true' ||
+    env.LANGCHAIN_TRACING_V2 === 'true'
+  );
+}
+
+function hasLangSmithCredentials(env: Env): boolean {
+  return hasText(env.LANGSMITH_API_KEY) || hasText(env.LANGSMITH_PROJECT);
+}
+
 function validateUrl(
   name: string,
   value: string | undefined,
@@ -80,6 +93,16 @@ export function validateServerEnv(env: Env = process.env): ServerConfigResult {
   validateUrl('DATABASE_URL', env.DATABASE_URL, invalid);
   validateUrl('LANGSMITH_ENDPOINT', env.LANGSMITH_ENDPOINT, invalid);
   validateUrl('REDIS_URL', env.REDIS_URL, invalid);
+  if (
+    nodeEnv === 'production' &&
+    hasLangSmithCredentials(env) &&
+    !hasEnabledLangSmithTracing(env)
+  ) {
+    invalid.push({
+      name: 'LANGSMITH_TRACING',
+      message: 'must be "true" when LANGSMITH_API_KEY or LANGSMITH_PROJECT is set',
+    });
+  }
 
   if (hasText(env.HOST) && env.HOST!.trim() !== env.HOST) {
     invalid.push({ name: 'HOST', message: 'must not contain leading or trailing whitespace' });

--- a/src/config.ts
+++ b/src/config.ts
@@ -104,7 +104,8 @@ export function validateServerEnv(env: Env = process.env): ServerConfigResult {
   ) {
     invalid.push({
       name: 'LANGSMITH_TRACING',
-      message: 'must be "true" when LANGSMITH_API_KEY or LANGSMITH_PROJECT is set',
+      message:
+        'must be "true" when LANGSMITH_API_KEY, LANGCHAIN_API_KEY, or LANGSMITH_PROJECT is set',
     });
   }
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -8,6 +8,7 @@ import { LangSmithOTLPSpanProcessor } from 'langsmith/experimental/otel/processo
 import { LangSmithOTLPTraceExporter } from 'langsmith/experimental/otel/exporter';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
 import { applySquireEnv } from './squire-env.ts';
+import { langsmithOtelHeaders } from './langsmith-otel.ts';
 
 const squireEnv = applySquireEnv();
 const langsmithProject = process.env.LANGSMITH_PROJECT ?? 'squire-production';
@@ -17,6 +18,7 @@ const sdk = new NodeSDK({
     new LangSmithOTLPSpanProcessor(
       new LangSmithOTLPTraceExporter({
         projectName: langsmithProject,
+        headers: langsmithOtelHeaders(),
         transformExportedSpan: (span) => {
           span.attributes['langsmith.metadata.environment'] = squireEnv;
           return span;

--- a/src/langsmith-otel.ts
+++ b/src/langsmith-otel.ts
@@ -1,0 +1,18 @@
+type Env = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+function hasText(value: string | undefined): value is string {
+  return value !== undefined && value.trim().length > 0;
+}
+
+export function langsmithOtelHeaders(env: Env = process.env): Record<string, string> | undefined {
+  if (hasText(env.OTEL_EXPORTER_OTLP_HEADERS)) return undefined;
+
+  const headers: Record<string, string> = {};
+  const apiKey = env.LANGSMITH_API_KEY ?? env.LANGCHAIN_API_KEY;
+  const workspaceId = env.LANGSMITH_WORKSPACE_ID;
+
+  if (hasText(apiKey)) headers['x-api-key'] = apiKey;
+  if (hasText(workspaceId)) headers['x-tenant-id'] = workspaceId.trim();
+
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -14,6 +14,7 @@ describe('validateServerEnv', () => {
     SESSION_SECRET: 'x'.repeat(32),
     LANGSMITH_API_KEY: 'langsmith-key',
     LANGSMITH_PROJECT: 'squire-production',
+    LANGSMITH_TRACING: 'true',
     GOOGLE_OAUTH_CLIENT_ID: 'google-client',
     GOOGLE_OAUTH_CLIENT_SECRET: 'google-secret',
     ORIGIN_SHARED_SECRET: 'origin-secret'.repeat(3),
@@ -53,9 +54,24 @@ describe('validateServerEnv', () => {
       ...validProductionEnv,
       LANGSMITH_API_KEY: undefined,
       LANGSMITH_PROJECT: undefined,
+      LANGSMITH_TRACING: undefined,
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('rejects production LangSmith credentials without tracing enabled', () => {
+    const result = validateServerEnv({
+      ...validProductionEnv,
+      LANGSMITH_TRACING: undefined,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected invalid env');
+    expect(result.error.invalid).toContainEqual({
+      name: 'LANGSMITH_TRACING',
+      message: 'must be "true" when LANGSMITH_API_KEY or LANGSMITH_PROJECT is set',
+    });
   });
 
   it('allows development to use the managed local database default', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -74,6 +74,22 @@ describe('validateServerEnv', () => {
     });
   });
 
+  it('rejects production LangChain tracing credentials without tracing enabled', () => {
+    const result = validateServerEnv({
+      ...validProductionEnv,
+      LANGSMITH_API_KEY: undefined,
+      LANGSMITH_TRACING: undefined,
+      LANGCHAIN_API_KEY: 'langchain-key',
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected invalid env');
+    expect(result.error.invalid).toContainEqual({
+      name: 'LANGSMITH_TRACING',
+      message: 'must be "true" when LANGSMITH_API_KEY or LANGSMITH_PROJECT is set',
+    });
+  });
+
   it('allows development to use the managed local database default', () => {
     const result = validateServerEnv({
       ...validProductionEnv,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -70,7 +70,8 @@ describe('validateServerEnv', () => {
     if (result.success) throw new Error('expected invalid env');
     expect(result.error.invalid).toContainEqual({
       name: 'LANGSMITH_TRACING',
-      message: 'must be "true" when LANGSMITH_API_KEY or LANGSMITH_PROJECT is set',
+      message:
+        'must be "true" when LANGSMITH_API_KEY, LANGCHAIN_API_KEY, or LANGSMITH_PROJECT is set',
     });
   });
 
@@ -78,6 +79,7 @@ describe('validateServerEnv', () => {
     const result = validateServerEnv({
       ...validProductionEnv,
       LANGSMITH_API_KEY: undefined,
+      LANGSMITH_PROJECT: undefined,
       LANGSMITH_TRACING: undefined,
       LANGCHAIN_API_KEY: 'langchain-key',
     });
@@ -86,7 +88,8 @@ describe('validateServerEnv', () => {
     if (result.success) throw new Error('expected invalid env');
     expect(result.error.invalid).toContainEqual({
       name: 'LANGSMITH_TRACING',
-      message: 'must be "true" when LANGSMITH_API_KEY or LANGSMITH_PROJECT is set',
+      message:
+        'must be "true" when LANGSMITH_API_KEY, LANGCHAIN_API_KEY, or LANGSMITH_PROJECT is set',
     });
   });
 

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -146,6 +146,7 @@ describe('deployment configuration', () => {
 
     expect(flyConfig).toContain('app = "maz-squire"');
     expect(flyConfig).toContain('SQUIRE_ENV = "production"');
+    expect(flyConfig).toContain('LANGSMITH_TRACING = "true"');
     expect(flyConfig).toContain('release_command = "node scripts/db-migrate.ts"');
     expect(flyConfig).toContain('internal_port = 8080');
     expect(flyConfig).toContain('auto_stop_machines = "off"');

--- a/test/langsmith-otel.test.ts
+++ b/test/langsmith-otel.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { langsmithOtelHeaders } from '../src/langsmith-otel.ts';
+
+describe('langsmithOtelHeaders', () => {
+  it('passes API key and workspace headers to the OTEL exporter', () => {
+    expect(
+      langsmithOtelHeaders({
+        LANGSMITH_API_KEY: 'ls-key',
+        LANGSMITH_WORKSPACE_ID: ' workspace-id ',
+      }),
+    ).toEqual({
+      'x-api-key': 'ls-key',
+      'x-tenant-id': 'workspace-id',
+    });
+  });
+
+  it('lets OTEL_EXPORTER_OTLP_HEADERS own custom headers when configured', () => {
+    expect(
+      langsmithOtelHeaders({
+        LANGSMITH_API_KEY: 'ls-key',
+        LANGSMITH_WORKSPACE_ID: 'workspace-id',
+        OTEL_EXPORTER_OTLP_HEADERS: 'x-api-key=other',
+      }),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- require `LANGSMITH_TRACING=true` when production LangSmith credentials are configured
- set the checked-in Fly env flag so future deploys keep tracing enabled
- send `LANGSMITH_WORKSPACE_ID` as the OTEL `x-tenant-id` header when present
- document the required tracing flag in setup and production operations docs

## Validation
- `npm test -- --run test/config.test.ts test/deployment-config.test.ts test/langsmith-otel.test.ts`
- `npm run check`
- `flyctl secrets set LANGSMITH_TRACING=true -a maz-squire`
- imported `LANGSMITH_WORKSPACE_ID` from `~/.config/maz/squire.env` into Fly without sourcing it locally
- `node scripts/check-deploy-health.ts --base-url https://squire.maz.org`

Linear: SQR-240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LangSmith OpenTelemetry tracing support with automatic OTEL header propagation and deploy-time flag.

* **Documentation**
  * Updated contributing, development, and production runbook guidance to include LangSmith tracing setup and required environment entries.

* **Configuration**
  * Deployment config includes a LangSmith tracing environment flag and runtime validation that requires tracing when credentials are present.

* **Tests**
  * Added/updated tests covering tracing header generation and validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->