### PR TITLE
Group LangSmith traces by conversation thread

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -687,12 +687,12 @@ Squire emits OpenTelemetry traces from the agent loop, tool calls, and HTTP hand
 
 Runtime agent traces carry safe correlation metadata so an operator can follow
 one user-visible answer without reading PII from stdout logs. Web-chat traces
-include request ID, conversation ID, user-message ID, user ID, `SQUIRE_ENV`,
-provider/model, tool surface, stop reason, token usage, and compact tool
-summaries. REST `/api/ask` traces include request ID and any caller-provided
-user/campaign IDs. The browser response includes `X-Request-ID`; the web chat
-URL and stream URL expose the conversation and user-message IDs needed to find
-the persisted turn.
+include request ID, conversation ID, LangSmith `thread_id` equal to the
+conversation ID, user-message ID, user ID, `SQUIRE_ENV`, provider/model, tool
+surface, stop reason, token usage, and compact tool summaries. REST `/api/ask`
+traces include request ID and any caller-provided user/campaign IDs. The
+browser response includes `X-Request-ID`; the web chat URL and stream URL expose
+the conversation and user-message IDs needed to find the persisted turn.
 
 **APM and RUM: open.** General application metrics (request latency, error rates, DB query performance) and real-user monitoring on the web channel are not yet wired up. **Datadog** is a candidate one-stop shop for both, but a previous evaluation found that Datadog's LLM observability API has limitations that make LangSmith a better fit for evals — so even if Datadog is adopted for APM / RUM, LangSmith stays for LLM-specific observability. See [Open Tech Questions](#open-tech-questions).
 

--- a/docs/SSE_CONTRACT.md
+++ b/docs/SSE_CONTRACT.md
@@ -20,9 +20,10 @@ Every browser-visible event written after `ask()` starts carries an SSE `id`
 field. The id is the turn-local persisted event sequence (`1`, `2`, `3`, ...),
 scoped to `(conversationId, userMessageId)`. The browser may reconnect with
 `Last-Event-ID`; the server replays only stored events with a larger sequence.
-The `userMessageId` is also the LangGraph `thread_id` for the run, so SSE
-replay and graph execution are keyed to the same turn. The SSE event log is not
-a durable LangGraph node checkpoint.
+The `userMessageId` is also the LangGraph checkpoint `thread_id` for the run, so
+SSE replay and graph execution are keyed to the same turn. LangSmith uses
+`metadata.thread_id = conversationId` to group all turns in the conversation.
+The SSE event log is not a durable LangGraph node checkpoint.
 
 - `text-delta`
   - Appends assistant answer text.

--- a/docs/runbooks/production-operations.md
+++ b/docs/runbooks/production-operations.md
@@ -291,8 +291,9 @@ Check LangSmith after the question:
 - Confirm `metadata.requestId` is present for the HTTP request that generated
   the answer.
 - Confirm web-chat traces include `metadata.conversationId`,
-  `metadata.userMessageId`, and `metadata.userId`; REST `/api/ask` traces may
-  also include `metadata.campaignId` when the caller provides it.
+  `metadata.thread_id` matching that conversation ID, `metadata.userMessageId`,
+  and `metadata.userId`; REST `/api/ask` traces may also include
+  `metadata.campaignId` when the caller provides it.
 - Confirm agent-run tags identify runtime, provider, model, tool surface, and
   production traffic.
 - Confirm child generation and tool observations show model/provider usage,
@@ -314,8 +315,8 @@ chat behavior.
    log value instead.
 3. In the root trace, inspect:
    - input question and final answer or error output
-   - `metadata.userId`, `metadata.conversationId`, `metadata.userMessageId`,
-     `metadata.requestId`, `metadata.squireEnv`
+   - `metadata.userId`, `metadata.conversationId`, `metadata.thread_id`,
+     `metadata.userMessageId`, `metadata.requestId`, `metadata.squireEnv`
    - `metadata.model`, `metadata.toolSurface`, iterations, tool-call count, and
      stop reason
    - tags: `runtime`, provider (`anthropic`), SDK (`claude-sdk`), model, tool

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -142,6 +142,8 @@ function langgraphCorrelationMetadata(options: AskOptions | undefined): Record<s
     runtime: GRAPH_RUNTIME_PREFIX,
     squireEnv: resolveSquireEnv(),
   };
+  const langsmithThreadId = langsmithThreadIdFor(options);
+  if (langsmithThreadId) metadata.thread_id = langsmithThreadId;
   if (options?.requestId) metadata.requestId = options.requestId;
   if (options?.conversationId) metadata.conversationId = options.conversationId;
   if (options?.userMessageId) metadata.userMessageId = options.userMessageId;
@@ -149,6 +151,10 @@ function langgraphCorrelationMetadata(options: AskOptions | undefined): Record<s
   if (options?.campaignId) metadata.campaignId = options.campaignId;
   if (options?.game) metadata.game = requireGameId(options.game);
   return metadata;
+}
+
+function langsmithThreadIdFor(options: AskOptions | undefined): string | undefined {
+  return options?.conversationId ?? options?.userMessageId;
 }
 
 function langgraphCorrelationAttributes(options: AskOptions | undefined): Attributes {
@@ -702,6 +708,7 @@ async function runLangGraphAgentLoop(
       );
       const finalState = await graph.invoke(createInitialState(question, options), {
         configurable: { thread_id: threadIdFor(options) },
+        metadata: langgraphCorrelationMetadata(options),
       });
       const result = {
         answer: finalState.finalAnswer,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -712,6 +712,8 @@ function agentCorrelationMetadata(options: AskOptions | undefined): Record<strin
   const metadata: Record<string, string> = {
     squireEnv: resolveSquireEnv(),
   };
+  const threadId = agentThreadIdFor(options);
+  if (threadId) metadata.thread_id = threadId;
   if (options?.requestId) metadata.requestId = options.requestId;
   if (options?.conversationId) metadata.conversationId = options.conversationId;
   if (options?.userMessageId) metadata.userMessageId = options.userMessageId;
@@ -722,6 +724,10 @@ function agentCorrelationMetadata(options: AskOptions | undefined): Record<strin
   if (options?.evalSuite) metadata.evalSuite = options.evalSuite;
   if (options?.evalCaseCategory) metadata.evalCaseCategory = options.evalCaseCategory;
   return metadata;
+}
+
+function agentThreadIdFor(options: AskOptions | undefined): string | undefined {
+  return options?.conversationId ?? options?.userMessageId;
 }
 
 function agentCorrelationAttributes(options: AskOptions | undefined): Attributes {
@@ -1274,6 +1280,7 @@ async function runAgentLoopInternal(
   const maxIterations = config.toolLoopLimit ?? MAX_AGENT_ITERATIONS;
   const broadSearchSynthesisThreshold =
     config.broadSearchSynthesisThreshold ?? MAX_RULE_SEARCHES_BEFORE_SYNTHESIS;
+  const correlationMetadata = agentCorrelationMetadata(options);
 
   const messages: MessageParam[] = [
     ...truncatedHistory.map((m: HistoryMessage) => ({
@@ -1313,6 +1320,7 @@ async function runAgentLoopInternal(
               tool_surface: toolSurface ?? 'legacy',
             },
             metadata: {
+              ...correlationMetadata,
               iteration: i + 1,
               allowTools: !forceSynthesis,
               messageCount: messages.length,
@@ -1338,6 +1346,7 @@ async function runAgentLoopInternal(
             model,
             usageDetails: langsmithUsageMetadata(tokenUsageFromMessage(message)),
             metadata: {
+              ...correlationMetadata,
               stopReason: message.stop_reason ?? 'unknown',
             },
           }),
@@ -1354,6 +1363,7 @@ async function runAgentLoopInternal(
         span.setAttributes(
           createObservationAttributes('generation', {
             output: { error: message },
+            metadata: correlationMetadata,
             level: 'ERROR',
             statusMessage: message,
           }),
@@ -1458,6 +1468,7 @@ async function runAgentLoopInternal(
                       input: compactForTrace(block.input),
                     },
                     metadata: {
+                      ...correlationMetadata,
                       iteration: i + 1,
                       toolId: block.id,
                       toolName: block.name,
@@ -1483,6 +1494,7 @@ async function runAgentLoopInternal(
                       sourceLabels: result.sourceBooks ?? [],
                       canonicalRefs,
                     },
+                    metadata: correlationMetadata,
                   }),
                   'squire.agent.tool.ok': toolOk,
                   'squire.agent.tool.output_summary': summary,
@@ -1495,6 +1507,7 @@ async function runAgentLoopInternal(
                 span.setAttributes(
                   createObservationAttributes('tool', {
                     output: { ok: false, error: message },
+                    metadata: correlationMetadata,
                     level: 'ERROR',
                     statusMessage: message,
                   }),

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -283,6 +283,7 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
       'langsmith.trace.name': 'squire.agent.langgraph',
       'langsmith.metadata.runtime': 'langgraph',
       'langsmith.metadata.squireEnv': 'test',
+      'langsmith.metadata.thread_id': '550e8400-e29b-41d4-a716-446655440000',
       'langsmith.metadata.requestId': 'req-langgraph',
       'langsmith.metadata.conversationId': '550e8400-e29b-41d4-a716-446655440000',
       'langsmith.metadata.userMessageId': '6ba7b810-9dad-11d1-80b4-00c04fd430c8',

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -311,6 +311,7 @@ describe('runAgentLoop', () => {
     });
     expect(runAttributes).toMatchObject({
       'langsmith.metadata.squireEnv': 'test',
+      'langsmith.metadata.thread_id': '550e8400-e29b-41d4-a716-446655440000',
       'langsmith.metadata.requestId': 'req-sqr-87',
       'langsmith.metadata.conversationId': '550e8400-e29b-41d4-a716-446655440000',
       'langsmith.metadata.userMessageId': '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
@@ -330,6 +331,11 @@ describe('runAgentLoop', () => {
     const iterationAttributes = spanAttributes('squire.agent.iteration');
     expect(iterationAttributes['langsmith.span.kind']).toBe('llm');
     expect(iterationAttributes['gen_ai.request.model']).toBe('claude-sonnet-4-6');
+    expect(iterationAttributes).toMatchObject({
+      'langsmith.metadata.thread_id': '550e8400-e29b-41d4-a716-446655440000',
+      'langsmith.metadata.conversationId': '550e8400-e29b-41d4-a716-446655440000',
+      'langsmith.metadata.userMessageId': '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+    });
     expect(parseJsonAttribute(iterationAttributes, 'gen_ai.prompt')).toMatchObject({
       iteration: 1,
       allowTools: true,
@@ -339,6 +345,32 @@ describe('runAgentLoop', () => {
     expect(parseJsonAttribute(iterationAttributes, 'gen_ai.completion')).toMatchObject({
       stopReason: 'end_turn',
       content: [{ type: 'text', text: 'Loot tokens are picked up in your hex.' }],
+    });
+  });
+
+  it('propagates LangSmith thread metadata to legacy tool spans', async () => {
+    mockSearchRules.mockResolvedValueOnce([
+      {
+        text: 'Loot: pick up all loot tokens.',
+        source: 'rulebook.pdf:42',
+        score: 0.9,
+      },
+    ]);
+    mockMessagesCreate
+      .mockResolvedValueOnce(toolUseResponse('search_rules', { query: 'loot action' }))
+      .mockResolvedValueOnce(textResponse('You pick up loot tokens.'));
+
+    await runAgentLoopWithTrajectory('What is the loot action?', {
+      toolSurface: 'legacy',
+      conversationId: '550e8400-e29b-41d4-a716-446655440000',
+      userMessageId: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+    });
+
+    const toolAttributes = spanAttributes('squire.agent.tool');
+    expect(toolAttributes).toMatchObject({
+      'langsmith.metadata.thread_id': '550e8400-e29b-41d4-a716-446655440000',
+      'langsmith.metadata.conversationId': '550e8400-e29b-41d4-a716-446655440000',
+      'langsmith.metadata.userMessageId': '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
     });
   });
 

--- a/test/deployment-operations-docs.test.ts
+++ b/test/deployment-operations-docs.test.ts
@@ -37,6 +37,7 @@ describe('deployment operations documentation', () => {
       'env:production',
       'Troubleshoot one production chat',
       'metadata.conversationId',
+      'metadata.thread_id',
       'metadata.userMessageId',
       'metadata.requestId',
       'X-Request-ID',


### PR DESCRIPTION
## Summary

- Add LangSmith `metadata.thread_id` to live agent trace metadata, preferring the Squire conversation id and falling back to the user-message id.
- Pass the same thread metadata into LangGraph runnable config without changing LangGraph checkpoint `thread_id` behavior.
- Update observability docs and tests to distinguish LangSmith thread grouping from Squire turn/checkpoint ids.

## Validation

- `npm run check`
- gstack `/review`: no issues found

Fixes SQR-244


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified observability specifications for agent runtime tracing and conversation correlation.
  * Updated production operations guide with enhanced metadata references for troubleshooting.

* **New Features**
  * Improved request correlation through enhanced tracing metadata propagation.

* **Tests**
  * Added test coverage validating tracing metadata propagation across agent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->