### PR TITLE
v0.1.15 feat: add game-scoped production refresh workflows

### DIFF
--- a/.github/workflows/production-reindex-pdfs.yml
+++ b/.github/workflows/production-reindex-pdfs.yml
@@ -13,10 +13,19 @@ on:
   workflow_dispatch:
     inputs:
       rebuild:
-        description: 'Truncate and rebuild all rule-source embeddings before indexing'
+        description: 'Truncate and rebuild the selected rule-source embeddings before indexing'
         required: false
         type: boolean
         default: false
+      game:
+        description: 'Game rule sources to index'
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - frosthaven
+          - gloomhaven-2e
 
 permissions:
   contents: read
@@ -38,6 +47,8 @@ jobs:
       VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
       NODE_ENV: production
       SQUIRE_ENV: production
+      SQUIRE_DATA_GAME: ${{ github.event.inputs.game || 'all' }}
+      SQUIRE_INDEX_GAME: ${{ github.event.inputs.game || 'all' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -90,7 +101,10 @@ jobs:
         run: npm run index
 
       - name: Sanity check embeddings
-        run: npm run production-data:check -- embeddings
+        run: npm run production-data:check -- embeddings --game "$SQUIRE_DATA_GAME"
+
+      - name: Smoke check production retrieval
+        run: npm run production-data:smoke -- --game "$SQUIRE_DATA_GAME"
 
       - name: Stop Fly Postgres proxy
         if: always()

--- a/.github/workflows/production-seed-cards.yml
+++ b/.github/workflows/production-seed-cards.yml
@@ -7,6 +7,16 @@ on:
       - 'data/extracted/**'
       - '!data/extracted/scenario-section-books.json'
   workflow_dispatch:
+    inputs:
+      game:
+        description: 'Game data to seed'
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - frosthaven
+          - gloomhaven-2e
 
 permissions:
   contents: read
@@ -27,6 +37,8 @@ jobs:
       PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
       NODE_ENV: production
       SQUIRE_ENV: production
+      SQUIRE_DATA_GAME: ${{ github.event.inputs.game || 'all' }}
+      SQUIRE_SEED_GAME: ${{ github.event.inputs.game || 'all' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -75,7 +87,7 @@ jobs:
         run: npm run seed:cards
 
       - name: Sanity check card data
-        run: npm run production-data:check -- cards
+        run: npm run production-data:check -- cards --game "$SQUIRE_DATA_GAME"
 
       - name: Stop Fly Postgres proxy
         if: always()

--- a/.github/workflows/production-seed-scenario-section-books.yml
+++ b/.github/workflows/production-seed-scenario-section-books.yml
@@ -14,6 +14,16 @@ on:
       - 'src/seed/seed-scenario-section-books.ts'
       - 'scripts/seed-scenario-section-books.ts'
   workflow_dispatch:
+    inputs:
+      game:
+        description: 'Game data to seed'
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - frosthaven
+          - gloomhaven-2e
 
 permissions:
   contents: read
@@ -34,6 +44,8 @@ jobs:
       PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
       NODE_ENV: production
       SQUIRE_ENV: production
+      SQUIRE_DATA_GAME: ${{ github.event.inputs.game || 'all' }}
+      SQUIRE_SEED_GAME: ${{ github.event.inputs.game || 'all' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -82,7 +94,7 @@ jobs:
         run: npm run seed:scenario-section-books
 
       - name: Sanity check scenario and section books
-        run: npm run production-data:check -- scenario-section-books
+        run: npm run production-data:check -- scenario-section-books --game "$SQUIRE_DATA_GAME"
 
       - name: Stop Fly Postgres proxy
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.1.15] - 2026-05-28
+
+### Added
+
+- Added production data game scopes for Frosthaven-only, Gloomhaven 2e-only, and all-game seed and reindex workflows.
+- Added production smoke checks that run game-scoped rules search, verify a structured item lookup, and confirm Frosthaven still responds after a GH2-scoped refresh.
+
+### Changed
+
+- Scoped production embedding rebuilds and stale-source deletion to the selected game unless the operator explicitly chooses all games.
+- Updated GH2 production refresh runbooks, development docs, architecture notes, and the product spec to reflect current Frosthaven and Gloomhaven 2e support.
+
 ## [0.1.14] - 2026-05-27
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -290,16 +290,19 @@ The web channel passes a `Session` domain object through the request lifecycle. 
 
 ## Game Dimension
 
-Squire targets multiple games in the \*haven family. Today: Frosthaven. Phase 2: Gloomhaven (2nd Edition). Future: possibly Jaws of the Lion, the original Gloomhaven, or others.
+Squire targets multiple games in the \*haven family. Today: Frosthaven and Gloomhaven (2nd Edition). Future: possibly Jaws of the Lion, the original Gloomhaven, or others.
 
 To prevent cross-contamination between games (e.g., the agent answering a GH2 question with a Frosthaven rule), each piece of game data carries a `game` dimension:
 
 - **Card records** carry an explicit `game` field: `'frosthaven' | 'gloomhaven-2e'` (extensible)
 - **Rule-source chunks** are implicitly tagged via filename prefix in `data/pdfs/` and `data/rule-sources/`: `fh-rule-book.pdf`, `gh2-rule-book.pdf`, `gh2-faq.html`, `gh2-errata.html`, etc. The `source` field in the vector store carries the basename.
 - **Atomic tools** accept an optional `game` filter parameter (e.g., `listCards('items', { game: 'gloomhaven-2e', prosperity: 4 })`)
-- **Agent system prompt** is told which game the user is asking about. Phase 2 uses a per-session game selector. Phase 4+ infers game from the user's active campaign.
+- **Agent system prompt** is told which game the user is asking about. The current web UI uses a per-session game selector. Phase 4+ infers game from the user's active campaign.
 
-The `game` column ships in **Phase 1** as part of the Storage & Data Migration project — every `card_*` table and the `embeddings` table includes `game text not null default 'frosthaven'` from day 1. Atomic tools accept the optional `game` parameter but don't filter on it until Phase 2. Pulling the column forward avoids 11 ALTER TABLE migrations later when GH2 lands. The `game` field on **import records** (the JSON shape produced by `src/import-*.ts`) is still added in Phase 2 alongside the GH2 import scripts, since today's Frosthaven importers don't need it.
+The `game` column ships on every `card_*` table, every scenario/section-book
+table, and the `rule_source_embeddings` table. Runtime reads, import records,
+seeders, and the LangGraph agent all preserve that game scope so GH2 answers do
+not cite Frosthaven sources and Frosthaven answers do not cite GH2 sources.
 
 ---
 
@@ -373,8 +376,10 @@ Production data updates are decoupled from image deploys. The weekly GHS refresh
 workflow opens reviewable PRs for `data/extracted/`; after those PRs merge,
 environment-protected GitHub Actions seed the production card tables. Separate
 production workflows seed scenario/section-book data and re-index rule-source
-embeddings, with manual rebuild mode reserved for deliberate embedding
-model/version changes. The operator procedure lives in
+embeddings. Those workflows accept `all`, `frosthaven`, or `gloomhaven-2e`
+game scopes so operators can refresh one game without deleting or requiring
+rows for the other. Manual embedding rebuild mode is reserved for deliberate
+embedding model/version changes or known corrupt indexes. The operator procedure lives in
 [docs/runbooks/production-operations.md](runbooks/production-operations.md).
 
 ### Character State
@@ -840,7 +845,7 @@ For developer setup, running the server, working on import scripts locally, and 
 
 5. **Claude API costs at scale.** Phase 1 cost is small. Once multi-user (Phase 3+) and the recommendation engine (Phase 5) ship, per-user cost increases. Mitigation: per-user daily budget circuit breakers, cache aggressively, monitor via LangSmith, model tiering (Haiku for cheap cases) when justified.
 
-6. **frosthaven-storyline.com may not support Gloomhaven (2nd Edition) (Phase 2 / Phase 6).** Brian uses storyline as his canonical campaign tracker for Frosthaven today. If storyline doesn't support GH2 by transition time, all four storyline-based ingestion options in Phase 6 become non-viable for GH2. Mitigation: option 5 in Phase 6 (GHS-as-tracker) sidesteps this entirely. Action: confirm storyline GH2 support before Phase 2 begins.
+6. **frosthaven-storyline.com may not support Gloomhaven (2nd Edition) (Phase 6).** Brian uses storyline as his canonical campaign tracker for Frosthaven today. If storyline doesn't support GH2 when automated ingestion begins, all four storyline-based ingestion options in Phase 6 become non-viable for GH2. Mitigation: option 5 in Phase 6 (GHS-as-tracker) sidesteps this entirely. Action: confirm storyline GH2 support before Phase 6 begins.
 
 7. **Prompt injection.** The knowledge agent assembles context from multiple sources (rulebook, scenario/section books, card data, conversation history, campaign state) and sends it to Claude. Every input path is a prompt injection surface. See [SECURITY.md](SECURITY.md) for the full threat model and mitigations.
 
@@ -858,11 +863,18 @@ For developer setup, running the server, working on import scripts locally, and 
 
 - **APM / RUM stack.** Datadog as a one-stop shop for application metrics and real-user monitoring (with LangSmith staying for LLM-specific observability), or stay LangSmith-only and skip APM until volume demands it?
 - **Character state ingestion path (Phase 6).** Browser extension vs JSON export vs storyline sync protocol vs screenshot+Vision vs GHS-as-tracker — defer until Phase 6 begins. The GH2 campaign may force this decision earlier than the Frosthaven one.
-- **Storyline GH2 support (Phase 2 prerequisite).** Confirm whether frosthaven-storyline.com supports Gloomhaven (2nd Edition). If not, Brian's GH2 campaign-tracking workflow needs to switch (most likely to GHS).
+- **Storyline GH2 support (Phase 6 input).** Confirm whether frosthaven-storyline.com supports Gloomhaven (2nd Edition) before automated character/campaign ingestion begins. If not, Brian's GH2 campaign-tracking workflow needs to switch (most likely to GHS).
 
 ---
 
 ## Changelog
+
+- **2026-05-27:** SQR-216 through SQR-219 refreshed the GH2 production data
+  architecture. Production card seeding, scenario/section-book seeding, and
+  rule-source reindexing now accept `all`, `frosthaven`, and `gloomhaven-2e`
+  scopes. The architecture now reflects that Frosthaven and Gloomhaven (2nd
+  Edition) are both current supported games, while campaign tracking and
+  automated ingestion remain later-phase work.
 
 - **2026-05-06:** SQR-59 picked the Phase 1 hosting platform: Fly.io app + Fly Managed Postgres (Basic) in one region, no staging. SQR-58 later put Route 53, CloudFront, and AWS WAF in front of the Fly origin with an origin-secret lock. App-to-DB traffic stays on private 6PN. Migrations run via `release_command` before traffic cutover. ARCHITECTURE.md §Deployment and §Cost updated to reflect the concrete pick. Reasoning, alternatives (Neon, Railway, Render, VPS, Cloudflare Workers), and re-evaluation triggers in [ADR 0016](adr/0016-phase-1-hosting-platform.md). Unblocks SQR-58 (WAF), SQR-42 (Dockerize), SQR-43 (migrate-on-deploy), SQR-44 (CI/CD).
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -512,7 +512,13 @@ embedding row keys. When an official PDF is image-based, the metadata can also
 point at the normalized OCR snapshot used for indexing. To refresh an official
 source, replace the stable file in place, update the matching metadata record,
 refresh any normalized snapshot, and rerun `npm run index`; unchanged sources
-are skipped and changed sources are re-indexed by content hash.
+are skipped and changed sources are re-indexed by content hash. Set
+`SQUIRE_INDEX_GAME=frosthaven`, `SQUIRE_INDEX_GAME=gloomhaven-2e`, or
+`SQUIRE_INDEX_GAME=all` when you need to scope a local or production reindex to
+one game or both games. `npm run index` needs Postgres and `VOYAGE_API_KEY`.
+After indexing production data, `npm run production-data:smoke -- --game gh2`
+performs a real GH2 rules search, a GH2 item lookup, and a Frosthaven
+preservation check; it needs the production DB proxy plus `VOYAGE_API_KEY`.
 
 The current GH2 rulebook snapshot is the Apple Vision baseline, generated on
 macOS with:
@@ -565,18 +571,22 @@ CSRF validation enter the path.
 `npm run seed:cards` is idempotent — re-run it any time the extracted
 card JSON refreshes. By default it seeds Frosthaven's legacy flat files
 (`data/extracted/<type>.json`) and every game directory that exists
-(`data/extracted/gh2/<type>.json`). Set `SQUIRE_SEED_GAME=fh` or
-`SQUIRE_SEED_GAME=gh2` to seed only one game. It validates each record with the matching
-`SCHEMAS[type]` Zod schema and skips anything that fails (the failures are
-warned to stderr so you can see what got dropped). Records are upserted on
-`(game, source_id)`, so a stale card row gets overwritten in place.
+(`data/extracted/gh2/<type>.json`). Set `SQUIRE_SEED_GAME=frosthaven`,
+`SQUIRE_SEED_GAME=gloomhaven-2e`, or their `fh` / `gh2` aliases to seed only
+one game. `SQUIRE_SEED_GAME=all` is equivalent to leaving the variable unset.
+It validates each record with the matching `SCHEMAS[type]` Zod schema and skips
+anything that fails (the failures are warned to stderr so you can see what got
+dropped). Records are upserted on `(game, source_id)`, so a stale card row gets
+overwritten in place.
 
 `npm run seed:scenario-section-books` is also idempotent. It replaces the
 `scenario_book_scenarios`, `section_book_sections`, and `book_references`
 rows for Frosthaven from `data/extracted/scenario-section-books.json` and
 for GH2 from `data/extracted/gh2/scenario-section-books.json` when present.
 GH2 section rows are structured GHS metadata summaries, not printed section
-book prose.
+book prose. It uses the same `SQUIRE_SEED_GAME=frosthaven`,
+`SQUIRE_SEED_GAME=gloomhaven-2e`, and `SQUIRE_SEED_GAME=all` scope as card
+seeding.
 
 As of SQR-56 and SQR-103, runtime reads come from Postgres only:
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,11 +1,11 @@
-# Squire — Frosthaven Knowledge Agent Product Specification
+# Squire — Frosthaven / Gloomhaven Knowledge Agent Product Specification
 
-**Version:** 3.1
-**Date:** 2026-04-07
-**Last Refreshed:** 2026-05-16
+**Version:** 3.2
+**Date:** 2026-05-27
+**Last Refreshed:** 2026-05-27
 **Owner:** Product (PM)
 **Companion doc:** [docs/ARCHITECTURE.md](ARCHITECTURE.md) — architect-owned tech spec (how / with-what / where)
-**Status:** Phase 1 in progress, MVP scoped. GH2 content expansion (Phase 2) deadline ~mid-2026.
+**Status:** Phase 1 production app is live. Phase 2 GH2 content expansion is partially live and production-refresh hardening is in progress.
 
 This document is the **product spec** — what Squire is, why it exists, who it's for, and when each capability lands. Technical architecture (stack, data layer, agent design, deployment, observability, tech risks) lives in the companion [ARCHITECTURE.md](ARCHITECTURE.md).
 
@@ -15,13 +15,13 @@ Squire is a deep game-knowledge agent for Gloomhaven and Frosthaven. It answers 
 
 Squire is **the agent**, not a specific app. It's reachable through multiple **channels** — primarily its own web UI today, with MCP-capable agent harnesses (Claude Code, Claude Desktop) as a second channel, and Discord / iMessage clients planned for the far future. All channels talk to the same underlying knowledge agent.
 
-**MVP (Phase 1):** A mobile-friendly web chat where Brian can pull out his phone at the table, log in with Google, and ask any Frosthaven rules question. Hosted publicly at `squire.maz.org` behind CloudFront and AWS WAF. The agent answers using semantic search across the Frosthaven books, deterministic scenario/section-book traversal for anchored story-book questions, and a generalized atomic-tools API over Gloomhaven Secretariat (GHS) structured game data.
+**Current product:** A mobile-friendly web chat where Brian can pull out his phone at the table, log in with Google, choose Frosthaven or Gloomhaven (2nd Edition), and ask rules or lookup questions. Hosted publicly at `squire.maz.org` behind CloudFront and AWS WAF. The agent answers using semantic search across the selected game's indexed books, deterministic scenario/section-book traversal for anchored story-book questions, and a generalized atomic-tools API over Gloomhaven Secretariat (GHS) structured game data.
 
-**Long-term product (Phases 2–8):** Gloomhaven (2nd Edition) content expansion, multi-user platform, campaign and character state, the recommendation engine (card selection at level-up, inventory optimization, pre-combat hand selection, long-term build planning), character state ingestion, polish (voice input, share/export, spoiler protection), and additional channels (Discord, iMessage).
+**Long-term product (Phases 3–8):** multi-user platform, campaign and character state, the recommendation engine (card selection at level-up, inventory optimization, pre-combat hand selection, long-term build planning), character state ingestion, polish (voice input, share/export, spoiler protection), and additional channels (Discord, iMessage).
 
 **Primary Use Cases:**
 
-- **Rules lookup and clarification** (MVP — at the table, on a phone)
+- **Rules lookup and clarification** (current — at the table, on a phone, game-scoped to Frosthaven or Gloomhaven 2e)
 - Card, item, monster, and scenario lookup (MVP)
 - Card selection when leveling up (future)
 - Inventory optimization (future)
@@ -98,7 +98,7 @@ Squire is **the agent**, not a specific app. It's reachable through multiple **c
 
 **Requirements:**
 
-- Retrieval across the Frosthaven rulebook plus scenario, section, and puzzle books
+- Retrieval across the selected game's indexed rule sources. Frosthaven includes rulebook plus scenario, section, and puzzle books; GH2 includes the current GH2 rulebook and supporting indexed snapshots as they are added.
 - Fast semantic search for rules queries
 - Exact scenario/section lookup and link-following for anchored story-book questions
 - Return relevant rule sections with page references
@@ -138,8 +138,8 @@ Character and campaign state lands in **Phase 4 (Campaign & character state)** w
 
 ### Data Sources (current)
 
-- **Static game data:** Gloomhaven Secretariat (GHS) structured data — see Data Architecture section. Imported via dedicated `src/import-*.ts` scripts.
-- **Book corpus:** the official Frosthaven rulebook, scenario books, section books, and puzzle book PDFs. The book corpus supports both semantic retrieval and exact scenario/section lookup. Gloomhaven (2nd Edition) book ingestion lands in Phase 2.
+- **Static game data:** Gloomhaven Secretariat (GHS) structured data for Frosthaven and Gloomhaven (2nd Edition) — see Data Architecture section. Imported via dedicated `src/import-*.ts` scripts.
+- **Book corpus:** official Frosthaven sources and the current GH2 sources checked into `data/pdfs/` / `data/rule-sources/`. The book corpus supports semantic retrieval, and scenario/section data supports exact lookup where the game has structured seed data.
 
 ### Data Sources (future, by phase)
 
@@ -223,9 +223,9 @@ The phases below reflect the **resequenced plan** as of the 2026-04-07 spec refr
 
 ### Phase 1: MVP — Rules Q&A at the table
 
-**Goal:** Brian can pull out his phone at the table, log in with Google, and ask Squire any Frosthaven rules question via a mobile-friendly web chat. Hosted publicly at `squire.maz.org` behind CloudFront and AWS WAF.
+**Goal:** Brian can pull out his phone at the table, log in with Google, and ask Squire Frosthaven rules questions via a mobile-friendly web chat. Hosted publicly at `squire.maz.org` behind CloudFront and AWS WAF.
 
-**Status as of 2026-05-16:** rules RAG pipeline, GHS imports, atomic tools, MCP server, web channel, Google OAuth, Fly deployment, custom domain, CI/CD, production health checks, and AWS WAF edge protection are built.
+**Status as of 2026-05-27:** rules RAG pipeline, GHS imports, atomic tools, LangGraph production agent, MCP server, web channel, Google OAuth, Fly deployment, custom domain, CI/CD, production health checks, and AWS WAF edge protection are built.
 
 **Tasks:**
 
@@ -252,7 +252,7 @@ The phases below reflect the **resequenced plan** as of the 2026-04-07 spec refr
 - Any recommendations beyond rules answers
 - Discord, iMessage, or other channels beyond the web UI and MCP
 
-**Deliverable:** Brian can pull out his phone at the table, log in with Google, and ask Squire any Frosthaven rules question via a mobile-friendly web chat. The agent answers using semantic book search, deterministic scenario/section traversal (`findScenario`, `getScenario`, `getSection`, `followLinks`), and the GHS card tools (`searchRules`, `searchCards`, `listCards`, `getCard`). Hosted publicly behind CloudFront and AWS WAF. Test suite passing.
+**Deliverable:** Brian can pull out his phone at the table, log in with Google, and ask Squire Frosthaven rules questions via a mobile-friendly web chat. The agent answers using semantic book search, deterministic scenario/section traversal (`findScenario`, `getScenario`, `getSection`, `followLinks`), and the GHS card tools (`searchRules`, `searchCards`, `listCards`, `getCard`). Hosted publicly behind CloudFront and AWS WAF. Test suite passing.
 
 ---
 
@@ -260,23 +260,20 @@ The phases below reflect the **resequenced plan** as of the 2026-04-07 spec refr
 
 **Goal:** Brian can pull out his phone at the GH2 table the day his group transitions and Squire works for the new game.
 
-**Deadline-driven:** Brian's group has roughly 3–4 months left in their Frosthaven campaign before transitioning to Gloomhaven (2nd Edition) (~mid-2026). Squire needs to be useful at the GH2 table when that happens. This is the only phase in the plan with a hard external deadline, which is why it sits right after MVP and ahead of multi-user.
+**Status as of 2026-05-27:** the `game` dimension is active through retrieval, card lookup, scenario/section lookup, and the web game selector. GH2 GHS extracts, GH2 scenario/section metadata, and the first GH2 rulebook snapshot are checked in. The remaining work is production-refresh hardening, eval verification, and the final production data refresh.
 
 **Tasks:**
 
-- Ingest the Gloomhaven (2nd Edition) rulebook, scenario-book, and section-book PDFs into `data/pdfs/` and reindex / reseed (`npm run index`, `npm run seed:scenario-section-books`)
-- Add GH2 data import scripts mirroring the existing GHS Frosthaven imports (`import-character-abilities.ts`, `import-items.ts`, `import-monster-stats.ts`, etc.). Gloomhaven Secretariat already supports Gloomhaven (2nd Edition), so the import path is unblocked.
-- **Turn on the `game` dimension** so the agent doesn't mix Frosthaven and GH2 rules in the same answer. The Storage & Data Migration project (Phase 1) ships the `game` column on every `card_*` table and the `embeddings` table with `default 'frosthaven'`, so existing rows are tagged correctly. The runtime code that _populates_ and _filters_ on the column is Phase 2 work — none of this exists today. Phase 2 will:
-  - Update the GH2 import scripts to write `game: 'gloomhaven-2e'` on each new row (the existing Frosthaven importers don't yet write a `game` field; they rely on the column default)
-  - Add filename-prefix → `game` derivation in `src/index-docs.ts` so rule chunks from `fh-*.pdf` get `game: 'frosthaven'` and chunks from `gh2-*.pdf` get `game: 'gloomhaven-2e'`. Today `IndexEntry` in `src/vector-store.ts` has no `game` field at all — Phase 2 adds it alongside the index-docs.ts changes.
-  - Wire the optional `game` filter parameter on the atomic tools through to the agent system prompt and through every call site that knows the active game
-- Update the agent system prompt to know which game the user is asking about (per-session game selector for MVP; inferred from campaign once Phase 4 lands)
-- Smoke test: ask both a Frosthaven and a Gloomhaven (2nd Edition) rules question in the same session and verify no cross-contamination
+- Maintain the GH2 rulebook snapshot in `data/rule-sources/` and reindex with `SQUIRE_INDEX_GAME=gloomhaven-2e npm run index`.
+- Maintain GH2 GHS extracts under `data/extracted/gh2/` and reseed with `SQUIRE_SEED_GAME=gloomhaven-2e npm run seed:cards`.
+- Maintain GH2 scenario/section metadata at `data/extracted/gh2/scenario-section-books.json` and reseed with `SQUIRE_SEED_GAME=gloomhaven-2e npm run seed:scenario-section-books`.
+- Keep the `game` dimension active through runtime retrieval, atomic tools, production seed workflows, production reindex workflows, evals, and the web game selector.
+- Smoke test: ask both a Frosthaven and a Gloomhaven (2nd Edition) rules question in the same session and verify no cross-contamination.
 
 **Risks:**
 
-- **frosthaven-storyline.com may not support Gloomhaven (2nd Edition).** Brian uses storyline as his canonical campaign tracker for Frosthaven today. If storyline doesn't support GH2 by transition time, his current campaign-tracking workflow breaks for the new game and the future Phase 6 ingestion path needs to be re-evaluated for GH2 specifically. Mitigation: confirm storyline GH2 support before this phase begins; if absent, consider switching campaign management to GHS itself for the GH2 campaign (GHS is also a campaign tracker, not just a data source — see Phase 6 ingestion options).
-- **Action item for Brian:** before this phase begins, verify that frosthaven-storyline.com (or its successor) supports Gloomhaven (2nd Edition). If not, plan the GH2 campaign-tracking workflow accordingly.
+- **frosthaven-storyline.com may not support Gloomhaven (2nd Edition).** Brian uses storyline as his canonical campaign tracker for Frosthaven today. If storyline doesn't support GH2 by the time automated ingestion begins, the Phase 6 ingestion path needs to be re-evaluated for GH2 specifically. Mitigation: confirm storyline GH2 support before Phase 6 begins; if absent, consider switching campaign management to GHS itself for the GH2 campaign.
+- **Action item for Brian:** before Phase 6 begins, verify that frosthaven-storyline.com (or its successor) supports Gloomhaven (2nd Edition). If not, plan the GH2 campaign-tracking workflow accordingly.
 
 **Out of scope:** original Gloomhaven (1st Edition), Jaws of the Lion, Crimson Scales, Forgotten Circles. Those stay in Future Enhancements.
 
@@ -359,7 +356,7 @@ The phases below reflect the **resequenced plan** as of the 2026-04-07 spec refr
 2. **Manual JSON export → upload** — user exports localStorage, uploads to Squire (lo-fi, no extension to maintain)
 3. **Sync via the storyline server protocol** — reverse-engineer the websocket sync to make Squire look like another client (fragile, unsupported)
 4. **Screenshot → Claude Vision** — original spec approach. Image preprocessing via Sharp (resize, normalize, compress) before sending to Claude Vision API. Cost ~$0.15–0.30 per character sync. Kept as a fallback for users who can't install an extension.
-5. **GHS as the campaign tracker** — Brian (or the user) uses **Gloomhaven Secretariat** as the campaign tracker instead of frosthaven-storyline.com, and Squire reads campaign state directly from GHS. Squire already imports static GHS data — extending it to read live user state is a much smaller jump than reverse-engineering a third-party site. Especially compelling for the **Gloomhaven (2nd Edition)** campaign (Phase 2), since storyline.com may not support GH2 at all. Tradeoff: requires Brian to switch his campaign-tracking workflow from storyline to GHS, which only happens if he likes GHS as a tracker.
+5. **GHS as the campaign tracker** — Brian (or the user) uses **Gloomhaven Secretariat** as the campaign tracker instead of frosthaven-storyline.com, and Squire reads campaign state directly from GHS. Squire already imports static GHS data — extending it to read live user state is a much smaller jump than reverse-engineering a third-party site. Especially compelling for the **Gloomhaven (2nd Edition)** campaign, since storyline.com may not support GH2 at all. Tradeoff: requires Brian to switch his campaign-tracking workflow from storyline to GHS, which only happens if he likes GHS as a tracker.
 
 **Risks:**
 
@@ -471,6 +468,14 @@ Squire is a deep Gloomhaven / Frosthaven knowledge agent. The MVP is small on pu
 ---
 
 ## Changelog
+
+- **2026-05-27 (v3.2):** Refreshed the spec for the current Phase 2 reality.
+  GH2 is no longer only future work: the game dimension, web selector, GH2 GHS
+  extracts, GH2 scenario/section metadata, and the first GH2 rulebook snapshot
+  are active. The remaining GH2 project work is production-refresh hardening,
+  eval verification, and the final production data refresh. Campaign and
+  character state remain deferred to Phase 4, with automated ingestion still in
+  Phase 6.
 
 - **2026-04-07 (v3.0.1):** Final-pass cleanup. Fixed "Phases 2–6" → "Phases 2–8" in the executive summary (8 phases now). Broadened Phase 6 goal/deliverable beyond storyline.com to acknowledge GHS-as-tracker as a viable alternative for the GH2 campaign.
 

--- a/docs/runbooks/production-operations.md
+++ b/docs/runbooks/production-operations.md
@@ -175,6 +175,18 @@ the environment secret `PRODUCTION_DATABASE_URL` to `DATABASE_URL`. They also se
 running migrations, and fail rather than silently writing to localhost or an
 obvious dev/test database.
 
+Manual runs for card data, scenario/section-book data, and rule-source
+embeddings include a `game` input:
+
+- `all` seeds or indexes both games.
+- `frosthaven` scopes the run to Frosthaven only.
+- `gloomhaven-2e` scopes the run to Gloomhaven (2nd Edition) only.
+
+Push-triggered runs default to `all`. Use the game-scoped runs for recovery,
+partial refreshes, and GH2-only verification. The production checks use the
+same scope, so a GH2-only run proves GH2 tables without depending on Frosthaven
+row counts, and a Frosthaven-only run leaves GH2 rows alone.
+
 ### Card data
 
 `Production seed card data` runs on merges to `main` that change
@@ -188,12 +200,14 @@ The workflow runs:
 npm run production-data:verify-db-url
 npm run db:migrate
 npm run seed:cards
-npm run production-data:check -- cards
+npm run production-data:check -- cards --game "$SQUIRE_DATA_GAME"
 ```
 
 `npm run seed:cards` is idempotent: it upserts current card rows and prunes rows
 that disappeared from the checked-in extract. The final sanity check requires
-every `card_*` table to contain data.
+every supported `card_*` table for the selected game to contain data. GH2
+building cards are intentionally excluded until upstream GHS publishes that
+data.
 
 ### Scenario and section books
 
@@ -208,7 +222,7 @@ The workflow runs:
 npm run production-data:verify-db-url
 npm run db:migrate
 npm run seed:scenario-section-books
-npm run production-data:check -- scenario-section-books
+npm run production-data:check -- scenario-section-books --game "$SQUIRE_DATA_GAME"
 ```
 
 `npm run seed:scenario-section-books` is safe to rerun. The sanity check requires
@@ -229,17 +243,23 @@ Normal mode runs:
 npm run production-data:verify-db-url
 npm run db:migrate
 npm run index
-npm run production-data:check -- embeddings
+npm run production-data:check -- embeddings --game "$SQUIRE_DATA_GAME"
+npm run production-data:smoke -- --game "$SQUIRE_DATA_GAME"
 ```
 
 Normal `npm run index` mode is content-hash based: unchanged rule sources are
 skipped, changed rule sources are re-indexed, new rule sources are added, and
-rows for removed rule sources are deleted. Use this path for ordinary source
-updates and chunking changes.
+rows for removed rule sources are deleted for the selected game only. Use this
+path for ordinary source updates and chunking changes. The smoke check performs
+a real game-scoped rules search and an item lookup. A GH2-scoped smoke run also
+checks a Frosthaven item and rules search so a GH2 refresh cannot silently break
+the existing Frosthaven table flow.
 
 Manual rebuild mode accepts `rebuild: true`. Because that truncates the
-`rule_source_embeddings` table before running `npm run index`, it should only be
-used for a deliberate embedding model/version change or a known corrupt index.
+selected `rule_source_embeddings` scope before running `npm run index`, it
+should only be used for a deliberate embedding model/version change or a known
+corrupt index. `game: all` truncates both games; `game: frosthaven` and
+`game: gloomhaven-2e` rebuild only that game's rows.
 The protected GitHub `production` environment is the approval gate for that
 rebuild. After changing the embedding model or vector dimensions, confirm the
 migration path first; a model-only change with the same dimensions can use

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "engines": {
@@ -23,6 +23,7 @@
     "sessions:sweep-expired": "node scripts/sweep-expired-sessions.ts",
     "production-data:verify-db-url": "node scripts/check-production-data.ts verify-url",
     "production-data:check": "node scripts/check-production-data.ts",
+    "production-data:smoke": "node scripts/check-production-data.ts smoke",
     "production-data:truncate-embeddings": "node scripts/check-production-data.ts truncate-embeddings",
     "query": "node src/query.ts",
     "serve": "node src/server.ts",

--- a/scripts/check-production-data.ts
+++ b/scripts/check-production-data.ts
@@ -4,7 +4,10 @@ import { pathToFileURL } from 'node:url';
 
 import { sql } from 'drizzle-orm';
 
-import { createStandaloneDb, type Db } from '../src/db.ts';
+import { createStandaloneDb, shutdownServerPool, type Db } from '../src/db.ts';
+import { requireGameId, SUPPORTED_GAME_IDS } from '../src/game.ts';
+import type { GameId } from '../src/game.ts';
+import { getCard, searchRules } from '../src/tools.ts';
 
 const CARD_TABLES = [
   'card_monster_stats',
@@ -26,6 +29,12 @@ const SCENARIO_SECTION_TABLES = [
 ] as const;
 
 type CheckCommand = 'cards' | 'scenario-section-books' | 'embeddings' | 'all';
+type ProductionDataCommand = CheckCommand | 'smoke' | 'verify-url' | 'truncate-embeddings';
+
+export interface ProductionDataOptions {
+  command: ProductionDataCommand;
+  games: GameId[];
+}
 
 export function assertProductionDatabaseUrl(rawUrl: string | undefined): string {
   const url = rawUrl?.trim();
@@ -106,17 +115,26 @@ export function assertProductionRuntimeEnv(env: NodeJS.ProcessEnv = process.env)
   }
 }
 
-async function countTable(db: Db, table: string): Promise<number> {
+async function countTableForGame(db: Db, table: string, game: GameId): Promise<number> {
   const result = await db.execute<{ count: number }>(
-    sql.raw(`SELECT COUNT(*)::int AS count FROM ${table}`),
+    sql`SELECT COUNT(*)::int AS count FROM ${sql.raw(table)} WHERE game = ${game}`,
   );
   return Number(result.rows[0]?.count ?? 0);
 }
 
-async function checkCards(db: Db): Promise<void> {
+const REQUIRED_CARD_TABLES_BY_GAME: Record<GameId, readonly (typeof CARD_TABLES)[number][]> = {
+  frosthaven: CARD_TABLES,
+  // Upstream GHS does not publish GH2 buildings yet. Treat that as expected
+  // missing coverage while still requiring every supported GH2 card table.
+  'gloomhaven-2e': CARD_TABLES.filter((table) => table !== 'card_buildings'),
+};
+
+async function checkCards(db: Db, games: readonly GameId[]): Promise<void> {
   const counts = new Map<string, number>();
-  for (const table of CARD_TABLES) {
-    counts.set(table, await countTable(db, table));
+  for (const game of games) {
+    for (const table of REQUIRED_CARD_TABLES_BY_GAME[game]) {
+      counts.set(`${game}/${table}`, await countTableForGame(db, table, game));
+    }
   }
 
   const emptyTables = [...counts.entries()]
@@ -129,14 +147,16 @@ async function checkCards(db: Db): Promise<void> {
 
   const total = [...counts.values()].reduce((sum, count) => sum + count, 0);
   console.log(
-    `OK card data sanity check passed across ${CARD_TABLES.length} tables (${total} rows).`,
+    `OK card data sanity check passed for ${games.join(', ')} across ${counts.size} game/table pair(s) (${total} rows).`,
   );
 }
 
-async function checkScenarioSectionBooks(db: Db): Promise<void> {
+async function checkScenarioSectionBooks(db: Db, games: readonly GameId[]): Promise<void> {
   const counts = new Map<string, number>();
-  for (const table of SCENARIO_SECTION_TABLES) {
-    counts.set(table, await countTable(db, table));
+  for (const game of games) {
+    for (const table of SCENARIO_SECTION_TABLES) {
+      counts.set(`${game}/${table}`, await countTableForGame(db, table, game));
+    }
   }
 
   const emptyTables = [...counts.entries()]
@@ -156,7 +176,13 @@ async function checkScenarioSectionBooks(db: Db): Promise<void> {
   );
 }
 
-async function checkEmbeddings(db: Db): Promise<void> {
+async function checkEmbeddingsForGames(db: Db, games: readonly GameId[]): Promise<void> {
+  for (const game of games) {
+    await checkEmbeddingsForGame(db, game);
+  }
+}
+
+async function checkEmbeddingsForGame(db: Db, game: GameId): Promise<void> {
   const result = await db.execute<{
     count: number;
     source_count: number;
@@ -167,45 +193,103 @@ async function checkEmbeddings(db: Db): Promise<void> {
       COUNT(DISTINCT source)::int AS source_count,
       COUNT(*) FILTER (WHERE content_hash IS NULL OR content_hash = '')::int AS missing_hash_count
     FROM rule_source_embeddings
+    WHERE game = ${game}
   `);
 
   const row = result.rows[0] ?? { count: 0, source_count: 0, missing_hash_count: 0 };
   if (row.count <= 0 || row.source_count <= 0) {
-    throw new Error('Embedding sanity check failed. The rule_source_embeddings table is empty.');
+    throw new Error(
+      `Embedding sanity check failed for ${game}. The rule_source_embeddings table has no rows for that game.`,
+    );
   }
   if (row.missing_hash_count > 0) {
     throw new Error(
-      `Embedding sanity check failed. ${row.missing_hash_count} row(s) are missing content_hash.`,
+      `Embedding sanity check failed for ${game}. ${row.missing_hash_count} row(s) are missing content_hash.`,
     );
   }
 
   console.log(
-    `OK embedding sanity check passed: ${row.count} chunks across ${row.source_count} source(s).`,
+    `OK embedding sanity check passed for ${game}: ${row.count} chunks across ${row.source_count} source(s).`,
   );
 }
 
-async function truncateEmbeddings(db: Db): Promise<void> {
-  await db.execute(sql`TRUNCATE TABLE rule_source_embeddings`);
-  console.log('OK truncated embeddings for a production rebuild.');
-}
-
-async function runCheck(db: Db, command: CheckCommand): Promise<void> {
-  if (command === 'cards' || command === 'all') await checkCards(db);
-  if (command === 'scenario-section-books' || command === 'all') {
-    await checkScenarioSectionBooks(db);
+async function truncateEmbeddings(db: Db, games: readonly GameId[]): Promise<void> {
+  if (games.length === SUPPORTED_GAME_IDS.length) {
+    await db.execute(sql`TRUNCATE TABLE rule_source_embeddings`);
+    console.log('OK truncated embeddings for every production game.');
+    return;
   }
-  if (command === 'embeddings' || command === 'all') await checkEmbeddings(db);
+
+  for (const game of games) {
+    await db.execute(sql`DELETE FROM rule_source_embeddings WHERE game = ${game}`);
+  }
+  console.log(`OK truncated embeddings for production game scope: ${games.join(', ')}.`);
 }
 
-function parseCommand(
-  rawCommand: string | undefined,
-): CheckCommand | 'verify-url' | 'truncate-embeddings' {
+const SMOKE_CARD_CHECKS: Record<GameId, { id: string; name: string }> = {
+  frosthaven: { id: 'gloomhavensecretariat:item/1', name: 'Spyglass' },
+  'gloomhaven-2e': { id: 'gloomhavensecretariat:item/1', name: 'Weathered Boots' },
+};
+
+function smokeGamesForScope(games: readonly GameId[]): GameId[] {
+  const smokeGames = new Set<GameId>(games);
+  if (smokeGames.has('gloomhaven-2e')) smokeGames.add('frosthaven');
+  return [...SUPPORTED_GAME_IDS].filter((game) => smokeGames.has(game));
+}
+
+async function checkRulesSmoke(game: GameId): Promise<void> {
+  const hits = await searchRules('advantage and disadvantage', 3, { game });
+  if (hits.length <= 0) {
+    throw new Error(`Production smoke failed for ${game}: rules search returned no hits.`);
+  }
+  const wrongGameHit = hits.find((hit) => hit.game !== game);
+  if (wrongGameHit) {
+    throw new Error(
+      `Production smoke failed for ${game}: rules search returned ${wrongGameHit.game} source ${wrongGameHit.source}.`,
+    );
+  }
+}
+
+async function checkStructuredSmoke(game: GameId): Promise<void> {
+  const expected = SMOKE_CARD_CHECKS[game];
+  const card = await getCard('items', expected.id, { game });
+  if (!card) {
+    throw new Error(`Production smoke failed for ${game}: item ${expected.id} was not found.`);
+  }
+  if (card.name !== expected.name) {
+    throw new Error(
+      `Production smoke failed for ${game}: item ${expected.id} resolved to ${JSON.stringify(
+        card.name,
+      )}, expected ${JSON.stringify(expected.name)}.`,
+    );
+  }
+}
+
+async function runSmoke(games: readonly GameId[]): Promise<void> {
+  const smokeGames = smokeGamesForScope(games);
+  for (const game of smokeGames) {
+    await checkRulesSmoke(game);
+    await checkStructuredSmoke(game);
+  }
+  console.log(`OK production smoke checks passed for ${smokeGames.join(', ')}.`);
+}
+
+async function runCheck(db: Db, command: CheckCommand, games: readonly GameId[]): Promise<void> {
+  if (command === 'cards' || command === 'all') await checkCards(db, games);
+  if (command === 'scenario-section-books' || command === 'all') {
+    await checkScenarioSectionBooks(db, games);
+  }
+  if (command === 'embeddings' || command === 'all') await checkEmbeddingsForGames(db, games);
+}
+
+function parseCommand(rawCommand: string | undefined): ProductionDataCommand {
   const command = rawCommand ?? 'all';
   if (
     command === 'cards' ||
     command === 'scenario-section-books' ||
     command === 'embeddings' ||
     command === 'all' ||
+    command === 'smoke' ||
     command === 'verify-url' ||
     command === 'truncate-embeddings'
   ) {
@@ -216,8 +300,49 @@ function parseCommand(
   );
 }
 
+function resolveGameScope(rawGame: string | undefined): GameId[] {
+  if (!rawGame || rawGame === 'all') return [...SUPPORTED_GAME_IDS];
+  return [requireGameId(rawGame)];
+}
+
+export function parseProductionDataOptions(
+  argv: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+): ProductionDataOptions {
+  const args = [...argv];
+  let commandArg: string | undefined;
+  let rawGame: string | undefined;
+
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (arg === '--game') {
+      rawGame = args.shift();
+      if (!rawGame) throw new Error('--game requires a value.');
+      continue;
+    }
+    if (arg?.startsWith('--game=')) {
+      rawGame = arg.slice('--game='.length);
+      if (!rawGame) throw new Error('--game requires a value.');
+      continue;
+    }
+    if (arg?.startsWith('-')) {
+      throw new Error(`Unknown production data option "${arg}". Expected --game <game>.`);
+    }
+    if (commandArg !== undefined) {
+      throw new Error(`Unexpected extra production data command "${arg}".`);
+    }
+    commandArg = arg;
+  }
+
+  const command = parseCommand(commandArg);
+  return {
+    command,
+    games: resolveGameScope(rawGame ?? env.SQUIRE_DATA_GAME),
+  };
+}
+
 async function main(): Promise<void> {
-  const command = parseCommand(process.argv[2]);
+  const { command, games } = parseProductionDataOptions();
   assertProductionRuntimeEnv();
   getProductionDatabaseTargetUrl();
 
@@ -227,12 +352,21 @@ async function main(): Promise<void> {
   }
 
   const url = getProductionDatabaseConnectionUrl();
+  if (command === 'smoke') {
+    try {
+      await runSmoke(games);
+    } finally {
+      await shutdownServerPool();
+    }
+    return;
+  }
+
   const handle = createStandaloneDb({ url, max: 1 });
   try {
     if (command === 'truncate-embeddings') {
-      await truncateEmbeddings(handle.db);
+      await truncateEmbeddings(handle.db, games);
     } else {
-      await runCheck(handle.db, command);
+      await runCheck(handle.db, command, games);
     }
   } finally {
     await handle.close();

--- a/scripts/seed-cards.ts
+++ b/scripts/seed-cards.ts
@@ -13,10 +13,11 @@ async function main(): Promise<void> {
   const { db, close } = getDb('cli');
   try {
     const explicitGame = process.env.SQUIRE_SEED_GAME ?? process.env.GHS_DATA_GAME;
-    const results = explicitGame
-      ? (await seedCards(db, { game: requireGameId(explicitGame) })).map((result) => ({
+    const game = explicitGame && explicitGame !== 'all' ? requireGameId(explicitGame) : null;
+    const results = game
+      ? (await seedCards(db, { game })).map((result) => ({
           ...result,
-          game: requireGameId(explicitGame),
+          game,
         }))
       : await seedAvailableCardGames(db);
     for (const r of results) {

--- a/scripts/seed-scenario-section-books.ts
+++ b/scripts/seed-scenario-section-books.ts
@@ -16,7 +16,7 @@ async function main(): Promise<void> {
   const { db, close } = getDb('cli');
   try {
     const explicitGame = process.env.SQUIRE_SEED_GAME ?? process.env.GHS_DATA_GAME;
-    const game = explicitGame ? requireGameId(explicitGame) : null;
+    const game = explicitGame && explicitGame !== 'all' ? requireGameId(explicitGame) : null;
     const results = game
       ? (await seedScenarioSectionBooks(db, { game })).map((result) => ({ ...result, game }))
       : await seedAvailableScenarioSectionBookGames(db);

--- a/src/index-docs.ts
+++ b/src/index-docs.ts
@@ -22,7 +22,7 @@ import {
   replaceEntriesForSources,
 } from './vector-store.ts';
 import type { IndexEntry } from './vector-store.ts';
-import { SUPPORTED_GAME_IDS, gameIdFromSourceFilename } from './game.ts';
+import { SUPPORTED_GAME_IDS, gameIdFromSourceFilename, requireGameId } from './game.ts';
 import type { GameId } from './game.ts';
 
 // Re-exported so seed / deployment workflows can reference the current value.
@@ -168,6 +168,12 @@ function discoverSourceDocuments(): SourceDocument[] {
   }));
 
   return [...pdfSources, ...normalizedTextSources];
+}
+
+export function resolveIndexGames(env: NodeJS.ProcessEnv = process.env): GameId[] {
+  const rawGame = env.SQUIRE_INDEX_GAME ?? env.SQUIRE_DATA_GAME ?? env.GHS_DATA_GAME;
+  if (!rawGame || rawGame === 'all') return [...SUPPORTED_GAME_IDS];
+  return [requireGameId(rawGame)];
 }
 
 /** Split text on double-newline boundaries into paragraphs. */
@@ -378,15 +384,17 @@ async function extractSourceText(source: SourceDocument, bytes: Buffer): Promise
 }
 
 export async function main(): Promise<void> {
-  const files = discoverSourceDocuments();
-  console.log(`Found ${files.length} rule source(s) to index.`);
+  const games = resolveIndexGames();
+  const selectedGames = new Set<GameId>(games);
+  const files = discoverSourceDocuments().filter((source) => selectedGames.has(source.game));
+  console.log(`Found ${files.length} rule source(s) to index for ${games.join(', ')}.`);
 
   const indexedSourceHashesByGame = new Map<string, Map<string, string | null>>();
-  for (const game of SUPPORTED_GAME_IDS) {
+  for (const game of games) {
     indexedSourceHashesByGame.set(game, await getIndexedSourceHashes(game));
   }
 
-  for (const game of SUPPORTED_GAME_IDS) {
+  for (const game of games) {
     const indexedSourceHashes = indexedSourceHashesByGame.get(game) ?? new Map();
     const currentSources = new Set(
       files.filter((source) => source.game === game).map((source) => source.file),

--- a/test/index-docs.test.ts
+++ b/test/index-docs.test.ts
@@ -65,6 +65,7 @@ import {
   htmlToIndexText,
   assertUsablePdfText,
   main,
+  resolveIndexGames,
 } from '../src/index-docs.ts';
 
 describe('splitIntoParagraphs', () => {
@@ -327,9 +328,23 @@ describe('chunkText', () => {
 describe('main', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.SQUIRE_INDEX_GAME;
+    delete process.env.SQUIRE_DATA_GAME;
+    delete process.env.GHS_DATA_GAME;
     mockDeleteEntriesForSources.mockResolvedValue(0);
     mockAddEntries.mockResolvedValue(undefined);
     mockReplaceEntriesForSources.mockResolvedValue(0);
+  });
+
+  it('resolves an optional game scope for production reindex workflows', () => {
+    expect(resolveIndexGames({})).toEqual(['frosthaven', 'gloomhaven-2e']);
+    expect(resolveIndexGames({ SQUIRE_INDEX_GAME: 'all' })).toEqual([
+      'frosthaven',
+      'gloomhaven-2e',
+    ]);
+    expect(resolveIndexGames({ SQUIRE_INDEX_GAME: 'gh2' })).toEqual(['gloomhaven-2e']);
+    expect(resolveIndexGames({ SQUIRE_DATA_GAME: 'frosthaven' })).toEqual(['frosthaven']);
+    expect(() => resolveIndexGames({ SQUIRE_INDEX_GAME: 'jotl' })).toThrow(/Unsupported game id/);
   });
 
   it('skips unchanged files already in the index', async () => {
@@ -562,6 +577,43 @@ describe('main', () => {
     expect(mockPdfParse).not.toHaveBeenCalled();
     expect(mockEmbedBatch).not.toHaveBeenCalled();
     expect(mockAddEntries).not.toHaveBeenCalled();
+  });
+
+  it('scopes stale deletion and indexing to the selected production game', async () => {
+    process.env.SQUIRE_INDEX_GAME = 'gh2';
+    const gh2Bytes = Buffer.from('gh2 changed pdf bytes');
+    mockReaddirSync.mockReturnValue(['fh-kept.pdf', 'gh2-changed.pdf']);
+    mockReadFileSync.mockImplementation((path) => {
+      if (String(path).endsWith('gh2-changed.pdf')) return gh2Bytes;
+      return Buffer.from('unexpected frosthaven read');
+    });
+    mockPdfParse.mockResolvedValue({ text: 'GH2 rules text. '.repeat(90) });
+    mockGetIndexedSourceHashes.mockImplementation((game: string) =>
+      Promise.resolve(
+        game === 'gloomhaven-2e'
+          ? new Map([
+              ['gh2-changed.pdf', 'old-hash'],
+              ['gh2-removed.pdf', 'removed-hash'],
+            ])
+          : new Map([['fh-removed.pdf', 'removed-fh-hash']]),
+      ),
+    );
+    mockEmbedBatch.mockResolvedValue([[0.2, 0.3]]);
+
+    await main();
+
+    expect(mockGetIndexedSourceHashes).toHaveBeenCalledTimes(1);
+    expect(mockGetIndexedSourceHashes).toHaveBeenCalledWith('gloomhaven-2e');
+    expect(mockDeleteEntriesForSources).toHaveBeenCalledWith(['gh2-removed.pdf'], 'gloomhaven-2e');
+    expect(mockDeleteEntriesForSources).not.toHaveBeenCalledWith(['fh-removed.pdf'], 'frosthaven');
+    expect(mockReplaceEntriesForSources).toHaveBeenCalledWith(
+      new Map([['gloomhaven-2e', ['gh2-changed.pdf']]]),
+      expect.any(Array),
+    );
+    const newEntries = mockReplaceEntriesForSources.mock.calls[0][1];
+    expect(new Set(newEntries.map((entry: { game: string }) => entry.game))).toEqual(
+      new Set(['gloomhaven-2e']),
+    );
   });
 
   it('keeps indexed rule source rows when the source file still exists', async () => {

--- a/test/production-data-workflows.test.ts
+++ b/test/production-data-workflows.test.ts
@@ -6,6 +6,7 @@ import {
   assertProductionDatabaseUrl,
   getProductionDatabaseConnectionUrl,
   getProductionDatabaseTargetUrl,
+  parseProductionDataOptions,
 } from '../scripts/check-production-data.ts';
 
 async function readProjectFile(path: string): Promise<string> {
@@ -33,6 +34,9 @@ describe('production data lifecycle workflows', () => {
     );
     expect(packageJson.scripts?.['production-data:check']).toBe(
       'node scripts/check-production-data.ts',
+    );
+    expect(packageJson.scripts?.['production-data:smoke']).toBe(
+      'node scripts/check-production-data.ts smoke',
     );
     expect(packageJson.scripts?.['production-data:truncate-embeddings']).toBe(
       'node scripts/check-production-data.ts truncate-embeddings',
@@ -119,6 +123,32 @@ describe('production data lifecycle workflows', () => {
     ).toThrow(/local Fly proxy/);
   });
 
+  it('parses production data check commands with explicit game scopes', () => {
+    expect(parseProductionDataOptions(['cards'])).toEqual({
+      command: 'cards',
+      games: ['frosthaven', 'gloomhaven-2e'],
+    });
+    expect(parseProductionDataOptions(['embeddings', '--game', 'gh2'])).toEqual({
+      command: 'embeddings',
+      games: ['gloomhaven-2e'],
+    });
+    expect(parseProductionDataOptions(['--game=gh2', 'smoke'])).toEqual({
+      command: 'smoke',
+      games: ['gloomhaven-2e'],
+    });
+    expect(
+      parseProductionDataOptions(['scenario-section-books'], {
+        SQUIRE_DATA_GAME: 'frosthaven',
+      }),
+    ).toEqual({
+      command: 'scenario-section-books',
+      games: ['frosthaven'],
+    });
+    expect(() => parseProductionDataOptions(['cards', '--game', 'jotl'])).toThrow(
+      /Unsupported game id/,
+    );
+  });
+
   it('seeds production card data only through the protected production environment', async () => {
     const workflow = await readProjectFile('.github/workflows/production-seed-cards.yml');
 
@@ -127,11 +157,18 @@ describe('production data lifecycle workflows', () => {
     expect(workflow).toContain('data/extracted/**');
     expect(workflow).toContain('!data/extracted/scenario-section-books.json');
     expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('game:');
+    expect(workflow).toContain('options:');
+    expect(workflow).toContain('- all');
+    expect(workflow).toContain('- frosthaven');
+    expect(workflow).toContain('- gloomhaven-2e');
     expect(workflow).toContain('name: production');
     expect(workflow).toContain('FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}');
     expect(workflow).toContain('PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}');
     expect(workflow).toContain('NODE_ENV: production');
     expect(workflow).toContain('SQUIRE_ENV: production');
+    expect(workflow).toContain("SQUIRE_DATA_GAME: ${{ github.event.inputs.game || 'all' }}");
+    expect(workflow).toContain("SQUIRE_SEED_GAME: ${{ github.event.inputs.game || 'all' }}");
     expect(workflow).toContain('superfly/flyctl-actions/setup-flyctl');
     expect(workflow).toContain('flyctl wireguard websockets enable');
     expect(workflow).toContain('flyctl proxy 15432:5432 "$remote_host" --app maz-squire');
@@ -139,7 +176,7 @@ describe('production data lifecycle workflows', () => {
     expect(workflow).toContain('run: npm run production-data:verify-db-url');
     expect(workflow).toContain('run: npm run db:migrate');
     expect(workflow).toContain('run: npm run seed:cards');
-    expect(workflow).toContain('run: npm run production-data:check -- cards');
+    expect(workflow).toContain('npm run production-data:check -- cards --game "$SQUIRE_DATA_GAME"');
     expect(workflow).not.toContain('refresh-data');
   });
 
@@ -156,13 +193,21 @@ describe('production data lifecycle workflows', () => {
     expect(workflow).toContain('src/seed/seed-scenario-section-books.ts');
     expect(workflow).toContain('scripts/seed-scenario-section-books.ts');
     expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('game:');
+    expect(workflow).toContain('- all');
+    expect(workflow).toContain('- frosthaven');
+    expect(workflow).toContain('- gloomhaven-2e');
     expect(workflow).toContain('name: production');
     expect(workflow).toContain('PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}');
+    expect(workflow).toContain("SQUIRE_DATA_GAME: ${{ github.event.inputs.game || 'all' }}");
+    expect(workflow).toContain("SQUIRE_SEED_GAME: ${{ github.event.inputs.game || 'all' }}");
     expect(workflow).toContain('flyctl proxy 15432:5432 "$remote_host" --app maz-squire');
     expect(workflow).toContain('run: npm run production-data:verify-db-url');
     expect(workflow).toContain('run: npm run db:migrate');
     expect(workflow).toContain('run: npm run seed:scenario-section-books');
-    expect(workflow).toContain('run: npm run production-data:check -- scenario-section-books');
+    expect(workflow).toContain(
+      'npm run production-data:check -- scenario-section-books --game "$SQUIRE_DATA_GAME"',
+    );
   });
 
   it('indexes production rule sources with normal and protected rebuild modes', async () => {
@@ -178,16 +223,25 @@ describe('production data lifecycle workflows', () => {
     expect(workflow).toContain('src/retrieval-source.ts');
     expect(workflow).toContain('workflow_dispatch:');
     expect(workflow).toContain('rebuild:');
+    expect(workflow).toContain('game:');
+    expect(workflow).toContain('- all');
+    expect(workflow).toContain('- frosthaven');
+    expect(workflow).toContain('- gloomhaven-2e');
     expect(workflow).toContain('default: false');
     expect(workflow).toContain('name: production');
     expect(workflow).toContain('PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}');
+    expect(workflow).toContain("SQUIRE_DATA_GAME: ${{ github.event.inputs.game || 'all' }}");
+    expect(workflow).toContain("SQUIRE_INDEX_GAME: ${{ github.event.inputs.game || 'all' }}");
     expect(workflow).toContain('flyctl proxy 15432:5432 "$remote_host" --app maz-squire');
     expect(workflow).toContain('run: npm run production-data:verify-db-url');
     expect(workflow).toContain('run: npm run db:migrate');
     expect(workflow).toContain("if: github.event_name == 'workflow_dispatch' && inputs.rebuild");
     expect(workflow).toContain('run: npm run production-data:truncate-embeddings');
     expect(workflow).toContain('run: npm run index');
-    expect(workflow).toContain('run: npm run production-data:check -- embeddings');
+    expect(workflow).toContain(
+      'npm run production-data:check -- embeddings --game "$SQUIRE_DATA_GAME"',
+    );
+    expect(workflow).toContain('npm run production-data:smoke -- --game "$SQUIRE_DATA_GAME"');
   });
 
   it('waits for production rule-source reindex before Fly deploy when retrieval changed', async () => {
@@ -220,7 +274,13 @@ describe('production data lifecycle workflows', () => {
       'npm run seed:cards',
       'npm run seed:scenario-section-books',
       'npm run index',
+      'npm run production-data:smoke',
+      'rules search',
+      'item lookup',
       'workflow_dispatch',
+      'frosthaven',
+      'gloomhaven-2e',
+      'both games',
       'rebuild',
       'embedding model/version change',
       'Partial failure',


### PR DESCRIPTION
## Summary

- Add game-scoped production seed/reindex controls for `all`, `frosthaven`, and `gloomhaven-2e`.
- Scope production data checks, embedding truncation, and stale-source deletion to the selected game.
- Add `production-data:smoke` for real game-scoped rules search plus structured item lookup, with GH2 smoke also checking Frosthaven preservation.
- Refresh GH2 development docs, production runbooks, product spec, and architecture notes.

## Issues

SQR-216
SQR-217
SQR-218
SQR-219

## Review

- Pre-landing diff review completed locally.
- No blocking findings after adding the SQR-217 smoke-check path.

## Verification

- `npm run db:migrate:test`
- `npm run check` (95 test files, 1324 tests)
- `npm run lint:actions`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production workflows for card seeding, scenario/section-book seeding, and rule-source reindexing now support game-scoped selection (Frosthaven, Gloomhaven 2e, or all).

* **Tests**
  * Added smoke test for production data validation.

* **Chores**
  * Version bumped to 0.1.15.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->