### PR TITLE
fix(setup): wait for local postgres readiness

### DIFF
--- a/.claude/hooks/worktree-setup.sh
+++ b/.claude/hooks/worktree-setup.sh
@@ -54,7 +54,26 @@ log "ensuring docker services are up"
 # up a per-worktree stack and collide on container_name/host port.)
 # Per-worktree DB and port isolation happens at app startup via
 # src/worktree-runtime.ts, not here.
-COMPOSE_PROJECT_NAME=squire docker compose up -d --wait --wait-timeout 60 >/dev/null
+wait_for_postgres() {
+  for attempt in {1..60}; do
+    if docker exec squire-postgres pg_isready -U squire -d squire >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  log "ERROR: postgres did not become ready within 60s"
+  return 1
+}
+
+if docker compose up --help 2>/dev/null | grep -q -- '--wait'; then
+  COMPOSE_PROJECT_NAME=squire docker compose up -d --wait --wait-timeout 60 >/dev/null
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_PROJECT_NAME=squire docker-compose up -d >/dev/null
+  wait_for_postgres
+else
+  COMPOSE_PROJECT_NAME=squire docker compose up -d >/dev/null
+  wait_for_postgres
+fi
 
 log "running migrations"
 npm run --silent db:migrate

--- a/.claude/hooks/worktree-setup.sh
+++ b/.claude/hooks/worktree-setup.sh
@@ -65,15 +65,15 @@ wait_for_postgres() {
   return 1
 }
 
-if docker compose up --help 2>/dev/null | grep -q -- '--wait'; then
-  COMPOSE_PROJECT_NAME=squire docker compose up -d --wait --wait-timeout 60 >/dev/null
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_PROJECT_NAME=squire docker compose up -d >/dev/null
 elif command -v docker-compose >/dev/null 2>&1; then
   COMPOSE_PROJECT_NAME=squire docker-compose up -d >/dev/null
-  wait_for_postgres
 else
-  COMPOSE_PROJECT_NAME=squire docker compose up -d >/dev/null
-  wait_for_postgres
+  log "ERROR: Docker Compose is not available"
+  exit 1
 fi
+wait_for_postgres || exit 1
 
 log "running migrations"
 npm run --silent db:migrate

--- a/.claude/hooks/worktree-setup.sh
+++ b/.claude/hooks/worktree-setup.sh
@@ -33,6 +33,7 @@ if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
   # shellcheck disable=SC1091
   . "$HOME/.nvm/nvm.sh"
   nvm use >/dev/null
+  export PATH="$NVM_BIN:$PATH"
 fi
 
 if [[ ! -e .env && -e "$source_tree/.env" ]]; then
@@ -53,7 +54,7 @@ log "ensuring docker services are up"
 # up a per-worktree stack and collide on container_name/host port.)
 # Per-worktree DB and port isolation happens at app startup via
 # src/worktree-runtime.ts, not here.
-COMPOSE_PROJECT_NAME=squire docker compose up -d >/dev/null
+COMPOSE_PROJECT_NAME=squire docker compose up -d --wait --wait-timeout 60 >/dev/null
 
 log "running migrations"
 npm run --silent db:migrate

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -19,15 +19,15 @@ wait_for_postgres() {
   echo "[worktree-setup] ERROR: postgres did not become ready within 60s" >&2
   return 1
 }
-if docker compose up --help 2>/dev/null | grep -q -- '--wait'; then
-  COMPOSE_PROJECT_NAME=squire docker compose up -d --wait --wait-timeout 60
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_PROJECT_NAME=squire docker compose up -d >/dev/null
 elif command -v docker-compose >/dev/null 2>&1; then
-  COMPOSE_PROJECT_NAME=squire docker-compose up -d
-  wait_for_postgres
+  COMPOSE_PROJECT_NAME=squire docker-compose up -d >/dev/null
 else
-  COMPOSE_PROJECT_NAME=squire docker compose up -d
-  wait_for_postgres
+  echo "[worktree-setup] ERROR: Docker Compose is not available" >&2
+  exit 1
 fi
+wait_for_postgres || exit 1
 npm run db:migrate
 npm run db:migrate:test
 # Seeding + indexing are both best-effort. seed:dev touches card data,

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -6,9 +6,10 @@ name = "squire"
 script = '''
 source "$HOME/.nvm/nvm.sh"
 nvm use
+export PATH="$NVM_BIN:$PATH"
 ln -sfn "$CODEX_SOURCE_TREE_PATH/.env" .env
 npm install --ignore-scripts
-docker compose up -d
+docker compose up -d --wait --wait-timeout 60
 npm run db:migrate
 npm run db:migrate:test
 # Seeding + indexing are both best-effort. seed:dev touches card data,

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -9,7 +9,25 @@ nvm use
 export PATH="$NVM_BIN:$PATH"
 ln -sfn "$CODEX_SOURCE_TREE_PATH/.env" .env
 npm install --ignore-scripts
-docker compose up -d --wait --wait-timeout 60
+wait_for_postgres() {
+  for attempt in {1..60}; do
+    if docker exec squire-postgres pg_isready -U squire -d squire >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "[worktree-setup] ERROR: postgres did not become ready within 60s" >&2
+  return 1
+}
+if docker compose up --help 2>/dev/null | grep -q -- '--wait'; then
+  COMPOSE_PROJECT_NAME=squire docker compose up -d --wait --wait-timeout 60
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_PROJECT_NAME=squire docker-compose up -d
+  wait_for_postgres
+else
+  COMPOSE_PROJECT_NAME=squire docker compose up -d
+  wait_for_postgres
+fi
 npm run db:migrate
 npm run db:migrate:test
 # Seeding + indexing are both best-effort. seed:dev touches card data,

--- a/docs/agent/worktree-setup.md
+++ b/docs/agent/worktree-setup.md
@@ -59,9 +59,9 @@ indexed — test suites own their fixtures.
 Step 4 is the only subtle one: `docker-compose.yml` hardcodes
 `container_name: squire-postgres` and binds host port `5432:5432`, so every
 checkout must share the same container. The setup script must run
-against the project name `squire`, wait for the existing Postgres healthcheck
-when Docker Compose V2 supports `--wait`, and otherwise poll `pg_isready` inside
-the container before migrations run.
+against the project name `squire` and poll `pg_isready` inside the container
+before migrations run. The adapters prefer Docker Compose V2 (`docker compose`)
+and fall back to legacy Compose V1 (`docker-compose`) when needed.
 
 ### Manual `.env` setup
 
@@ -112,15 +112,15 @@ wait_for_postgres() {
   echo "[worktree-setup] ERROR: postgres did not become ready within 60s" >&2
   return 1
 }
-if docker compose up --help 2>/dev/null | grep -q -- '--wait'; then
-  COMPOSE_PROJECT_NAME=squire docker compose up -d --wait --wait-timeout 60
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_PROJECT_NAME=squire docker compose up -d >/dev/null
 elif command -v docker-compose >/dev/null 2>&1; then
-  COMPOSE_PROJECT_NAME=squire docker-compose up -d
-  wait_for_postgres
+  COMPOSE_PROJECT_NAME=squire docker-compose up -d >/dev/null
 else
-  COMPOSE_PROJECT_NAME=squire docker compose up -d
-  wait_for_postgres
+  echo "[worktree-setup] ERROR: Docker Compose is not available" >&2
+  exit 1
 fi
+wait_for_postgres || exit 1
 npm run db:migrate
 npm run db:migrate:test
 # Seeding + indexing are both best-effort. seed:dev touches card data,

--- a/docs/agent/worktree-setup.md
+++ b/docs/agent/worktree-setup.md
@@ -59,8 +59,9 @@ indexed — test suites own their fixtures.
 Step 4 is the only subtle one: `docker-compose.yml` hardcodes
 `container_name: squire-postgres` and binds host port `5432:5432`, so every
 checkout must share the same container. The setup script must run
-`docker compose up -d --wait --wait-timeout 60` against the project name
-`squire`.
+against the project name `squire`, wait for the existing Postgres healthcheck
+when Docker Compose V2 supports `--wait`, and otherwise poll `pg_isready` inside
+the container before migrations run.
 
 ### Manual `.env` setup
 
@@ -101,7 +102,25 @@ nvm use
 export PATH="$NVM_BIN:$PATH"
 ln -sfn "$CODEX_SOURCE_TREE_PATH/.env" .env
 npm install --ignore-scripts
-docker compose up -d --wait --wait-timeout 60
+wait_for_postgres() {
+  for attempt in {1..60}; do
+    if docker exec squire-postgres pg_isready -U squire -d squire >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "[worktree-setup] ERROR: postgres did not become ready within 60s" >&2
+  return 1
+}
+if docker compose up --help 2>/dev/null | grep -q -- '--wait'; then
+  COMPOSE_PROJECT_NAME=squire docker compose up -d --wait --wait-timeout 60
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_PROJECT_NAME=squire docker-compose up -d
+  wait_for_postgres
+else
+  COMPOSE_PROJECT_NAME=squire docker compose up -d
+  wait_for_postgres
+fi
 npm run db:migrate
 npm run db:migrate:test
 # Seeding + indexing are both best-effort. seed:dev touches card data,

--- a/docs/agent/worktree-setup.md
+++ b/docs/agent/worktree-setup.md
@@ -33,7 +33,8 @@ Given the app handles isolation, bootstrap is small:
    copy it when the worktree needs different local values.
 3. `npm install --ignore-scripts` (husky hooks would otherwise refuse to
    install into a linked worktree).
-4. Bring up the **one** shared `squire-postgres` container.
+4. Bring up the **one** shared `squire-postgres` container and wait for its
+   healthcheck before running migrations.
 5. Run `db:migrate` and `db:migrate:test` — both are worktree-aware and create
    `squire_<slug>` / `squire_<slug>_test` on first run.
 6. `npm run seed:dev` — upsert card data, scenario/section book records, and
@@ -58,7 +59,8 @@ indexed — test suites own their fixtures.
 Step 4 is the only subtle one: `docker-compose.yml` hardcodes
 `container_name: squire-postgres` and binds host port `5432:5432`, so every
 checkout must share the same container. The setup script must run
-`docker compose up -d` against the project name `squire`.
+`docker compose up -d --wait --wait-timeout 60` against the project name
+`squire`.
 
 ### Manual `.env` setup
 
@@ -96,9 +98,10 @@ Codex runs `setup.script` on worktree creation.
 script = '''
 source "$HOME/.nvm/nvm.sh"
 nvm use
+export PATH="$NVM_BIN:$PATH"
 ln -sfn "$CODEX_SOURCE_TREE_PATH/.env" .env
 npm install --ignore-scripts
-docker compose up -d
+docker compose up -d --wait --wait-timeout 60
 npm run db:migrate
 npm run db:migrate:test
 # Seeding + indexing are both best-effort. seed:dev touches card data,
@@ -151,7 +154,8 @@ Two intentional differences from the Codex script:
    name each time and try to stand up a second `squire-postgres` alongside
    the one from the source tree or another worktree. Pinning the project
    name forces every worktree onto the one shared container, matching
-   Codex's implicit behavior.
+   Codex's implicit behavior. It also waits on the same Postgres healthcheck
+   before migrations run.
 
 Other than those two points, the commands are identical. Both adapters are
 safe to run concurrently on the same machine: the port-claim registry in


### PR DESCRIPTION
## Summary
- wait for the existing Postgres Compose healthcheck before running worktree migrations
- put the selected nvm Node bin first so setup commands use `.nvmrc`'s Node version
- keep the Codex and Claude worktree setup adapters documented in sync

## Validation
- fixed setup script rerun exited 0: install, Compose wait, dev/test migrations, seed, index
- `npm run check` with `node=v26.1.0`: 112 test files passed, 1429 tests passed
- `npm run agent:check`

## Linear
One-off Codex environment repair task; no SQR issue was assigned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docker bring-up now waits for PostgreSQL readiness to avoid race conditions, with compatibility fallbacks between compose CLI versions and an explicit error if neither is available.
  * Development environment ensures the active Node/npm binaries are used by updating PATH before setup steps.

* **Documentation**
  * Setup guides clarified to include the bring-up-and-wait step, use a consistent project name, and updated Docker Compose guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->