### PR TITLE
SQR-250 Harden PDF extraction eval runner guardrails

### DIFF
--- a/docs/plans/sqr-188-189-pdf-extraction-vendor-eval-plan.md
+++ b/docs/plans/sqr-188-189-pdf-extraction-vendor-eval-plan.md
@@ -102,6 +102,20 @@ The shared harness contains:
   summaries, manifests, and small redacted samples while keeping full raw
   provider payloads out of git by default.
 
+SQR-250 hardens the runner so paid provider execution is explicit and
+repeatable:
+
+- Selected-page runs are the default. A full Gloomhaven (2nd Edition) rulebook
+  run must pass `--allow-full-rulebook`.
+- Estimated provider cost is checked before provider work. Runs that exceed
+  `--max-estimated-cost-usd` must pass `--allow-estimated-cost`.
+- Successful normalized provider artifacts are cached by provider, source hash,
+  provider config hash, and page set. Re-runs reuse the artifact unless
+  `--refresh-provider-output` is passed.
+- The manifest records cache hits, retry count, rate-limit count, timeout,
+  concurrency cap, estimated and actual cost, and whether full-rulebook or cost
+  overrides were used.
+
 The shared failure taxonomy is `timeout`, `rate_limit`, `credential_failure`,
 `provider_error`, `partial_page_failure`, `invalid_artifact`, `cost_guardrail`,
 and `unsupported_configuration`.

--- a/eval/pdf-extraction/cli.ts
+++ b/eval/pdf-extraction/cli.ts
@@ -7,6 +7,12 @@ export interface PdfExtractionCliOptions {
   outputDir: string;
   runLabel: string;
   retryCount: number;
+  allowFullRulebook: boolean;
+  allowEstimatedCostOverride: boolean;
+  maxEstimatedCostUsd: number;
+  providerConcurrency: number;
+  refreshProviderOutput: boolean;
+  timeoutMs: number;
 }
 
 function valueFor(args: string[], prefix: string): string | undefined {
@@ -50,6 +56,26 @@ function parseNonNegativeInteger(args: string[], prefix: string, fallback: numbe
   return parsed;
 }
 
+function parsePositiveInteger(args: string[], prefix: string, fallback: number): number {
+  const raw = valueFor(args, prefix);
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`Invalid ${prefix.slice(0, -1)}: expected a positive integer.`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeNumber(args: string[], prefix: string, fallback: number): number {
+  const raw = valueFor(args, prefix);
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Invalid ${prefix.slice(0, -1)}: expected a non-negative number.`);
+  }
+  return parsed;
+}
+
 function rejectUnknownFlags(args: string[]): void {
   const supportedPrefixes = [
     '--provider=',
@@ -59,8 +85,14 @@ function rejectUnknownFlags(args: string[]): void {
     '--run-label=',
     '--retry-count=',
     '--max-estimated-cost-usd=',
+    '--provider-concurrency=',
+    '--timeout-ms=',
   ];
-  const supportedLiterals = new Set(['--allow-full-rulebook']);
+  const supportedLiterals = new Set([
+    '--allow-full-rulebook',
+    '--allow-estimated-cost',
+    '--refresh-provider-output',
+  ]);
 
   for (const arg of args) {
     if (!arg.startsWith('--')) continue;
@@ -75,20 +107,14 @@ function rejectUnknownFlags(args: string[]): void {
 export function parsePdfExtractionArgs(args: string[]): PdfExtractionCliOptions {
   rejectUnknownFlags(args);
 
-  if (args.includes('--allow-full-rulebook')) {
-    throw new Error('Full-rulebook provider runs are implemented by SQR-250.');
-  }
-  if (args.some((arg) => arg.startsWith('--max-estimated-cost-usd='))) {
-    throw new Error('Cost guardrails are implemented by SQR-250.');
-  }
-
   const provider = parseProvider(args);
   const sourcePath = valueFor(args, '--source=');
   if (!sourcePath) throw new Error('Missing --source.');
 
+  const allowFullRulebook = args.includes('--allow-full-rulebook');
   const pages = parsePages(valueFor(args, '--pages='));
-  if (pages.length === 0) {
-    throw new Error('Selected pages are required until the guarded full-rulebook runner exists.');
+  if (pages.length === 0 && !allowFullRulebook) {
+    throw new Error('Selected pages are required unless --allow-full-rulebook is set.');
   }
 
   return {
@@ -98,5 +124,11 @@ export function parsePdfExtractionArgs(args: string[]): PdfExtractionCliOptions 
     outputDir: valueFor(args, '--output-dir=') ?? 'eval/results/pdf-extraction',
     runLabel: valueFor(args, '--run-label=') ?? `pdf-extraction-${new Date().toISOString()}`,
     retryCount: parseNonNegativeInteger(args, '--retry-count=', 0),
+    allowFullRulebook,
+    allowEstimatedCostOverride: args.includes('--allow-estimated-cost'),
+    maxEstimatedCostUsd: parseNonNegativeNumber(args, '--max-estimated-cost-usd=', 1),
+    providerConcurrency: parsePositiveInteger(args, '--provider-concurrency=', 1),
+    refreshProviderOutput: args.includes('--refresh-provider-output'),
+    timeoutMs: parsePositiveInteger(args, '--timeout-ms=', 120_000),
   };
 }

--- a/eval/pdf-extraction/manifest.ts
+++ b/eval/pdf-extraction/manifest.ts
@@ -8,10 +8,26 @@ export interface ExtractionManifestCache {
   hit: boolean;
 }
 
+export interface ExtractionManifestExecution {
+  selectedPages: number[];
+  fullRulebook: boolean;
+  fullRulebookOverride: boolean;
+  estimatedCostUsd?: number;
+  maxEstimatedCostUsd?: number;
+  costOverride: boolean;
+  retryLimit: number;
+  retryCount: number;
+  timeoutMs?: number;
+  concurrencyLimit?: number;
+  rateLimitCount: number;
+  refreshedProviderOutput: boolean;
+}
+
 export interface ExtractionManifestInput {
   artifactPath: string;
   normalizedArtifactHash: string;
   cache: ExtractionManifestCache;
+  execution?: ExtractionManifestExecution;
 }
 
 export interface ExtractionManifest {
@@ -29,6 +45,7 @@ export interface ExtractionManifest {
   cost: ExtractionArtifact['cost'];
   privacy: ExtractionArtifact['privacy'];
   cache: ExtractionManifestCache;
+  execution: ExtractionManifestExecution;
 }
 
 export function buildExtractionManifest(
@@ -50,6 +67,20 @@ export function buildExtractionManifest(
     cost: artifact.cost,
     privacy: artifact.privacy,
     cache: input.cache,
+    execution: input.execution ?? {
+      selectedPages: artifact.run.pageRange ?? artifact.pages.map((page) => page.pageNumber),
+      fullRulebook: !artifact.run.pageRange || artifact.run.pageRange.length === 0,
+      fullRulebookOverride: false,
+      estimatedCostUsd: artifact.cost.estimatedUsd,
+      maxEstimatedCostUsd: undefined,
+      costOverride: false,
+      retryLimit: 0,
+      retryCount: 0,
+      timeoutMs: undefined,
+      concurrencyLimit: undefined,
+      rateLimitCount: 0,
+      refreshedProviderOutput: false,
+    },
   };
 }
 

--- a/eval/pdf-extraction/provider.ts
+++ b/eval/pdf-extraction/provider.ts
@@ -10,6 +10,7 @@ export interface PdfExtractionRunInput {
   outputDir: string;
   runLabel: string;
   retryCount: number;
+  timeoutMs?: number;
 }
 
 export interface PdfExtractionProvider {

--- a/eval/pdf-extraction/runner.ts
+++ b/eval/pdf-extraction/runner.ts
@@ -1,3 +1,6 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
 import { buildExtractionManifest, type ExtractionManifest } from './manifest.ts';
 import {
   classifyProviderError,
@@ -30,16 +33,28 @@ export type PdfExtractionStatusEvent =
       runLabel: string;
       failureClass: ExtractionFailureClass;
       message: string;
+    }
+  | {
+      stage: 'retrying';
+      provider: PdfExtractionProviderId;
+      runLabel: string;
+      failureClass: ExtractionFailureClass;
+      message: string;
+      retryCount: number;
     };
 
 export interface PdfExtractionRunnerInput extends PdfExtractionRunInput {
   registry: ProviderRegistry;
   provider: PdfExtractionProviderId;
+  sourceHash: string;
+  providerConfigHash: string;
   artifactPath?: string;
-  cache?: {
-    key?: string;
-    hit?: boolean;
-  };
+  allowFullRulebook?: boolean;
+  allowEstimatedCostOverride?: boolean;
+  estimatedCostUsd?: number;
+  maxEstimatedCostUsd?: number;
+  providerConcurrency?: number;
+  refreshProviderOutput?: boolean;
   onStatus?: (event: PdfExtractionStatusEvent) => void;
 }
 
@@ -49,45 +64,216 @@ export interface PdfExtractionRunnerResult {
 }
 
 function defaultArtifactPath(input: PdfExtractionRunnerInput): string {
-  return `${input.outputDir}/normalized/${input.provider}/${input.runLabel}.json`;
+  const pageKey = input.pages.length === 0 ? 'full-rulebook' : `pages-${input.pages.join('-')}`;
+  return `${input.outputDir}/normalized/${input.provider}/${input.sourceHash.slice(7)}/${input.providerConfigHash.slice(7)}/${pageKey}.json`;
 }
 
-function defaultCacheKey(artifact: ExtractionArtifact): string {
-  const pages =
-    artifact.run.pageRange?.join(',') ?? artifact.pages.map((page) => page.pageNumber).join(',');
-  return `${artifact.provider}:${artifact.source.sha256}:${artifact.providerConfigHash}:${pages}`;
+function defaultCacheKey(input: PdfExtractionRunnerInput): string {
+  const pages = input.pages.length === 0 ? 'full-rulebook' : input.pages.join(',');
+  return `${input.provider}:${input.sourceHash}:${input.providerConfigHash}:${pages}`;
+}
+
+function isRetryableFailure(failureClass: ExtractionFailureClass): boolean {
+  return (
+    failureClass === 'rate_limit' || failureClass === 'timeout' || failureClass === 'provider_error'
+  );
+}
+
+function validateGuardrails(input: PdfExtractionRunnerInput): void {
+  if (input.pages.length === 0 && !input.allowFullRulebook) {
+    throw new Error('Full-rulebook PDF extraction requires --allow-full-rulebook.');
+  }
+
+  if (
+    input.maxEstimatedCostUsd !== undefined &&
+    input.estimatedCostUsd !== undefined &&
+    input.estimatedCostUsd > input.maxEstimatedCostUsd &&
+    !input.allowEstimatedCostOverride
+  ) {
+    throw new Error(
+      `Estimated PDF extraction cost $${input.estimatedCostUsd.toFixed(2)} exceeds --max-estimated-cost-usd=${input.maxEstimatedCostUsd} and requires --allow-estimated-cost.`,
+    );
+  }
+
+  if (
+    input.providerConcurrency !== undefined &&
+    (!Number.isInteger(input.providerConcurrency) || input.providerConcurrency < 1)
+  ) {
+    throw new Error(
+      `Invalid ${input.provider} PDF extraction concurrency: expected a positive integer.`,
+    );
+  }
+
+  if (input.retryCount < 0 || !Number.isInteger(input.retryCount)) {
+    throw new Error('Invalid PDF extraction retry count: expected a non-negative integer.');
+  }
+}
+
+async function readCachedArtifact(artifactPath: string): Promise<ExtractionArtifact | undefined> {
+  try {
+    const raw = await readFile(artifactPath, 'utf8');
+    const artifact = validateExtractionArtifact(JSON.parse(raw));
+    return artifact.run.status === 'succeeded' ? artifact : undefined;
+  } catch (error) {
+    if (typeof error === 'object' && error && 'code' in error && error.code === 'ENOENT') {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function writeNormalizedArtifact(
+  artifactPath: string,
+  artifact: ExtractionArtifact,
+): Promise<void> {
+  await mkdir(dirname(artifactPath), { recursive: true });
+  await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, 'utf8');
+}
+
+function assertArtifactMatchesRequest(
+  artifact: ExtractionArtifact,
+  input: PdfExtractionRunnerInput,
+): void {
+  if (artifact.provider !== input.provider) {
+    throw new Error(
+      `Provider artifact mismatch: expected ${input.provider}, got ${artifact.provider}.`,
+    );
+  }
+  if (artifact.source.sha256 !== input.sourceHash) {
+    throw new Error(
+      `Source artifact hash mismatch: expected ${input.sourceHash}, got ${artifact.source.sha256}.`,
+    );
+  }
+  if (artifact.providerConfigHash !== input.providerConfigHash) {
+    throw new Error(
+      `Provider config artifact hash mismatch: expected ${input.providerConfigHash}, got ${artifact.providerConfigHash}.`,
+    );
+  }
+}
+
+function buildManifestForArtifact(
+  artifact: ExtractionArtifact,
+  input: PdfExtractionRunnerInput,
+  artifactPath: string,
+  cacheHit: boolean,
+  retryCount: number,
+  rateLimitCount: number,
+): ExtractionManifest {
+  return buildExtractionManifest(artifact, {
+    artifactPath,
+    normalizedArtifactHash: computeStableSha256(artifact),
+    cache: {
+      key: defaultCacheKey(input),
+      hit: cacheHit,
+    },
+    execution: {
+      selectedPages: input.pages,
+      fullRulebook: input.pages.length === 0,
+      fullRulebookOverride: input.allowFullRulebook ?? false,
+      estimatedCostUsd: input.estimatedCostUsd ?? artifact.cost.estimatedUsd,
+      maxEstimatedCostUsd: input.maxEstimatedCostUsd,
+      costOverride: input.allowEstimatedCostOverride ?? false,
+      retryLimit: input.retryCount,
+      retryCount,
+      timeoutMs: input.timeoutMs,
+      concurrencyLimit: input.providerConcurrency,
+      rateLimitCount,
+      refreshedProviderOutput: input.refreshProviderOutput ?? false,
+    },
+  });
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number | undefined): Promise<T> {
+  if (timeoutMs === undefined) return promise;
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`PDF extraction provider timed out after ${timeoutMs}ms.`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 export async function runPdfExtraction(
   input: PdfExtractionRunnerInput,
 ): Promise<PdfExtractionRunnerResult> {
   const provider = input.registry.get(input.provider);
+  validateGuardrails(input);
+
   input.onStatus?.({ stage: 'started', provider: input.provider, runLabel: input.runLabel });
 
-  let rawArtifact: unknown;
-  try {
-    rawArtifact = await provider.extract({
-      sourcePath: input.sourcePath,
-      pages: input.pages,
-      outputDir: input.outputDir,
-      runLabel: input.runLabel,
-      retryCount: input.retryCount,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+  const artifactPath = input.artifactPath ?? defaultArtifactPath(input);
+  const cachedArtifact = input.refreshProviderOutput
+    ? undefined
+    : await readCachedArtifact(artifactPath);
+  if (cachedArtifact) {
+    assertArtifactMatchesRequest(cachedArtifact, input);
+    const manifest = buildManifestForArtifact(cachedArtifact, input, artifactPath, true, 0, 0);
+    const result = { artifact: cachedArtifact, manifest };
     input.onStatus?.({
-      stage: 'failed',
+      stage: 'succeeded',
       provider: input.provider,
       runLabel: input.runLabel,
-      failureClass: classifyProviderError(error),
-      message,
+      manifest: result.manifest,
     });
-    throw error;
+    return result;
+  }
+
+  let rawArtifact: unknown;
+  let observedRetryCount = 0;
+  let rateLimitCount = 0;
+  for (;;) {
+    try {
+      rawArtifact = await withTimeout(
+        provider.extract({
+          sourcePath: input.sourcePath,
+          pages: input.pages,
+          outputDir: input.outputDir,
+          runLabel: input.runLabel,
+          retryCount: input.retryCount,
+          timeoutMs: input.timeoutMs,
+        }),
+        input.timeoutMs,
+      );
+      break;
+    } catch (error) {
+      const failureClass = classifyProviderError(error);
+      if (failureClass === 'rate_limit') rateLimitCount += 1;
+      const message = error instanceof Error ? error.message : String(error);
+      if (!isRetryableFailure(failureClass) || observedRetryCount >= input.retryCount) {
+        input.onStatus?.({
+          stage: 'failed',
+          provider: input.provider,
+          runLabel: input.runLabel,
+          failureClass,
+          message,
+        });
+        throw error;
+      }
+      observedRetryCount += 1;
+      input.onStatus?.({
+        stage: 'retrying',
+        provider: input.provider,
+        runLabel: input.runLabel,
+        failureClass,
+        message,
+        retryCount: observedRetryCount,
+      });
+    }
   }
 
   let artifact: ExtractionArtifact;
   try {
     artifact = validateExtractionArtifact(rawArtifact);
+    assertArtifactMatchesRequest(artifact, input);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     input.onStatus?.({
@@ -105,16 +291,17 @@ export async function runPdfExtraction(
     );
   }
 
+  await writeNormalizedArtifact(artifactPath, artifact);
   const result = {
     artifact,
-    manifest: buildExtractionManifest(artifact, {
-      artifactPath: input.artifactPath ?? defaultArtifactPath(input),
-      normalizedArtifactHash: computeStableSha256(artifact),
-      cache: {
-        key: input.cache?.key ?? defaultCacheKey(artifact),
-        hit: input.cache?.hit ?? false,
-      },
-    }),
+    manifest: buildManifestForArtifact(
+      artifact,
+      input,
+      artifactPath,
+      false,
+      observedRetryCount,
+      rateLimitCount,
+    ),
   };
   input.onStatus?.({
     stage: 'succeeded',

--- a/eval/pdf-extraction/runner.ts
+++ b/eval/pdf-extraction/runner.ts
@@ -74,9 +74,7 @@ function defaultCacheKey(input: PdfExtractionRunnerInput): string {
 }
 
 function isRetryableFailure(failureClass: ExtractionFailureClass): boolean {
-  return (
-    failureClass === 'rate_limit' || failureClass === 'timeout' || failureClass === 'provider_error'
-  );
+  return failureClass === 'rate_limit' || failureClass === 'provider_error';
 }
 
 function validateGuardrails(input: PdfExtractionRunnerInput): void {

--- a/eval/pdf-extraction/runner.ts
+++ b/eval/pdf-extraction/runner.ts
@@ -1,5 +1,6 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, open, readFile, rename, unlink } from 'node:fs/promises';
 import { dirname } from 'node:path';
+import { ZodError } from 'zod';
 
 import { buildExtractionManifest, type ExtractionManifest } from './manifest.ts';
 import {
@@ -116,6 +117,9 @@ async function readCachedArtifact(artifactPath: string): Promise<ExtractionArtif
     if (typeof error === 'object' && error && 'code' in error && error.code === 'ENOENT') {
       return undefined;
     }
+    if (error instanceof SyntaxError || error instanceof ZodError) {
+      return undefined;
+    }
     throw error;
   }
 }
@@ -125,7 +129,64 @@ async function writeNormalizedArtifact(
   artifact: ExtractionArtifact,
 ): Promise<void> {
   await mkdir(dirname(artifactPath), { recursive: true });
-  await writeFile(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`, 'utf8');
+  const tempPath = `${artifactPath}.${process.pid}.${Date.now()}.tmp`;
+  const file = await open(tempPath, 'w');
+  try {
+    await file.writeFile(`${JSON.stringify(artifact, null, 2)}\n`, 'utf8');
+    await file.sync();
+  } finally {
+    await file.close();
+  }
+  try {
+    await rename(tempPath, artifactPath);
+  } catch (error) {
+    await unlink(tempPath).catch(() => undefined);
+    throw error;
+  }
+}
+
+function pageSetLabel(pages: number[]): string {
+  return pages.length === 0 ? 'full-rulebook' : pages.join(',');
+}
+
+function normalizePageSet(pages: number[]): number[] {
+  return [...new Set(pages)].sort((left, right) => left - right);
+}
+
+function assertPageSelectionMatchesRequest(
+  artifact: ExtractionArtifact,
+  input: PdfExtractionRunnerInput,
+): void {
+  const artifactRunPages = artifact.run.pageRange ?? [];
+  if (input.pages.length === 0) {
+    if (artifactRunPages.length > 0) {
+      throw new Error(
+        `Page artifact mismatch: expected full-rulebook, got ${pageSetLabel(normalizePageSet(artifactRunPages))}.`,
+      );
+    }
+    if (
+      artifact.source.pageCount !== undefined &&
+      artifact.pages.length !== artifact.source.pageCount
+    ) {
+      throw new Error(
+        `Page artifact mismatch: expected ${artifact.source.pageCount} full-rulebook pages, got ${artifact.pages.length}.`,
+      );
+    }
+    return;
+  }
+
+  const expectedPages = normalizePageSet(input.pages);
+  const actualPages = normalizePageSet(
+    artifactRunPages.length > 0 ? artifactRunPages : artifact.pages.map((page) => page.pageNumber),
+  );
+  if (
+    expectedPages.length !== actualPages.length ||
+    expectedPages.some((page, index) => page !== actualPages[index])
+  ) {
+    throw new Error(
+      `Page artifact mismatch: expected ${pageSetLabel(expectedPages)}, got ${pageSetLabel(actualPages)}.`,
+    );
+  }
 }
 
 function assertArtifactMatchesRequest(
@@ -147,6 +208,7 @@ function assertArtifactMatchesRequest(
       `Provider config artifact hash mismatch: expected ${input.providerConfigHash}, got ${artifact.providerConfigHash}.`,
     );
   }
+  assertPageSelectionMatchesRequest(artifact, input);
 }
 
 function buildManifestForArtifact(

--- a/test/pdf-extraction-cli.test.ts
+++ b/test/pdf-extraction-cli.test.ts
@@ -12,6 +12,9 @@ describe('parsePdfExtractionArgs', () => {
         '--output-dir=eval/results/pdf-extraction',
         '--run-label=textract-smoke',
         '--retry-count=2',
+        '--max-estimated-cost-usd=0.50',
+        '--provider-concurrency=1',
+        '--timeout-ms=60000',
       ]),
     ).toEqual({
       provider: 'aws-textract',
@@ -20,25 +23,30 @@ describe('parsePdfExtractionArgs', () => {
       outputDir: 'eval/results/pdf-extraction',
       runLabel: 'textract-smoke',
       retryCount: 2,
+      allowFullRulebook: false,
+      allowEstimatedCostOverride: false,
+      maxEstimatedCostUsd: 0.5,
+      providerConcurrency: 1,
+      refreshProviderOutput: false,
+      timeoutMs: 60000,
     });
   });
 
-  it('rejects full-rulebook and cost guardrail flags reserved for SQR-250', () => {
-    expect(() =>
+  it('parses explicit full-rulebook and cost override flags', () => {
+    expect(
       parsePdfExtractionArgs([
         '--provider=aws-textract',
         '--source=data/pdfs/gh2-rule-book.pdf',
         '--allow-full-rulebook',
-      ]),
-    ).toThrow(/Full-rulebook provider runs are implemented by SQR-250/);
-
-    expect(() =>
-      parsePdfExtractionArgs([
-        '--provider=aws-textract',
-        '--source=data/pdfs/gh2-rule-book.pdf',
+        '--allow-estimated-cost',
         '--max-estimated-cost-usd=1',
       ]),
-    ).toThrow(/Cost guardrails are implemented by SQR-250/);
+    ).toMatchObject({
+      pages: [],
+      allowFullRulebook: true,
+      allowEstimatedCostOverride: true,
+      maxEstimatedCostUsd: 1,
+    });
   });
 
   it('rejects empty and unsupported providers', () => {
@@ -64,6 +72,26 @@ describe('parsePdfExtractionArgs', () => {
   it('requires selected pages until the guarded full-rulebook runner exists', () => {
     expect(() =>
       parsePdfExtractionArgs(['--provider=llamaparse', '--source=data/pdfs/gh2-rule-book.pdf']),
-    ).toThrow(/Selected pages are required/);
+    ).toThrow(/Selected pages are required unless --allow-full-rulebook is set/);
+  });
+
+  it('rejects invalid guardrail values', () => {
+    expect(() =>
+      parsePdfExtractionArgs([
+        '--provider=llamaparse',
+        '--source=data/pdfs/gh2-rule-book.pdf',
+        '--pages=30',
+        '--max-estimated-cost-usd=-1',
+      ]),
+    ).toThrow(/Invalid --max-estimated-cost-usd/);
+
+    expect(() =>
+      parsePdfExtractionArgs([
+        '--provider=llamaparse',
+        '--source=data/pdfs/gh2-rule-book.pdf',
+        '--pages=30',
+        '--provider-concurrency=0',
+      ]),
+    ).toThrow(/Invalid --provider-concurrency/);
   });
 });

--- a/test/pdf-extraction-runner.test.ts
+++ b/test/pdf-extraction-runner.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import { runPdfExtraction, type PdfExtractionStatusEvent } from '../eval/pdf-extraction/runner.ts';
@@ -70,6 +74,7 @@ function registryWith(provider: PdfExtractionProvider) {
 
 describe('runPdfExtraction', () => {
   it('executes the selected provider and returns a normalized manifest', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'squire-pdf-extraction-runner-'));
     const extract = vi.fn<PdfExtractionProvider['extract']>().mockResolvedValue(artifact);
     const registry = registryWith({
       id: 'aws-textract',
@@ -83,30 +88,48 @@ describe('runPdfExtraction', () => {
       registry,
       provider: 'aws-textract',
       sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+      sourceHash: artifact.source.sha256,
+      providerConfigHash: artifact.providerConfigHash,
       pages: [30],
-      outputDir: 'eval/results/pdf-extraction',
+      outputDir,
       runLabel: 'run-textract-page-30',
       retryCount: 0,
+      maxEstimatedCostUsd: 0.1,
+      estimatedCostUsd: 0.05,
+      providerConcurrency: 1,
       onStatus: (event) => statusEvents.push(event),
     });
 
     expect(extract).toHaveBeenCalledWith({
       sourcePath: 'data/pdfs/gh2-rule-book.pdf',
       pages: [30],
-      outputDir: 'eval/results/pdf-extraction',
+      outputDir,
       runLabel: 'run-textract-page-30',
       retryCount: 0,
+      timeoutMs: undefined,
     });
     expect(result.artifact.provider).toBe('aws-textract');
     expect(result.manifest).toMatchObject({
       schemaVersion: 'squire-pdf-extraction-manifest-v1',
       provider: 'aws-textract',
       runId: 'run-textract-page-30',
-      normalizedArtifactPath:
-        'eval/results/pdf-extraction/normalized/aws-textract/run-textract-page-30.json',
+      normalizedArtifactPath: `${outputDir}/normalized/aws-textract/${artifact.source.sha256.slice(7)}/${artifact.providerConfigHash.slice(7)}/pages-30.json`,
       cache: {
         key: `${artifact.provider}:${artifact.source.sha256}:${artifact.providerConfigHash}:30`,
         hit: false,
+      },
+      execution: {
+        selectedPages: [30],
+        fullRulebook: false,
+        fullRulebookOverride: false,
+        estimatedCostUsd: 0.05,
+        maxEstimatedCostUsd: 0.1,
+        costOverride: false,
+        retryLimit: 0,
+        retryCount: 0,
+        rateLimitCount: 0,
+        concurrencyLimit: 1,
+        refreshedProviderOutput: false,
       },
     });
     expect(result.manifest.normalizedArtifactHash).toMatch(/^sha256:[a-f0-9]{64}$/);
@@ -114,6 +137,7 @@ describe('runPdfExtraction', () => {
   });
 
   it('rejects provider results that do not satisfy the shared artifact schema', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'squire-pdf-extraction-invalid-'));
     const invalidArtifact = { ...artifact };
     delete (invalidArtifact as Partial<ExtractionArtifact>).providerConfigHash;
     const registry = registryWith({
@@ -128,8 +152,10 @@ describe('runPdfExtraction', () => {
         registry,
         provider: 'aws-textract',
         sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+        sourceHash: artifact.source.sha256,
+        providerConfigHash: artifact.providerConfigHash,
         pages: [30],
-        outputDir: 'eval/results/pdf-extraction',
+        outputDir,
         runLabel: 'run-textract-page-30',
         retryCount: 0,
       }),
@@ -137,6 +163,7 @@ describe('runPdfExtraction', () => {
   });
 
   it('reports classified provider failures before rethrowing them', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'squire-pdf-extraction-failure-'));
     const registry = registryWith({
       id: 'aws-textract',
       displayName: 'AWS Textract',
@@ -152,8 +179,10 @@ describe('runPdfExtraction', () => {
         registry,
         provider: 'aws-textract',
         sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+        sourceHash: artifact.source.sha256,
+        providerConfigHash: artifact.providerConfigHash,
         pages: [30],
-        outputDir: 'eval/results/pdf-extraction',
+        outputDir,
         runLabel: 'run-textract-page-30',
         retryCount: 0,
         onStatus: (event) => statusEvents.push(event),
@@ -168,6 +197,252 @@ describe('runPdfExtraction', () => {
         runLabel: 'run-textract-page-30',
         failureClass: 'rate_limit',
         message: 'rate limited',
+      },
+    ]);
+  });
+
+  it('refuses full-rulebook runs before calling the provider unless explicitly allowed', async () => {
+    const extract = vi.fn<PdfExtractionProvider['extract']>().mockResolvedValue(artifact);
+    const registry = registryWith({
+      id: 'aws-textract',
+      displayName: 'AWS Textract',
+      version: 'textract-test',
+      extract,
+    });
+
+    await expect(
+      runPdfExtraction({
+        registry,
+        provider: 'aws-textract',
+        sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+        sourceHash: artifact.source.sha256,
+        providerConfigHash: artifact.providerConfigHash,
+        pages: [],
+        outputDir: 'eval/results/pdf-extraction',
+        runLabel: 'run-textract-full',
+        retryCount: 0,
+      }),
+    ).rejects.toThrow(/Full-rulebook PDF extraction requires --allow-full-rulebook/);
+    expect(extract).not.toHaveBeenCalled();
+  });
+
+  it('refuses estimated-cost overruns before calling the provider unless explicitly allowed', async () => {
+    const extract = vi.fn<PdfExtractionProvider['extract']>().mockResolvedValue(artifact);
+    const registry = registryWith({
+      id: 'aws-textract',
+      displayName: 'AWS Textract',
+      version: 'textract-test',
+      extract,
+    });
+
+    await expect(
+      runPdfExtraction({
+        registry,
+        provider: 'aws-textract',
+        sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+        sourceHash: artifact.source.sha256,
+        providerConfigHash: artifact.providerConfigHash,
+        pages: [30],
+        outputDir: 'eval/results/pdf-extraction',
+        runLabel: 'run-textract-page-30',
+        retryCount: 0,
+        estimatedCostUsd: 0.25,
+        maxEstimatedCostUsd: 0.1,
+      }),
+    ).rejects.toThrow(/exceeds --max-estimated-cost-usd=0.1/);
+    expect(extract).not.toHaveBeenCalled();
+  });
+
+  it('validates provider concurrency caps before paid provider work', async () => {
+    const extract = vi.fn<PdfExtractionProvider['extract']>().mockResolvedValue(artifact);
+    const registry = registryWith({
+      id: 'aws-textract',
+      displayName: 'AWS Textract',
+      version: 'textract-test',
+      extract,
+    });
+
+    await expect(
+      runPdfExtraction({
+        registry,
+        provider: 'aws-textract',
+        sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+        sourceHash: artifact.source.sha256,
+        providerConfigHash: artifact.providerConfigHash,
+        pages: [30],
+        outputDir: 'eval/results/pdf-extraction',
+        runLabel: 'run-textract-page-30',
+        retryCount: 0,
+        providerConcurrency: 0,
+      }),
+    ).rejects.toThrow(/Invalid aws-textract PDF extraction concurrency/);
+    expect(extract).not.toHaveBeenCalled();
+  });
+
+  it('reuses successful content-addressed artifacts by default', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'squire-pdf-extraction-cache-'));
+    const extract = vi.fn<PdfExtractionProvider['extract']>().mockResolvedValue(artifact);
+    const registry = registryWith({
+      id: 'aws-textract',
+      displayName: 'AWS Textract',
+      version: 'textract-test',
+      extract,
+    });
+
+    const first = await runPdfExtraction({
+      registry,
+      provider: 'aws-textract',
+      sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+      sourceHash: artifact.source.sha256,
+      providerConfigHash: artifact.providerConfigHash,
+      pages: [30],
+      outputDir,
+      runLabel: 'run-textract-page-30',
+      retryCount: 0,
+    });
+    const second = await runPdfExtraction({
+      registry,
+      provider: 'aws-textract',
+      sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+      sourceHash: artifact.source.sha256,
+      providerConfigHash: artifact.providerConfigHash,
+      pages: [30],
+      outputDir,
+      runLabel: 'run-textract-page-30-repeat',
+      retryCount: 0,
+    });
+
+    expect(extract).toHaveBeenCalledTimes(1);
+    expect(second.artifact).toEqual(first.artifact);
+    expect(second.manifest.cache).toMatchObject({ hit: true });
+    expect(JSON.parse(await readFile(first.manifest.normalizedArtifactPath, 'utf8'))).toMatchObject(
+      {
+        schemaVersion: 'squire-pdf-extraction-v1',
+        provider: 'aws-textract',
+      },
+    );
+  });
+
+  it('refreshes content-addressed artifacts when explicitly requested', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'squire-pdf-extraction-refresh-'));
+    const refreshedArtifact = {
+      ...artifact,
+      run: {
+        ...artifact.run,
+        id: 'run-textract-page-30-refreshed',
+      },
+    } satisfies ExtractionArtifact;
+    const extract = vi
+      .fn<PdfExtractionProvider['extract']>()
+      .mockResolvedValueOnce(artifact)
+      .mockResolvedValueOnce(refreshedArtifact);
+    const registry = registryWith({
+      id: 'aws-textract',
+      displayName: 'AWS Textract',
+      version: 'textract-test',
+      extract,
+    });
+
+    await runPdfExtraction({
+      registry,
+      provider: 'aws-textract',
+      sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+      sourceHash: artifact.source.sha256,
+      providerConfigHash: artifact.providerConfigHash,
+      pages: [30],
+      outputDir,
+      runLabel: 'run-textract-page-30',
+      retryCount: 0,
+    });
+    const refreshed = await runPdfExtraction({
+      registry,
+      provider: 'aws-textract',
+      sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+      sourceHash: artifact.source.sha256,
+      providerConfigHash: artifact.providerConfigHash,
+      pages: [30],
+      outputDir,
+      runLabel: 'run-textract-page-30',
+      retryCount: 0,
+      refreshProviderOutput: true,
+    });
+
+    expect(extract).toHaveBeenCalledTimes(2);
+    expect(refreshed.artifact.run.id).toBe('run-textract-page-30-refreshed');
+    expect(refreshed.manifest.cache).toMatchObject({ hit: false });
+    expect(refreshed.manifest.execution.refreshedProviderOutput).toBe(true);
+  });
+
+  it('retries rate limits and records retry audit fields in the manifest', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'squire-pdf-extraction-retry-'));
+    const extract = vi
+      .fn<PdfExtractionProvider['extract']>()
+      .mockRejectedValueOnce(Object.assign(new Error('rate limited'), { status: 429 }))
+      .mockResolvedValueOnce(artifact);
+    const registry = registryWith({
+      id: 'aws-textract',
+      displayName: 'AWS Textract',
+      version: 'textract-test',
+      extract,
+    });
+    const statusEvents: PdfExtractionStatusEvent[] = [];
+
+    const result = await runPdfExtraction({
+      registry,
+      provider: 'aws-textract',
+      sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+      sourceHash: artifact.source.sha256,
+      providerConfigHash: artifact.providerConfigHash,
+      pages: [30],
+      outputDir,
+      runLabel: 'run-textract-page-30',
+      retryCount: 1,
+      onStatus: (event) => statusEvents.push(event),
+    });
+
+    expect(extract).toHaveBeenCalledTimes(2);
+    expect(statusEvents.map((event) => event.stage)).toEqual(['started', 'retrying', 'succeeded']);
+    expect(result.manifest.execution).toMatchObject({
+      retryLimit: 1,
+      retryCount: 1,
+      rateLimitCount: 1,
+    });
+  });
+
+  it('times out provider calls and reports the timeout failure class', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'squire-pdf-extraction-timeout-'));
+    const extract = vi.fn<PdfExtractionProvider['extract']>(() => new Promise(() => undefined));
+    const registry = registryWith({
+      id: 'aws-textract',
+      displayName: 'AWS Textract',
+      version: 'textract-test',
+      extract,
+    });
+    const statusEvents: PdfExtractionStatusEvent[] = [];
+
+    await expect(
+      runPdfExtraction({
+        registry,
+        provider: 'aws-textract',
+        sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+        sourceHash: artifact.source.sha256,
+        providerConfigHash: artifact.providerConfigHash,
+        pages: [30],
+        outputDir,
+        runLabel: 'run-textract-page-30',
+        retryCount: 0,
+        timeoutMs: 1,
+        onStatus: (event) => statusEvents.push(event),
+      }),
+    ).rejects.toThrow(/timed out after 1ms/);
+    expect(statusEvents).toEqual([
+      { stage: 'started', provider: 'aws-textract', runLabel: 'run-textract-page-30' },
+      {
+        stage: 'failed',
+        provider: 'aws-textract',
+        runLabel: 'run-textract-page-30',
+        failureClass: 'timeout',
+        message: 'PDF extraction provider timed out after 1ms.',
       },
     ]);
   });

--- a/test/pdf-extraction-runner.test.ts
+++ b/test/pdf-extraction-runner.test.ts
@@ -446,4 +446,31 @@ describe('runPdfExtraction', () => {
       },
     ]);
   });
+
+  it('does not retry timed-out provider calls without provider abort support', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'squire-pdf-extraction-timeout-retry-'));
+    const extract = vi.fn<PdfExtractionProvider['extract']>(() => new Promise(() => undefined));
+    const registry = registryWith({
+      id: 'aws-textract',
+      displayName: 'AWS Textract',
+      version: 'textract-test',
+      extract,
+    });
+
+    await expect(
+      runPdfExtraction({
+        registry,
+        provider: 'aws-textract',
+        sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+        sourceHash: artifact.source.sha256,
+        providerConfigHash: artifact.providerConfigHash,
+        pages: [30],
+        outputDir,
+        runLabel: 'run-textract-page-30',
+        retryCount: 2,
+        timeoutMs: 1,
+      }),
+    ).rejects.toThrow(/timed out after 1ms/);
+    expect(extract).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/pdf-extraction-runner.test.ts
+++ b/test/pdf-extraction-runner.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -321,6 +321,78 @@ describe('runPdfExtraction', () => {
         provider: 'aws-textract',
       },
     );
+  });
+
+  it('treats corrupt cached artifacts as cache misses and refreshes them', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'squire-pdf-extraction-corrupt-cache-'));
+    const artifactPath = join(outputDir, 'normalized', 'aws-textract', 'pages-30.json');
+    await mkdir(dirname(artifactPath), { recursive: true });
+    await writeFile(artifactPath, '{not valid json', 'utf8');
+    const extract = vi.fn<PdfExtractionProvider['extract']>().mockResolvedValue(artifact);
+    const registry = registryWith({
+      id: 'aws-textract',
+      displayName: 'AWS Textract',
+      version: 'textract-test',
+      extract,
+    });
+
+    const result = await runPdfExtraction({
+      registry,
+      provider: 'aws-textract',
+      sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+      sourceHash: artifact.source.sha256,
+      providerConfigHash: artifact.providerConfigHash,
+      artifactPath,
+      pages: [30],
+      outputDir,
+      runLabel: 'run-textract-page-30',
+      retryCount: 0,
+    });
+
+    expect(extract).toHaveBeenCalledTimes(1);
+    expect(result.manifest.cache.hit).toBe(false);
+    expect(JSON.parse(await readFile(artifactPath, 'utf8'))).toMatchObject({
+      schemaVersion: 'squire-pdf-extraction-v1',
+      provider: 'aws-textract',
+    });
+  });
+
+  it('rejects provider artifacts whose page set does not match the request', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'squire-pdf-extraction-page-mismatch-'));
+    const wrongPageArtifact = {
+      ...artifact,
+      run: {
+        ...artifact.run,
+        pageRange: [31],
+      },
+      pages: [
+        {
+          ...artifact.pages[0],
+          pageNumber: 31,
+        },
+      ],
+    } satisfies ExtractionArtifact;
+    const extract = vi.fn<PdfExtractionProvider['extract']>().mockResolvedValue(wrongPageArtifact);
+    const registry = registryWith({
+      id: 'aws-textract',
+      displayName: 'AWS Textract',
+      version: 'textract-test',
+      extract,
+    });
+
+    await expect(
+      runPdfExtraction({
+        registry,
+        provider: 'aws-textract',
+        sourcePath: 'data/pdfs/gh2-rule-book.pdf',
+        sourceHash: artifact.source.sha256,
+        providerConfigHash: artifact.providerConfigHash,
+        pages: [30],
+        outputDir,
+        runLabel: 'run-textract-page-30',
+        retryCount: 0,
+      }),
+    ).rejects.toThrow(/Page artifact mismatch: expected 30, got 31/);
   });
 
   it('refreshes content-addressed artifacts when explicitly requested', async () => {


### PR DESCRIPTION
## Summary
- add full-rulebook, estimated-cost, concurrency, timeout, retry, and cache controls to the PDF extraction eval runner
- persist successful normalized artifacts at content-addressed paths and reuse them unless refresh is explicit
- expand manifest audit fields and CLI parsing for paid-provider guardrails
- document the hardened runner contract in the PDF extraction vendor eval plan

## Review
- pre-landing review found timeout retries were unsafe without provider abort support; fixed by making timeouts terminal

## Validation
- npm run check

Fixes SQR-250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI guardrails for PDF extraction: page-selection default with explicit full-rulebook override, estimated-cost prechecks with override, provider concurrency cap, and per-run timeout.
  * Deterministic artifact paths and deterministic caching/reuse with an explicit refresh override.
  * Retries for rate-limit and provider errors, with retry status events.

* **Improvements**
  * Manifests now record execution metadata: cache hit/refreshed status, retry/rate-limit/timeout/concurrency telemetry, cost/override usage, and selected-page vs full-run details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->