### PR TITLE
Add durable SSE stream replay

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -425,13 +425,26 @@ _Phase 5 (with the recommendation engine). See [SPEC.md](SPEC.md). Curated URL l
   means "no source tools fired" or "pre-SQR-98 row"; both render with the
   footer hidden
 - Browser streaming contract:
+  - transcript markup carries stable `data-testid` hooks for headless QA:
+    `conversation-transcript`, `question-turn`, `answer-turn`,
+    `answer-content`, `answer-progress`, `answer-artifacts`, and
+    `consulted-footer`
+  - question and answer `<article>` elements are accessible by stable
+    visually-hidden headings ("Your question", "Squire answer") so browser
+    accessibility snapshots expose transcript content as named turns
   - `text-delta` appends inert plain text only
+  - browser-visible events after `ask()` starts are persisted in
+    `message_stream_events` with turn-local SSE ids, so reconnects can replay
+    from `Last-Event-ID` without re-running the agent
   - terminal `done` carries the sanitized final HTML fragment and the
     persisted `consultedSources` for replay (the `recentQuestionsNavHtml`
     field was removed in SQR-108 / ADR 0012 — the conversation page is a
     scrolling transcript with no chip rail to refresh)
   - the same server-side renderer is used for persisted reloads and final
     post-stream replacement
+  - if a process dies after partial stream events but before a terminal event,
+    the reconnect path persists one assistant failure and terminal `error`
+    rather than restarting graph execution and duplicating prior deltas
 
 ---
 

--- a/docs/SSE_CONTRACT.md
+++ b/docs/SSE_CONTRACT.md
@@ -16,6 +16,14 @@ Scope:
 
 The browser consumes these SSE event names:
 
+Every browser-visible event written after `ask()` starts carries an SSE `id`
+field. The id is the turn-local persisted event sequence (`1`, `2`, `3`, ...),
+scoped to `(conversationId, userMessageId)`. The browser may reconnect with
+`Last-Event-ID`; the server replays only stored events with a larger sequence.
+The `userMessageId` is also the LangGraph `thread_id` for the run, so SSE
+replay and graph execution are keyed to the same turn. The SSE event log is not
+a durable LangGraph node checkpoint.
+
 - `text-delta`
   - Appends assistant answer text.
   - Payload: `{ "delta": string }`
@@ -63,6 +71,34 @@ The browser consumes these SSE event names:
 The browser does not consume provider-native stream chunks directly. Any new
 internal event must be mapped here before it can become browser-visible.
 
+## Resume and Replay
+
+`GET /chat/:conversationId/messages/:messageId/stream` writes browser-visible
+events to `message_stream_events` before sending them over SSE. The durable log
+covers answer text, tool rows, progress rows, structured artifacts, terminal
+`done`, and terminal `error`.
+
+Replay rules:
+
+1. `Last-Event-ID` is parsed as a turn-local integer sequence. Missing or
+   invalid values mean replay from the beginning.
+2. The server sends only events with `sequence > Last-Event-ID`.
+3. If a stored `done` or `error` is replayed, the route closes without calling
+   the agent again.
+4. If non-terminal events exist and the original turn is still running, the
+   reconnecting stream polls the persisted event log until a terminal event is
+   available.
+5. If non-terminal events exist but no generation lock remains, the process
+   cannot safely continue the prior graph run. The route persists one assistant
+   failure row if needed, appends a terminal `error`, and closes.
+
+This means already-written stream text is durable across browser reconnects and
+server restarts. It does not mean an interrupted LangGraph run can always resume
+model/tool execution exactly where it stopped; that requires a durable graph
+checkpoint for the interrupted node. When no active lock or completed assistant
+row exists, Squire prefers one explicit failure over duplicating answer text or
+tool artifacts from a restarted run.
+
 ## Required success-path invariants
 
 For every successful stream:
@@ -82,6 +118,9 @@ For every successful stream:
    from `tool-result` events as they arrive; `consultedSources` is the
    authoritative replay payload used when no tool events fired during this
    connection (duplicate `/stream` hit, reconnect, already-persisted row).
+7. On replay, the same persisted event ids are reused. Replayed `text-delta`,
+   tool, progress, artifact, and terminal events must not be regenerated with
+   new ids.
 
 Important:
 

--- a/docs/adr/0017-phase-1-web-chat-reliability-policy.md
+++ b/docs/adr/0017-phase-1-web-chat-reliability-policy.md
@@ -74,6 +74,20 @@ SSE stream
           └── failure -> persist one assistant failure, emit terminal error
 ```
 
+SSE events written after `ask()` starts are also persisted in
+`message_stream_events` with a turn-local sequence id. On browser reconnect,
+the stream route honors `Last-Event-ID` and replays only later stored events.
+If a terminal `done` or `error` already exists, replay closes without calling
+the agent again. The stream log is keyed by `userMessageId`, which is also the
+LangGraph `thread_id` for the run.
+
+If a reconnect finds partial stored events and the original generation is still
+locked, the route waits for more stored events and relays them. If partial
+stored events exist but no generation lock remains, the previous graph run is
+not safely resumable from the SSE layer alone. The route persists one assistant
+failure row if needed and appends a terminal stream error instead of restarting
+the agent and risking duplicate answer text or artifacts.
+
 Duplicate assistant turns are avoided by taking a transaction-scoped advisory
 lock on the `(conversationId, userMessageId)` pair and reusing any existing
 assistant response for that user message.
@@ -113,6 +127,11 @@ alerts. SQR-86 only fixes the policy boundary and tests.
 - Plain-form users can recover from one clear transport failure without seeing
   an error.
 - SSE users never see a mixed stream from two backend attempts.
+- Browser reconnects replay already-persisted stream events by id instead of
+  depending on in-process buffers.
+- A process crash can preserve already-written stream text, progress rows, and
+  artifacts, but cannot continue an incomplete graph run unless a completed
+  assistant row or active generation lock exists.
 - The transcript has exactly one assistant outcome per user message: answer or
   failure.
 - The retry classifier remains a small private implementation detail tested

--- a/docs/runbooks/production-operations.md
+++ b/docs/runbooks/production-operations.md
@@ -324,7 +324,23 @@ chat behavior.
    input/output, stop reason, and token usage. Tool observations show tool name,
    compact input, output summary, source labels, canonical refs, and tool
    errors.
-5. If LangSmith has no trace for the turn, check Fly logs around the same time
+5. If the user saw a reconnect, duplicate text, or a stream that ended early,
+   inspect the durable SSE log for that user message. Event `sequence` values
+   are the browser `id` / `Last-Event-ID` values.
+
+   ```sql
+   select sequence, event, payload, created_at
+   from message_stream_events
+   where user_message_id = '<userMessageId>'
+   order by sequence;
+   ```
+
+   A stored `done` or `error` means reconnects should replay and close without
+   another agent run. Partial non-terminal rows with no active generation lock
+   are expected to end in one persisted assistant failure rather than a silent
+   graph restart.
+
+6. If LangSmith has no trace for the turn, check Fly logs around the same time
    and request ID:
 
    ```bash
@@ -332,7 +348,7 @@ chat behavior.
    fly logs -a maz-squire --no-tail | grep '<conversationId>'
    ```
 
-6. If the failure follows a deploy, check the GitHub deploy run before changing
+7. If the failure follows a deploy, check the GitHub deploy run before changing
    app code:
 
    ```bash

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -348,6 +348,43 @@ export async function streamAssistantTurn(input: {
   });
 }
 
+export async function persistAssistantFailureTurn(input: {
+  conversationId: string;
+  userMessageId: string;
+  content?: string;
+}): Promise<ConversationMessage> {
+  return getDb('server').db.transaction(async (tx) => {
+    await tx.execute(sql`
+      select pg_advisory_xact_lock(
+        hashtext(${input.conversationId}),
+        hashtext(${input.userMessageId})
+      )
+    `);
+
+    const existingAssistantMessage = await MessageRepository.findAssistantResponse({
+      conversationId: input.conversationId,
+      responseToMessageId: input.userMessageId,
+    });
+    if (existingAssistantMessage) {
+      return existingAssistantMessage;
+    }
+
+    const failureMessage = await MessageRepository.createResponse(tx, {
+      conversationId: input.conversationId,
+      role: 'assistant',
+      content: input.content ?? GENERIC_FAILURE_MESSAGE,
+      isError: true,
+      responseToMessageId: input.userMessageId,
+    });
+    await ConversationRepository.touchLastMessageAt(
+      tx,
+      input.conversationId,
+      failureMessage.createdAt,
+    );
+    return failureMessage;
+  });
+}
+
 export async function startConversation(input: {
   userId: string;
   question: string;

--- a/src/db/migrations/20260527002000_message_stream_events/migration.sql
+++ b/src/db/migrations/20260527002000_message_stream_events/migration.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "message_stream_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "conversation_id" uuid NOT NULL REFERENCES "conversations"("id") ON DELETE cascade,
+  "user_message_id" uuid NOT NULL REFERENCES "messages"("id") ON DELETE cascade,
+  "sequence" integer NOT NULL,
+  "event" text NOT NULL,
+  "payload" jsonb NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX "message_stream_events_user_message_sequence_idx"
+  ON "message_stream_events" ("user_message_id", "sequence");
+
+CREATE INDEX "message_stream_events_conversation_message_idx"
+  ON "message_stream_events" ("conversation_id", "user_message_id");
+
+CREATE UNIQUE INDEX "message_stream_events_user_message_terminal_idx"
+  ON "message_stream_events" ("user_message_id")
+  WHERE "event" IN ('done', 'error');

--- a/src/db/repositories/message-stream-event-repository.ts
+++ b/src/db/repositories/message-stream-event-repository.ts
@@ -138,19 +138,11 @@ export async function isTurnGenerationLocked(input: {
 }): Promise<boolean> {
   const { db } = getDb('server');
   const result = await db.execute(sql`
-    select pg_try_advisory_lock(
+    select pg_try_advisory_xact_lock(
       hashtext(${input.conversationId}),
       hashtext(${input.userMessageId})
     ) as acquired
   `);
   const acquired = Boolean((result.rows[0] as { acquired?: boolean } | undefined)?.acquired);
-  if (acquired) {
-    await db.execute(sql`
-      select pg_advisory_unlock(
-        hashtext(${input.conversationId}),
-        hashtext(${input.userMessageId})
-      )
-    `);
-  }
   return !acquired;
 }

--- a/src/db/repositories/message-stream-event-repository.ts
+++ b/src/db/repositories/message-stream-event-repository.ts
@@ -1,0 +1,156 @@
+import { and, asc, eq, gt, sql } from 'drizzle-orm';
+
+import { getDb } from '../../db.ts';
+import { messageStreamEvents } from '../schema/conversations.ts';
+
+export type BrowserStreamEventName =
+  | 'text-delta'
+  | 'tool-start'
+  | 'tool-result'
+  | 'tool-progress'
+  | 'answer-artifact'
+  | 'done'
+  | 'error';
+
+export interface MessageStreamEvent {
+  sequence: number;
+  event: BrowserStreamEventName;
+  payload: Record<string, unknown>;
+  createdAt: Date;
+}
+
+const TERMINAL_EVENTS = new Set<BrowserStreamEventName>(['done', 'error']);
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object' && error !== null && (error as { code?: string }).code === '23505'
+  );
+}
+
+function toDomain(row: typeof messageStreamEvents.$inferSelect): MessageStreamEvent {
+  return {
+    sequence: row.sequence,
+    event: row.event as BrowserStreamEventName,
+    payload: row.payload,
+    createdAt: row.createdAt,
+  };
+}
+
+export function isTerminalEvent(event: MessageStreamEvent): boolean {
+  return TERMINAL_EVENTS.has(event.event);
+}
+
+export async function listAfter(input: {
+  userMessageId: string;
+  afterSequence?: number;
+}): Promise<MessageStreamEvent[]> {
+  const { db } = getDb('server');
+  const afterSequence = input.afterSequence ?? 0;
+  const rows = await db
+    .select()
+    .from(messageStreamEvents)
+    .where(
+      afterSequence > 0
+        ? and(
+            eq(messageStreamEvents.userMessageId, input.userMessageId),
+            gt(messageStreamEvents.sequence, afterSequence),
+          )
+        : eq(messageStreamEvents.userMessageId, input.userMessageId),
+    )
+    .orderBy(asc(messageStreamEvents.sequence));
+
+  return rows.map((row) => toDomain(row));
+}
+
+export async function findTerminal(userMessageId: string): Promise<MessageStreamEvent | null> {
+  const { db } = getDb('server');
+  const rows = await db
+    .select()
+    .from(messageStreamEvents)
+    .where(eq(messageStreamEvents.userMessageId, userMessageId))
+    .orderBy(asc(messageStreamEvents.sequence));
+  const terminal = rows.find((row) => row.event === 'done' || row.event === 'error');
+  return terminal ? toDomain(terminal) : null;
+}
+
+async function insertNext(input: {
+  conversationId: string;
+  userMessageId: string;
+  event: BrowserStreamEventName;
+  payload: Record<string, unknown>;
+}): Promise<MessageStreamEvent> {
+  const { db } = getDb('server');
+  const result = await db.execute(sql`
+    with next_sequence as (
+      select coalesce(max(sequence), 0) + 1 as sequence
+      from message_stream_events
+      where user_message_id = ${input.userMessageId}
+    )
+    insert into message_stream_events (
+      conversation_id,
+      user_message_id,
+      sequence,
+      event,
+      payload
+    )
+    select
+      ${input.conversationId},
+      ${input.userMessageId},
+      sequence,
+      ${input.event},
+      ${JSON.stringify(input.payload)}::jsonb
+    from next_sequence
+    returning sequence, event, payload, created_at as "createdAt"
+  `);
+  const row = result.rows[0] as
+    | { sequence: number; event: string; payload: Record<string, unknown>; createdAt: Date }
+    | undefined;
+  if (!row) throw new Error('Failed to insert message stream event');
+  return {
+    sequence: row.sequence,
+    event: row.event as BrowserStreamEventName,
+    payload: row.payload,
+    createdAt: row.createdAt,
+  };
+}
+
+export async function append(input: {
+  conversationId: string;
+  userMessageId: string;
+  event: BrowserStreamEventName;
+  payload: Record<string, unknown>;
+}): Promise<MessageStreamEvent> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await insertNext(input);
+    } catch (error) {
+      if (!isUniqueViolation(error)) throw error;
+      const terminal = await findTerminal(input.userMessageId);
+      if (terminal && TERMINAL_EVENTS.has(input.event)) return terminal;
+    }
+  }
+  return insertNext(input);
+}
+
+export async function isTurnGenerationLocked(input: {
+  conversationId: string;
+  userMessageId: string;
+}): Promise<boolean> {
+  const { db } = getDb('server');
+  const result = await db.execute(sql`
+    select pg_try_advisory_lock(
+      hashtext(${input.conversationId}),
+      hashtext(${input.userMessageId})
+    ) as acquired
+  `);
+  const acquired = Boolean((result.rows[0] as { acquired?: boolean } | undefined)?.acquired);
+  if (acquired) {
+    await db.execute(sql`
+      select pg_advisory_unlock(
+        hashtext(${input.conversationId}),
+        hashtext(${input.userMessageId})
+      )
+    `);
+  }
+  return !acquired;
+}

--- a/src/db/schema/conversations.ts
+++ b/src/db/schema/conversations.ts
@@ -1,6 +1,8 @@
+import { sql } from 'drizzle-orm';
 import {
   type AnyPgColumn,
   boolean,
+  integer,
   index,
   jsonb,
   pgTable,
@@ -60,5 +62,29 @@ export const messages = pgTable(
   (t) => [
     index('messages_conversation_created_at_idx').on(t.conversationId, t.createdAt),
     uniqueIndex('messages_response_to_message_id_idx').on(t.responseToMessageId),
+  ],
+);
+
+export const messageStreamEvents = pgTable(
+  'message_stream_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    conversationId: uuid('conversation_id')
+      .notNull()
+      .references(() => conversations.id, { onDelete: 'cascade' }),
+    userMessageId: uuid('user_message_id')
+      .notNull()
+      .references(() => messages.id, { onDelete: 'cascade' }),
+    sequence: integer('sequence').notNull(),
+    event: text('event').notNull(),
+    payload: jsonb('payload').$type<Record<string, unknown>>().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('message_stream_events_user_message_sequence_idx').on(t.userMessageId, t.sequence),
+    uniqueIndex('message_stream_events_user_message_terminal_idx')
+      .on(t.userMessageId)
+      .where(sql`${t.event} in ('done', 'error')`),
+    index('message_stream_events_conversation_message_idx').on(t.conversationId, t.userMessageId),
   ],
 );

--- a/src/server.ts
+++ b/src/server.ts
@@ -1285,6 +1285,11 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
             userMessageId: loaded.message.id,
           }))
         ) {
+          const replay = await replayStoredEvents();
+          if (replay.reachedTerminal) {
+            return;
+          }
+
           const assistantMessage = await persistAssistantFailureTurn({
             conversationId: loaded.conversation.id,
             userMessageId: loaded.message.id,
@@ -1298,6 +1303,11 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
         if (replay.reachedTerminal) {
           return;
         }
+      }
+
+      const replay = await replayStoredEvents();
+      if (replay.reachedTerminal) {
+        return;
       }
 
       const assistantMessage = await persistAssistantFailureTurn({

--- a/src/server.ts
+++ b/src/server.ts
@@ -102,9 +102,12 @@ import {
   GENERIC_FAILURE_MESSAGE,
   loadConversation,
   loadConversationMessage,
+  persistAssistantFailureTurn,
   startConversation,
   streamAssistantTurn,
 } from './chat/conversation-service.ts';
+import * as MessageStreamEventRepository from './db/repositories/message-stream-event-repository.ts';
+import type { BrowserStreamEventName } from './db/repositories/message-stream-event-repository.ts';
 
 export const app = new Hono();
 
@@ -971,6 +974,18 @@ export function computePendingStreamUrls(
 // cost. Older turns are dropped (no "load earlier" affordance yet — file
 // a follow-up if anyone scrolls past 50 turns and feels the cliff).
 const TRANSCRIPT_MESSAGE_LIMIT = 100;
+const STREAM_REPLAY_POLL_MS = 100;
+const STREAM_REPLAY_MAX_POLLS = 1_200;
+
+function parseLastEventSequence(headerValue: string | undefined): number {
+  if (!headerValue) return 0;
+  const parsed = Number.parseInt(headerValue, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 app.get('/chat/:conversationId', async (c) => {
   const session = c.get('session')!;
@@ -1133,6 +1148,9 @@ app.post('/chat/:conversationId/messages', async (c) => {
 app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
   const requestId = correlateRequest(c);
   const session = c.get('session')!;
+  const lastEventSequence = parseLastEventSequence(
+    c.req.header('last-event-id') ?? c.req.header('Last-Event-ID'),
+  );
   const loaded = await loadConversationMessage({
     conversationId: c.req.param('conversationId'),
     messageId: c.req.param('messageId'),
@@ -1168,6 +1186,128 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
   return streamSSE(c, async (stream) => {
     let progressSequence = 0;
     let artifactSequence = 0;
+    let replayCursor = lastEventSequence;
+
+    const writeStoredEvent = async (
+      storedEvent: MessageStreamEventRepository.MessageStreamEvent,
+    ) => {
+      await stream.writeSSE({
+        id: String(storedEvent.sequence),
+        event: storedEvent.event,
+        data: JSON.stringify(storedEvent.payload),
+      });
+      replayCursor = storedEvent.sequence;
+    };
+
+    const persistAndWrite = async (
+      event: BrowserStreamEventName,
+      payload: Record<string, unknown>,
+    ) => {
+      const storedEvent = await MessageStreamEventRepository.append({
+        conversationId: loaded.conversation.id,
+        userMessageId: loaded.message.id,
+        event,
+        payload,
+      });
+      if (storedEvent.sequence > replayCursor) {
+        await writeStoredEvent(storedEvent);
+      }
+      return storedEvent;
+    };
+
+    const replayStoredEvents = async (): Promise<{
+      wroteAny: boolean;
+      reachedTerminal: boolean;
+    }> => {
+      const storedEvents = await MessageStreamEventRepository.listAfter({
+        userMessageId: loaded.message.id,
+        afterSequence: replayCursor,
+      });
+      let wroteAny = false;
+      let reachedTerminal = false;
+      for (const storedEvent of storedEvents) {
+        await writeStoredEvent(storedEvent);
+        wroteAny = true;
+        if (MessageStreamEventRepository.isTerminalEvent(storedEvent)) {
+          reachedTerminal = true;
+          break;
+        }
+      }
+      return { wroteAny, reachedTerminal };
+    };
+
+    const appendTerminalForAssistantMessage = async (
+      assistantMessage: Awaited<ReturnType<typeof streamAssistantTurn>>,
+    ) => {
+      if (assistantMessage.isError) {
+        await persistAndWrite('error', {
+          kind: 'transport',
+          message:
+            assistantMessage.content === GENERIC_FAILURE_MESSAGE
+              ? 'Trouble connecting. Please try again.'
+              : assistantMessage.content,
+          recoverable: true,
+        });
+        return;
+      }
+
+      await persistAndWrite('done', {
+        html: renderAssistantContentHtml(assistantMessage.content),
+        // SQR-98: send the persisted consulted_sources along with `done` so
+        // the client can rebuild the footer on replay — duplicate /stream
+        // hits, HTMX reconnects, or any path where persistAssistantOutcome
+        // returns an already-persisted row return here with no tool_result
+        // events fired. Without this, the footer would stay hidden on the
+        // reconnected turn until a full page reload.
+        // SQR-108 / ADR 0012 E-3: the `recentQuestionsNavHtml` field was
+        // dropped — the conversation page is a scrolling transcript with
+        // no recent-questions chip rail to refresh.
+        consultedSources: assistantMessage.consultedSources,
+      });
+    };
+
+    const existingTerminal = await MessageStreamEventRepository.findTerminal(loaded.message.id);
+    if (existingTerminal && existingTerminal.sequence <= replayCursor) {
+      return;
+    }
+
+    const initialReplay = await replayStoredEvents();
+    if (initialReplay.reachedTerminal) {
+      return;
+    }
+
+    const hasPriorStreamEvents = replayCursor > 0 || initialReplay.wroteAny;
+    if (hasPriorStreamEvents) {
+      for (let polls = 0; polls < STREAM_REPLAY_MAX_POLLS; polls += 1) {
+        if (
+          !(await MessageStreamEventRepository.isTurnGenerationLocked({
+            conversationId: loaded.conversation.id,
+            userMessageId: loaded.message.id,
+          }))
+        ) {
+          const assistantMessage = await persistAssistantFailureTurn({
+            conversationId: loaded.conversation.id,
+            userMessageId: loaded.message.id,
+          });
+          await appendTerminalForAssistantMessage(assistantMessage);
+          return;
+        }
+
+        await delay(STREAM_REPLAY_POLL_MS);
+        const replay = await replayStoredEvents();
+        if (replay.reachedTerminal) {
+          return;
+        }
+      }
+
+      const assistantMessage = await persistAssistantFailureTurn({
+        conversationId: loaded.conversation.id,
+        userMessageId: loaded.message.id,
+      });
+      await appendTerminalForAssistantMessage(assistantMessage);
+      return;
+    }
+
     const assistantMessage = await streamAssistantTurn({
       conversationId: loaded.conversation.id,
       question: loaded.message.content,
@@ -1177,25 +1317,19 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
       requestId,
       onEvent: async (event, data) => {
         if (event === 'text') {
-          await stream.writeSSE({
-            event: 'text-delta',
-            data: JSON.stringify(data),
-          });
+          await persistAndWrite('text-delta', data);
           return;
         }
 
         if (event === 'tool_call') {
           const payload = data as { name?: string };
           const name = payload.name ?? 'tool';
-          await stream.writeSSE({
-            event: 'tool-start',
-            data: JSON.stringify({
-              id: buildToolStatusId(name),
-              // Keep the SSE wire contract: always send a string label
-              // (REFERENCE fallback for utility/traversal tools) so the
-              // tool-indicator UI doesn't need to know about nulls.
-              label: toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL,
-            }),
+          await persistAndWrite('tool-start', {
+            id: buildToolStatusId(name),
+            // Keep the SSE wire contract: always send a string label
+            // (REFERENCE fallback for utility/traversal tools) so the
+            // tool-indicator UI doesn't need to know about nulls.
+            label: toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL,
           });
           return;
         }
@@ -1208,13 +1342,10 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
           }
           const name = payload.toolName ?? 'tool';
           progressSequence += 1;
-          await stream.writeSSE({
-            event: 'tool-progress',
-            data: JSON.stringify({
-              id: `${buildToolStatusId(name)}-progress-${progressSequence}`,
-              label: toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL,
-              message,
-            }),
+          await persistAndWrite('tool-progress', {
+            id: `${buildToolStatusId(name)}-progress-${progressSequence}`,
+            label: toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL,
+            message,
           });
           return;
         }
@@ -1242,16 +1373,13 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
                 : retrievalSourceLabelToFooterLabel(rawSourceLabel);
           const ref = typeof payload.ref === 'string' ? payload.ref.trim() : '';
           artifactSequence += 1;
-          await stream.writeSSE({
-            event: 'answer-artifact',
-            data: JSON.stringify({
-              id: `section-quote-${artifactSequence}`,
-              kind: 'section-quote',
-              title,
-              body,
-              sourceLabel,
-              ref: ref.length > 0 ? ref : null,
-            }),
+          await persistAndWrite('answer-artifact', {
+            id: `section-quote-${artifactSequence}`,
+            kind: 'section-quote',
+            title,
+            body,
+            sourceLabel,
+            ref: ref.length > 0 ? ref : null,
           });
           return;
         }
@@ -1268,50 +1396,17 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
                   .map(retrievalSourceLabelToFooterLabel)
                   .filter((l): l is NonNullable<typeof l> => l !== null)
               : [toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL];
-          await stream.writeSSE({
-            event: 'tool-result',
-            data: JSON.stringify({
-              id: buildToolStatusId(name),
-              labels: labels.length > 0 ? labels : [TOOL_SOURCE_FALLBACK_LABEL],
-              ok: payload.ok ?? true,
-            }),
+          await persistAndWrite('tool-result', {
+            id: buildToolStatusId(name),
+            labels: labels.length > 0 ? labels : [TOOL_SOURCE_FALLBACK_LABEL],
+            ok: payload.ok ?? true,
           });
           return;
         }
       },
     });
 
-    if (assistantMessage.isError) {
-      await stream.writeSSE({
-        event: 'error',
-        data: JSON.stringify({
-          kind: 'transport',
-          message:
-            assistantMessage.content === GENERIC_FAILURE_MESSAGE
-              ? 'Trouble connecting. Please try again.'
-              : assistantMessage.content,
-          recoverable: true,
-        }),
-      });
-      return;
-    }
-
-    await stream.writeSSE({
-      event: 'done',
-      data: JSON.stringify({
-        html: renderAssistantContentHtml(assistantMessage.content),
-        // SQR-98: send the persisted consulted_sources along with `done` so
-        // the client can rebuild the footer on replay — duplicate /stream
-        // hits, HTMX reconnects, or any path where persistAssistantOutcome
-        // returns an already-persisted row return here with no tool_result
-        // events fired. Without this, the footer would stay hidden on the
-        // reconnected turn until a full page reload.
-        // SQR-108 / ADR 0012 E-3: the `recentQuestionsNavHtml` field was
-        // dropped — the conversation page is a scrolling transcript with
-        // no recent-questions chip rail to refresh.
-        consultedSources: assistantMessage.consultedSources,
-      }),
-    });
+    await appendTerminalForAssistantMessage(assistantMessage);
   });
 });
 

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -220,11 +220,22 @@ async function renderDocument(options: DocumentOptions): Promise<HtmlEscapedStri
     </html>`;
 }
 
+function messageIdFromStreamUrl(streamUrl: string): string | null {
+  return streamUrl.match(/\/messages\/([^/]+)\/stream$/)?.[1] ?? null;
+}
+
 function renderQuestionTurn(
   content: string,
-  options: { eyebrowLabel?: string } = {},
+  options: { eyebrowLabel?: string; messageId?: string } = {},
 ): HtmlEscapedString {
-  return html`<article class="squire-turn squire-question">
+  const labelId = options.messageId ? `squire-question-label-${options.messageId}` : null;
+  return html`<article
+    class="squire-turn squire-question"
+    data-testid="question-turn"
+    ${options.messageId ? html`data-message-id="${options.messageId}"` : html``}
+    ${labelId ? html`aria-labelledby="${labelId}"` : html`aria-label="Your question"`}
+  >
+    <h2 class="sr-only" ${labelId ? html`id="${labelId}"` : html``}>Your question</h2>
     ${options.eyebrowLabel
       ? html`<span class="squire-question__eyebrow">${options.eyebrowLabel}</span>`
       : html``}
@@ -233,7 +244,7 @@ function renderQuestionTurn(
 }
 
 function renderAnswerContent(content: HtmlEscapedString): HtmlEscapedString {
-  return html`<div class="squire-answer__content squire-markdown">
+  return html`<div class="squire-answer__content squire-markdown" data-testid="answer-content">
     ${content}
   </div>` as HtmlEscapedString;
 }
@@ -270,6 +281,7 @@ function renderMarkdownSpecimenCard(options: {
 // populate on `done`. Collapsing to one constant locks the contract.
 const HIDDEN_CONSULTED_FOOTER = html`<footer
   class="squire-toolcall"
+  data-testid="consulted-footer"
   aria-live="off"
   hidden
 ></footer>` as HtmlEscapedString;
@@ -285,7 +297,7 @@ function renderConsultedFooter(message: ConversationMessage): HtmlEscapedString 
   if (labels.length === 0) {
     return HIDDEN_CONSULTED_FOOTER;
   }
-  return html`<footer class="squire-toolcall" aria-live="off">
+  return html`<footer class="squire-toolcall" data-testid="consulted-footer" aria-live="off">
     ${formatConsultedFooter(labels)}
   </footer>` as HtmlEscapedString;
 }
@@ -294,9 +306,17 @@ function renderAnswerTurn(message: ConversationMessage): HtmlEscapedString {
   const content = message.isError
     ? (html`<p>${message.content}</p>` as HtmlEscapedString)
     : renderAssistantContent(message.content);
+  const labelId = `squire-answer-label-${message.id}`;
   return html`<article
     class="squire-turn squire-answer${message.isError ? ' squire-answer--error' : ''}"
+    data-testid="answer-turn"
+    data-message-id="${message.id}"
+    ${message.responseToMessageId
+      ? html`data-response-to-message-id="${message.responseToMessageId}"`
+      : html``}
+    aria-labelledby="${labelId}"
   >
+    <h2 class="sr-only" id="${labelId}">Squire answer</h2>
     ${renderAnswerContent(content)} ${renderConsultedFooter(message)}
   </article>` as HtmlEscapedString;
 }
@@ -307,14 +327,22 @@ function renderPendingAnswerSkeleton(streamUrl: string): HtmlEscapedString {
   // `<article class="squire-answer--pending">` itself, so squire.js can find
   // the active stream regardless of whether the article was rendered as part
   // of a full transcript or appended via `hx-swap="beforeend"`.
+  const userMessageId = messageIdFromStreamUrl(streamUrl);
+  const labelId = userMessageId
+    ? `squire-pending-answer-label-${userMessageId}`
+    : 'squire-pending-answer-label';
   return html`<article
     class="squire-turn squire-answer squire-answer--pending"
+    data-testid="answer-turn"
+    ${userMessageId ? html`data-response-to-message-id="${userMessageId}"` : html``}
     data-stream-state="pending"
     data-stream-url="${streamUrl}"
+    aria-labelledby="${labelId}"
   >
-    <div class="squire-answer__tools" aria-live="off"></div>
-    <div class="squire-answer__artifacts" aria-live="polite"></div>
-    <div class="squire-answer__content squire-markdown"></div>
+    <h2 class="sr-only" id="${labelId}">Squire answer</h2>
+    <div class="squire-answer__tools" data-testid="answer-progress" aria-live="off"></div>
+    <div class="squire-answer__artifacts" data-testid="answer-artifacts" aria-live="polite"></div>
+    <div class="squire-answer__content squire-markdown" data-testid="answer-content"></div>
     <div class="squire-answer__skeleton" aria-hidden="true">
       <div class="squire-answer__skeleton-dropcap"></div>
       <div class="squire-answer__skeleton-line squire-answer__skeleton-line--full"></div>
@@ -796,6 +824,7 @@ export function renderConversationTranscript(options: {
 
   return html`<section
     class="squire-transcript"
+    data-testid="conversation-transcript"
     role="log"
     aria-live="polite"
     aria-label="Conversation transcript"
@@ -808,7 +837,9 @@ export function renderConversationTranscript(options: {
       // SSE; (3) orphan question with no assistant row and no stream URL —
       // shows the question alone (defensive: no expected production path
       // produces this, but a crashed/aborted stream could leave one behind).
-      return html`${renderQuestionTurn(pair.userMessage.content)}
+      return html`${renderQuestionTurn(pair.userMessage.content, {
+        messageId: pair.userMessage.id,
+      })}
       ${pair.assistantMessage
         ? renderAnswerTurn(pair.assistantMessage)
         : streamUrl
@@ -828,6 +859,8 @@ export function renderConversationTurnAppendFragment(options: {
   question: string;
   streamUrl: string;
 }): HtmlEscapedString {
-  return html`${renderQuestionTurn(options.question)}
+  return html`${renderQuestionTurn(options.question, {
+    messageId: messageIdFromStreamUrl(options.streamUrl) ?? undefined,
+  })}
   ${renderPendingAnswerSkeleton(options.streamUrl)}` as HtmlEscapedString;
 }

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -151,6 +151,18 @@ html {
   border: 0;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 .sr-only-focusable:focus,
 .sr-only-focusable:focus-visible {
   position: fixed;

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -54,7 +54,7 @@ import { createCsrfToken } from '../src/auth/csrf.ts';
 import { SESSION_COOKIE_NAME, getSessionSecret } from '../src/auth/session-middleware.ts';
 import * as SessionRepository from '../src/db/repositories/session-repository.ts';
 import { SESSION_LIFETIME_MS } from '../src/db/repositories/session-repository.ts';
-import { loadConversation } from '../src/chat/conversation-service.ts';
+import { GENERIC_FAILURE_MESSAGE, loadConversation } from '../src/chat/conversation-service.ts';
 import { users } from '../src/db/schema/core.ts';
 import { conversations, messages } from '../src/db/schema/conversations.ts';
 
@@ -194,7 +194,10 @@ async function seedConversationWithTurns(
   };
 }
 
-function parseSse(text: string): Array<{ event: string; data: unknown }> {
+function parseSse(
+  text: string,
+  options: { includeIds?: boolean } = {},
+): Array<{ id?: string | null; event: string; data: unknown }> {
   // Keep these assertions aligned with docs/SSE_CONTRACT.md, which defines the
   // browser-visible event model rather than the service's internal emit API.
   return text
@@ -203,8 +206,10 @@ function parseSse(text: string): Array<{ event: string; data: unknown }> {
     .filter(Boolean)
     .map((chunk) => {
       const event = chunk.match(/^event:\s*(.+)$/m)?.[1] ?? 'message';
+      const id = chunk.match(/^id:\s*(.+)$/m)?.[1] ?? null;
       const rawData = chunk.match(/^data:\s*(.+)$/m)?.[1] ?? '{}';
       return {
+        ...(options.includeIds ? { id } : {}),
         event,
         data: JSON.parse(rawData),
       };
@@ -958,7 +963,7 @@ describe('conversation web backend', () => {
     expect(streamUrl).toBeTruthy();
 
     const streamRes = await requestWithAuth(auth, `http://localhost:3000${streamUrl}`);
-    const events = parseSse(await streamRes.text());
+    const events = parseSse(await streamRes.text(), { includeIds: true });
     const doneEvent = events.at(-1);
     expect(doneEvent?.event).toBe('done');
     const doneData = doneEvent?.data as Record<string, unknown>;
@@ -1555,21 +1560,25 @@ describe('conversation web backend', () => {
     const streamRes = await requestWithAuth(auth, `http://localhost:3000${streamUrl}`);
     expect(streamRes.status).toBe(200);
     expect(streamRes.headers.get('content-security-policy')).toBeNull();
-    const events = parseSse(await streamRes.text());
+    const events = parseSse(await streamRes.text(), { includeIds: true });
     expect(events).toEqual([
       {
+        id: expect.any(String),
         event: 'tool-start',
         data: { id: 'rulebook', label: 'RULEBOOK' },
       },
       {
+        id: expect.any(String),
         event: 'text-delta',
         data: { delta: 'Loot tokens in your hex are picked up with **style**.' },
       },
       {
+        id: expect.any(String),
         event: 'tool-result',
         data: { id: 'rulebook', labels: ['RULEBOOK'], ok: true },
       },
       {
+        id: expect.any(String),
         event: 'done',
         data: expect.objectContaining({
           html: '<p>Loot tokens in your hex are picked up with <strong>style</strong>.</p>\n',
@@ -1589,6 +1598,261 @@ describe('conversation web backend', () => {
         role: 'assistant',
         content: 'Loot tokens in your hex are picked up with **style**.',
         isError: false,
+      },
+    ]);
+  });
+
+  it('replays stored stream events after Last-Event-ID without re-running the agent', async () => {
+    mockAsk.mockImplementationOnce(async (_question, options) => {
+      await options?.emit?.('tool_call', { name: 'search_rules' });
+      await options?.emit?.('text', { delta: 'First half. ' });
+      await options?.emit?.('text', { delta: 'Second half.' });
+      await options?.emit?.('tool_result', { name: 'search_rules', ok: true });
+      await options?.emit?.('done', {});
+      return 'First half. Second half.';
+    });
+
+    const auth = await createAuthContext();
+
+    const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'hx-request': 'true',
+      },
+      body: formBody({
+        question: 'Replay this stream',
+        idempotencyKey: 'idem-stream-replay',
+      }),
+    });
+
+    const body = await createRes.text();
+    const streamUrl = body.match(/data-stream-url="([^"]+)"/)?.[1];
+    expect(streamUrl).toBeTruthy();
+
+    const firstStreamRes = await requestWithAuth(auth, `http://localhost:3000${streamUrl}`);
+    const firstEvents = parseSse(await firstStreamRes.text(), { includeIds: true });
+    expect(firstEvents.map((event) => event.event)).toEqual([
+      'tool-start',
+      'text-delta',
+      'text-delta',
+      'tool-result',
+      'done',
+    ]);
+    expect(firstEvents.map((event) => event.id)).toEqual(['1', '2', '3', '4', '5']);
+
+    mockAsk.mockClear();
+    const replayRes = await requestWithAuth(auth, `http://localhost:3000${streamUrl}`, {
+      headers: {
+        'Last-Event-ID': '2',
+      },
+    });
+    const replayEvents = parseSse(await replayRes.text(), { includeIds: true });
+
+    expect(mockAsk).not.toHaveBeenCalled();
+    expect(replayEvents.map((event) => event.id)).toEqual(['3', '4', '5']);
+    expect(replayEvents.map((event) => event.event)).toEqual(['text-delta', 'tool-result', 'done']);
+  });
+
+  it('waits for an active stream and replays the terminal event on reconnect', async () => {
+    let finishAnswer!: () => void;
+    const answerGate = new Promise<void>((resolve) => {
+      finishAnswer = resolve;
+    });
+    mockAsk.mockImplementationOnce(async (_question, options) => {
+      await options?.emit?.('text', { delta: 'Partial live answer.' });
+      await answerGate;
+      await options?.emit?.('done', {});
+      return 'Partial live answer.';
+    });
+
+    const auth = await createAuthContext();
+
+    const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'hx-request': 'true',
+      },
+      body: formBody({
+        question: 'Reconnect while running',
+        idempotencyKey: 'idem-stream-active-reconnect',
+      }),
+    });
+
+    const body = await createRes.text();
+    const streamUrl = body.match(/data-stream-url="([^"]+)"/)?.[1];
+    expect(streamUrl).toBeTruthy();
+
+    const firstStreamPromise = requestWithAuth(auth, `http://localhost:3000${streamUrl}`);
+    const userMessageId = streamUrl!.split('/').at(-2)!;
+    await vi.waitFor(async () => {
+      const rows = await getDb('server').db.execute(sql`
+        select sequence, event
+        from message_stream_events
+        where user_message_id = ${userMessageId}
+      `);
+      expect(rows.rows).toEqual([{ sequence: 1, event: 'text-delta' }]);
+    });
+
+    const replayPromise = requestWithAuth(auth, `http://localhost:3000${streamUrl}`, {
+      headers: {
+        'Last-Event-ID': '1',
+      },
+    });
+    await vi.waitFor(() => {
+      expect(mockAsk).toHaveBeenCalledTimes(1);
+    });
+
+    finishAnswer();
+
+    const firstEvents = parseSse(await (await firstStreamPromise).text(), { includeIds: true });
+    expect(firstEvents.map((event) => event.id)).toEqual(['1', '2']);
+    expect(firstEvents.map((event) => event.event)).toEqual(['text-delta', 'done']);
+
+    const replayEvents = parseSse(await (await replayPromise).text(), { includeIds: true });
+    expect(mockAsk).toHaveBeenCalledTimes(1);
+    expect(replayEvents).toEqual([
+      {
+        id: '2',
+        event: 'done',
+        data: expect.objectContaining({
+          html: '<p>Partial live answer.</p>\n',
+        }),
+      },
+    ]);
+  });
+
+  it('replays a stored terminal error after reconnect without re-running the agent', async () => {
+    mockAsk.mockImplementationOnce(async (_question, options) => {
+      await options?.emit?.('text', { delta: 'Partial answer.' });
+      throw new Error('network connection lost');
+    });
+
+    const auth = await createAuthContext();
+
+    const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'hx-request': 'true',
+      },
+      body: formBody({
+        question: 'Replay failed stream',
+        idempotencyKey: 'idem-stream-error-replay',
+      }),
+    });
+
+    const body = await createRes.text();
+    const streamUrl = body.match(/data-stream-url="([^"]+)"/)?.[1];
+    expect(streamUrl).toBeTruthy();
+
+    const firstStreamRes = await requestWithAuth(auth, `http://localhost:3000${streamUrl}`);
+    const firstEvents = parseSse(await firstStreamRes.text(), { includeIds: true });
+    expect(firstEvents.map((event) => event.event)).toEqual(['text-delta', 'error']);
+    expect(firstEvents.map((event) => event.id)).toEqual(['1', '2']);
+
+    mockAsk.mockClear();
+    const replayRes = await requestWithAuth(auth, `http://localhost:3000${streamUrl}`, {
+      headers: {
+        'Last-Event-ID': '1',
+      },
+    });
+    const replayEvents = parseSse(await replayRes.text(), { includeIds: true });
+
+    expect(mockAsk).not.toHaveBeenCalled();
+    expect(replayEvents).toEqual([
+      {
+        id: '2',
+        event: 'error',
+        data: {
+          kind: 'transport',
+          message: 'Trouble connecting. Please try again.',
+          recoverable: true,
+        },
+      },
+    ]);
+  });
+
+  it('terminates a partially persisted stream after process restart without duplicating text', async () => {
+    const auth = await createAuthContext();
+    const { db } = getDb('server');
+
+    const [conversation] = await db
+      .insert(conversations)
+      .values({
+        userId: auth.userId,
+      })
+      .returning();
+    const [userMessage] = await db
+      .insert(messages)
+      .values({
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'Interrupted question',
+      })
+      .returning();
+    await db.execute(sql`
+      insert into message_stream_events (
+        conversation_id,
+        user_message_id,
+        sequence,
+        event,
+        payload
+      )
+      values (
+        ${conversation.id},
+        ${userMessage.id},
+        1,
+        'text-delta',
+        ${JSON.stringify({ delta: 'Already streamed.' })}::jsonb
+      )
+    `);
+
+    const streamRes = await requestWithAuth(
+      auth,
+      `http://localhost:3000/chat/${conversation.id}/messages/${userMessage.id}/stream`,
+      {
+        headers: {
+          'Last-Event-ID': '1',
+        },
+      },
+    );
+    const events = parseSse(await streamRes.text(), { includeIds: true });
+
+    expect(mockAsk).not.toHaveBeenCalled();
+    expect(events).toEqual([
+      {
+        id: '2',
+        event: 'error',
+        data: {
+          kind: 'transport',
+          message: 'Trouble connecting. Please try again.',
+          recoverable: true,
+        },
+      },
+    ]);
+
+    const storedMessages = await db.execute(sql`
+      select role, content, is_error as "isError", response_to_message_id as "responseToMessageId"
+      from messages
+      order by created_at asc, id asc
+    `);
+    expect(storedMessages.rows).toEqual([
+      {
+        role: 'user',
+        content: 'Interrupted question',
+        isError: false,
+        responseToMessageId: null,
+      },
+      {
+        role: 'assistant',
+        content: GENERIC_FAILURE_MESSAGE,
+        isError: true,
+        responseToMessageId: userMessage.id,
       },
     ]);
   });

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -544,14 +544,30 @@ describe('renderConversationTurnAppendFragment (SQR-108 / ADR 0012 E-3)', () => 
     // is meant to drop into an existing transcript via `beforeend`.
     expect(body).not.toMatch(/<section[^>]*class="squire-transcript/);
     expect(body).toMatch(/<article[^>]*class="squire-turn squire-question"/);
+    expect(body).toContain('data-testid="question-turn"');
+    expect(body).toContain('data-message-id="msg-456"');
+    expect(body).toContain('aria-labelledby="squire-question-label-msg-456"');
+    expect(body).toContain(
+      '<h2 class="sr-only" id="squire-question-label-msg-456">Your question</h2>',
+    );
     expect(body).toContain('Can I loot through a doorway?');
     expect(body).toMatch(
       /<article[^>]*class="squire-turn squire-answer squire-answer--pending"[^>]*data-stream-state="pending"[^>]*data-stream-url="\/chat\/conv-123\/messages\/msg-456\/stream"/,
     );
-    expect(body).toMatch(/<div[^>]*class="squire-answer__content squire-markdown"><\/div>/);
-    expect(body).toMatch(/<div[^>]*class="squire-answer__tools"[^>]*aria-live="off"><\/div>/);
+    expect(body).toContain('data-testid="answer-turn"');
+    expect(body).toContain('data-response-to-message-id="msg-456"');
+    expect(body).toContain('aria-labelledby="squire-pending-answer-label-msg-456"');
+    expect(body).toContain(
+      '<h2 class="sr-only" id="squire-pending-answer-label-msg-456">Squire answer</h2>',
+    );
     expect(body).toMatch(
-      /<div[^>]*class="squire-answer__artifacts"[^>]*aria-live="polite"><\/div>/,
+      /<div[^>]*class="squire-answer__content squire-markdown"[^>]*data-testid="answer-content"[^>]*><\/div>/,
+    );
+    expect(body).toMatch(
+      /<div[^>]*class="squire-answer__tools"[^>]*data-testid="answer-progress"[^>]*aria-live="off"><\/div>/,
+    );
+    expect(body).toMatch(
+      /<div[^>]*class="squire-answer__artifacts"[^>]*data-testid="answer-artifacts"[^>]*aria-live="polite"><\/div>/,
     );
     expect(body).toMatch(/class="squire-answer__skeleton"[^>]*aria-hidden="true"/);
     expect(body).toContain('squire-answer__skeleton-dropcap');
@@ -606,7 +622,31 @@ describe('renderConversationTranscript (SQR-108 / ADR 0012)', () => {
     expect(body).toMatch(
       /<section[^>]*class="squire-transcript"[^>]*role="log"[^>]*aria-live="polite"/,
     );
+    expect(body).toContain('data-testid="conversation-transcript"');
     expect(body).toContain('data-conversation-id="conv-123"');
+  });
+
+  it('renders stable headless-test hooks and named turn articles', () => {
+    const body = String(
+      actualLayout.renderConversationTranscript({
+        conversationId: 'conv-123',
+        messages: messages.slice(0, 2),
+      }),
+    );
+
+    expect(body).toContain('data-testid="conversation-transcript"');
+    expect(body).toMatch(
+      /<article[^>]*class="squire-turn squire-question"[^>]*data-testid="question-turn"[^>]*data-message-id="m1"[^>]*aria-labelledby="squire-question-label-m1"/,
+    );
+    expect(body).toContain('<h2 class="sr-only" id="squire-question-label-m1">Your question</h2>');
+    expect(body).toMatch(
+      /<article[^>]*class="squire-turn squire-answer"[^>]*data-testid="answer-turn"[^>]*data-message-id="m2"[^>]*data-response-to-message-id="m1"[^>]*aria-labelledby="squire-answer-label-m2"/,
+    );
+    expect(body).toContain('<h2 class="sr-only" id="squire-answer-label-m2">Squire answer</h2>');
+    expect(body).toMatch(
+      /<div[^>]*class="squire-answer__content squire-markdown"[^>]*data-testid="answer-content"/,
+    );
+    expect(body).toMatch(/<footer[^>]*data-testid="consulted-footer"/);
   });
 
   it('renders prior turns oldest-first then a pending skeleton for any user message in pendingStreamUrls', () => {
@@ -786,7 +826,9 @@ describe('conversation transcript rendering helpers', () => {
         }),
       );
 
-      const contentStart = body.indexOf('squire-answer__content squire-markdown">');
+      const contentStart = body.search(
+        /class="squire-answer__content squire-markdown"[^>]*data-testid="answer-content"/,
+      );
       expect(contentStart).not.toBe(-1);
       const contentSlice = body.slice(contentStart);
       expect(contentSlice).toContain(leadElement);


### PR DESCRIPTION
## Summary
- persist browser-visible chat stream events with turn-local SSE ids
- replay stored events from Last-Event-ID without re-running completed turns
- make transcript turns and answer parts visible to headless browser/accessibility tests
- document the replay contract, crash boundary, and production inspection query

## Validation
- npm run check
- browser QA on localhost:5148: unauth redirect, dev login, first-turn chat, follow-up chat, transcript reload, accessibility snapshot, no console errors
- DB spot-check confirmed persisted stream event sequences and terminal done events for live QA turns

Fixes SQR-238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-driven SSE replay on reconnect (resume from last event id) with per-turn persisted event sequencing and safer terminal/failure handling.

* **Documentation**
  * Updated architecture, SSE contract, ADR, and runbooks to describe durable stream persistence, replay rules, and reconnect diagnostics.

* **Improvements**
  * Accessibility and stable test hooks added to conversation transcript markup; styling for visually hidden screen-reader content.

* **Tests**
  * Expanded tests covering SSE replay, partial-stream termination, and related accessibility hooks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->