### PR TITLE
feat(pdf-extraction): add Marker Datalab adapter

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -662,6 +662,17 @@ provider/model. The normalized artifact records workflow settings, JobId,
 workflow metadata, processing status, node stats, page map, table HTML parsing,
 coordinates, estimated cost, and retention assumptions in `providerMetadata`.
 
+Marker/Datalab is available as a paid, opt-in extraction adapter. The adapter
+uses Datalab's managed Convert API, which runs the Marker/Chandra document
+conversion stack and returns Markdown, JSON, and chunks from a single request.
+The adapter defaults to `accurate` mode for the image-heavy Gloomhaven (2nd
+Edition) rulebook, requests table row bounding boxes and link extraction, writes
+raw provider JSON under `eval/results/pdf-extraction/raw/marker-datalab/`, and
+normalizes page markdown, text, headings, table cells, geometry, images,
+versions, parse quality, provider cost, and latency into the shared extraction
+artifact. Selected-page runs pass Datalab's zero-indexed `page_range`, so
+`--pages=30` is sent as `page_range=29`.
+
 Required live-run environment:
 
 ```bash
@@ -677,6 +688,21 @@ UNSTRUCTURED_GENERATIVE_OCR_SUBTYPE=openai_ocr
 UNSTRUCTURED_GENERATIVE_OCR_PROVIDER_TYPE=openai
 UNSTRUCTURED_GENERATIVE_OCR_MODEL=<model-name>
 ```
+
+```bash
+DATALAB_API_KEY=...
+# optional:
+DATALAB_BASE_URL=https://www.datalab.to
+DATALAB_MODE=accurate
+DATALAB_REGION=us
+DATALAB_SKIP_CACHE=0
+DATALAB_COST_PER_PAGE_USD=0.006
+```
+
+The default cost estimate follows Datalab's published managed API pricing:
+`fast` and `balanced` use `$0.004` per page, while `accurate` uses `$0.006` per
+page. Keep `DATALAB_COST_PER_PAGE_USD` aligned with account pricing if that
+changes.
 
 Run selected pages first and keep the cost ceiling explicit:
 
@@ -698,6 +724,27 @@ tests mock the workflow-job runtime and cover success, failed jobs, poll
 timeouts, rate-limit mapping, invalid output, table normalization, coordinate
 normalization, optional generative OCR settings, and selected-page cost
 guardrails.
+
+```bash
+npm run pdf-extraction:run -- \
+  --provider=marker-datalab \
+  --source=data/pdfs/gh2-rule-book.pdf \
+  --pages=2,30,31,32,33,41,42,57,72 \
+  --output-dir=eval/results/pdf-extraction \
+  --run-label=marker-datalab-smoke \
+  --max-estimated-cost-usd=0.10 \
+  --timeout-ms=600000
+```
+
+Full-rulebook Marker/Datalab runs must pass `--allow-full-rulebook`; if the
+estimated selected-page cost exceeds `--max-estimated-cost-usd`, pass
+`--allow-estimated-cost` only after checking the intended spend. Commit-time
+tests mock the Datalab runtime and cover success, failed requests, poll timeout,
+rate-limit mapping, invalid output, provider config hashing, table geometry,
+and selected-page cost guardrails. Local Marker remains useful for future
+self-hosted comparisons, but this adapter intentionally targets managed Datalab
+so the eval harness can run without installing local PyTorch/Surya model
+weights.
 
 This is a baseline, not the final extraction decision. See
 [docs/plans/sqr-188-189-pdf-extraction-vendor-eval-plan.md](plans/sqr-188-189-pdf-extraction-vendor-eval-plan.md)

--- a/eval/pdf-extraction/marker-datalab.ts
+++ b/eval/pdf-extraction/marker-datalab.ts
@@ -287,14 +287,14 @@ export async function readMarkerDatalabJsonResponse(response: Response): Promise
   return parsed;
 }
 
-async function createMarkerDatalabRestRuntime(): Promise<MarkerDatalabRuntime> {
+export async function createMarkerDatalabRestRuntime(): Promise<MarkerDatalabRuntime> {
   const apiKey = apiKeyFromEnv();
   const baseUrl = baseUrlFromEnv();
   return {
     async startConvert(input) {
       const form = new FormData();
       form.append(
-        'file.0',
+        'file',
         new Blob([await readFile(input.sourcePath)], { type: 'application/pdf' }),
         basename(input.sourcePath),
       );
@@ -730,6 +730,14 @@ function actualCostUsd(result: MarkerDatalabConvertResult): number | undefined {
   return undefined;
 }
 
+function rawResult(result: MarkerDatalabConvertResult): MarkerDatalabConvertResult {
+  if (!result.result_url) return result;
+  return {
+    ...result,
+    result_url: '[redacted]',
+  };
+}
+
 export function estimatedMarkerDatalabCostUsd(pages: number[]): number | undefined {
   if (pages.length === 0) return undefined;
   const mode = modeFromEnv();
@@ -785,7 +793,7 @@ export function createMarkerDatalabProvider(
         const rawPayload = {
           request,
           start,
-          result,
+          result: rawResult(result),
         };
         const rawJson = `${JSON.stringify(rawPayload, null, 2)}\n`;
         await writeFile(outputPath, rawJson, 'utf8');
@@ -844,7 +852,7 @@ export function createMarkerDatalabProvider(
               kind: 'provider-json',
               path: outputPath,
               sha256: sha256(rawJson),
-              redacted: false,
+              redacted: result.result_url !== undefined,
               persisted: true,
             },
           ],

--- a/eval/pdf-extraction/marker-datalab.ts
+++ b/eval/pdf-extraction/marker-datalab.ts
@@ -582,6 +582,11 @@ function attr(node: HtmlNode, name: string): string | undefined {
   return node.attrs?.find((entry) => entry.name.toLowerCase() === name)?.value;
 }
 
+function positiveSpan(value: string | undefined): number {
+  const parsed = Number(value ?? '1');
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+}
+
 function tableCellsFromHtml(html: string): ExtractionTableCell[] {
   const fragment = parseFragment(html) as HtmlNode;
   return nodesByTag(fragment, 'tr').flatMap((row, rowIndex) =>
@@ -590,8 +595,8 @@ function tableCellsFromHtml(html: string): ExtractionTableCell[] {
       .map((cell, columnIndex) => ({
         row: rowIndex,
         column: columnIndex,
-        rowSpan: Number(attr(cell, 'rowspan') ?? 1),
-        columnSpan: Number(attr(cell, 'colspan') ?? 1),
+        rowSpan: positiveSpan(attr(cell, 'rowspan')),
+        columnSpan: positiveSpan(attr(cell, 'colspan')),
         text: htmlTextFromNode(cell),
       })),
   );

--- a/eval/pdf-extraction/marker-datalab.ts
+++ b/eval/pdf-extraction/marker-datalab.ts
@@ -1,0 +1,860 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { basename, dirname } from 'node:path';
+
+import { parseFragment } from 'parse5';
+
+import type { PdfExtractionProvider, PdfExtractionRunInput } from './provider.ts';
+import {
+  computeProviderConfigHash,
+  validateExtractionArtifact,
+  type ExtractionArtifact,
+  type ExtractionBlock,
+  type ExtractionPage,
+  type ExtractionTable,
+  type ExtractionTableCell,
+} from './schema.ts';
+
+type MarkerDatalabMode = 'fast' | 'balanced' | 'accurate';
+type HtmlNode = {
+  nodeName?: string;
+  tagName?: string;
+  value?: string;
+  attrs?: { name: string; value: string }[];
+  childNodes?: HtmlNode[];
+};
+
+interface MarkerDatalabBlock {
+  id?: string;
+  block_id?: string;
+  block_type?: string;
+  type?: string;
+  html?: string;
+  text?: string;
+  markdown?: string;
+  polygon?: unknown;
+  bbox?: unknown;
+  children?: MarkerDatalabBlock[] | null;
+  page_id?: number;
+  page?: number;
+}
+
+export interface MarkerDatalabConvertRequest {
+  mode: MarkerDatalabMode;
+  outputFormat: string;
+  pageRange?: string;
+  paginate: boolean;
+  addBlockIds: boolean;
+  includeMarkdownInChunks: boolean;
+  disableImageExtraction: boolean;
+  disableImageCaptions: boolean;
+  tokenEfficientMarkdown: boolean;
+  skipCache: boolean;
+  saveCheckpoint: boolean;
+  extras: string;
+}
+
+export interface MarkerDatalabStartResult {
+  requestId: string;
+  requestCheckUrl: string;
+  versions?: Record<string, unknown>;
+}
+
+export interface MarkerDatalabConvertResult {
+  status?: string;
+  result_url?: string;
+  expires_in?: number;
+  output_format?: string;
+  chunks?: unknown;
+  json?: unknown;
+  markdown?: string | null;
+  html?: string | null;
+  images?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  success?: boolean | null;
+  error?: string | null;
+  parse_quality_score?: number | null;
+  page_count?: number | null;
+  total_cost?: number | null;
+  cost_breakdown?: Record<string, unknown>;
+  runtime?: number | null;
+  checkpoint_id?: string | null;
+  versions?: Record<string, unknown>;
+  requestId?: string;
+}
+
+export interface MarkerDatalabRuntime {
+  startConvert(input: {
+    sourcePath: string;
+    request: MarkerDatalabConvertRequest;
+  }): Promise<MarkerDatalabStartResult>;
+  getConvertResult(input: {
+    requestId: string;
+    requestCheckUrl: string;
+  }): Promise<MarkerDatalabConvertResult>;
+}
+
+export interface MarkerDatalabProviderDeps {
+  runtime?: MarkerDatalabRuntime;
+  now?: () => string;
+  sleep?: (ms: number) => Promise<void>;
+  mode?: MarkerDatalabMode;
+  region?: string;
+  skipCache?: boolean;
+  pollIntervalMs?: number;
+  maxPollAttempts?: number;
+  costPerPageUsd?: number;
+}
+
+const MARKER_DATALAB_OUTPUT_FORMAT = 'markdown,json,chunks';
+const MARKER_DATALAB_EXTRAS = 'table_row_bboxes,extract_links,new_block_types';
+const MARKER_DATALAB_DEFAULT_MODE: MarkerDatalabMode = 'accurate';
+const MARKER_DATALAB_FAST_BALANCED_COST_PER_PAGE_USD = 0.004;
+const MARKER_DATALAB_ACCURATE_COST_PER_PAGE_USD = 0.006;
+
+export const MARKER_DATALAB_PROVIDER_VERSION = 'datalab-convert-v1-marker-chandra';
+
+function providerConfigFor(input: {
+  mode: MarkerDatalabMode;
+  skipCache: boolean;
+  costPerPageUsd: number;
+}) {
+  return {
+    api: 'Datalab Convert API v1',
+    engine: 'Datalab managed Marker/Chandra conversion',
+    mode: input.mode,
+    outputFormat: MARKER_DATALAB_OUTPUT_FORMAT,
+    selectedPages: 'page_range-zero-indexed-v1',
+    paginate: true,
+    addBlockIds: true,
+    includeMarkdownInChunks: true,
+    disableImageExtraction: false,
+    disableImageCaptions: false,
+    tokenEfficientMarkdown: false,
+    skipCache: input.skipCache,
+    saveCheckpoint: false,
+    extras: MARKER_DATALAB_EXTRAS.split(','),
+    costPerPageUsd: input.costPerPageUsd,
+  };
+}
+
+export const MARKER_DATALAB_PROVIDER_CONFIG = providerConfigFor({
+  mode: MARKER_DATALAB_DEFAULT_MODE,
+  skipCache: false,
+  costPerPageUsd: MARKER_DATALAB_ACCURATE_COST_PER_PAGE_USD,
+});
+export const MARKER_DATALAB_PROVIDER_CONFIG_HASH = computeProviderConfigHash(
+  MARKER_DATALAB_PROVIDER_CONFIG,
+);
+
+export function markerDatalabProviderConfigHash(input: {
+  mode: MarkerDatalabMode;
+  skipCache: boolean;
+  costPerPageUsd: number;
+}): string {
+  return computeProviderConfigHash(providerConfigFor(input));
+}
+
+export function markerDatalabProviderConfigHashFromEnv(): string {
+  const mode = modeFromEnv();
+  return markerDatalabProviderConfigHash({
+    mode,
+    skipCache: skipCacheFromEnv(),
+    costPerPageUsd: costPerPageFromEnv(mode),
+  });
+}
+
+function sha256(bytes: Buffer | string): string {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+async function fileSha256(path: string): Promise<string> {
+  return sha256(await readFile(path));
+}
+
+function safePathSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'run';
+}
+
+function rawOutputPath(
+  input: PdfExtractionRunInput,
+  sourceHash: string,
+  providerConfigHash: string,
+): string {
+  return `${input.outputDir}/raw/marker-datalab/${sourceHash.slice(7)}/${providerConfigHash.slice(7)}/${safePathSegment(input.runLabel)}.json`;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function pageRange(pages: number[]): string | undefined {
+  if (pages.length === 0) return undefined;
+  return pages.map((page) => String(page - 1)).join(',');
+}
+
+function makeRequest(input: {
+  pages: number[];
+  mode: MarkerDatalabMode;
+  skipCache: boolean;
+}): MarkerDatalabConvertRequest {
+  return {
+    mode: input.mode,
+    outputFormat: MARKER_DATALAB_OUTPUT_FORMAT,
+    ...(pageRange(input.pages) ? { pageRange: pageRange(input.pages) } : {}),
+    paginate: true,
+    addBlockIds: true,
+    includeMarkdownInChunks: true,
+    disableImageExtraction: false,
+    disableImageCaptions: false,
+    tokenEfficientMarkdown: false,
+    skipCache: input.skipCache,
+    saveCheckpoint: false,
+    extras: MARKER_DATALAB_EXTRAS,
+  };
+}
+
+function modeFromEnv(): MarkerDatalabMode {
+  const mode = process.env.DATALAB_MODE ?? MARKER_DATALAB_DEFAULT_MODE;
+  if (!['fast', 'balanced', 'accurate'].includes(mode)) {
+    throw new Error('Invalid DATALAB_MODE: expected fast, balanced, or accurate.');
+  }
+  return mode as MarkerDatalabMode;
+}
+
+function regionFromEnv(): string {
+  return process.env.DATALAB_REGION ?? 'us';
+}
+
+function skipCacheFromEnv(): boolean {
+  return process.env.DATALAB_SKIP_CACHE === '1';
+}
+
+function defaultCostForMode(mode: MarkerDatalabMode): number {
+  return mode === 'accurate'
+    ? MARKER_DATALAB_ACCURATE_COST_PER_PAGE_USD
+    : MARKER_DATALAB_FAST_BALANCED_COST_PER_PAGE_USD;
+}
+
+function costPerPageFromEnv(mode: MarkerDatalabMode): number {
+  const cost = process.env.DATALAB_COST_PER_PAGE_USD;
+  if (!cost) return defaultCostForMode(mode);
+  const value = Number(cost);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error('Invalid DATALAB_COST_PER_PAGE_USD: expected a non-negative number.');
+  }
+  return value;
+}
+
+function apiKeyFromEnv(): string {
+  const key = process.env.DATALAB_API_KEY;
+  if (!key) throw new Error('Missing DATALAB_API_KEY for live Marker/Datalab extraction.');
+  return key;
+}
+
+function baseUrlFromEnv(): string {
+  return (process.env.DATALAB_BASE_URL ?? 'https://www.datalab.to').replace(/\/+$/g, '');
+}
+
+function requestIdFrom(response: Response): string | undefined {
+  return (
+    response.headers.get('x-request-id') ??
+    response.headers.get('x-trace-id') ??
+    response.headers.get('request-id') ??
+    undefined
+  );
+}
+
+export async function readMarkerDatalabJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  let parsed: unknown = {};
+  if (text) {
+    try {
+      parsed = JSON.parse(text) as unknown;
+    } catch {
+      parsed = { detail: text };
+    }
+  }
+  if (!response.ok) {
+    const detail =
+      typeof parsed === 'object' && parsed && 'detail' in parsed
+        ? JSON.stringify((parsed as { detail?: unknown }).detail)
+        : text || response.statusText;
+    throw Object.assign(new Error(`Datalab HTTP ${response.status}: ${detail}`), {
+      status: response.status,
+    });
+  }
+  return parsed;
+}
+
+async function createMarkerDatalabRestRuntime(): Promise<MarkerDatalabRuntime> {
+  const apiKey = apiKeyFromEnv();
+  const baseUrl = baseUrlFromEnv();
+  return {
+    async startConvert(input) {
+      const form = new FormData();
+      form.append(
+        'file.0',
+        new Blob([await readFile(input.sourcePath)], { type: 'application/pdf' }),
+        basename(input.sourcePath),
+      );
+      form.append('mode', input.request.mode);
+      form.append('output_format', input.request.outputFormat);
+      if (input.request.pageRange) form.append('page_range', input.request.pageRange);
+      form.append('paginate', String(input.request.paginate));
+      form.append('add_block_ids', String(input.request.addBlockIds));
+      form.append('include_markdown_in_chunks', String(input.request.includeMarkdownInChunks));
+      form.append('disable_image_extraction', String(input.request.disableImageExtraction));
+      form.append('disable_image_captions', String(input.request.disableImageCaptions));
+      form.append('token_efficient_markdown', String(input.request.tokenEfficientMarkdown));
+      form.append('skip_cache', String(input.request.skipCache));
+      form.append('save_checkpoint', String(input.request.saveCheckpoint));
+      form.append('extras', input.request.extras);
+
+      const response = await fetch(`${baseUrl}/api/v1/convert`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'X-API-Key': apiKey,
+        },
+        body: form,
+      });
+      const json = (await readMarkerDatalabJsonResponse(response)) as {
+        request_id?: unknown;
+        request_check_url?: unknown;
+        error?: unknown;
+        success?: unknown;
+        versions?: Record<string, unknown>;
+      };
+      if (json.success === false) {
+        throw new Error(
+          `provider error: Datalab conversion failed to start: ${json.error ?? 'unknown failure'}.`,
+        );
+      }
+      if (typeof json.request_id !== 'string') {
+        throw new Error('provider error: Datalab conversion did not return a request_id.');
+      }
+      if (typeof json.request_check_url !== 'string') {
+        throw new Error('provider error: Datalab conversion did not return a request_check_url.');
+      }
+      return {
+        requestId: json.request_id,
+        requestCheckUrl: json.request_check_url.startsWith('http')
+          ? json.request_check_url
+          : `${baseUrl}${json.request_check_url}`,
+        versions: json.versions,
+      };
+    },
+    async getConvertResult(input) {
+      const response = await fetch(input.requestCheckUrl, {
+        headers: {
+          Accept: 'application/json',
+          'X-API-Key': apiKey,
+        },
+      });
+      const json = (await readMarkerDatalabJsonResponse(response)) as MarkerDatalabConvertResult;
+      return {
+        ...json,
+        requestId: requestIdFrom(response),
+      };
+    },
+  };
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function collectResult(
+  runtime: MarkerDatalabRuntime,
+  start: MarkerDatalabStartResult,
+  maxPollAttempts: number,
+  pollIntervalMs: number,
+  sleep: (ms: number) => Promise<void>,
+): Promise<{ result: MarkerDatalabConvertResult; requestIds: string[] }> {
+  const requestIds: string[] = [];
+  for (let attempt = 1; attempt <= maxPollAttempts; attempt += 1) {
+    const result = await runtime.getConvertResult({
+      requestId: start.requestId,
+      requestCheckUrl: start.requestCheckUrl,
+    });
+    if (result.requestId) requestIds.push(result.requestId);
+    const status = result.status?.toLowerCase();
+    if (status === 'complete') {
+      if (result.success === false) {
+        throw new Error(
+          `provider error: Datalab request ${start.requestId} failed: ${result.error ?? 'unknown failure'}.`,
+        );
+      }
+      return { result, requestIds };
+    }
+    if (status === 'failed' || status === 'error') {
+      throw new Error(
+        `provider error: Datalab request ${start.requestId} failed: ${result.error ?? 'unknown failure'}.`,
+      );
+    }
+    if (attempt === maxPollAttempts) {
+      throw new Error(
+        `timeout: Datalab request ${start.requestId} did not finish after ${maxPollAttempts} polling attempts.`,
+      );
+    }
+    await sleep(pollIntervalMs);
+  }
+  throw new Error(`timeout: Datalab request ${start.requestId} did not finish.`);
+}
+
+function markerDatalabError(error: unknown): Error {
+  if (typeof error === 'object' && error && 'status' in error) {
+    const status = Number((error as { status?: unknown }).status);
+    const message = error instanceof Error ? error.message : `HTTP ${status}`;
+    if (status === 429) {
+      return Object.assign(new Error(`rate limit: ${message}`), { status: 429, cause: error });
+    }
+    if (status === 401 || status === 403) {
+      return Object.assign(new Error(`credential failure: ${message}`), {
+        status,
+        cause: error,
+      });
+    }
+  }
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function blockChildren(block: MarkerDatalabBlock): MarkerDatalabBlock[] {
+  return Array.isArray(block.children) ? block.children : [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function datalabBlock(value: unknown): MarkerDatalabBlock | undefined {
+  if (!isRecord(value)) return undefined;
+  if (
+    typeof value.block_type !== 'string' &&
+    typeof value.type !== 'string' &&
+    !Array.isArray(value.children)
+  ) {
+    return undefined;
+  }
+  return value as MarkerDatalabBlock;
+}
+
+function findPageBlocks(value: unknown): MarkerDatalabBlock[] {
+  const pages: MarkerDatalabBlock[] = [];
+  const visit = (entry: unknown) => {
+    if (Array.isArray(entry)) {
+      entry.forEach(visit);
+      return;
+    }
+    const block = datalabBlock(entry);
+    if (!block) return;
+    const kind = block.block_type ?? block.type;
+    if (kind === 'Page') pages.push(block);
+    for (const child of blockChildren(block)) visit(child);
+  };
+  visit(value);
+  return pages;
+}
+
+function walkBlocks(block: MarkerDatalabBlock): MarkerDatalabBlock[] {
+  return blockChildren(block).flatMap((child) => [child, ...walkBlocks(child)]);
+}
+
+function pageIndexFromBlock(block: MarkerDatalabBlock): number | undefined {
+  if (Number.isInteger(block.page_id)) return block.page_id;
+  if (Number.isInteger(block.page)) return block.page;
+  const id = block.id ?? block.block_id;
+  if (!id) return undefined;
+  const match = /\/page\/(\d+)\b/.exec(id);
+  return match ? Number(match[1]) : undefined;
+}
+
+function pageNumberFor(block: MarkerDatalabBlock, order: number, requestedPages: number[]): number {
+  const providerPageIndex = pageIndexFromBlock(block);
+  if (providerPageIndex !== undefined) {
+    const originalPage = providerPageIndex + 1;
+    if (requestedPages.length === 0 || requestedPages.includes(originalPage)) return originalPage;
+  }
+  if (requestedPages.length > 0 && order < requestedPages.length) return requestedPages[order];
+  return providerPageIndex === undefined ? order + 1 : providerPageIndex + 1;
+}
+
+function htmlText(html: string): string {
+  const fragment = parseFragment(html) as HtmlNode;
+  const collect = (node: HtmlNode): string[] => {
+    if (typeof node.value === 'string') return [node.value];
+    return (node.childNodes ?? []).flatMap(collect);
+  };
+  return collect(fragment).join(' ').replace(/\s+/g, ' ').trim();
+}
+
+function blockText(block: MarkerDatalabBlock): string {
+  if (typeof block.text === 'string') return block.text.trim();
+  if (typeof block.markdown === 'string') return block.markdown.trim();
+  if (typeof block.html === 'string') return htmlText(block.html);
+  return '';
+}
+
+function blockType(block: MarkerDatalabBlock): ExtractionBlock['type'] {
+  switch (block.block_type ?? block.type) {
+    case 'SectionHeader':
+    case 'Title':
+      return 'heading';
+    case 'Text':
+    case 'TextInlineMath':
+    case 'ListItem':
+    case 'Code':
+    case 'Equation':
+    case 'Form':
+      return 'paragraph';
+    case 'Table':
+    case 'TableGroup':
+      return 'table';
+    case 'Picture':
+    case 'PictureGroup':
+    case 'Figure':
+    case 'FigureGroup':
+      return 'image';
+    case 'PageHeader':
+      return 'header';
+    case 'PageFooter':
+      return 'footer';
+    case 'Page':
+      return 'other';
+    default:
+      return 'other';
+  }
+}
+
+function polygonBBox(value: unknown): ExtractionBlock['bbox'] {
+  if (!Array.isArray(value)) return undefined;
+  const points = value
+    .filter((point): point is [number, number] => Array.isArray(point) && point.length >= 2)
+    .map(([x, y]) => ({ x: Number(x), y: Number(y) }))
+    .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.y));
+  if (points.length === 0) return undefined;
+  const minX = Math.min(...points.map((point) => point.x));
+  const maxX = Math.max(...points.map((point) => point.x));
+  const minY = Math.min(...points.map((point) => point.y));
+  const maxY = Math.max(...points.map((point) => point.y));
+  return {
+    x: round(Math.max(0, minX)),
+    y: round(Math.max(0, minY)),
+    width: round(Math.max(0, maxX - minX)),
+    height: round(Math.max(0, maxY - minY)),
+  };
+}
+
+function bboxFromBlock(block: MarkerDatalabBlock): ExtractionBlock['bbox'] {
+  const polygon = polygonBBox(block.polygon);
+  if (polygon) return polygon;
+  if (!isRecord(block.bbox)) return undefined;
+  const x = Number(block.bbox.x);
+  const y = Number(block.bbox.y);
+  const width = Number(block.bbox.width);
+  const height = Number(block.bbox.height);
+  if (![x, y, width, height].every(Number.isFinite)) return undefined;
+  return {
+    x: round(Math.max(0, x)),
+    y: round(Math.max(0, y)),
+    width: round(Math.max(0, width)),
+    height: round(Math.max(0, height)),
+  };
+}
+
+function blockFor(pageNumber: number, block: MarkerDatalabBlock, order: number): ExtractionBlock {
+  return {
+    id: block.id ?? block.block_id ?? `p${pageNumber}-b${order}`,
+    type: blockType(block),
+    order,
+    text: blockText(block),
+    ...(bboxFromBlock(block) ? { bbox: bboxFromBlock(block) } : {}),
+  };
+}
+
+function nodesByTag(node: HtmlNode, tagName: string): HtmlNode[] {
+  const matches = node.tagName === tagName ? [node] : [];
+  return matches.concat((node.childNodes ?? []).flatMap((child) => nodesByTag(child, tagName)));
+}
+
+function attr(node: HtmlNode, name: string): string | undefined {
+  return node.attrs?.find((entry) => entry.name.toLowerCase() === name)?.value;
+}
+
+function tableCellsFromHtml(html: string): ExtractionTableCell[] {
+  const fragment = parseFragment(html) as HtmlNode;
+  return nodesByTag(fragment, 'tr').flatMap((row, rowIndex) =>
+    (row.childNodes ?? [])
+      .filter((cell) => cell.tagName === 'th' || cell.tagName === 'td')
+      .map((cell, columnIndex) => ({
+        row: rowIndex,
+        column: columnIndex,
+        rowSpan: Number(attr(cell, 'rowspan') ?? 1),
+        columnSpan: Number(attr(cell, 'colspan') ?? 1),
+        text: htmlTextFromNode(cell),
+      })),
+  );
+}
+
+function htmlTextFromNode(node: HtmlNode): string {
+  const collect = (entry: HtmlNode): string[] => {
+    if (typeof entry.value === 'string') return [entry.value];
+    return (entry.childNodes ?? []).flatMap(collect);
+  };
+  return collect(node).join(' ').replace(/\s+/g, ' ').trim();
+}
+
+function tableForBlock(
+  pageNumber: number,
+  block: MarkerDatalabBlock,
+  order: number,
+): ExtractionTable | undefined {
+  if (blockType(block) !== 'table' || typeof block.html !== 'string') return undefined;
+  const cells = tableCellsFromHtml(block.html);
+  if (cells.length === 0) return undefined;
+  return {
+    id: block.id ?? block.block_id ?? `p${pageNumber}-table-${order}`,
+    order,
+    ...(bboxFromBlock(block) ? { bbox: bboxFromBlock(block) } : {}),
+    cells,
+  };
+}
+
+function markdownForBlocks(blocks: ExtractionBlock[]): string {
+  return blocks
+    .map((block) => (block.type === 'heading' ? `## ${block.text}` : block.text))
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function toExtractionPage(
+  pageBlock: MarkerDatalabBlock,
+  order: number,
+  requestedPages: number[],
+): ExtractionPage {
+  const pageNumber = pageNumberFor(pageBlock, order, requestedPages);
+  const sourceBlocks = walkBlocks(pageBlock).filter(
+    (block) => (block.block_type ?? block.type) !== 'Page',
+  );
+  const blocks = sourceBlocks.map((block, index) => blockFor(pageNumber, block, index));
+  const tables = sourceBlocks
+    .map((block, index) => tableForBlock(pageNumber, block, index))
+    .filter((table): table is ExtractionTable => table !== undefined);
+  const bbox = bboxFromBlock(pageBlock);
+  const markdown =
+    typeof pageBlock.markdown === 'string' && pageBlock.markdown.trim()
+      ? pageBlock.markdown.trim()
+      : markdownForBlocks(blocks);
+  const text = blocks
+    .map((block) => block.text)
+    .filter(Boolean)
+    .join('\n\n');
+
+  return {
+    pageNumber,
+    width: bbox?.width ?? 612,
+    height: bbox?.height ?? 792,
+    unit: 'pt',
+    markdown,
+    text,
+    blocks,
+    tables,
+  };
+}
+
+function fallbackPageFromMarkdown(
+  result: MarkerDatalabConvertResult,
+  requestedPages: number[],
+): ExtractionPage[] {
+  const markdown = result.markdown?.trim();
+  if (!markdown) throw new Error('invalid artifact: Datalab output contained no pages.');
+  const pages = requestedPages.length > 0 ? requestedPages : [1];
+  if (pages.length !== 1) {
+    throw new Error('invalid artifact: Datalab JSON output is required for multi-page runs.');
+  }
+  const lines = markdown
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const blocks = lines.map((line, order) => ({
+    id: `p${pages[0]}-b${order}`,
+    type: /^#{1,6}\s+/.test(line) ? 'heading' : 'line',
+    order,
+    text: line.replace(/^#{1,6}\s+/, ''),
+  })) satisfies ExtractionBlock[];
+  return [
+    {
+      pageNumber: pages[0],
+      width: 612,
+      height: 792,
+      unit: 'pt',
+      markdown,
+      text: blocks.map((block) => block.text).join('\n\n'),
+      blocks,
+      tables: [],
+    },
+  ];
+}
+
+function normalizePages(
+  result: MarkerDatalabConvertResult,
+  requestedPages: number[],
+): ExtractionPage[] {
+  const pageBlocks = findPageBlocks(result.json);
+  const pages =
+    pageBlocks.length > 0
+      ? pageBlocks.map((page, order) => toExtractionPage(page, order, requestedPages))
+      : fallbackPageFromMarkdown(result, requestedPages);
+  if (requestedPages.length > 0) {
+    const byPage = new Map(pages.map((page) => [page.pageNumber, page]));
+    return requestedPages.map((pageNumber) => {
+      const page = byPage.get(pageNumber);
+      if (!page) throw new Error(`invalid artifact: Datalab output omitted page ${pageNumber}.`);
+      return page;
+    });
+  }
+  return pages.sort((left, right) => left.pageNumber - right.pageNumber);
+}
+
+function actualCostUsd(result: MarkerDatalabConvertResult): number | undefined {
+  if (typeof result.total_cost === 'number' && Number.isFinite(result.total_cost)) {
+    return round(result.total_cost / 100);
+  }
+  const breakdown = result.cost_breakdown;
+  if (!breakdown) return undefined;
+  for (const key of ['final_cost', 'client_cost', 'total_cost', 'list_cost']) {
+    const value = breakdown[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return round(value / 100);
+  }
+  return undefined;
+}
+
+export function estimatedMarkerDatalabCostUsd(pages: number[]): number | undefined {
+  if (pages.length === 0) return undefined;
+  const mode = modeFromEnv();
+  return round(pages.length * costPerPageFromEnv(mode));
+}
+
+export function createMarkerDatalabProvider(
+  deps: MarkerDatalabProviderDeps = {},
+): PdfExtractionProvider {
+  const now = deps.now ?? (() => new Date().toISOString());
+  const sleep = deps.sleep ?? defaultSleep;
+  const mode = deps.mode ?? modeFromEnv();
+  const region = deps.region ?? regionFromEnv();
+  const skipCache = deps.skipCache ?? skipCacheFromEnv();
+  const pollIntervalMs = deps.pollIntervalMs ?? 2_000;
+  const maxPollAttempts = deps.maxPollAttempts ?? 150;
+  const costPerPageUsd = deps.costPerPageUsd ?? costPerPageFromEnv(mode);
+
+  return {
+    id: 'marker-datalab',
+    displayName: 'Marker/Datalab',
+    version: MARKER_DATALAB_PROVIDER_VERSION,
+    async extract(input) {
+      const startedAt = now();
+      const startMs = Date.now();
+      const sourceHash = await fileSha256(input.sourcePath);
+      const providerConfigHash = markerDatalabProviderConfigHash({
+        mode,
+        skipCache,
+        costPerPageUsd,
+      });
+      const outputPath = rawOutputPath(input, sourceHash, providerConfigHash);
+      await mkdir(dirname(outputPath), { recursive: true });
+      const runtime = deps.runtime ?? (await createMarkerDatalabRestRuntime());
+
+      try {
+        const request = makeRequest({ pages: input.pages, mode, skipCache });
+        const start = await runtime.startConvert({
+          sourcePath: input.sourcePath,
+          request,
+        });
+        const { result, requestIds } = await collectResult(
+          runtime,
+          start,
+          maxPollAttempts,
+          pollIntervalMs,
+          sleep,
+        );
+        const selectedPages = normalizePages(result, input.pages);
+        const completedAt = now();
+        const pagesProcessed = selectedPages.length;
+        const estimatedUsd = round(pagesProcessed * costPerPageUsd);
+        const rawPayload = {
+          request,
+          start,
+          result,
+        };
+        const rawJson = `${JSON.stringify(rawPayload, null, 2)}\n`;
+        await writeFile(outputPath, rawJson, 'utf8');
+        const artifact = {
+          schemaVersion: 'squire-pdf-extraction-v1',
+          provider: 'marker-datalab',
+          providerVersion: MARKER_DATALAB_PROVIDER_VERSION,
+          providerConfigHash,
+          source: {
+            path: input.sourcePath,
+            sha256: sourceHash,
+            ...(typeof result.page_count === 'number' && result.page_count > 0
+              ? { pageCount: result.page_count }
+              : {}),
+          },
+          run: {
+            id: input.runLabel,
+            startedAt,
+            completedAt,
+            status: 'succeeded',
+            pageRange: input.pages.length === 0 ? undefined : input.pages,
+            latencyMs: Math.max(0, Date.now() - startMs),
+          },
+          cost: {
+            estimatedUsd,
+            actualUsd: actualCostUsd(result) ?? estimatedUsd,
+            pagesProcessed,
+            costPerPageUsd,
+          },
+          privacy: {
+            retentionPolicy:
+              'Datalab managed conversion stores hosted results temporarily and documents result deletion after processing; raw outputs are persisted only in the configured eval output directory.',
+            trainingUse: 'not-used-for-training',
+            region,
+          },
+          providerMetadata: {
+            mode,
+            outputFormat: request.outputFormat,
+            pageRange: request.pageRange,
+            skipCache,
+            requestId: start.requestId,
+            requestCheckUrl: start.requestCheckUrl,
+            requestIds,
+            parseQualityScore: result.parse_quality_score,
+            runtime: result.runtime,
+            outputFormatReturned: result.output_format,
+            resultUrlExpiresIn: result.expires_in,
+            checkpointId: result.checkpoint_id,
+            versions: { start: start.versions, result: result.versions },
+            metadata: result.metadata,
+            imageCount: result.images ? Object.keys(result.images).length : 0,
+            costBreakdown: result.cost_breakdown,
+          },
+          rawArtifacts: [
+            {
+              kind: 'provider-json',
+              path: outputPath,
+              sha256: sha256(rawJson),
+              redacted: false,
+              persisted: true,
+            },
+          ],
+          pages: selectedPages,
+        } satisfies ExtractionArtifact;
+
+        return validateExtractionArtifact(artifact);
+      } catch (error) {
+        throw markerDatalabError(error);
+      }
+    },
+  };
+}

--- a/eval/pdf-extraction/providers.ts
+++ b/eval/pdf-extraction/providers.ts
@@ -1,6 +1,7 @@
 import { createAppleVisionProvider } from './apple-vision.ts';
 import { createAwsTextractProvider } from './aws-textract.ts';
 import { createLlamaParseProvider } from './llamaparse.ts';
+import { createMarkerDatalabProvider } from './marker-datalab.ts';
 import { createProviderRegistry, type ProviderRegistry } from './provider.ts';
 import { createUnstructuredProvider } from './unstructured.ts';
 
@@ -10,5 +11,6 @@ export function createPdfExtractionProviderRegistry(): ProviderRegistry {
   registry.register(createAwsTextractProvider());
   registry.register(createLlamaParseProvider());
   registry.register(createUnstructuredProvider());
+  registry.register(createMarkerDatalabProvider());
   return registry;
 }

--- a/eval/pdf-extraction/run.ts
+++ b/eval/pdf-extraction/run.ts
@@ -6,6 +6,10 @@ import { APPLE_VISION_PROVIDER_CONFIG_HASH } from './apple-vision.ts';
 import { AWS_TEXTRACT_PROVIDER_CONFIG_HASH, estimatedAwsTextractCostUsd } from './aws-textract.ts';
 import { parsePdfExtractionArgs, type PdfExtractionCliOptions } from './cli.ts';
 import { estimatedLlamaParseCostUsd, llamaParseProviderConfigHashFromEnv } from './llamaparse.ts';
+import {
+  estimatedMarkerDatalabCostUsd,
+  markerDatalabProviderConfigHashFromEnv,
+} from './marker-datalab.ts';
 import { writeExtractionManifest } from './manifest.ts';
 import type { ProviderRegistry } from './provider.ts';
 import { createPdfExtractionProviderRegistry } from './providers.ts';
@@ -55,6 +59,7 @@ function providerConfigHash(provider: PdfExtractionProviderId, override?: string
   if (provider === 'aws-textract') return AWS_TEXTRACT_PROVIDER_CONFIG_HASH;
   if (provider === 'llamaparse') return llamaParseProviderConfigHashFromEnv();
   if (provider === 'unstructured') return unstructuredProviderConfigHashFromEnv();
+  if (provider === 'marker-datalab') return markerDatalabProviderConfigHashFromEnv();
   throw new Error(`Unsupported PDF extraction provider config: ${provider}.`);
 }
 
@@ -63,6 +68,7 @@ function estimatedCostUsdFor(input: PdfExtractionCliOptions): number | undefined
   if (input.provider === 'aws-textract') return estimatedAwsTextractCostUsd(input.pages);
   if (input.provider === 'llamaparse') return estimatedLlamaParseCostUsd(input.pages);
   if (input.provider === 'unstructured') return estimatedUnstructuredCostUsd(input.pages);
+  if (input.provider === 'marker-datalab') return estimatedMarkerDatalabCostUsd(input.pages);
   return undefined;
 }
 

--- a/test/pdf-extraction-eval-run.test.ts
+++ b/test/pdf-extraction-eval-run.test.ts
@@ -334,4 +334,48 @@ describe('PDF extraction eval run', () => {
     );
     expect(extract).not.toHaveBeenCalled();
   });
+
+  it('applies Marker/Datalab selected-page cost guardrails before provider work', async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), 'squire-pdf-extraction-eval-run-'));
+    const registry = createProviderRegistry();
+    const extract = vi.fn<PdfExtractionProvider['extract']>().mockResolvedValue({
+      ...artifact,
+      provider: 'marker-datalab',
+    });
+    registry.register({
+      id: 'marker-datalab',
+      displayName: 'Marker/Datalab',
+      version: 'marker-datalab-test',
+      extract,
+    });
+
+    await expect(
+      runPdfExtractionEval(
+        {
+          provider: 'marker-datalab',
+          sourcePath: artifact.source.path,
+          pages: [30],
+          outputDir,
+          runLabel: 'marker-datalab-page-30',
+          retryCount: 0,
+          allowFullRulebook: false,
+          allowEstimatedCostOverride: false,
+          maxEstimatedCostUsd: 0.001,
+          providerConcurrency: 1,
+          refreshProviderOutput: false,
+          timeoutMs: 120_000,
+        },
+        {
+          registry,
+          sourceHash: artifact.source.sha256,
+          providerConfigHash: artifact.providerConfigHash,
+          groundTruth: [],
+          scoreArtifact: async () => scoreExtractionArtifact(artifact, []),
+        },
+      ),
+    ).rejects.toThrow(
+      /Estimated PDF extraction cost \$0.01 exceeds --max-estimated-cost-usd=0.001/,
+    );
+    expect(extract).not.toHaveBeenCalled();
+  });
 });

--- a/test/pdf-extraction-marker-datalab.test.ts
+++ b/test/pdf-extraction-marker-datalab.test.ts
@@ -1,0 +1,340 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createMarkerDatalabProvider,
+  markerDatalabProviderConfigHash,
+  MARKER_DATALAB_PROVIDER_CONFIG_HASH,
+  readMarkerDatalabJsonResponse,
+  type MarkerDatalabRuntime,
+} from '../eval/pdf-extraction/marker-datalab.ts';
+import { validateExtractionArtifact } from '../eval/pdf-extraction/schema.ts';
+
+function markerDatalabRuntime(overrides: Partial<MarkerDatalabRuntime> = {}): MarkerDatalabRuntime {
+  return {
+    startConvert: vi.fn().mockResolvedValue({
+      requestId: 'request-123',
+      requestCheckUrl: 'https://www.datalab.to/api/v1/convert/request-123',
+      versions: { marker: '1.10.2' },
+    }),
+    getConvertResult: vi.fn().mockResolvedValue({
+      status: 'complete',
+      success: true,
+      output_format: 'markdown,json,chunks',
+      markdown:
+        '# Loot\n\nLoot X lets a figure loot all loot tokens within range X.\n\n| Term | Meaning |\n| --- | --- |\n| Loot | Range |',
+      json: [
+        {
+          id: '/page/29/Page/0',
+          block_type: 'Page',
+          polygon: [
+            [0, 0],
+            [612, 0],
+            [612, 792],
+            [0, 792],
+          ],
+          children: [
+            {
+              id: '/page/29/SectionHeader/0',
+              block_type: 'SectionHeader',
+              html: '<h1>Loot</h1>',
+              polygon: [
+                [70, 80],
+                [180, 80],
+                [180, 104],
+                [70, 104],
+              ],
+              children: null,
+            },
+            {
+              id: '/page/29/Text/1',
+              block_type: 'Text',
+              html: '<p>Loot X lets a figure loot all loot tokens within range X.</p>',
+              children: null,
+            },
+            {
+              id: '/page/29/Table/2',
+              block_type: 'Table',
+              html: '<table><tr><th>Term</th><th>Meaning</th></tr><tr><td>Loot</td><td>Range</td></tr></table>',
+              polygon: [
+                [64, 300],
+                [260, 300],
+                [260, 360],
+                [64, 360],
+              ],
+              children: null,
+            },
+          ],
+        },
+      ],
+      chunks: {
+        blocks: [{ text: 'Loot X lets a figure loot all loot tokens within range X.' }],
+      },
+      images: { 'page-29-image-0.png': '<base64>' },
+      metadata: {
+        table_of_contents: [{ title: 'Loot', page_id: 29 }],
+      },
+      parse_quality_score: 4.8,
+      page_count: 1,
+      total_cost: 1,
+      cost_breakdown: { final_cost: 1, list_cost: 1 },
+      runtime: 2.4,
+      versions: { marker: '1.10.2', chandra: '2026-01' },
+      requestId: 'poll-request-1',
+    }),
+    ...overrides,
+  };
+}
+
+async function sourceFixture() {
+  const outputDir = await mkdtemp(join(tmpdir(), 'squire-marker-datalab-'));
+  const sourcePath = join(outputDir, 'gh2-rule-book.pdf');
+  await writeFile(sourcePath, 'fake pdf bytes', 'utf8');
+  return { outputDir, sourcePath };
+}
+
+describe('Marker/Datalab PDF extraction provider', () => {
+  it('wraps selected-page Datalab output in the shared normalized artifact schema', async () => {
+    const { outputDir, sourcePath } = await sourceFixture();
+    const runtime = markerDatalabRuntime();
+    const provider = createMarkerDatalabProvider({
+      runtime,
+      now: () => '2026-06-01T00:00:00.000Z',
+      costPerPageUsd: 0.006,
+    });
+
+    const artifact = await provider.extract({
+      sourcePath,
+      pages: [30],
+      outputDir,
+      runLabel: 'marker-datalab smoke',
+      retryCount: 0,
+      timeoutMs: 120_000,
+    });
+
+    expect(runtime.startConvert).toHaveBeenCalledWith({
+      sourcePath,
+      request: expect.objectContaining({
+        mode: 'accurate',
+        outputFormat: 'markdown,json,chunks',
+        pageRange: '29',
+        addBlockIds: true,
+        includeMarkdownInChunks: true,
+        extras: 'table_row_bboxes,extract_links,new_block_types',
+      }),
+    });
+    expect(runtime.getConvertResult).toHaveBeenCalledWith({
+      requestId: 'request-123',
+      requestCheckUrl: 'https://www.datalab.to/api/v1/convert/request-123',
+    });
+    expect(validateExtractionArtifact(artifact)).toEqual(artifact);
+    expect(artifact).toMatchObject({
+      provider: 'marker-datalab',
+      providerConfigHash: MARKER_DATALAB_PROVIDER_CONFIG_HASH,
+      run: {
+        id: 'marker-datalab smoke',
+        status: 'succeeded',
+        pageRange: [30],
+      },
+      cost: {
+        estimatedUsd: 0.006,
+        actualUsd: 0.01,
+        pagesProcessed: 1,
+        costPerPageUsd: 0.006,
+      },
+      privacy: {
+        trainingUse: 'not-used-for-training',
+        region: 'us',
+      },
+      providerMetadata: {
+        mode: 'accurate',
+        outputFormat: 'markdown,json,chunks',
+        pageRange: '29',
+        requestId: 'request-123',
+        parseQualityScore: 4.8,
+        imageCount: 1,
+      },
+    });
+    expect(artifact.rawArtifacts).toEqual([
+      expect.objectContaining({ kind: 'provider-json', redacted: false, persisted: true }),
+    ]);
+    expect(await readFile(artifact.rawArtifacts[0].path!, 'utf8')).toContain(
+      '"requestId": "request-123"',
+    );
+    expect(artifact.pages[0]).toMatchObject({
+      pageNumber: 30,
+      width: 612,
+      height: 792,
+      unit: 'pt',
+      markdown: expect.stringContaining('Loot'),
+      text: expect.stringContaining('Loot X lets a figure loot all loot tokens within range X.'),
+      blocks: [
+        expect.objectContaining({ type: 'heading', text: 'Loot' }),
+        expect.objectContaining({
+          type: 'paragraph',
+          text: 'Loot X lets a figure loot all loot tokens within range X.',
+        }),
+        expect.objectContaining({ type: 'table', text: 'Term Meaning Loot Range' }),
+      ],
+      tables: [
+        expect.objectContaining({
+          bbox: { x: 64, y: 300, width: 196, height: 60 },
+          cells: [
+            expect.objectContaining({ row: 0, column: 0, text: 'Term' }),
+            expect.objectContaining({ row: 0, column: 1, text: 'Meaning' }),
+            expect.objectContaining({ row: 1, column: 0, text: 'Loot' }),
+            expect.objectContaining({ row: 1, column: 1, text: 'Range' }),
+          ],
+        }),
+      ],
+    });
+  });
+
+  it('surfaces failed convert requests as provider errors', async () => {
+    const { outputDir, sourcePath } = await sourceFixture();
+    const provider = createMarkerDatalabProvider({
+      runtime: markerDatalabRuntime({
+        getConvertResult: vi.fn().mockResolvedValue({
+          status: 'failed',
+          success: false,
+          error: 'document could not be processed',
+        }),
+      }),
+      now: () => '2026-06-01T00:00:00.000Z',
+    });
+
+    await expect(
+      provider.extract({
+        sourcePath,
+        pages: [30],
+        outputDir,
+        runLabel: 'marker-datalab failure',
+        retryCount: 0,
+      }),
+    ).rejects.toThrow(
+      /provider error: Datalab request request-123 failed: document could not be processed/,
+    );
+  });
+
+  it('fails polling timeouts before waiting forever on processing requests', async () => {
+    const { outputDir, sourcePath } = await sourceFixture();
+    const provider = createMarkerDatalabProvider({
+      runtime: markerDatalabRuntime({
+        getConvertResult: vi.fn().mockResolvedValue({
+          status: 'processing',
+          success: true,
+        }),
+      }),
+      sleep: vi.fn().mockResolvedValue(undefined),
+      maxPollAttempts: 2,
+      now: () => '2026-06-01T00:00:00.000Z',
+    });
+
+    await expect(
+      provider.extract({
+        sourcePath,
+        pages: [30],
+        outputDir,
+        runLabel: 'marker-datalab timeout',
+        retryCount: 0,
+      }),
+    ).rejects.toThrow(
+      /timeout: Datalab request request-123 did not finish after 2 polling attempts/,
+    );
+  });
+
+  it('maps Datalab throttling errors to rate-limit failures', async () => {
+    const { outputDir, sourcePath } = await sourceFixture();
+    const provider = createMarkerDatalabProvider({
+      runtime: markerDatalabRuntime({
+        startConvert: vi.fn().mockRejectedValue(
+          Object.assign(new Error('too many conversion jobs'), {
+            status: 429,
+          }),
+        ),
+      }),
+      now: () => '2026-06-01T00:00:00.000Z',
+    });
+
+    await expect(
+      provider.extract({
+        sourcePath,
+        pages: [30],
+        outputDir,
+        runLabel: 'marker-datalab rate limited',
+        retryCount: 0,
+      }),
+    ).rejects.toMatchObject({ status: 429 });
+  });
+
+  it('preserves HTTP status on non-JSON provider errors', async () => {
+    await expect(
+      readMarkerDatalabJsonResponse(
+        new Response('upstream unavailable', {
+          status: 502,
+          statusText: 'Bad Gateway',
+        }),
+      ),
+    ).rejects.toMatchObject({
+      status: 502,
+      message: expect.stringContaining('upstream unavailable'),
+    });
+  });
+
+  it('hashes the effective runtime provider configuration', async () => {
+    const { outputDir, sourcePath } = await sourceFixture();
+    const provider = createMarkerDatalabProvider({
+      runtime: markerDatalabRuntime(),
+      mode: 'balanced',
+      skipCache: true,
+      costPerPageUsd: 0.004,
+      now: () => '2026-06-01T00:00:00.000Z',
+    });
+
+    const artifact = await provider.extract({
+      sourcePath,
+      pages: [30],
+      outputDir,
+      runLabel: 'marker-datalab effective config',
+      retryCount: 0,
+    });
+
+    expect(artifact.providerConfigHash).toBe(
+      markerDatalabProviderConfigHash({
+        mode: 'balanced',
+        skipCache: true,
+        costPerPageUsd: 0.004,
+      }),
+    );
+    expect(artifact.providerConfigHash).not.toBe(MARKER_DATALAB_PROVIDER_CONFIG_HASH);
+    expect(artifact.rawArtifacts[0].path).toContain(artifact.providerConfigHash.slice(7));
+  });
+
+  it('rejects completed requests that omit requested page output', async () => {
+    const { outputDir, sourcePath } = await sourceFixture();
+    const provider = createMarkerDatalabProvider({
+      runtime: markerDatalabRuntime({
+        getConvertResult: vi.fn().mockResolvedValue({
+          status: 'complete',
+          success: true,
+          json: [],
+          markdown: null,
+        }),
+      }),
+      now: () => '2026-06-01T00:00:00.000Z',
+    });
+
+    await expect(
+      provider.extract({
+        sourcePath,
+        pages: [30],
+        outputDir,
+        runLabel: 'marker-datalab invalid',
+        retryCount: 0,
+      }),
+    ).rejects.toThrow(/invalid artifact: Datalab output contained no pages/);
+  });
+});

--- a/test/pdf-extraction-marker-datalab.test.ts
+++ b/test/pdf-extraction-marker-datalab.test.ts
@@ -2,10 +2,11 @@ import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createMarkerDatalabProvider,
+  createMarkerDatalabRestRuntime,
   markerDatalabProviderConfigHash,
   MARKER_DATALAB_PROVIDER_CONFIG_HASH,
   readMarkerDatalabJsonResponse,
@@ -95,6 +96,11 @@ async function sourceFixture() {
   await writeFile(sourcePath, 'fake pdf bytes', 'utf8');
   return { outputDir, sourcePath };
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
 
 describe('Marker/Datalab PDF extraction provider', () => {
   it('wraps selected-page Datalab output in the shared normalized artifact schema', async () => {
@@ -284,6 +290,61 @@ describe('Marker/Datalab PDF extraction provider', () => {
     });
   });
 
+  it('uploads local PDFs with the Datalab file multipart field', async () => {
+    const { sourcePath } = await sourceFixture();
+    vi.stubEnv('DATALAB_API_KEY', 'test-key');
+    vi.stubEnv('DATALAB_BASE_URL', 'https://datalab.test');
+    const fetch = vi.fn<typeof globalThis.fetch>(async (url, init) => {
+      expect(url).toBe('https://datalab.test/api/v1/convert');
+      expect(init?.method).toBe('POST');
+      expect(init?.headers).toMatchObject({
+        Accept: 'application/json',
+        'X-API-Key': 'test-key',
+      });
+      const body = init?.body as FormData;
+      expect(body.get('file')).toBeInstanceOf(Blob);
+      expect(body.get('file.0')).toBeNull();
+      expect(body.get('mode')).toBe('accurate');
+      expect(body.get('output_format')).toBe('markdown,json,chunks');
+      expect(body.get('page_range')).toBe('29');
+      return new Response(
+        JSON.stringify({
+          request_id: 'request-123',
+          request_check_url: '/api/v1/convert/request-123',
+          success: true,
+          versions: { marker: '1.10.2' },
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal('fetch', fetch);
+
+    const runtime = await createMarkerDatalabRestRuntime();
+    const result = await runtime.startConvert({
+      sourcePath,
+      request: {
+        mode: 'accurate',
+        outputFormat: 'markdown,json,chunks',
+        pageRange: '29',
+        paginate: true,
+        addBlockIds: true,
+        includeMarkdownInChunks: true,
+        disableImageExtraction: false,
+        disableImageCaptions: false,
+        tokenEfficientMarkdown: false,
+        skipCache: false,
+        saveCheckpoint: false,
+        extras: 'table_row_bboxes,extract_links,new_block_types',
+      },
+    });
+
+    expect(result).toEqual({
+      requestId: 'request-123',
+      requestCheckUrl: 'https://datalab.test/api/v1/convert/request-123',
+      versions: { marker: '1.10.2' },
+    });
+  });
+
   it('hashes the effective runtime provider configuration', async () => {
     const { outputDir, sourcePath } = await sourceFixture();
     const provider = createMarkerDatalabProvider({
@@ -311,6 +372,36 @@ describe('Marker/Datalab PDF extraction provider', () => {
     );
     expect(artifact.providerConfigHash).not.toBe(MARKER_DATALAB_PROVIDER_CONFIG_HASH);
     expect(artifact.rawArtifacts[0].path).toContain(artifact.providerConfigHash.slice(7));
+  });
+
+  it('redacts signed result URLs from persisted raw provider output', async () => {
+    const { outputDir, sourcePath } = await sourceFixture();
+    const signedResultUrl = 'https://signed.datalab.test/result.json?token=secret';
+    const provider = createMarkerDatalabProvider({
+      runtime: markerDatalabRuntime({
+        getConvertResult: vi.fn().mockResolvedValue({
+          ...((await markerDatalabRuntime().getConvertResult({
+            requestId: 'request-123',
+            requestCheckUrl: 'https://www.datalab.to/api/v1/convert/request-123',
+          })) as object),
+          result_url: signedResultUrl,
+        }),
+      }),
+      now: () => '2026-06-01T00:00:00.000Z',
+    });
+
+    const artifact = await provider.extract({
+      sourcePath,
+      pages: [30],
+      outputDir,
+      runLabel: 'marker-datalab redacted result url',
+      retryCount: 0,
+    });
+
+    expect(artifact.rawArtifacts[0].redacted).toBe(true);
+    const raw = await readFile(artifact.rawArtifacts[0].path!, 'utf8');
+    expect(raw).not.toContain(signedResultUrl);
+    expect(raw).toContain('"result_url": "[redacted]"');
   });
 
   it('rejects completed requests that omit requested page output', async () => {

--- a/test/pdf-extraction-marker-datalab.test.ts
+++ b/test/pdf-extraction-marker-datalab.test.ts
@@ -59,7 +59,7 @@ function markerDatalabRuntime(overrides: Partial<MarkerDatalabRuntime> = {}): Ma
             {
               id: '/page/29/Table/2',
               block_type: 'Table',
-              html: '<table><tr><th>Term</th><th>Meaning</th></tr><tr><td>Loot</td><td>Range</td></tr></table>',
+              html: '<table><tr><th rowspan="0" colspan="foo">Term</th><th rowspan="2" colspan="3">Meaning</th></tr><tr><td>Loot</td><td>Range</td></tr></table>',
               polygon: [
                 [64, 300],
                 [260, 300],
@@ -189,8 +189,20 @@ describe('Marker/Datalab PDF extraction provider', () => {
         expect.objectContaining({
           bbox: { x: 64, y: 300, width: 196, height: 60 },
           cells: [
-            expect.objectContaining({ row: 0, column: 0, text: 'Term' }),
-            expect.objectContaining({ row: 0, column: 1, text: 'Meaning' }),
+            expect.objectContaining({
+              row: 0,
+              column: 0,
+              rowSpan: 1,
+              columnSpan: 1,
+              text: 'Term',
+            }),
+            expect.objectContaining({
+              row: 0,
+              column: 1,
+              rowSpan: 2,
+              columnSpan: 3,
+              text: 'Meaning',
+            }),
             expect.objectContaining({ row: 1, column: 0, text: 'Loot' }),
             expect.objectContaining({ row: 1, column: 1, text: 'Range' }),
           ],

--- a/test/pdf-extraction-registry.test.ts
+++ b/test/pdf-extraction-registry.test.ts
@@ -36,6 +36,10 @@ describe('PDF extraction provider registry', () => {
       id: 'unstructured',
       displayName: 'Unstructured',
     });
+    expect(registry.get('marker-datalab')).toMatchObject({
+      id: 'marker-datalab',
+      displayName: 'Marker/Datalab',
+    });
   });
 
   it('registers providers by stable id and lists them in insertion order', () => {


### PR DESCRIPTION
## Summary
- Add the managed Datalab Convert API adapter for the existing `marker-datalab` provider id.
- Wire provider registry, provider config hashing, selected-page cost guardrails, and docs.
- Normalize Markdown/JSON output into the shared artifact schema, including page blocks, headings, table geometry, cost, runtime, image metadata, versions, and retention metadata.
- Align the live upload field with Datalab's API and redact signed result URLs from persisted raw artifacts.

## Validation
- `npx vitest run test/pdf-extraction-marker-datalab.test.ts test/pdf-extraction-registry.test.ts test/pdf-extraction-eval-run.test.ts` passed: 3 files, 18 tests.
- `npm run typecheck` passed.
- `npm run check` passed: 111 files, 1423 tests.
- Live smoke passed:
  - `node --env-file=.env eval/pdf-extraction/run.ts --provider=marker-datalab --source=data/pdfs/gh2-rule-book.pdf --pages=30 --output-dir=eval/results/pdf-extraction --run-label=marker-datalab-live-smoke-page-30 --max-estimated-cost-usd=0.10 --timeout-ms=600000 --refresh-provider-output`
  - latency 33050ms, estimated cost /bin/zsh.006, actual cost /bin/zsh.01, page 30 normalized with 20 blocks, 6087 text chars.
  - Score summary: required phrase recall 0.98, heading recall 1, reading order 1, table cell recall 1, retrieval top1/top3/top5 4/4, citeable context 2/4.
  - DATALAB_API_KEY was not found in marker-datalab artifacts.

Fixes SQR-233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Marker/Datalab as a PDF extraction provider with configurable modes, caching options, and per-page cost estimation.

* **Documentation**
  * Updated PDF extraction developer guide with Marker/Datalab usage, required environment variables, page-mapping details, and guidance to align cost-per-page with published pricing.

* **Tests**
  * Added tests covering Marker/Datalab provider behavior, cost guardrails, registry inclusion, error handling, polling, and result normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->