### PR TITLE
fix(agent): resolve GH2 high-level monster stats

### DIFF
--- a/eval/suites/gloomhaven-2e.json
+++ b/eval/suites/gloomhaven-2e.json
@@ -196,6 +196,20 @@
     "caseCategory": "monster-stats"
   },
   {
+    "id": "gh2-monster-living-spirit-elite-level-7-hp",
+    "category": "monster-stats",
+    "question": "How many hit points does an elite level 7 Living Spirit have in Gloomhaven 2e?",
+    "finalAnswer": {
+      "expected": "An elite level 7 Living Spirit has 10 hit points.",
+      "grading": "Must answer 10 HP from the Gloomhaven 2e Living Spirit monster stat row for levels 4-7. Must not stop at the levels 0-3 row or say the data is missing."
+    },
+    "source": "data/extracted/gh2/monster-stats.json",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "monster-stats"
+  },
+  {
     "id": "gh2-scenario-11-reward",
     "category": "scenarios",
     "question": "What is Gloomhaven 2e scenario 11 called, and what does it unlock?",

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -633,7 +633,7 @@ async function runLangGraphAgentLoop(
         stopReason: state.stopReason,
       });
       const draftAnswer =
-        state.lastResponse && !hasToolUse(state.lastResponse)
+        state.toolCalls.length === 0 && state.lastResponse && !hasToolUse(state.lastResponse)
           ? textFromMessage(state.lastResponse)
           : '';
       if (draftAnswer) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -669,6 +669,14 @@ function displayTitleForCard(record: Record<string, unknown>, type: CardType): s
   return type;
 }
 
+function resolutionTitleForCard(record: Record<string, unknown>, type: CardType): string {
+  const title = displayTitleForCard(record, type);
+  if (type === 'monster-stats' && typeof record.levelRange === 'string') {
+    return `${title} (levels ${record.levelRange})`;
+  }
+  return title;
+}
+
 function cardMatchConfidence(
   query: string,
   record: Record<string, unknown>,
@@ -704,6 +712,29 @@ function extractLevelQuery(query: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
+function levelRangeIncludes(levelRange: unknown, level: number): boolean {
+  if (typeof levelRange !== 'string') return false;
+  const match = levelRange.match(/^(\d+)\s*[-–]\s*(\d+)$/);
+  if (!match) return false;
+  const min = Number(match[1]);
+  const max = Number(match[2]);
+  return Number.isFinite(min) && Number.isFinite(max) && level >= min && level <= max;
+}
+
+function recordLevelMatches(
+  type: CardType,
+  record: Record<string, unknown>,
+  level: number,
+): boolean {
+  if (type === 'monster-stats') return levelRangeIncludes(record.levelRange, level);
+
+  const value = record.level;
+  if (typeof value === 'number') return value === level;
+  if (typeof value === 'string' && /^\d+$/.test(value)) return Number(value) === level;
+
+  return true;
+}
+
 function extractExactItemNumberQuery(query: string): number | null {
   const match = query.match(/\bitems?\s*#?\s*0*(\d{1,3})\b/i);
   return match ? Number(match[1]) : null;
@@ -714,6 +745,22 @@ function normalizedCardNumber(record: Record<string, unknown>): number | null {
   if (typeof value !== 'string' && typeof value !== 'number') return null;
   const match = String(value).match(/^0*(\d{1,3})$/);
   return match ? Number(match[1]) : null;
+}
+
+function naturalCardSearchScore(
+  query: string,
+  record: Record<string, unknown>,
+  type: CardType,
+): number {
+  let score = cardMatchConfidence(query, record, type);
+  if (
+    type === 'monster-stats' &&
+    /\b(?:hp|hit points?|level|elite|normal|monsters?|stats?|stat block)\b/i.test(query) &&
+    !/\b(?:abilit(?:y|ies)|deck)\b/i.test(query)
+  ) {
+    score += 0.1;
+  }
+  return score;
 }
 
 async function resolveCards(
@@ -735,11 +782,11 @@ async function resolveCards(
     const records = await load(type, normalizedOpts);
     for (const rawRecord of records) {
       const record = stripInternalKeys(rawRecord);
-      if (level !== null && record.level !== level) continue;
+      if (level !== null && !recordLevelMatches(type, record, level)) continue;
 
       const sourceId = record.sourceId;
       if (typeof sourceId !== 'string') continue;
-      const title = displayTitleForCard(record, type);
+      const title = resolutionTitleForCard(record, type);
       if (type === 'items' && exactItemNumber !== null) {
         if (normalizedCardNumber(record) !== exactItemNumber) continue;
         candidates.push({
@@ -779,7 +826,7 @@ async function resolveCards(
           source: `source:${game}/cards`,
           sourceLabel: 'GHS Card Data',
         },
-        confidence: cardMatchConfidence(query, record, type),
+        confidence: naturalCardSearchScore(query, record, type),
         matchReason: cardMatchReason(query, record, type),
       });
     }
@@ -796,7 +843,7 @@ async function resolveCards(
         entity: {
           kind: 'card',
           ref: canonicalCardRef(record._type, sourceId, game),
-          title: displayTitleForCard(stripped, record._type),
+          title: resolutionTitleForCard(stripped, record._type),
           source: `source:${game}/cards`,
           sourceLabel: 'GHS Card Data',
         },
@@ -1075,7 +1122,14 @@ export async function searchRules(query: string, topK = 6, opts?: ToolOpts): Pro
  * Returns structured results with card type, data, and `ts_rank` score.
  */
 export async function searchCards(query: string, topK = 6, opts?: ToolOpts): Promise<CardResult[]> {
-  const ranked = await searchExtractedRanked(query, topK, normalizeToolOpts(opts));
+  const normalizedOpts = normalizeToolOpts(opts);
+  const level = extractLevelQuery(query);
+  const naturalLevelMatches =
+    level === null ? [] : await searchCardsByNaturalFields(query, topK, normalizedOpts);
+  if (naturalLevelMatches.length > 0) return naturalLevelMatches;
+
+  const ranked = await searchExtractedRanked(query, topK, normalizedOpts);
+  if (ranked.length === 0) return searchCardsByNaturalFields(query, topK, normalizedOpts);
   return ranked.map(({ record, score }) => {
     const { _type, ...rest } = record;
     return {
@@ -1084,6 +1138,54 @@ export async function searchCards(query: string, topK = 6, opts?: ToolOpts): Pro
       score,
     };
   });
+}
+
+async function searchCardsByNaturalFields(
+  query: string,
+  topK: number,
+  opts: ToolOpts,
+): Promise<CardResult[]> {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (normalizedQuery === '') return [];
+
+  const level = extractLevelQuery(query);
+  const matches: CardResult[] = [];
+  for (const type of TYPES) {
+    const records = await load(type, opts);
+    for (const rawRecord of records) {
+      const record = stripInternalKeys(rawRecord);
+      if (level !== null && !recordLevelMatches(type, record, level)) continue;
+
+      const searchable = [
+        record.name,
+        record.cardName,
+        record.monsterType,
+        record.characterClass,
+        record.number,
+        record.sourceId,
+      ]
+        .filter((v): v is string | number => typeof v === 'string' || typeof v === 'number')
+        .map((v) => String(v).toLowerCase());
+      const matchesNaturalName = searchable.some(
+        (value) => normalizedQuery.includes(value) || value.includes(normalizedQuery),
+      );
+      if (!matchesNaturalName) continue;
+
+      matches.push({
+        type,
+        data: record,
+        score: naturalCardSearchScore(query, record, type),
+      });
+    }
+  }
+
+  return matches
+    .sort((a, b) => {
+      const scoreDelta = b.score - a.score;
+      if (scoreDelta !== 0) return scoreDelta;
+      return displayTitleForCard(a.data, a.type).localeCompare(displayTitleForCard(b.data, b.type));
+    })
+    .slice(0, topK);
 }
 
 // ─── Discovery tools ─────────────────────────────────────────────────────────

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -708,8 +708,8 @@ function cardMatchReason(query: string, record: Record<string, unknown>, type: C
 }
 
 function extractLevelQuery(query: string): number | null {
-  const match = query.match(/\blevel\s+(\d+)\b/i);
-  return match ? Number(match[1]) : null;
+  const match = query.match(/\b(?:level|lvl)\s+(\d+)\b|\bl\s*(\d+)\b/i);
+  return match ? Number(match[1] ?? match[2]) : null;
 }
 
 function levelRangeIncludes(levelRange: unknown, level: number): boolean {
@@ -732,7 +732,7 @@ function recordLevelMatches(
   if (typeof value === 'number') return value === level;
   if (typeof value === 'string' && /^\d+$/.test(value)) return Number(value) === level;
 
-  return true;
+  return false;
 }
 
 function extractExactItemNumberQuery(query: string): number | null {
@@ -837,6 +837,7 @@ async function resolveCards(
     for (const { record } of ranked) {
       if (!cardTypes.includes(record._type)) continue;
       const stripped = stripInternalKeys(record);
+      if (level !== null && !recordLevelMatches(record._type, stripped, level)) continue;
       const sourceId = stripped.sourceId;
       if (typeof sourceId !== 'string') continue;
       candidates.push({
@@ -1129,8 +1130,16 @@ export async function searchCards(query: string, topK = 6, opts?: ToolOpts): Pro
   if (naturalLevelMatches.length > 0) return naturalLevelMatches;
 
   const ranked = await searchExtractedRanked(query, topK, normalizedOpts);
-  if (ranked.length === 0) return searchCardsByNaturalFields(query, topK, normalizedOpts);
-  return ranked.map(({ record, score }) => {
+  const rankedLevelMatches =
+    level === null
+      ? ranked
+      : ranked.filter(({ record }) =>
+          recordLevelMatches(record._type, stripInternalKeys(record), level),
+        );
+  if (rankedLevelMatches.length === 0) {
+    return searchCardsByNaturalFields(query, topK, normalizedOpts);
+  }
+  return rankedLevelMatches.map(({ record, score }) => {
     const { _type, ...rest } = record;
     return {
       type: _type,

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -4,6 +4,7 @@ const {
   mockMessagesCreate,
   mockMessagesStream,
   mockSearchKnowledge,
+  mockListCards,
   mockNeighbors,
   mockOpenEntity,
   mockStartedSpans,
@@ -12,6 +13,7 @@ const {
   mockMessagesCreate: vi.fn(),
   mockMessagesStream: vi.fn(),
   mockSearchKnowledge: vi.fn(),
+  mockListCards: vi.fn(),
   mockNeighbors: vi.fn(),
   mockOpenEntity: vi.fn(),
   mockStartedSpans: [] as Array<{ name: string; span: { attributes: Record<string, unknown> } }>,
@@ -67,7 +69,7 @@ vi.mock('../src/tools.ts', () => ({
   searchRules: vi.fn(),
   searchCards: vi.fn(),
   listCardTypes: vi.fn(),
-  listCards: vi.fn(),
+  listCards: mockListCards,
   getCard: vi.fn(),
   findScenario: vi.fn(),
   getScenario: vi.fn(),
@@ -178,6 +180,12 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
         }),
       )
       .mockResolvedValueOnce(textResponse('Use loot abilities to pick up loot tokens.'));
+    mockMessagesStream.mockReturnValueOnce(
+      mockStream(textResponse('Use loot abilities to pick up loot tokens.'), [
+        'Use loot abilities ',
+        'to pick up loot tokens.',
+      ]),
+    );
     const emitted: Array<[AgentStreamEventName, unknown]> = [];
 
     const result = await runLangGraphAgentLoopWithTrajectory('How does loot work?', {
@@ -192,14 +200,12 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
     expect(result.trajectory.model).toBe('langgraph:claude-sonnet-4-6');
     expect(result.trajectory.toolCalls).toHaveLength(1);
     expect(mockMessagesCreate).toHaveBeenCalledTimes(2);
-    expect(mockMessagesStream).not.toHaveBeenCalled();
+    expect(mockMessagesStream).toHaveBeenCalledTimes(1);
     expect(mockMessagesCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: expect.arrayContaining([expect.objectContaining({ name: 'search_knowledge' })]),
       }),
     );
-    expect(mockMessagesStream).not.toHaveBeenCalled();
-
     const userVisibleEvents = emitted.filter(([event]) => event !== 'debug');
     expect(userVisibleEvents).toEqual([
       ['tool_progress', { message: 'Searching selected sources', toolName: 'search_knowledge' }],
@@ -208,9 +214,48 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
         { name: 'search_knowledge', input: { query: 'loot', scope: ['rules_passage'] } },
       ],
       ['tool_result', { name: 'search_knowledge', ok: true, sourceBooks: ['Rulebook'] }],
-      ['text', { delta: 'Use loot abilities to pick up loot tokens.' }],
+      ['text', { delta: 'Use loot abilities ' }],
+      ['text', { delta: 'to pick up loot tokens.' }],
       ['done', {}],
     ]);
+  });
+
+  it('does not expose post-tool retrieval prose as the final answer', async () => {
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('list_cards', {
+          type: 'monster-stats',
+          filter: { name: 'Living Spirit' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        textResponse('The stat card only covers levels 0-3. I need to check levels 4-7.'),
+      )
+      .mockResolvedValueOnce(textResponse('An elite level 7 Living Spirit has 10 hit points.'));
+    mockListCards.mockResolvedValueOnce([
+      {
+        name: 'Living Spirit',
+        levelRange: '0-3',
+        sourceId: 'gloomhavensecretariat:monster-stat/living-spirit/0-3',
+      },
+      {
+        name: 'Living Spirit',
+        levelRange: '4-7',
+        sourceId: 'gloomhavensecretariat:monster-stat/living-spirit/4-7',
+        elite: { '7': { hp: 10, move: 4, attack: 6 } },
+      },
+    ]);
+
+    const result = await runLangGraphAgentLoopWithTrajectory(
+      'How many hit points does an elite level 7 Living Spirit have?',
+      {
+        toolSurface: 'redesigned',
+        userMessageId: 'message-living-spirit',
+      },
+    );
+
+    expect(result.answer).toBe('An elite level 7 Living Spirit has 10 hit points.');
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(3);
   });
 
   it('continues after neighbors before finalizing answers that need target content', async () => {
@@ -252,7 +297,12 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
           scope: ['rules_passage'],
         }),
       )
-      .mockResolvedValueOnce(textResponse('Use loot abilities to pick up loot tokens.'));
+      .mockResolvedValueOnce(textResponse('I found the loot rule.'));
+    mockMessagesStream.mockReturnValueOnce(
+      mockStream(textResponse('Use loot abilities to pick up loot tokens.'), [
+        'Use loot abilities to pick up loot tokens.',
+      ]),
+    );
 
     await runLangGraphAgentLoopWithTrajectory('How does loot work?', {
       emit: async () => undefined,
@@ -272,9 +322,9 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
       finalAnswer: 'Use loot abilities to pick up loot tokens.',
     });
     expect(parseJsonAttribute(attributes, 'langsmith.usage_metadata')).toEqual({
-      input_tokens: 180,
-      output_tokens: 70,
-      total_tokens: 250,
+      input_tokens: 260,
+      output_tokens: 90,
+      total_tokens: 350,
       input_token_details: { cache_creation: 0, cache_read: 0 },
     });
     expect(attributes).toMatchObject({
@@ -299,8 +349,8 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
       'squire.agent.iterations': 2,
       'squire.agent.tool_call_count': 1,
       'squire.agent.stop_reason': 'end_turn',
-      'squire.agent.input_tokens': 180,
-      'squire.agent.output_tokens': 70,
+      'squire.agent.input_tokens': 260,
+      'squire.agent.output_tokens': 90,
       'squire.agent.cache_creation_input_tokens': 0,
       'squire.agent.cache_read_input_tokens': 0,
     });

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -63,8 +63,8 @@ describe('eval dataset', () => {
   });
 
   it('keeps the existing final-answer cases and adds enough trajectory coverage', () => {
-    expect(cases).toHaveLength(59);
-    expect(cases.filter(evalCaseHasFinalAnswer)).toHaveLength(37);
+    expect(cases).toHaveLength(60);
+    expect(cases.filter(evalCaseHasFinalAnswer)).toHaveLength(38);
     expect(countTrajectoryCases(cases)).toBeGreaterThanOrEqual(25);
   });
 
@@ -116,7 +116,7 @@ describe('eval dataset', () => {
     });
     expect(baselineCountsFor(cases, 'gloomhaven-2e')).toEqual({
       game: 'gloomhaven-2e',
-      finalAnswerCases: 17,
+      finalAnswerCases: 18,
       trajectoryCases: 11,
       boundaryCases: 2,
     });
@@ -200,6 +200,16 @@ describe('eval dataset', () => {
 
     expect(evalCase?.finalAnswer?.expected).toMatch(/character may use either/i);
     expect(evalCase?.finalAnswer?.grading).not.toMatch(/Frosthaven-specific character-choice/);
+  });
+
+  it('guards the GH2 high-level Living Spirit monster-stat smoke miss', () => {
+    const evalCase = cases.find(
+      (candidate) => candidate.id === 'gh2-monster-living-spirit-elite-level-7-hp',
+    );
+
+    expect(evalCase?.question).toMatch(/elite level 7 Living Spirit/i);
+    expect(evalCase?.finalAnswer?.expected).toMatch(/10 hit points/i);
+    expect(evalCase?.finalAnswer?.grading).toMatch(/levels 4-7/i);
   });
 
   it('treats read-now chain traversal as a neighbors requirement', () => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1308,6 +1308,33 @@ describe('searchCards', () => {
     });
   });
 
+  it('applies level filters when a monster stat query falls through to ranked search', async () => {
+    const results = await searchCards('spirit shield elite l7', 6, {
+      game: 'gloomhaven-2e',
+    });
+
+    expect(results[0]).toMatchObject({
+      type: 'monster-stats',
+      data: {
+        name: 'Living Spirit',
+        levelRange: '4-7',
+        sourceId: 'gloomhavensecretariat:monster-stat/living-spirit/4-7',
+        elite: {
+          '7': {
+            hp: 10,
+          },
+        },
+      },
+    });
+    expect(
+      results.some(
+        (result) =>
+          result.type === 'monster-stats' &&
+          result.data.sourceId === 'gloomhavensecretariat:monster-stat/living-spirit/0-3',
+      ),
+    ).toBe(false);
+  });
+
   it('respects topK parameter', async () => {
     const results = await searchCards('attack', 2);
     expect(results.length).toBeLessThanOrEqual(2);

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1284,6 +1284,30 @@ describe('searchCards', () => {
     expect(results[0].type).toBe('monster-stats');
   });
 
+  it('resolves GH2 high-level monster stat questions to the matching level band', async () => {
+    const results = await searchCards(
+      'how many hit points does an elite level 7 living spirit have',
+      6,
+      {
+        game: 'gloomhaven-2e',
+      },
+    );
+
+    expect(results[0]).toMatchObject({
+      type: 'monster-stats',
+      data: {
+        name: 'Living Spirit',
+        levelRange: '4-7',
+        sourceId: 'gloomhavensecretariat:monster-stat/living-spirit/4-7',
+        elite: {
+          '7': {
+            hp: 10,
+          },
+        },
+      },
+    });
+  });
+
   it('respects topK parameter', async () => {
     const results = await searchCards('attack', 2);
     expect(results.length).toBeLessThanOrEqual(2);
@@ -1540,7 +1564,7 @@ describe('knowledge discovery tools', () => {
       expect.objectContaining({
         kind: 'card',
         ref: expect.stringMatching(/^card:frosthaven\/monster-stats\//),
-        title: 'Living Bones',
+        title: expect.stringMatching(/^Living Bones \(levels /),
       }),
     );
     expect(monster.candidates[0].entity).not.toHaveProperty('data');
@@ -1559,6 +1583,38 @@ describe('knowledge discovery tools', () => {
       ]),
     );
     expect(ability.candidates[0].entity).not.toHaveProperty('data');
+  });
+
+  it('resolveEntity keeps only the matching GH2 monster stat level band', async () => {
+    const result = await resolveEntity('elite level 7 living spirit', {
+      kinds: ['monster-stat'],
+      game: 'gloomhaven-2e',
+      limit: 3,
+    });
+
+    expect(result.candidates.map((candidate) => candidate.entity.ref)).toContain(
+      'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/living-spirit/4-7',
+    );
+    expect(result.candidates.map((candidate) => candidate.entity.ref)).not.toContain(
+      'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/living-spirit/0-3',
+    );
+  });
+
+  it('resolveEntity ranks generic monster queries toward stat rows before ability cards', async () => {
+    const result = await resolveEntity('Living Spirit monster', {
+      kinds: ['monster'],
+      game: 'gloomhaven-2e',
+      limit: 6,
+    });
+
+    expect(result.candidates.slice(0, 2).map((candidate) => candidate.entity.ref)).toEqual([
+      'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/living-spirit/0-3',
+      'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/living-spirit/4-7',
+    ]);
+    expect(result.candidates.slice(0, 2).map((candidate) => candidate.entity.title)).toEqual([
+      'Living Spirit (levels 0-3)',
+      'Living Spirit (levels 4-7)',
+    ]);
   });
 
   it('resolveEntity treats item number queries as exact item refs', async () => {


### PR DESCRIPTION
## Summary
- add the GH2 Living Spirit elite level 7 HP smoke miss to the LangSmith-backed eval fixture
- rank natural monster-stat lookups toward stat rows and the matching level band before ability cards
- prevent LangGraph from treating post-tool retrieval prose as the final answer

## Validation
- `npm run check`
- `npm run test:db -- test/tools.test.ts test/eval-dataset.test.ts`
- `npm run test:unit -- test/agent-langgraph.test.ts`
- `npm run eval -- --seed`
- `npm run eval -- --matrix --id=gh2-monster-living-spirit-elite-level-7-hp --run-label=gh2-living-spirit-resolver-fix --local-report=/tmp/squire-gh2-living-spirit-resolver-fixed-eval.json`

Passing LangSmith trace: https://smith.langchain.com/o/44be4d80-ba50-4833-ae22-6e176be2dbf2/projects/p/4638c4e9-64ce-4a3e-86dd-111779e71635/r/019e6cc0-a472-7000-8000-0283bce595f4?poll=true

Fixes SQR-248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Level-aware filtering and improved scoring for Gloomhaven 2e monster-stat searches; clearer level-band titles in results

* **Bug Fixes**
  * Tighter final-answer derivation to avoid spurious post-tool prose
  * Better prioritization between extracted-ranked and natural-field search results

* **Tests**
  * Added/updated tests for monster-stat level matching, search ranking, streaming answers, and updated eval counts

* **Dataset**
  * Added an eval case for Living Spirit (elite level 7) HP verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->