### PR TITLE
SQR-249: Add production retrieval scoring for PDF extraction eval

### DIFF
--- a/eval/pdf-extraction/retrieval-scoring.ts
+++ b/eval/pdf-extraction/retrieval-scoring.ts
@@ -1,0 +1,354 @@
+import { basename } from 'node:path';
+
+import { chunkText } from '../../src/index-docs.ts';
+import { embed, embedBatch } from '../../src/embedder.ts';
+import { GLOOMHAVEN_2E_GAME_ID, type GameId } from '../../src/game.ts';
+import {
+  EMBEDDING_VERSION,
+  addEntries,
+  deleteEntriesForSources,
+  search,
+  type IndexEntry,
+  type ScoredEntry,
+} from '../../src/vector-store.ts';
+import { rerankRuleSourceHits, VOYAGE_EMBEDDING_DIMENSION } from '../../src/voyage-retrieval.ts';
+import { scoreExtractionArtifact } from './scoring.ts';
+import type {
+  ExtractionScoreSummary,
+  RetrievalFailureClass,
+  RetrievalHitScore,
+  RetrievalQueryScore,
+} from './scoring.ts';
+import {
+  GroundTruthDatasetSchema,
+  type ExtractionArtifact,
+  type ExtractionBlock,
+  type GroundTruthRecord,
+} from './schema.ts';
+
+const RETRIEVAL_EMBEDDING_MODEL = 'voyage-4-large';
+const DEFAULT_TOP_K = 5;
+const DEFAULT_RERANK_CANDIDATE_LIMIT = 40;
+
+export interface PdfExtractionRetrievalScoringOptions {
+  runId: string;
+  game?: GameId;
+  topK?: number;
+  rerankCandidateLimit?: number;
+  cleanup?: boolean;
+}
+
+export interface PdfExtractionRetrievalScoringDeps {
+  embedDocuments?: (texts: string[]) => Promise<number[][]>;
+  embedQuery?: (text: string) => Promise<number[]>;
+  addEntries?: (entries: IndexEntry[]) => Promise<void>;
+  deleteEntriesForSources?: (sources: string[], game: GameId) => Promise<number>;
+  search?: (
+    queryEmbedding: number[],
+    k: number,
+    opts: { game: GameId; sourcePrefix: string },
+  ) => Promise<ScoredEntry[]>;
+  rerank?: (query: string, hits: ScoredEntry[], topK: number) => Promise<ScoredEntry[]>;
+}
+
+interface EvalChunkIndex {
+  entries: IndexEntry[];
+  sources: string[];
+  sourcePrefix: string;
+  pages: Set<number>;
+}
+
+function unique<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+function normalizeText(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function requiredTerms(expectedText: string): string[] {
+  return unique(
+    normalizeText(expectedText)
+      .split(/[^a-z0-9]+/)
+      .filter((word) => word.length >= 3),
+  );
+}
+
+function containsExpectedText(hit: ScoredEntry, record: GroundTruthRecord): boolean {
+  const text = normalizeText(hit.text);
+  return requiredTerms(record.expectedText).every((term) => text.includes(term));
+}
+
+function containsForbiddenContext(hit: ScoredEntry, record: GroundTruthRecord): boolean {
+  const text = normalizeText(hit.text);
+  return record.forbiddenRetrievalContextTerms.some((term) => text.includes(normalizeText(term)));
+}
+
+function validateEmbeddingShape(embedding: number[], label: string): void {
+  if (embedding.length !== VOYAGE_EMBEDDING_DIMENSION) {
+    throw new Error(
+      `${label} returned ${embedding.length} dimension(s), expected ${VOYAGE_EMBEDDING_DIMENSION}.`,
+    );
+  }
+  const badIndex = embedding.findIndex((value) => !Number.isFinite(value));
+  if (badIndex >= 0) {
+    throw new Error(`${label} dimension ${badIndex} was not finite.`);
+  }
+}
+
+function failureClassFor(error: unknown): RetrievalFailureClass {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/dimension|finite/.test(message)) return 'invalid_embedding_shape';
+  if (/rerank/i.test(message)) return 'rerank_failure';
+  if (/embedding|Voyage/i.test(message)) return 'embedding_failure';
+  return 'storage_failure';
+}
+
+function sourcePage(source: string): number | null {
+  const rawPage = source.match(/\/page-(\d+)\//)?.[1];
+  return rawPage ? Number(rawPage) : null;
+}
+
+function boxesIntersect(
+  a: NonNullable<GroundTruthRecord['region']>,
+  b: NonNullable<ExtractionBlock['bbox']>,
+): boolean {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+}
+
+function artifactHasExpectedRegion(
+  artifact: ExtractionArtifact,
+  record: GroundTruthRecord,
+): boolean {
+  if (!record.region) return true;
+  const region = record.region;
+  const page = artifact.pages.find((candidate) => candidate.pageNumber === record.page);
+  if (!page) return false;
+  return page.blocks.some((block) => block.bbox && boxesIntersect(region, block.bbox));
+}
+
+function hitScores(hits: ScoredEntry[]): RetrievalHitScore[] {
+  return hits.slice(0, DEFAULT_TOP_K).map((hit, index) => ({
+    rank: index + 1,
+    id: hit.id,
+    source: hit.source,
+    page: sourcePage(hit.source),
+    chunkIndex: hit.chunkIndex,
+    game: hit.game,
+    score: hit.score,
+    scoreKind: hit.scoreKind ?? 'vector',
+  }));
+}
+
+function emptyQueryScore(
+  record: GroundTruthRecord,
+  query: string,
+  failureClasses: RetrievalFailureClass[],
+): RetrievalQueryScore {
+  return {
+    recordId: record.id,
+    query,
+    expectedSource: record.source,
+    expectedPage: record.page,
+    expectedRegion: record.region ?? undefined,
+    top1Hit: false,
+    top3Hit: false,
+    top5Hit: false,
+    citeableContextHit: false,
+    hits: [],
+    failureClasses,
+  };
+}
+
+async function buildEvalChunkIndex(
+  artifact: ExtractionArtifact,
+  options: Required<Pick<PdfExtractionRetrievalScoringOptions, 'runId' | 'game'>>,
+  deps: Required<Pick<PdfExtractionRetrievalScoringDeps, 'embedDocuments'>>,
+): Promise<EvalChunkIndex> {
+  const sourcePrefix = `eval/pdf-extraction/${options.runId}/${artifact.provider}/`;
+  const sourceBase = basename(artifact.source.path);
+  const chunks = artifact.pages.flatMap((page) => {
+    const source = `${sourcePrefix}page-${page.pageNumber}/${sourceBase}`;
+    return chunkText(page.markdown || page.text, source).map((chunk) => ({
+      ...chunk,
+      pageNumber: page.pageNumber,
+    }));
+  });
+  const embeddings = await deps.embedDocuments(chunks.map((chunk) => chunk.text));
+  if (embeddings.length !== chunks.length) {
+    throw new Error(
+      `document embedding provider returned ${embeddings.length} embedding(s) for ${chunks.length} chunk(s).`,
+    );
+  }
+
+  const entries = chunks.map((chunk, index): IndexEntry => {
+    const embedding = embeddings[index]!;
+    validateEmbeddingShape(embedding, `document embedding ${index}`);
+    return {
+      id: `${sourcePrefix}page-${chunk.pageNumber}/chunk-${chunk.chunkIndex}`,
+      source: chunk.source,
+      chunkIndex: chunk.chunkIndex,
+      text: chunk.text,
+      embedding,
+      game: options.game,
+      contentHash: artifact.source.sha256,
+    };
+  });
+
+  return {
+    entries,
+    sources: unique(entries.map((entry) => entry.source)),
+    sourcePrefix,
+    pages: new Set(chunks.map((chunk) => chunk.pageNumber)),
+  };
+}
+
+async function scoreRetrievalQuery(
+  record: GroundTruthRecord,
+  query: string,
+  artifact: ExtractionArtifact,
+  index: EvalChunkIndex,
+  options: Required<
+    Pick<PdfExtractionRetrievalScoringOptions, 'game' | 'topK' | 'rerankCandidateLimit'>
+  >,
+  deps: Required<Pick<PdfExtractionRetrievalScoringDeps, 'embedQuery' | 'search' | 'rerank'>>,
+): Promise<RetrievalQueryScore> {
+  const failureClasses: RetrievalFailureClass[] = [];
+  if (!index.pages.has(record.page)) failureClasses.push('missing_expected_page');
+  const expectedRegionHit = artifactHasExpectedRegion(artifact, record);
+  if (!expectedRegionHit) failureClasses.push('missing_expected_region');
+
+  let hits: ScoredEntry[];
+  try {
+    const queryEmbedding = await deps.embedQuery(query);
+    validateEmbeddingShape(queryEmbedding, 'query embedding');
+    const vectorHits = await deps.search(queryEmbedding, options.rerankCandidateLimit, {
+      game: options.game,
+      sourcePrefix: index.sourcePrefix,
+    });
+    hits = await deps.rerank(query, vectorHits, options.topK);
+  } catch (error) {
+    return emptyQueryScore(record, query, unique([...failureClasses, failureClassFor(error)]));
+  }
+
+  if (hits.length === 0) failureClasses.push('no_hits');
+  const top5 = hits.slice(0, options.topK);
+  const top1Hit = top5.slice(0, 1).some((hit) => sourcePage(hit.source) === record.page);
+  const top3Hit = top5.slice(0, 3).some((hit) => sourcePage(hit.source) === record.page);
+  const top5Hit = top5.some((hit) => sourcePage(hit.source) === record.page);
+  const citeableContextHit = top5.some(
+    (hit) =>
+      sourcePage(hit.source) === record.page &&
+      expectedRegionHit &&
+      containsExpectedText(hit, record) &&
+      !containsForbiddenContext(hit, record),
+  );
+
+  if (top5Hit && expectedRegionHit && !citeableContextHit) {
+    failureClasses.push('misleading_context');
+  }
+
+  return {
+    recordId: record.id,
+    query,
+    expectedSource: record.source,
+    expectedPage: record.page,
+    expectedRegion: record.region ?? undefined,
+    top1Hit,
+    top3Hit,
+    top5Hit,
+    citeableContextHit,
+    hits: hitScores(top5),
+    failureClasses: unique(failureClasses),
+  };
+}
+
+function summarizeRetrieval(
+  queryScores: RetrievalQueryScore[],
+): ExtractionScoreSummary['retrieval'] {
+  const failureClasses = unique(queryScores.flatMap((score) => score.failureClasses));
+  const firstHits = queryScores.map((score) => score.hits[0]).filter((hit) => hit !== undefined);
+  return {
+    queryCount: queryScores.length,
+    top1Hits: queryScores.filter((score) => score.top1Hit).length,
+    top3Hits: queryScores.filter((score) => score.top3Hit).length,
+    top5Hits: queryScores.filter((score) => score.top5Hit).length,
+    citeableContextHits: queryScores.filter((score) => score.citeableContextHit).length,
+    queryScores,
+    failureClasses,
+    scoreKindCounts: {
+      vector: firstHits.filter((hit) => hit.scoreKind === 'vector').length,
+      rerank: firstHits.filter((hit) => hit.scoreKind === 'rerank').length,
+    },
+    embedding: {
+      model: RETRIEVAL_EMBEDDING_MODEL,
+      dimensions: VOYAGE_EMBEDDING_DIMENSION,
+      version: EMBEDDING_VERSION,
+    },
+  };
+}
+
+export async function scoreExtractionArtifactWithProductionRetrieval(
+  artifact: ExtractionArtifact,
+  groundTruthInput: GroundTruthRecord[],
+  options: PdfExtractionRetrievalScoringOptions,
+  deps: PdfExtractionRetrievalScoringDeps = {},
+): Promise<ExtractionScoreSummary> {
+  const groundTruth = GroundTruthDatasetSchema.parse(groundTruthInput);
+  const base = scoreExtractionArtifact(artifact, groundTruth);
+  const resolvedOptions = {
+    runId: options.runId,
+    game: options.game ?? GLOOMHAVEN_2E_GAME_ID,
+    topK: options.topK ?? DEFAULT_TOP_K,
+    rerankCandidateLimit: options.rerankCandidateLimit ?? DEFAULT_RERANK_CANDIDATE_LIMIT,
+    cleanup: options.cleanup ?? true,
+  };
+  const resolvedDeps = {
+    embedDocuments: deps.embedDocuments ?? embedBatch,
+    embedQuery: deps.embedQuery ?? embed,
+    addEntries: deps.addEntries ?? addEntries,
+    deleteEntriesForSources: deps.deleteEntriesForSources ?? deleteEntriesForSources,
+    search: deps.search ?? search,
+    rerank: deps.rerank ?? rerankRuleSourceHits,
+  };
+
+  let index: EvalChunkIndex | undefined;
+  try {
+    index = await buildEvalChunkIndex(artifact, resolvedOptions, resolvedDeps);
+    await resolvedDeps.addEntries(index.entries);
+  } catch (error) {
+    const failureClass = failureClassFor(error);
+    const queryScores = groundTruth.flatMap((record) =>
+      record.retrievalQueries.map((query) => emptyQueryScore(record, query, [failureClass])),
+    );
+    return {
+      ...base,
+      retrieval: summarizeRetrieval(queryScores),
+      failures: [...base.failures, `retrieval scoring failed: ${failureClass}`],
+    };
+  }
+
+  try {
+    const queryScores: RetrievalQueryScore[] = [];
+    for (const record of groundTruth) {
+      for (const query of record.retrievalQueries) {
+        queryScores.push(
+          await scoreRetrievalQuery(record, query, artifact, index, resolvedOptions, resolvedDeps),
+        );
+      }
+    }
+    const retrieval = summarizeRetrieval(queryScores);
+    return {
+      ...base,
+      retrieval,
+      failures: [
+        ...base.failures,
+        ...retrieval.failureClasses!.map((failureClass) => `retrieval scoring: ${failureClass}`),
+      ],
+    };
+  } finally {
+    if (resolvedOptions.cleanup) {
+      await resolvedDeps.deleteEntriesForSources(index.sources, resolvedOptions.game);
+    }
+  }
+}

--- a/eval/pdf-extraction/retrieval-scoring.ts
+++ b/eval/pdf-extraction/retrieval-scoring.ts
@@ -98,9 +98,15 @@ function validateEmbeddingShape(embedding: number[], label: string): void {
 
 function failureClassFor(error: unknown): RetrievalFailureClass {
   const message = error instanceof Error ? error.message : String(error);
-  if (/dimension|finite/.test(message)) return 'invalid_embedding_shape';
+  if (/dimension|finite/i.test(message)) return 'invalid_embedding_shape';
   if (/rerank/i.test(message)) return 'rerank_failure';
-  if (/embedding|Voyage/i.test(message)) return 'embedding_failure';
+  if (
+    /(document embedding|query embedding|failed to embed|\bembed\b|vectori[sz]e|voyage embed)/i.test(
+      message,
+    )
+  ) {
+    return 'embedding_failure';
+  }
   return 'storage_failure';
 }
 
@@ -232,7 +238,8 @@ async function scoreRetrievalQuery(
   }
 
   if (hits.length === 0) failureClasses.push('no_hits');
-  const top5 = hits.slice(0, options.topK);
+  const ranked = hits.slice(0, options.topK);
+  const top5 = ranked.slice(0, DEFAULT_TOP_K);
   const top1Hit = top5.slice(0, 1).some((hit) => sourcePage(hit.source) === record.page);
   const top3Hit = top5.slice(0, 3).some((hit) => sourcePage(hit.source) === record.page);
   const top5Hit = top5.some((hit) => sourcePage(hit.source) === record.page);

--- a/eval/pdf-extraction/scoring.ts
+++ b/eval/pdf-extraction/scoring.ts
@@ -23,6 +23,52 @@ export interface RetrievalScoreSummary {
   top3Hits: number;
   top5Hits: number;
   citeableContextHits: number;
+  queryScores?: RetrievalQueryScore[];
+  failureClasses?: RetrievalFailureClass[];
+  scoreKindCounts?: {
+    vector: number;
+    rerank: number;
+  };
+  embedding?: {
+    model: string;
+    dimensions: number;
+    version: string;
+  };
+}
+
+export type RetrievalFailureClass =
+  | 'embedding_failure'
+  | 'invalid_embedding_shape'
+  | 'missing_expected_page'
+  | 'missing_expected_region'
+  | 'misleading_context'
+  | 'no_hits'
+  | 'rerank_failure'
+  | 'storage_failure';
+
+export interface RetrievalHitScore {
+  rank: number;
+  id: string;
+  source: string;
+  page: number | null;
+  chunkIndex: number;
+  game: string;
+  score: number;
+  scoreKind: 'vector' | 'rerank';
+}
+
+export interface RetrievalQueryScore {
+  recordId: string;
+  query: string;
+  expectedSource: string;
+  expectedPage: number;
+  expectedRegion?: GroundTruthRecord['region'];
+  top1Hit: boolean;
+  top3Hit: boolean;
+  top5Hit: boolean;
+  citeableContextHit: boolean;
+  hits: RetrievalHitScore[];
+  failureClasses: RetrievalFailureClass[];
 }
 
 export interface ExtractionScoreSummary {

--- a/src/vector-store.ts
+++ b/src/vector-store.ts
@@ -49,6 +49,11 @@ export interface ScoredEntry {
 export interface SearchOptions {
   /** Game filter. Defaults to `'frosthaven'`. */
   game?: GameId | string;
+  /**
+   * Optional source prefix filter. Production callers omit this; eval callers
+   * use it to keep temporary chunks isolated while preserving pgvector ordering.
+   */
+  sourcePrefix?: string;
 }
 
 /**
@@ -260,6 +265,9 @@ export async function search(
 
   const game = resolveGame(opts.game);
   const vectorLiteral = `[${queryEmbedding.join(',')}]`;
+  const sourcePrefixFilter = opts.sourcePrefix
+    ? sql`AND source LIKE ${`${opts.sourcePrefix}%`}`
+    : sql``;
 
   try {
     const { db } = getDb('server');
@@ -280,6 +288,7 @@ export async function search(
         1 - (embedding <=> ${vectorLiteral}::vector) AS score
       FROM rule_source_embeddings
       WHERE game = ${game}
+        ${sourcePrefixFilter}
       ORDER BY embedding <=> ${vectorLiteral}::vector
       LIMIT ${k}
     `);

--- a/src/vector-store.ts
+++ b/src/vector-store.ts
@@ -71,6 +71,10 @@ function resolveGame(game?: GameId | string): GameId {
   return requireGameId(game);
 }
 
+function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
 /**
  * Ensure the HNSW cosine index exists on `rule_source_embeddings.embedding`.
  *
@@ -266,7 +270,7 @@ export async function search(
   const game = resolveGame(opts.game);
   const vectorLiteral = `[${queryEmbedding.join(',')}]`;
   const sourcePrefixFilter = opts.sourcePrefix
-    ? sql`AND source LIKE ${`${opts.sourcePrefix}%`}`
+    ? sql`AND source LIKE ${`${escapeLikePattern(opts.sourcePrefix)}%`} ESCAPE '\\'`
     : sql``;
 
   try {

--- a/test/helpers/test-slices.ts
+++ b/test/helpers/test-slices.ts
@@ -14,6 +14,7 @@ export const DB_BACKED_TEST_FILES = [
   'test/extracted-data.test.ts',
   'test/gh2-imported-data.test.ts',
   'test/llm-budget.test.ts',
+  'test/pdf-extraction-retrieval-scoring.test.ts',
   'test/scenario-section-data.test.ts',
   'test/seed/seed-cards.test.ts',
   'test/seed/seed-dev-user.test.ts',

--- a/test/pdf-extraction-retrieval-scoring.test.ts
+++ b/test/pdf-extraction-retrieval-scoring.test.ts
@@ -222,6 +222,36 @@ describe('PDF extraction production retrieval scoring', () => {
     });
   });
 
+  it('treats eval run ids as literal source prefixes', async () => {
+    await addEntries([
+      {
+        id: 'wildcard-contaminant',
+        source: 'eval/pdf-extraction/run-likeAX/marker-datalab/page-99/gh2',
+        chunkIndex: 0,
+        text: 'Loot X lets a figure loot all money tokens and treasure tiles within range X.',
+        embedding: axisVector(0),
+        game: GLOOMHAVEN_2E_GAME_ID,
+      },
+    ]);
+
+    const summary = await scoreExtractionArtifactWithProductionRetrieval(
+      artifactWithPages([
+        {
+          pageNumber: 30,
+          text: 'Loot\n\nLoot X lets a figure loot all money tokens and treasure tiles within range X.',
+        },
+      ]),
+      [record()],
+      { runId: 'run-like_%' },
+      deps({ documentEmbeddings: [axisVector(1)] }),
+    );
+
+    expect(summary.retrieval.queryScores?.[0]?.hits[0]).toMatchObject({
+      page: 30,
+      source: 'eval/pdf-extraction/run-like_%/marker-datalab/page-30/gh2-rule-book.pdf',
+    });
+  });
+
   it('flags misleading retrieved context as not citeable', async () => {
     const summary = await scoreExtractionArtifactWithProductionRetrieval(
       artifactWithPages([

--- a/test/pdf-extraction-retrieval-scoring.test.ts
+++ b/test/pdf-extraction-retrieval-scoring.test.ts
@@ -1,0 +1,320 @@
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  scoreExtractionArtifactWithProductionRetrieval,
+  type PdfExtractionRetrievalScoringDeps,
+} from '../eval/pdf-extraction/retrieval-scoring.ts';
+import {
+  computeProviderConfigHash,
+  type ExtractionArtifact,
+  type GroundTruthRecord,
+} from '../eval/pdf-extraction/schema.ts';
+import { GLOOMHAVEN_2E_GAME_ID } from '../src/game.ts';
+import { addEntries } from '../src/vector-store.ts';
+import type { ScoredEntry } from '../src/vector-store.ts';
+
+import { resetTestDb, setupTestDb, teardownTestDb } from './helpers/db.ts';
+
+function axisVector(axis: number, dim = 1024): number[] {
+  const vector = new Array<number>(dim).fill(0);
+  vector[axis] = 1;
+  return vector;
+}
+
+function artifactWithPages(pages: Array<{ pageNumber: number; text: string }>): ExtractionArtifact {
+  return {
+    schemaVersion: 'squire-pdf-extraction-v1',
+    provider: 'marker-datalab',
+    providerVersion: 'marker-test',
+    providerConfigHash: computeProviderConfigHash({ fixture: 'retrieval-scoring' }),
+    source: {
+      path: 'data/pdfs/gh2-rule-book.pdf',
+      sha256: `sha256:${'2'.repeat(64)}`,
+      pageCount: 74,
+    },
+    run: {
+      id: 'run-marker-retrieval',
+      startedAt: '2026-05-29T00:00:00.000Z',
+      completedAt: '2026-05-29T00:00:02.000Z',
+      status: 'succeeded',
+      pageRange: pages.map((page) => page.pageNumber),
+      latencyMs: 2_000,
+    },
+    cost: {
+      estimatedUsd: 0,
+      actualUsd: 0,
+      pagesProcessed: pages.length,
+      costPerPageUsd: 0,
+    },
+    privacy: {
+      retentionPolicy: 'local only',
+      trainingUse: 'not-used-for-training',
+    },
+    rawArtifacts: [],
+    pages: pages.map((page) => ({
+      pageNumber: page.pageNumber,
+      width: 612,
+      height: 792,
+      unit: 'pt',
+      markdown: page.text,
+      text: page.text,
+      blocks: [
+        { id: `p${page.pageNumber}-heading`, type: 'heading', order: 0, text: 'Loot' },
+        { id: `p${page.pageNumber}-body`, type: 'paragraph', order: 1, text: page.text },
+      ],
+      tables: [],
+    })),
+  };
+}
+
+function record(overrides: Partial<GroundTruthRecord> = {}): GroundTruthRecord {
+  return {
+    id: 'gh2-rulebook-page-30-loot',
+    source: 'data/pdfs/gh2-rule-book.pdf',
+    page: 30,
+    region: null,
+    category: 'loot',
+    expectedText: 'Loot X lets a figure loot all money tokens and treasure tiles within range X.',
+    expectedHeadings: ['Loot'],
+    expectedTables: [],
+    retrievalQueries: ['How does Loot X work in Gloomhaven 2e?'],
+    forbiddenRetrievalContextTerms: [],
+    ...overrides,
+  };
+}
+
+function deps(input: {
+  documentEmbeddings?: number[][];
+  queryEmbeddings?: number[][];
+  rerank?: PdfExtractionRetrievalScoringDeps['rerank'];
+}): PdfExtractionRetrievalScoringDeps {
+  let queryIndex = 0;
+  return {
+    embedDocuments: async () => input.documentEmbeddings ?? [axisVector(0)],
+    embedQuery: async () => input.queryEmbeddings?.[queryIndex++] ?? axisVector(0),
+    rerank: input.rerank ?? (async (_query: string, hits: ScoredEntry[]) => hits),
+  };
+}
+
+let db: Awaited<ReturnType<typeof setupTestDb>>;
+
+beforeAll(async () => {
+  db = await setupTestDb();
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+});
+
+describe('PDF extraction production retrieval scoring', () => {
+  it('scores a vector-only hit through pgvector and cleans up eval rows', async () => {
+    const artifact = artifactWithPages([
+      {
+        pageNumber: 30,
+        text: [
+          'Loot',
+          '',
+          'Loot X lets a figure loot all money tokens and treasure tiles within range X.',
+          'The looting figure removes those tokens from the map.',
+        ].join('\n'),
+      },
+    ]);
+
+    const summary = await scoreExtractionArtifactWithProductionRetrieval(
+      artifact,
+      [record()],
+      { runId: 'run-vector-only' },
+      deps({ documentEmbeddings: [axisVector(0)] }),
+    );
+
+    expect(summary.retrieval.top1Hits).toBe(1);
+    expect(summary.retrieval.top3Hits).toBe(1);
+    expect(summary.retrieval.top5Hits).toBe(1);
+    expect(summary.retrieval.citeableContextHits).toBe(1);
+    expect(summary.retrieval.queryScores?.[0]).toMatchObject({
+      recordId: 'gh2-rulebook-page-30-loot',
+      top1Hit: true,
+      top3Hit: true,
+      top5Hit: true,
+      citeableContextHit: true,
+      failureClasses: [],
+    });
+    expect(summary.retrieval.queryScores?.[0]?.hits[0]).toMatchObject({
+      page: 30,
+      scoreKind: 'vector',
+    });
+
+    const rows = await db.execute<{ count: string }>(
+      sql`SELECT COUNT(*)::text AS count FROM rule_source_embeddings WHERE source LIKE 'eval/pdf-extraction/run-vector-only/%'`,
+    );
+    expect(Number(rows.rows[0].count)).toBe(0);
+  });
+
+  it('credits a hit promoted by the production reranker', async () => {
+    const artifact = artifactWithPages([
+      {
+        pageNumber: 30,
+        text: 'Loot\n\nLoot X lets a figure loot all money tokens and treasure tiles within range X.',
+      },
+      {
+        pageNumber: 31,
+        text: 'Recover\n\nRecover abilities return cards and are unrelated to loot questions.',
+      },
+    ]);
+
+    const summary = await scoreExtractionArtifactWithProductionRetrieval(
+      artifact,
+      [record()],
+      { runId: 'run-reranked' },
+      deps({
+        documentEmbeddings: [axisVector(1), axisVector(0)],
+        rerank: async (_query, hits) => [
+          {
+            ...hits.find((hit) => hit.source.includes('/page-30/'))!,
+            score: 0.99,
+            scoreKind: 'rerank',
+          },
+          ...hits.filter((hit) => !hit.source.includes('/page-30/')),
+        ],
+      }),
+    );
+
+    expect(summary.retrieval.top1Hits).toBe(1);
+    expect(summary.retrieval.scoreKindCounts).toEqual({ rerank: 1, vector: 0 });
+    expect(summary.retrieval.queryScores?.[0]?.hits[0]).toMatchObject({
+      page: 30,
+      scoreKind: 'rerank',
+    });
+  });
+
+  it('uses the GH2 game filter so same-namespace Frosthaven rows cannot win', async () => {
+    await addEntries([
+      {
+        id: 'fh-contaminant',
+        source: 'eval/pdf-extraction/run-wrong-game/marker-datalab/page-30/fh',
+        chunkIndex: 0,
+        text: 'Loot X lets a figure loot all money tokens and treasure tiles within range X.',
+        embedding: axisVector(0),
+        game: 'frosthaven',
+      },
+    ]);
+
+    const summary = await scoreExtractionArtifactWithProductionRetrieval(
+      artifactWithPages([
+        {
+          pageNumber: 30,
+          text: 'Loot\n\nLoot X lets a figure loot all money tokens and treasure tiles within range X.',
+        },
+      ]),
+      [record()],
+      { runId: 'run-wrong-game' },
+      deps({ documentEmbeddings: [axisVector(1)] }),
+    );
+
+    expect(summary.retrieval.queryScores?.[0]?.hits[0]).toMatchObject({
+      game: GLOOMHAVEN_2E_GAME_ID,
+      page: 30,
+    });
+  });
+
+  it('flags misleading retrieved context as not citeable', async () => {
+    const summary = await scoreExtractionArtifactWithProductionRetrieval(
+      artifactWithPages([
+        {
+          pageNumber: 30,
+          text: [
+            'Loot',
+            '',
+            'Loot X lets a figure loot all money tokens and treasure tiles within range X.',
+            'Summon loot tokens during setup.',
+          ].join('\n'),
+        },
+      ]),
+      [record({ forbiddenRetrievalContextTerms: ['summon loot tokens'] })],
+      { runId: 'run-misleading' },
+      deps({ documentEmbeddings: [axisVector(0)] }),
+    );
+
+    expect(summary.retrieval.top1Hits).toBe(1);
+    expect(summary.retrieval.citeableContextHits).toBe(0);
+    expect(summary.retrieval.failureClasses).toEqual(['misleading_context']);
+    expect(summary.retrieval.queryScores?.[0]?.failureClasses).toContain('misleading_context');
+  });
+
+  it('records a missing expected page when no retrieved hit cites that page', async () => {
+    const summary = await scoreExtractionArtifactWithProductionRetrieval(
+      artifactWithPages([
+        {
+          pageNumber: 31,
+          text: 'Recover\n\nRecover abilities return cards and are unrelated to loot questions.',
+        },
+      ]),
+      [record()],
+      { runId: 'run-missing-page' },
+      deps({ documentEmbeddings: [axisVector(0)] }),
+    );
+
+    expect(summary.retrieval.top1Hits).toBe(0);
+    expect(summary.retrieval.failureClasses).toContain('missing_expected_page');
+    expect(summary.retrieval.queryScores?.[0]).toMatchObject({
+      top1Hit: false,
+      top3Hit: false,
+      top5Hit: false,
+      citeableContextHit: false,
+    });
+  });
+
+  it('records a missing expected region when the page is retrieved without region evidence', async () => {
+    const summary = await scoreExtractionArtifactWithProductionRetrieval(
+      artifactWithPages([
+        {
+          pageNumber: 30,
+          text: 'Loot\n\nLoot X lets a figure loot all money tokens and treasure tiles within range X.',
+        },
+      ]),
+      [
+        record({
+          region: { x: 60, y: 120, width: 490, height: 300 },
+        }),
+      ],
+      { runId: 'run-missing-region' },
+      deps({ documentEmbeddings: [axisVector(0)] }),
+    );
+
+    expect(summary.retrieval.top1Hits).toBe(1);
+    expect(summary.retrieval.citeableContextHits).toBe(0);
+    expect(summary.retrieval.failureClasses).toContain('missing_expected_region');
+    expect(summary.retrieval.queryScores?.[0]).toMatchObject({
+      expectedRegion: { x: 60, y: 120, width: 490, height: 300 },
+      top1Hit: true,
+      citeableContextHit: false,
+      failureClasses: ['missing_expected_region'],
+    });
+  });
+
+  it('records invalid embedding shape before vector storage', async () => {
+    const summary = await scoreExtractionArtifactWithProductionRetrieval(
+      artifactWithPages([
+        {
+          pageNumber: 30,
+          text: 'Loot\n\nLoot X lets a figure loot all money tokens and treasure tiles within range X.',
+        },
+      ]),
+      [record()],
+      { runId: 'run-invalid-shape' },
+      deps({ documentEmbeddings: [[1, 0, 0]] }),
+    );
+
+    expect(summary.retrieval.queryCount).toBe(1);
+    expect(summary.retrieval.top1Hits).toBe(0);
+    expect(summary.retrieval.failureClasses).toEqual(['invalid_embedding_shape']);
+    expect(summary.failures).toEqual(
+      expect.arrayContaining([expect.stringContaining('invalid_embedding_shape')]),
+    );
+  });
+});

--- a/test/pdf-extraction-retrieval-scoring.test.ts
+++ b/test/pdf-extraction-retrieval-scoring.test.ts
@@ -87,12 +87,14 @@ function record(overrides: Partial<GroundTruthRecord> = {}): GroundTruthRecord {
 function deps(input: {
   documentEmbeddings?: number[][];
   queryEmbeddings?: number[][];
+  search?: PdfExtractionRetrievalScoringDeps['search'];
   rerank?: PdfExtractionRetrievalScoringDeps['rerank'];
 }): PdfExtractionRetrievalScoringDeps {
   let queryIndex = 0;
   return {
-    embedDocuments: async () => input.documentEmbeddings ?? [axisVector(0)],
+    embedDocuments: async (texts) => input.documentEmbeddings ?? texts.map(() => axisVector(0)),
     embedQuery: async () => input.queryEmbeddings?.[queryIndex++] ?? axisVector(0),
+    search: input.search,
     rerank: input.rerank ?? (async (_query: string, hits: ScoredEntry[]) => hits),
   };
 }
@@ -190,6 +192,44 @@ describe('PDF extraction production retrieval scoring', () => {
       page: 30,
       scoreKind: 'rerank',
     });
+  });
+
+  it('keeps top-5 scoring fixed when callers request more hits', async () => {
+    const summary = await scoreExtractionArtifactWithProductionRetrieval(
+      artifactWithPages([
+        { pageNumber: 25, text: 'Setup\n\nScenario setup text.' },
+        { pageNumber: 26, text: 'Movement\n\nMove abilities spend movement points.' },
+        { pageNumber: 27, text: 'Attack\n\nAttack abilities draw attack modifiers.' },
+        { pageNumber: 28, text: 'Heal\n\nHeal abilities remove damage.' },
+        { pageNumber: 29, text: 'Elements\n\nElements can be infused and consumed.' },
+        {
+          pageNumber: 30,
+          text: 'Loot\n\nLoot X lets a figure loot all money tokens and treasure tiles within range X.',
+        },
+      ]),
+      [record()],
+      { runId: 'run-top-k-six', topK: 6 },
+      deps({
+        search: async () =>
+          [25, 26, 27, 28, 29, 30].map((page, index) => ({
+            id: `hit-${page}`,
+            source: `eval/pdf-extraction/run-top-k-six/marker-datalab/page-${page}/gh2-rule-book.pdf`,
+            chunkIndex: 0,
+            text: page === 30 ? record().expectedText : `Distractor page ${page}`,
+            game: GLOOMHAVEN_2E_GAME_ID,
+            score: 1 - index * 0.01,
+            scoreKind: 'vector',
+          })),
+      }),
+    );
+
+    expect(summary.retrieval.top5Hits).toBe(0);
+    expect(summary.retrieval.queryScores?.[0]).toMatchObject({
+      top1Hit: false,
+      top3Hit: false,
+      top5Hit: false,
+    });
+    expect(summary.retrieval.queryScores?.[0]?.hits).toHaveLength(5);
   });
 
   it('uses the GH2 game filter so same-namespace Frosthaven rows cannot win', async () => {
@@ -325,6 +365,28 @@ describe('PDF extraction production retrieval scoring', () => {
       citeableContextHit: false,
       failureClasses: ['missing_expected_region'],
     });
+  });
+
+  it('classifies vector-store failures separately from embedding provider failures', async () => {
+    const summary = await scoreExtractionArtifactWithProductionRetrieval(
+      artifactWithPages([
+        {
+          pageNumber: 30,
+          text: 'Loot\n\nLoot X lets a figure loot all money tokens and treasure tiles within range X.',
+        },
+      ]),
+      [record()],
+      { runId: 'run-storage-failure' },
+      deps({
+        documentEmbeddings: [axisVector(0)],
+        search: async () => {
+          throw new Error('relation "rule_source_embeddings" does not exist');
+        },
+      }),
+    );
+
+    expect(summary.retrieval.failureClasses).toEqual(['storage_failure']);
+    expect(summary.failures).toContain('retrieval scoring: storage_failure');
   });
 
   it('records invalid embedding shape before vector storage', async () => {


### PR DESCRIPTION
## Summary
- add production-path retrieval scoring for PDF extraction artifacts using chunkText, Voyage embedding shape validation, pgvector search, GH2 game filtering, and rerank scoring
- namespace temporary eval rows by run/provider and clean up inserted rows after scoring
- record per-query retrieval evidence, score kind counts, embedding config, and failure classes for page, region, misleading context, missing hits, rerank, storage, and embedding failures
- add DB-backed coverage for vector-only hits, reranked hits, wrong-game exclusion, literal namespace filtering, misleading context, missing expected page/region, and invalid embedding shape

## Review
- Pre-landing review found one isolation issue: sourcePrefix used SQL LIKE without escaping run-id wildcard characters. Fixed by escaping LIKE metacharacters and adding a regression test.

## Test plan
- npx vitest run --config vitest.db.config.ts test/pdf-extraction-retrieval-scoring.test.ts
- npm run check

Fixes SQR-249


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end retrieval scoring for PDF extraction evaluations with configurable embedder and reranker options
  * Source-prefix filtering for vector-store searches
  * Optional automatic cleanup of run-generated vector entries after scoring

* **Enhancements**
  * Expanded retrieval diagnostics: per-query scores, failure classifications, score-kind counts, and embedding metadata

* **Tests**
  * New comprehensive tests covering scoring scenarios, failures, and cleanup behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maz-org/squire/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->