### PR TITLE
Fix GH2 eval retrieval grounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.1.13] - 2026-05-27
+
+### Changed
+
+- Improved Gloomhaven (2nd Edition) condition-rule retrieval so core definitions stay ahead of loose FAQ keyword hits while interaction questions still use normal relevance ordering.
+- Updated GH2 eval expectations for advantage and direct open-ref cross-game boundary prompts to match the checked-in rules and prompt wording.
+- Marked structured `ok: false` tool payloads as unsuccessful evidence in agent trajectories.
+
+### Fixed
+
+- Restored GH2 scenario/section seed data after canonical-ref cleanup tests so shuffled DB test runs keep GH2 records available.
+
 ## [0.1.12] - 2026-05-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improved Gloomhaven (2nd Edition) condition-rule retrieval so core definitions stay ahead of loose FAQ keyword hits while interaction questions still use normal relevance ordering.
 - Updated GH2 eval expectations for advantage and direct open-ref cross-game boundary prompts to match the checked-in rules and prompt wording.
 - Marked structured `ok: false` tool payloads as unsuccessful evidence in agent trajectories.
+- Updated agent prompts to search current FAQ/errata before opening section references for correction or outdated-reference questions.
 
 ### Fixed
 

--- a/eval/suites/cross-game-boundary.json
+++ b/eval/suites/cross-game-boundary.json
@@ -30,8 +30,8 @@
       "grading": "Must identify both game-qualified scenario records and state that they are not the same scenario. Answers that silently reuse one game's scenario 61 for the other game should fail."
     },
     "trajectory": {
-      "requiredTools": ["resolve_entity", "open_entity"],
-      "requiredToolKinds": ["resolution", "open"],
+      "requiredTools": ["open_entity"],
+      "requiredToolKinds": ["open"],
       "forbiddenTools": ["search_rules"],
       "requiredRefs": ["scenario:frosthaven/061", "scenario:gloomhaven-2e/061"],
       "maxToolCalls": 8,
@@ -52,8 +52,8 @@
       "grading": "Must distinguish the two game-qualified section refs and reject cross-game evidence reuse. Answers that cite only one game or blend both sections should fail."
     },
     "trajectory": {
-      "requiredTools": ["resolve_entity", "open_entity"],
-      "requiredToolKinds": ["resolution", "open"],
+      "requiredTools": ["open_entity"],
+      "requiredToolKinds": ["open"],
       "forbiddenTools": ["search_rules"],
       "requiredRefs": ["section:gloomhaven-2e/67.1", "section:frosthaven/67.1"],
       "maxToolCalls": 8,

--- a/eval/suites/gloomhaven-2e.json
+++ b/eval/suites/gloomhaven-2e.json
@@ -74,8 +74,8 @@
     "category": "rulebook",
     "question": "How does advantage work with attack modifier cards in Gloomhaven (2nd Edition)?",
     "finalAnswer": {
-      "expected": "With advantage, the attacker draws two modifier cards and uses the better one, with rolling and ambiguous cases resolved by the Gloomhaven 2e attack modifier rules.",
-      "grading": "Must mention drawing two modifiers and using the better result. Should not import the Frosthaven-specific character-choice wording."
+      "expected": "With advantage, the attacker draws two modifier cards and uses one of them. A monster uses the better one, while a character may use either one. Rolling and ambiguous cases are resolved by the Gloomhaven 2e attack modifier rules.",
+      "grading": "Must mention drawing two modifiers. Must mention that monsters use the better one and characters may use either one. Should include the rolling modifier rule or ambiguity handling."
     },
     "source": "gh2-rule-book.md",
     "game": "gloomhaven-2e",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.98.0",
         "@hono/node-server": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "engines": {

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -21,6 +21,7 @@ import {
   executeToolCall,
   hasUsefulNeighborsResult,
   hasUsefulResolutionResult,
+  isToolResultOk,
   isBroadRuleSearchTool,
   isNonRuleSearchTool,
   summarizeToolOutput,
@@ -546,12 +547,13 @@ async function runLangGraphAgentLoop(
 
         const toolEndedAtMs = Date.now();
         const { summary, canonicalRefs } = summarizeToolOutput(toolResult.content);
+        const toolOk = !isError && isToolResultOk(toolResult);
         nextToolCalls.push({
           iteration: state.iterations,
           id: block.id,
           name: block.name,
           input,
-          ok: !isError,
+          ok: toolOk,
           outputSummary: summary,
           sourceLabels: toolResult.sourceBooks ?? [],
           canonicalRefs,
@@ -571,7 +573,7 @@ async function runLangGraphAgentLoop(
         if (emit) {
           await emit('tool_result', {
             name: block.name,
-            ok: !isError,
+            ok: toolOk,
             sourceBooks: toolResult.sourceBooks,
           });
           const artifact = sectionArtifactFromToolResult(block.name, toolResult);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -80,6 +80,8 @@ Grounding rules:
 - If the available data does not answer the question, say what is missing instead of guessing.
 - For Gloomhaven (2nd Edition) current-rule questions, treat official FAQ and errata as current corrections and clarifications over printed rulebook text when relevant.
 - Cite FAQ or errata when you rely on it. Rulebook-only answers are allowed when no current-source clarification applies.
+- For Gloomhaven (2nd Edition) correction, errata, campaign sheet, "current section," or outdated-reference questions, search current FAQ/errata rule passages before opening a section ref. A missing section ref is not enough to answer a correction question.
+- For core rule or condition-definition questions, search rules passages directly. If FAQ/errata hits only discuss edge cases, keep searching for the rulebook definition before answering.
 - Resolve natural user language to refs when exact records are needed, then open or traverse those refs.
 - For scenario/section relationship questions, resolve the named scenario or section first, then open or traverse the canonical ref.
 - For named or numbered card-data records such as item 1, Spyglass, monsters, buildings, events, battle goals, personal quests, and character mats, resolve the record first and then open the exact canonical ref returned by resolve_entity.
@@ -111,6 +113,8 @@ Scope rules:
 
 Guidelines:
 - For Gloomhaven (2nd Edition) current-rule questions, treat official FAQ and errata as current corrections and clarifications over printed rulebook text when relevant.
+- For Gloomhaven (2nd Edition) correction, errata, campaign sheet, "current section," or outdated-reference questions, search current FAQ/errata rule passages before opening a section ref. A missing section ref is not enough to answer a correction question.
+- For core rule or condition-definition questions, search rules passages directly. If FAQ/errata hits only discuss edge cases, keep searching for the rulebook definition before answering.
 - Cite FAQ or errata when you rely on it. Rulebook-only answers are allowed when no current-source clarification applies.
 - Use inspect_sources and schema when you need to discover available kinds, filters, refs, or relations
 - Use resolve_entity to turn natural references into opener-ready scenario, section, card type, or card refs
@@ -811,6 +815,15 @@ export function hasUsefulResolutionResult(result: ToolCallResult): boolean {
   }
 }
 
+export function isToolResultOk(result: ToolCallResult): boolean {
+  try {
+    const parsed = JSON.parse(result.content) as { ok?: unknown };
+    return parsed.ok !== false;
+  } catch {
+    return true;
+  }
+}
+
 function sourceLabelsFromResult(value: unknown): string[] {
   const seen = new Set<string>();
   const labels: string[] = [];
@@ -1448,16 +1461,17 @@ async function runAgentLoopInternal(
                   { game: activeGame },
                 );
                 const { summary, canonicalRefs } = summarizeToolOutput(result.content);
+                const toolOk = isToolResultOk(result);
                 span.setAttributes({
                   ...createObservationAttributes('tool', {
                     output: {
-                      ok: true,
+                      ok: toolOk,
                       summary,
                       sourceLabels: result.sourceBooks ?? [],
                       canonicalRefs,
                     },
                   }),
-                  'squire.agent.tool.ok': true,
+                  'squire.agent.tool.ok': toolOk,
                   'squire.agent.tool.output_summary': summary,
                   'squire.agent.tool.source_labels': result.sourceBooks ?? [],
                   'squire.agent.tool.canonical_refs': canonicalRefs,
@@ -1491,12 +1505,13 @@ async function runAgentLoopInternal(
           }
           const toolEndedAtMs = Date.now();
           const { summary, canonicalRefs } = summarizeToolOutput(toolResult.content);
+          const toolOk = !isError && isToolResultOk(toolResult);
           toolCalls.push({
             iteration: i + 1,
             id: block.id,
             name: block.name,
             input: block.input as Record<string, unknown>,
-            ok: !isError,
+            ok: toolOk,
             outputSummary: summary,
             sourceLabels: toolResult.sourceBooks ?? [],
             canonicalRefs,
@@ -1519,7 +1534,7 @@ async function runAgentLoopInternal(
           if (emit) {
             await emit('tool_result', {
               name: block.name,
-              ok: !isError,
+              ok: toolOk,
               sourceBooks: toolResult.sourceBooks,
             });
           }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -427,6 +427,19 @@ export interface ToolCallResult {
   sourceBooks?: string[];
 }
 
+function toolFailureResult(code: string, message: string): ToolCallResult {
+  return {
+    content: JSON.stringify(
+      {
+        ok: false,
+        error: { code, message },
+      },
+      null,
+      2,
+    ),
+  };
+}
+
 export interface ToolExecutionContext {
   /** Active game from runtime context. Explicit tool input overrides this. */
   game?: string;
@@ -991,7 +1004,7 @@ export async function executeToolCall(
       const card = gameOpts
         ? await getCard(input.type as CardType, input.id as string, gameOpts)
         : await getCard(input.type as CardType, input.id as string);
-      if (!card) return { content: `Card not found: ${input.type}/${input.id}` };
+      if (!card) return toolFailureResult('not_found', `Card not found: ${input.type}/${input.id}`);
       return { content: JSON.stringify(card, null, 2) };
     }
     case 'find_scenario': {
@@ -1004,14 +1017,14 @@ export async function executeToolCall(
       const scenario = gameOpts
         ? await getScenario(input.ref as string, gameOpts)
         : await getScenario(input.ref as string);
-      if (!scenario) return { content: `Scenario not found: ${input.ref}` };
+      if (!scenario) return toolFailureResult('not_found', `Scenario not found: ${input.ref}`);
       return { content: JSON.stringify(scenario, null, 2) };
     }
     case 'get_section': {
       const section = gameOpts
         ? await getSection(input.ref as string, gameOpts)
         : await getSection(input.ref as string);
-      if (!section) return { content: `Section not found: ${input.ref}` };
+      if (!section) return toolFailureResult('not_found', `Section not found: ${input.ref}`);
       return { content: JSON.stringify(section, null, 2) };
     }
     case 'follow_links': {
@@ -1024,7 +1037,7 @@ export async function executeToolCall(
       return { content: JSON.stringify(links, null, 2) };
     }
     default:
-      return { content: `Unknown tool: ${name}` };
+      return toolFailureResult('unknown_tool', `Unknown tool: ${name}`);
   }
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -303,7 +303,25 @@ function normalizeToolOpts(opts?: ToolOpts): NormalizedToolOpts {
 }
 
 const CURRENT_RULE_SOURCE_SCORE_WINDOW = 0.08;
-const CURRENT_RULE_SOURCE_EXTRA_CANDIDATES = 4;
+const CURRENT_RULE_SOURCE_EXTRA_CANDIDATES = 12;
+const CONDITION_NAMES = [
+  'bane',
+  'bless',
+  'brittle',
+  'curse',
+  'disarm',
+  'immobilize',
+  'impair',
+  'invisible',
+  'muddle',
+  'poison',
+  'regenerate',
+  'strengthen',
+  'stun',
+  'ward',
+  'wound',
+] as const;
+type ConditionName = (typeof CONDITION_NAMES)[number];
 
 function currentRuleSourceCandidateLimit(requestedLimit: number, game: GameId): number {
   if (game !== GLOOMHAVEN_2E_GAME_ID) return requestedLimit;
@@ -321,11 +339,72 @@ function currentRuleSourceRank(sourceType: RuleSourceType): number {
   return 2;
 }
 
+function isConditionDefinitionText(
+  query: string,
+  text: string,
+  sourceType: RuleSourceType,
+): boolean {
+  if (sourceType !== 'rulebook') return false;
+  const queryText = query.toLowerCase();
+  const hitText = text.toLowerCase();
+  const conditions = CONDITION_NAMES.filter((name) => containsConditionWord(queryText, name));
+  if (conditions.length === 0 || !isConditionDefinitionQuery(queryText, conditions)) return false;
+
+  // Short glossary definitions are easy for vector search to bury below FAQ
+  // edge cases. Keep the actual rulebook definition visible when the query asks
+  // what a condition does.
+  return conditions.some((condition) => hitText.includes(`${condition}:`));
+}
+
+function isConditionDefinitionQuery(queryText: string, conditions: ConditionName[]): boolean {
+  if (
+    conditions.length > 1 &&
+    /\b(?:against|combine|during|interact|timing|versus|vs|while|with)\b/.test(queryText)
+  ) {
+    return false;
+  }
+
+  return conditions.some((condition) => {
+    const escaped = condition.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return (
+      new RegExp(`\\bwhat\\s+(?:does|is)\\s+(?:the\\s+)?${escaped}\\b`).test(queryText) ||
+      new RegExp(`\\bwhat\\s+does\\s+(?:the\\s+)?${escaped}\\s+condition\\s+do\\b`).test(
+        queryText,
+      ) ||
+      new RegExp(`\\bdefine\\s+(?:the\\s+)?${escaped}\\b`).test(queryText) ||
+      new RegExp(`\\b(?:definition|effect|rules?)\\s+(?:for|of)\\s+(?:the\\s+)?${escaped}\\b`).test(
+        queryText,
+      ) ||
+      new RegExp(`\\b${escaped}\\s+(?:condition\\s+)?(?:definition|effect|rules?)\\b`).test(
+        queryText,
+      ) ||
+      new RegExp(`\\b${escaped}\\s+condition\\s+(?:mean|do)\\b`).test(queryText)
+    );
+  });
+}
+
+function containsConditionWord(text: string, condition: ConditionName): boolean {
+  const escaped = condition.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`\\b${escaped}\\b`).test(text);
+}
+
+function isConditionDefinitionHit(
+  query: string,
+  hit: ScoredEntry,
+  sourceType: RuleSourceType,
+): boolean {
+  return isConditionDefinitionText(query, hit.text, sourceType);
+}
+
 function isGh2RuleCitation(citation: KnowledgeCitation | undefined): citation is KnowledgeCitation {
   return citation?.sourceRef.startsWith(`source:${GLOOMHAVEN_2E_GAME_ID}/`) ?? false;
 }
 
-function rankRuleHitsForCurrentSources(hits: ScoredEntry[], game: GameId): ScoredEntry[] {
+function rankRuleHitsForCurrentSources(
+  hits: ScoredEntry[],
+  game: GameId,
+  query = '',
+): ScoredEntry[] {
   return hits
     .map((hit, index) => ({
       hit,
@@ -333,6 +412,10 @@ function rankRuleHitsForCurrentSources(hits: ScoredEntry[], game: GameId): Score
       provenance: ruleSourceProvenance(hit.source, normalizeToolGame(hit.game ?? game)),
     }))
     .sort((a, b) => {
+      const aDefinition = isConditionDefinitionHit(query, a.hit, a.provenance.sourceType);
+      const bDefinition = isConditionDefinitionHit(query, b.hit, b.provenance.sourceType);
+      if (aDefinition !== bDefinition) return aDefinition ? -1 : 1;
+
       const scoreDelta = b.hit.score - a.hit.score;
       const aCurrent = a.provenance.game === GLOOMHAVEN_2E_GAME_ID;
       const bCurrent = b.provenance.game === GLOOMHAVEN_2E_GAME_ID;
@@ -351,10 +434,24 @@ function rankRuleHitsForCurrentSources(hits: ScoredEntry[], game: GameId): Score
     .map(({ hit }) => hit);
 }
 
-function compareKnowledgeHits(a: KnowledgeSearchHit, b: KnowledgeSearchHit): number {
+function compareKnowledgeHits(a: KnowledgeSearchHit, b: KnowledgeSearchHit, query = ''): number {
   const scoreDelta = b.score - a.score;
   const aCitation = a.citations[0];
   const bCitation = b.citations[0];
+
+  if (
+    a.entity.kind === 'rules_passage' &&
+    b.entity.kind === 'rules_passage' &&
+    isGh2RuleCitation(aCitation) &&
+    isGh2RuleCitation(bCitation) &&
+    aCitation.sourceType &&
+    bCitation.sourceType &&
+    query
+  ) {
+    const aDefinition = isConditionDefinitionText(query, a.snippet, aCitation.sourceType);
+    const bDefinition = isConditionDefinitionText(query, b.snippet, bCitation.sourceType);
+    if (aDefinition !== bDefinition) return aDefinition ? -1 : 1;
+  }
 
   if (
     a.entity.kind === 'rules_passage' &&
@@ -928,7 +1025,7 @@ export async function searchRules(query: string, topK = 6, opts?: ToolOpts): Pro
   const candidateLimit = currentRuleSourceCandidateLimit(topK, game);
   const hits: ScoredEntry[] = await search(queryEmbedding, candidateLimit, { game });
 
-  return rankRuleHitsForCurrentSources(hits, game)
+  return rankRuleHitsForCurrentSources(hits, game, query)
     .slice(0, topK)
     .map((h) => ({
       text: h.text,
@@ -1410,7 +1507,7 @@ export async function searchKnowledge(
     const candidateLimit = currentRuleSourceCandidateLimit(perScope, game);
     const rules = await search(queryEmbedding, candidateLimit, { game });
     hits.push(
-      ...rankRuleHitsForCurrentSources(rules, game)
+      ...rankRuleHitsForCurrentSources(rules, game, query)
         .slice(0, perScope)
         .map((rule) => {
           const entity = summarizeRule(rule, game);
@@ -1489,7 +1586,7 @@ export async function searchKnowledge(
     );
   }
 
-  hits.sort(compareKnowledgeHits);
+  hits.sort((a, b) => compareKnowledgeHits(a, b, query));
   return {
     ok: true,
     query,

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -114,6 +114,7 @@ import {
   runAgentLoopWithEvalConfig,
   runAgentLoopWithTrajectory,
   executeToolCall,
+  isToolResultOk,
   AGENT_TOOLS,
   LEGACY_AGENT_TOOLS,
   AGENT_SYSTEM_PROMPT,
@@ -1474,6 +1475,24 @@ describe('executeToolCall', () => {
   it('returns error for unknown tool', async () => {
     const result = await executeToolCall('unknown_tool', {});
     expect(result.content).toContain('Unknown tool');
+  });
+});
+
+describe('isToolResultOk', () => {
+  it('treats structured not_found tool payloads as unsuccessful evidence', () => {
+    expect(
+      isToolResultOk({
+        content: JSON.stringify({
+          ok: false,
+          error: { code: 'not_found', message: 'Section not found' },
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('treats successful structured payloads and plain text as usable tool results', () => {
+    expect(isToolResultOk({ content: JSON.stringify({ ok: true, results: [] }) })).toBe(true);
+    expect(isToolResultOk({ content: 'plain legacy tool output' })).toBe(true);
   });
 });
 

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -1391,7 +1391,13 @@ describe('executeToolCall', () => {
   it('returns not found for missing card', async () => {
     mockGetCard.mockReturnValue(null);
     const result = await executeToolCall('get_card', { type: 'items', id: 'missing' });
-    expect(result.content).toContain('Card not found');
+    expect(JSON.parse(result.content)).toEqual({
+      ok: false,
+      error: {
+        code: 'not_found',
+        message: 'Card not found: items/missing',
+      },
+    });
   });
 
   it('dispatches find_scenario', async () => {
@@ -1474,7 +1480,13 @@ describe('executeToolCall', () => {
 
   it('returns error for unknown tool', async () => {
     const result = await executeToolCall('unknown_tool', {});
-    expect(result.content).toContain('Unknown tool');
+    expect(JSON.parse(result.content)).toEqual({
+      ok: false,
+      error: {
+        code: 'unknown_tool',
+        message: 'Unknown tool: unknown_tool',
+      },
+    });
   });
 });
 
@@ -1595,6 +1607,34 @@ describe('runAgentLoop with emit (streaming)', () => {
       sourceBooks: ['Rulebook'],
     });
     expect(emit).toHaveBeenCalledWith('done', {});
+  });
+
+  it('emits and records structured ok:false tool payloads as unsuccessful', async () => {
+    mockGetCard.mockReturnValueOnce(null);
+    const toolMsg = toolUseResponse('get_card', {
+      type: 'items',
+      id: 'missing',
+    });
+    const finalMsg = textResponse('I could not find that card.');
+    mockMessagesStream
+      .mockReturnValueOnce(mockStream(toolMsg))
+      .mockReturnValueOnce(mockStream(finalMsg, ['I could not find that card.']));
+    const emit = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runAgentLoopWithTrajectory('test', { emit, toolSurface: 'legacy' });
+
+    expect(result.trajectory.toolCalls[0]).toMatchObject({
+      name: 'get_card',
+      ok: false,
+      outputSummary: 'json object (ok, error)',
+    });
+    expect(emit).toHaveBeenCalledWith(
+      'tool_result',
+      expect.objectContaining({
+        name: 'get_card',
+        ok: false,
+      }),
+    );
   });
 
   it('does not treat streamed scratch text before tool use as the final answer', async () => {

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -160,6 +160,28 @@ describe('eval dataset', () => {
     expect(evalCase?.trajectory?.requiredRefs).toContain('section:gloomhaven-2e/67.1');
   });
 
+  it('does not require resolution for cross-game cases that explicitly ask to open refs', () => {
+    const scenarioCase = cases.find(
+      (candidate) => candidate.id === 'boundary-scenario-61-fh-then-gh2',
+    );
+    const sectionCase = cases.find(
+      (candidate) => candidate.id === 'boundary-section-67-gh2-then-fh',
+    );
+
+    for (const evalCase of [scenarioCase, sectionCase]) {
+      expect(evalCase?.question).toMatch(/\bOpen\b/);
+      expect(evalCase?.trajectory?.requiredTools).toEqual(['open_entity']);
+      expect(evalCase?.trajectory?.requiredToolKinds).toEqual(['open']);
+    }
+  });
+
+  it('keeps the GH2 advantage expectation aligned with the checked-in rulebook wording', () => {
+    const evalCase = cases.find((candidate) => candidate.id === 'gh2-rule-advantage');
+
+    expect(evalCase?.finalAnswer?.expected).toMatch(/character may use either/i);
+    expect(evalCase?.finalAnswer?.grading).not.toMatch(/Frosthaven-specific character-choice/);
+  });
+
   it('treats read-now chain traversal as a neighbors requirement', () => {
     const evalCase = cases.find((candidate) => candidate.id === 'traj-section-read-now-chain');
 

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -57,6 +57,7 @@ import { findScenarios } from '../src/scenario-section-data.ts';
 import { getDb } from '../src/db.ts';
 import { scenarioBookScenarios } from '../src/db/schema/scenario-section-books.ts';
 import { GLOOMHAVEN_2E_GAME_ID } from '../src/game.ts';
+import { seedAvailableScenarioSectionBookGames } from '../src/seed/seed-scenario-section-books.ts';
 
 import { setupTestDb, teardownTestDb } from './helpers/db.ts';
 
@@ -581,6 +582,7 @@ describe('GH2 canonical entity refs', () => {
       DELETE FROM scenario_book_scenarios
       WHERE game = ${GLOOMHAVEN_2E_GAME_ID} AND ref = ${GH2_CANONICAL_SCENARIO_REF}
     `);
+    await seedAvailableScenarioSectionBookGames(db);
   });
 
   it('normalizes alias-qualified GH2 scenario refs to the canonical game id', async () => {
@@ -786,6 +788,170 @@ describe('searchKnowledge', () => {
       'faq',
       'rulebook',
     ]);
+  });
+
+  it.each([
+    {
+      condition: 'Poison',
+      definition:
+        'Poison: All attacks targeting the figure gain +1 Attack. Poison is removed when the figure is healed.',
+    },
+    {
+      condition: 'Wound',
+      definition:
+        'Wound: The figure suffers 1 damage at the start of each of their turns. Wound is removed when the figure is healed.',
+    },
+  ])(
+    'keeps GH2 rulebook $condition condition definitions ahead of loose FAQ keyword hits',
+    async ({ condition, definition }) => {
+      mockSearch.mockResolvedValueOnce([
+        {
+          id: 'gh2-faq.html::70',
+          text: `FAQ edge case about ${condition} timing and targeting order.`,
+          source: 'gh2-faq.html',
+          chunkIndex: 70,
+          game: GLOOMHAVEN_2E_GAME_ID,
+          score: 0.55,
+        },
+        {
+          id: 'gh2-faq.html::14',
+          text: `Personal Quest text mentioning ${condition} without defining it.`,
+          source: 'gh2-faq.html',
+          chunkIndex: 14,
+          game: GLOOMHAVEN_2E_GAME_ID,
+          score: 0.49,
+        },
+        {
+          id: 'gh2-rule-book.md::55',
+          text: definition,
+          source: 'gh2-rule-book.md',
+          chunkIndex: 55,
+          game: GLOOMHAVEN_2E_GAME_ID,
+          score: 0.38,
+        },
+      ]);
+
+      const result = await searchKnowledge(`What does the ${condition} condition do?`, {
+        scope: ['rules_passage'],
+        limit: 3,
+        game: 'gh2',
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error(result.error.message);
+      expect(result.results[0]).toMatchObject({
+        entity: expect.objectContaining({
+          ref: 'rules:gloomhaven-2e/gh2-rule-book.md#chunk=55',
+        }),
+        snippet: expect.stringContaining(`${condition}:`),
+      });
+    },
+  );
+
+  it('promotes condition definitions for generated condition-rules searches', async () => {
+    mockSearch.mockResolvedValueOnce([
+      {
+        id: 'gh2-faq.html::70',
+        text: 'FAQ edge case about Poison timing and targeting order.',
+        source: 'gh2-faq.html',
+        chunkIndex: 70,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.55,
+      },
+      {
+        id: 'gh2-rule-book.md::55',
+        text: 'Poison: All attacks targeting the figure gain +1 Attack. Poison is removed when the figure is healed.',
+        source: 'gh2-rule-book.md',
+        chunkIndex: 55,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.38,
+      },
+    ]);
+
+    const result = await searchKnowledge('Gloomhaven 2e Poison condition rules official', {
+      scope: ['rules_passage'],
+      limit: 2,
+      game: 'gh2',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.results[0]).toMatchObject({
+      entity: expect.objectContaining({
+        ref: 'rules:gloomhaven-2e/gh2-rule-book.md#chunk=55',
+      }),
+      snippet: expect.stringContaining('Poison:'),
+    });
+  });
+
+  it('does not promote condition definitions for interaction questions', async () => {
+    mockSearch.mockResolvedValueOnce([
+      {
+        id: 'gh2-faq.html::70',
+        text: 'FAQ edge case about Poison and Ward timing during an attack.',
+        source: 'gh2-faq.html',
+        chunkIndex: 70,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.55,
+      },
+      {
+        id: 'gh2-rule-book.md::55',
+        text: 'Poison: All attacks targeting the figure gain +1 Attack. Poison is removed when the figure is healed.',
+        source: 'gh2-rule-book.md',
+        chunkIndex: 55,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.38,
+      },
+    ]);
+
+    const result = await searchKnowledge('How does Poison interact with Ward?', {
+      scope: ['rules_passage'],
+      limit: 2,
+      game: 'gh2',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.results[0]).toMatchObject({
+      entity: expect.objectContaining({
+        ref: 'rules:gloomhaven-2e/gh2-faq.html#chunk=70',
+      }),
+    });
+  });
+
+  it('does not treat condition names as substrings inside unrelated words', async () => {
+    mockSearch.mockResolvedValueOnce([
+      {
+        id: 'gh2-faq.html::70',
+        text: 'FAQ edge case about campaign reward timing.',
+        source: 'gh2-faq.html',
+        chunkIndex: 70,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.55,
+      },
+      {
+        id: 'gh2-rule-book.md::55',
+        text: 'Ward: The next attack targeting the figure gains disadvantage.',
+        source: 'gh2-rule-book.md',
+        chunkIndex: 55,
+        game: GLOOMHAVEN_2E_GAME_ID,
+        score: 0.38,
+      },
+    ]);
+
+    const result = await searchKnowledge('How do campaign rewards work?', {
+      scope: ['rules_passage'],
+      limit: 2,
+      game: 'gh2',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.results[0]).toMatchObject({
+      entity: expect.objectContaining({
+        ref: 'rules:gloomhaven-2e/gh2-faq.html#chunk=70',
+      }),
+    });
   });
 
   it('returns an empty successful result set for no-result searches', async () => {


### PR DESCRIPTION
## Summary
- keep Gloomhaven (2nd Edition) condition definition retrieval grounded on rulebook definitions without overriding interaction-query relevance
- treat structured `ok: false` tool payloads as unsuccessful evidence in agent trajectories
- align GH2 eval expectations for advantage and direct open-ref cross-game prompts with checked-in data and prompt wording
- bump package version to 0.1.13 and update CHANGELOG

## Validation
- `npx vitest run test/tools.test.ts test/agent.test.ts test/eval-dataset.test.ts`
- `npm run check`
- live eval `gh2-rule-poison` pass after word-boundary cleanup
- live eval `gh2-rule-wound` pass
- live eval `gh2-traj-rule-poison-citation` pass
- earlier full GH2 table rerun reached 16/17, with the only miss from an Anthropic 529 provider overload; rerun of that case passed
- cross-game boundary suite rerun passed 3/3

## Overfit check
The condition-ranking change is query-shape based, not case-ID based: definition/rules/effect questions can surface exact rulebook glossary entries above loose FAQ keyword hits, while interaction questions like Poison with Ward keep normal relevance ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a CHANGELOG entry for v0.1.13.

* **Bug Fixes**
  * Restored Gloomhaven 2nd Edition scenario/section data in tests.

* **Improvements**
  * Prioritized core condition definitions over FAQ keyword hits for GH2 search results.
  * Agent now checks current FAQ/errata before opening section references.
  * Treats structured tool payloads with explicit failure flags as unsuccessful in logs.
  * Clarified advantage-rule wording and simplified open-only handling for certain cross-game open requests.

* **Tests**
  * Updated/added tests to lock these behaviors and expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->