### PR TITLE
fix(eval): allow OpenAI in LangGraph matrix runtime

### DIFF
--- a/eval/matrix-runtime.ts
+++ b/eval/matrix-runtime.ts
@@ -161,6 +161,7 @@ async function runOpenAiMatrixCase(
     client,
     evalCase: input.evalCase,
     providerConfig: input.providerConfig,
+    agentRuntime: input.agentRuntime,
     runLabel: input.runLabel,
     toolSurface: input.toolSurface,
     traceWriter,
@@ -200,12 +201,13 @@ export function createEvalMatrixRunner(
     }
 
     if (input.agentRuntime === 'langgraph') {
-      if (input.providerConfig.provider !== 'anthropic') {
-        throw new Error(
-          'LangGraph eval runtime currently supports Anthropic provider configs only.',
-        );
+      if (input.providerConfig.provider === 'anthropic') {
+        return runAnthropicMatrixCase(input, anthropic, traceWriter);
       }
-      return runAnthropicMatrixCase(input, anthropic, traceWriter);
+      if (input.providerConfig.provider === 'openai') {
+        return runOpenAiMatrixCase(input, anthropic, traceWriter, openAiClient, env);
+      }
+      throw new Error(`Matrix runner does not support provider ${input.providerConfig.provider}.`);
     }
 
     if (input.providerConfig.provider === 'anthropic') {

--- a/eval/matrix-runtime.ts
+++ b/eval/matrix-runtime.ts
@@ -200,16 +200,6 @@ export function createEvalMatrixRunner(
       return runDeepAgentsMatrixCase(input, anthropic, traceWriter);
     }
 
-    if (input.agentRuntime === 'langgraph') {
-      if (input.providerConfig.provider === 'anthropic') {
-        return runAnthropicMatrixCase(input, anthropic, traceWriter);
-      }
-      if (input.providerConfig.provider === 'openai') {
-        return runOpenAiMatrixCase(input, anthropic, traceWriter, openAiClient, env);
-      }
-      throw new Error(`Matrix runner does not support provider ${input.providerConfig.provider}.`);
-    }
-
     if (input.providerConfig.provider === 'anthropic') {
       return runAnthropicMatrixCase(input, anthropic, traceWriter);
     }

--- a/eval/openai-runner.ts
+++ b/eval/openai-runner.ts
@@ -7,7 +7,7 @@ import {
   type ToolCallResult,
 } from '../src/agent.ts';
 import type { ToolTrajectoryStep, TokenUsage } from '../src/agent.ts';
-import type { EvalProviderConfig, EvalToolSurface } from './cli.ts';
+import type { EvalAgentRuntime, EvalProviderConfig, EvalToolSurface } from './cli.ts';
 import { gamePairForCase, langSmithDatasetNameForCase, sourceAuthorityForCase } from './dataset.ts';
 import {
   OPENAI_TOOL_SCHEMA_VERSION,
@@ -124,6 +124,7 @@ export interface RunOpenAiResponsesEvalCaseOptions {
   client?: OpenAiResponsesClient;
   evalCase: EvalCase;
   providerConfig: EvalProviderConfig;
+  agentRuntime?: EvalAgentRuntime;
   runLabel: string;
   toolSurface: EvalToolSurface;
   traceWriter?: EvalTraceWriter;
@@ -542,7 +543,7 @@ export async function runOpenAiResponsesEvalCase(
       caseCategory: options.evalCase.caseCategory,
       sourceAuthority: sourceAuthorityForCase(options.evalCase),
       gamePair: gamePairForCase(options.evalCase),
-      agentRuntime: 'claude-sdk',
+      agentRuntime: options.agentRuntime ?? 'claude-sdk',
       provider: 'openai',
       model: options.providerConfig.model,
       resolvedModel,

--- a/test/eval-matrix-runtime.test.ts
+++ b/test/eval-matrix-runtime.test.ts
@@ -330,15 +330,58 @@ describe('eval matrix runtime adapter', () => {
     });
   });
 
-  it('rejects LangGraph matrix rows for non-Anthropic providers', async () => {
+  it('routes LangGraph OpenAI matrix rows through the OpenAI runner with LangGraph trace identity', async () => {
+    mockRunOpenAiResponsesEvalCase.mockResolvedValue({
+      ok: true,
+      answer: 'Spyglass reveals the top card.',
+      failureClass: 'none',
+      trajectory: {
+        toolCalls: [],
+        finalAnswer: 'Spyglass reveals the top card.',
+        tokenUsage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          totalTokens: 15,
+        },
+        model: 'gpt-5.5',
+        iterations: 2,
+        stopReason: 'completed',
+      },
+      trace: trace({
+        traceId: 'openai-langgraph-trace',
+        agentRuntime: 'langgraph',
+        provider: 'openai',
+        model: 'gpt-5.5',
+        resolvedModel: 'gpt-5.5',
+      }),
+    });
     const runner = createEvalMatrixRunner({ OPENAI_API_KEY: 'test-key' });
 
-    await expect(
-      runner({
-        ...input('openai'),
+    const output = await runner({
+      ...input('openai'),
+      agentRuntime: 'langgraph',
+      traceId: 'openai-langgraph-trace',
+      traceUrl: 'https://smith.langchain.test/traces/openai-langgraph-trace',
+    });
+
+    expect(mockRunOpenAiResponsesEvalCase).toHaveBeenCalledWith(
+      expect.objectContaining({
         agentRuntime: 'langgraph',
+        providerConfig: expect.objectContaining({
+          provider: 'openai',
+          model: 'gpt-5.5',
+        }),
+        traceId: 'openai-langgraph-trace',
       }),
-    ).rejects.toThrow(/LangGraph eval runtime currently supports Anthropic/);
+    );
+    expect(output).toMatchObject({
+      ok: true,
+      traceId: 'openai-langgraph-trace',
+      traceUrl: 'https://smith.langchain.test/traces/openai-langgraph-trace',
+      failureClass: 'none',
+    });
   });
 
   it('falls back to the matrix cost estimate when provider traces have no cost', async () => {

--- a/test/eval-openai-runner.test.ts
+++ b/test/eval-openai-runner.test.ts
@@ -83,6 +83,32 @@ describe('OpenAI Responses eval runner', () => {
     );
   });
 
+  it('records the requested agent runtime in OpenAI eval traces', async () => {
+    const client = responsesClient({
+      id: 'resp_1',
+      model: 'gpt-5.5-2026-04-23',
+      status: 'completed',
+      output_text: 'Spyglass reveals the top card.',
+      output: [
+        {
+          type: 'message',
+          content: [{ type: 'output_text', text: 'Spyglass reveals the top card.' }],
+        },
+      ],
+    });
+
+    const result = await runOpenAiResponsesEvalCase({
+      client,
+      evalCase,
+      providerConfig,
+      agentRuntime: 'langgraph',
+      runLabel: 'unit-openai',
+      toolSurface: 'redesigned',
+    });
+
+    expect(result.trace.agentRuntime).toBe('langgraph');
+  });
+
   it('runs a manual stateless Responses tool loop without previous_response_id', async () => {
     const reasoningItem = {
       type: 'reasoning',


### PR DESCRIPTION
## Summary
- route `langgraph` + OpenAI matrix rows through the OpenAI Responses eval runner instead of rejecting them at dispatch
- preserve the requested agent runtime in OpenAI eval traces so LangSmith rows show `langgraph:openai:<model>`
- add regression coverage for matrix dispatch and OpenAI trace runtime identity

## Validation
- `npm run test:unit -- test/eval-matrix-runtime.test.ts test/eval-openai-runner.test.ts`
- `npm run eval -- --matrix --provider=openai --model=gpt-5.5 --game=gloomhaven-2e --suite=table-qa --id=gh2-monster-living-spirit-elite-level-7-hp --run-label=sqr-251-openai-langgraph-smoke-2026-05-31 --timeout-ms=60000 --tool-loop-limit=6 --broad-search-synthesis-threshold=2 --max-estimated-cost-usd=1 --local-report=/tmp/sqr-251-openai-langgraph-smoke.json`
- `npm run check`

Fixes SQR-251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - OpenAI evaluations can be configured with an agent runtime.
  - LangGraph agent runtime can be used with OpenAI provider runs.

* **Improvements**
  - Matrix runner now selects runners based on provider, with clearer handling for unsupported providers.

* **Tests**
  - Added/updated tests verifying agentRuntime is respected and OpenAI routing works for LangGraph runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->