### PR TITLE
fix(ci): detect retrieval changes from commit files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,10 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          changed="$(git diff-tree --no-commit-id --name-only -r -m "$HEAD_SHA")"
+          changed="$(
+            gh api "repos/${{ github.repository }}/commits/$HEAD_SHA" \
+              --jq '.files[].filename'
+          )"
           if ! printf '%s\n' "$changed" | grep -Eq '^(data/pdfs/|data/rule-sources/|src/index-docs\.ts$|src/vector-store\.ts$|src/embedder\.ts$|src/retrieval-source\.ts$)'; then
             echo "No production rule-source reindex needed for this deploy."
             exit 0

--- a/test/production-data-workflows.test.ts
+++ b/test/production-data-workflows.test.ts
@@ -195,6 +195,7 @@ describe('production data lifecycle workflows', () => {
 
     expect(workflow).toContain('actions: read');
     expect(workflow).toContain('Wait for production rule-source reindex when retrieval changed');
+    expect(workflow).toContain('gh api "repos/${{ github.repository }}/commits/$HEAD_SHA"');
     expect(workflow).toContain('src/vector-store\\.ts');
     expect(workflow).toContain('production-reindex-pdfs.yml');
     expect(workflow).toContain('gh run watch "$run_id" --exit-status --interval 30');


### PR DESCRIPTION
## Summary
- make the Fly deploy gate read changed files from the GitHub commit API instead of shallow local git history
- keep the production reindex wait ahead of deploy when retrieval/indexing files change
- add a workflow contract assertion for the commit-file lookup

## Validation
- npm run check
- actionlint .github/workflows/deploy.yml .github/workflows/production-reindex-pdfs.yml
- npx vitest run --config vitest.split.config.ts test/production-data-workflows.test.ts

Follow-up to SQR-247 / PR #456.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated deployment validation tests for improved accuracy.

* **Chores**
  * Enhanced deployment workflow to use a more reliable method for detecting file changes during production releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->