### PR TITLE
feat(api): add public QA rate limits

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -621,6 +621,12 @@ The knowledge agent:
 
 Today this is already a real tool loop. The system prompt nudges Claude to prefer deterministic scenario/section traversal when a question is anchored to a scenario number, title, or section ref, and to fall back to semantic book search for fuzzier questions. The HTTP entry point is still a convenience path; the retrieval strategy is no longer a hard-coded `searchRules + searchCards` bundle.
 
+The REST entry point is protected by bearer auth, a 30-request/minute
+Redis/Valkey-backed app limit per token user or OAuth client, bounded request
+text, and a daily LLM budget precheck before the SSE stream opens. Budget
+exhaustion returns a distinct `llm_budget_exceeded` 429 response; request-rate
+exhaustion returns `rate_limited` with `Retry-After`.
+
 The conversation agent calls this entry point via in-process function call, not HTTP. The HTTP endpoint exists for testing and for other channels (CLI, scripts, future Discord bot).
 
 ---

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -170,12 +170,14 @@ attacker could run up significant costs.
 
 **Mitigations:**
 
-- Redis/Valkey-backed app rate limits for interactive surfaces, with tighter
-  limits on expensive routes such as `/api/ask`, `/mcp`, and
-  `/api/search/rules`
+- Redis/Valkey-backed app rate limits for interactive surfaces: `/api/ask`
+  is limited to 30/minute, `/api/search/rules` and `/api/search/cards` are
+  limited to 60/minute, and `/mcp` is limited to 120/minute. Authenticated
+  API limits key by token user when present, otherwise OAuth client id.
 - Daily cost budget with circuit breaker (reject requests when budget
   exceeded)
-- Cap `history` array length in `/api/ask`
+- Cap `/api/ask` request size: 2,000-character question, 20 history messages,
+  and 2,000 characters per history message
 - Embedding result cache (same query leads to same embedding)
 - Monitor API spend with alerts
 
@@ -367,6 +369,10 @@ development-scoped dependencies`. The repository is public, so GitHub enables
 
 - Redis/Valkey-backed app rate limits per trusted IP, OAuth client, and token
   user where available
+- Production requires `REDIS_URL`; limiter outages fail closed with HTTP 503
+  and `rate_limit_unavailable` security logs
+- `/api/ask` has a daily LLM budget precheck before opening the SSE stream; its
+  budget-exhaustion response is distinct from rate-limit exhaustion
 - Connection limits
 - Response size limits
 - Consider caching for embeddings and frequent queries

--- a/docs/runbooks/production-operations.md
+++ b/docs/runbooks/production-operations.md
@@ -53,6 +53,11 @@ AWS WAF remains the coarse outer filter. Squire-specific limits live in the app
 and use Redis/Valkey-compatible `rate-limiter-flexible` counters (`REDIS_URL`) so
 limits are shared across app machines and restarts.
 
+Production startup fails when `NODE_ENV=production` and `REDIS_URL` is missing.
+If the Redis/Valkey limiter is unavailable at request time, protected app routes
+fail closed with HTTP 503 and a structured `rate_limit_unavailable` security
+log rather than falling back to unlimited traffic.
+
 `POST /register` is limited to 10 requests per hour per trusted client IP.
 Rate-limit denials return 429 with `Retry-After` and emit structured security
 log events with a hashed identity. They do not write `oauth_audit_log` rows;
@@ -69,6 +74,25 @@ fall back to the trusted client IP resolver, then a shared `unknown` bucket if n
 trusted IP can be resolved. MCP denials return HTTP 429 before the Streamable
 HTTP transport starts and emit the same structured `rate_limit_rejected` log
 shape with `identity_kind` set to `user`, `client`, `ip`, or `unknown`.
+
+Route-control matrix:
+
+| Route                                                   | Auth                       | App rate limit                                                              | Budget breaker             | Notes                                                                                               |
+| ------------------------------------------------------- | -------------------------- | --------------------------------------------------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------- |
+| `/api/live`, `/api/health`                              | None                       | None                                                                        | None                       | Intentionally public health/readiness endpoints.                                                    |
+| `POST /register`                                        | None                       | 10/hour per trusted client IP                                               | None                       | Dynamic OAuth client registration.                                                                  |
+| `GET /auth/google/start`                                | Session bootstrap          | 10/minute per trusted client IP                                             | None                       | Google sign-in initiation.                                                                          |
+| `GET /auth/google/callback`                             | Session bootstrap          | 20/minute per trusted client IP                                             | None                       | Google sign-in callback.                                                                            |
+| `GET /api/search/rules`                                 | Bearer token               | 60/minute per token user, otherwise OAuth client                            | None                       | Runs embedding/vector/rerank retrieval work.                                                        |
+| `GET /api/search/cards`                                 | Bearer token               | 60/minute per token user, otherwise OAuth client                            | None                       | Runs card search over extracted data.                                                               |
+| `POST /api/ask`                                         | Bearer token               | 30/minute per token user, otherwise OAuth client                            | Daily LLM budget precheck  | Caps question text at 2,000 chars, history at 20 messages, and each history message at 2,000 chars. |
+| `/mcp`                                                  | Bearer token after limiter | 120/minute per token user, otherwise OAuth client, trusted IP, or `unknown` | None at transport boundary | Returns 429 before creating the Streamable HTTP transport.                                          |
+| `/api/card-types`, `/api/cards`, `/api/cards/:type/:id` | Bearer token               | None                                                                        | None                       | Catalog reads use checked-in/imported game data only; no provider/model work.                       |
+
+Rate-limit exhaustion returns HTTP 429 with `error: "rate_limited"` and a
+`Retry-After` header. LLM budget exhaustion returns HTTP 429 with
+`error: "llm_budget_exceeded"` before opening the `/api/ask` SSE stream and does
+not include `Retry-After`; the budget resets at UTC midnight.
 
 ## Secrets and environment
 

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -83,6 +83,24 @@ export const MCP_REQUEST_RATE_LIMIT_POLICY: RateLimitPolicy = {
   windowMs: 60 * 1000,
 };
 
+export const API_ASK_RATE_LIMIT_POLICY: RateLimitPolicy = {
+  name: 'api_ask_request',
+  limit: 30,
+  windowMs: 60 * 1000,
+};
+
+export const API_RULE_SEARCH_RATE_LIMIT_POLICY: RateLimitPolicy = {
+  name: 'api_search_rules',
+  limit: 60,
+  windowMs: 60 * 1000,
+};
+
+export const API_CARD_SEARCH_RATE_LIMIT_POLICY: RateLimitPolicy = {
+  name: 'api_search_cards',
+  limit: 60,
+  windowMs: 60 * 1000,
+};
+
 function hasText(value: string | undefined): value is string {
   return value !== undefined && value.trim().length > 0;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,9 @@ import { originSharedSecretMiddleware } from './origin-lock.ts';
 import { resolveTrustedClientIp } from './http/trusted-client-ip.ts';
 import { LlmBudgetExceededError } from './llm-budget.ts';
 import {
+  API_ASK_RATE_LIMIT_POLICY,
+  API_CARD_SEARCH_RATE_LIMIT_POLICY,
+  API_RULE_SEARCH_RATE_LIMIT_POLICY,
   GOOGLE_OAUTH_CALLBACK_RATE_LIMIT_POLICY,
   GOOGLE_OAUTH_START_RATE_LIMIT_POLICY,
   getDefaultRateLimiter,
@@ -303,9 +306,27 @@ interface McpRateLimitResult {
   identityKind: McpRateLimitIdentityKind;
 }
 
+type ApiRateLimitIdentityKind = 'user' | 'client';
+
+interface ApiRateLimitIdentity {
+  kind: ApiRateLimitIdentityKind;
+  value: string;
+}
+
+interface ApiRateLimitResult {
+  decision: RateLimitDecision;
+  identityKind: ApiRateLimitIdentityKind;
+}
+
 function authInfoUserId(authInfo: AuthInfo): string | undefined {
   const userId = authInfo.extra?.userId;
   return typeof userId === 'string' && userId.trim().length > 0 ? userId : undefined;
+}
+
+function resolveApiRateLimitIdentity(authInfo: AuthInfo): ApiRateLimitIdentity {
+  const userId = authInfoUserId(authInfo);
+  if (userId) return { kind: 'user', value: `user:${userId}` };
+  return { kind: 'client', value: `client:${authInfo.clientId}` };
 }
 
 function resolveMcpRateLimitIdentity(
@@ -330,6 +351,18 @@ async function checkMcpRateLimit(
   const identity = resolveMcpRateLimitIdentity(c, authInfo);
   const decision = await getDefaultRateLimiter().consume({
     policy: MCP_REQUEST_RATE_LIMIT_POLICY,
+    identity: identity.value,
+  });
+  return { decision, identityKind: identity.kind };
+}
+
+async function checkApiRateLimit(
+  authInfo: AuthInfo,
+  policy: RateLimitPolicy,
+): Promise<ApiRateLimitResult> {
+  const identity = resolveApiRateLimitIdentity(authInfo);
+  const decision = await getDefaultRateLimiter().consume({
+    policy,
     identity: identity.value,
   });
   return { decision, identityKind: identity.kind };
@@ -363,6 +396,34 @@ function mcpRateLimitedResponse(c: Context, result: McpRateLimitResult) {
   );
 }
 
+function apiRateLimitedResponse(c: Context, result: ApiRateLimitResult, route: string) {
+  const retryAfterSeconds = Math.max(1, result.decision.retryAfterSeconds);
+  writeSecurityLog({
+    event: 'rate_limit_rejected',
+    fields: {
+      route,
+      method: c.req.method,
+      policy: result.decision.policy.name,
+      limit: result.decision.policy.limit,
+      window_ms: result.decision.policy.windowMs,
+      identity_hash: result.decision.identityHash,
+      identity_kind: result.identityKind,
+      retry_after_seconds: retryAfterSeconds,
+      reset_after_seconds: result.decision.resetAfterSeconds,
+    },
+  });
+
+  c.header('Retry-After', String(retryAfterSeconds));
+  return c.json(
+    {
+      error: 'rate_limited',
+      error_description: 'Too many API requests. Try again later.',
+      retry_after_seconds: retryAfterSeconds,
+    },
+    429,
+  );
+}
+
 function budgetExceededResponse(c: Context, error: LlmBudgetExceededError) {
   return c.json(
     {
@@ -374,6 +435,32 @@ function budgetExceededResponse(c: Context, error: LlmBudgetExceededError) {
       remaining_usd: error.status.remainingUsd,
     },
     429,
+  );
+}
+
+function apiRateLimitUnavailableResponse(
+  c: Context,
+  error: unknown,
+  route: string,
+  policy: RateLimitPolicy,
+) {
+  writeSecurityLog({
+    event: 'rate_limit_unavailable',
+    level: 'error',
+    fields: {
+      route,
+      method: c.req.method,
+      policy: policy.name,
+      ...errorLogFields(error),
+    },
+  });
+
+  return c.json(
+    {
+      error: 'temporarily_unavailable',
+      error_description: 'API is temporarily unavailable. Try again later.',
+    },
+    503,
   );
 }
 
@@ -1466,6 +1553,29 @@ function requireBearerAuth(): MiddlewareHandler {
   };
 }
 
+function requireBearerAuthAndRateLimit(policy: RateLimitPolicy, route: string): MiddlewareHandler {
+  return async (c, next) => {
+    const authResult = await authenticateBearer(c);
+    if (!authResult.ok) {
+      return bearerAuthFailureResponse(c, authResult);
+    }
+
+    let rateLimit: ApiRateLimitResult;
+    try {
+      rateLimit = await checkApiRateLimit(authResult.authInfo, policy);
+    } catch (error) {
+      return apiRateLimitUnavailableResponse(c, error, route, policy);
+    }
+
+    if (!rateLimit.decision.allowed) {
+      return apiRateLimitedResponse(c, rateLimit, route);
+    }
+
+    c.set('authInfo', authResult.authInfo);
+    await next();
+  };
+}
+
 function requireMcpAuthAndRateLimit(): MiddlewareHandler {
   return async (c, next) => {
     const authResult = await authenticateBearer(c);
@@ -1492,11 +1602,18 @@ function requireMcpAuthAndRateLimit(): MiddlewareHandler {
 }
 
 // Protect API endpoints (except health) and MCP
-app.use('/api/search/*', requireBearerAuth());
+app.use(
+  '/api/search/rules',
+  requireBearerAuthAndRateLimit(API_RULE_SEARCH_RATE_LIMIT_POLICY, '/api/search/rules'),
+);
+app.use(
+  '/api/search/cards',
+  requireBearerAuthAndRateLimit(API_CARD_SEARCH_RATE_LIMIT_POLICY, '/api/search/cards'),
+);
 app.use('/api/cards/*', requireBearerAuth());
 app.use('/api/cards', requireBearerAuth());
 app.use('/api/card-types', requireBearerAuth());
-app.use('/api/ask', requireBearerAuth());
+app.use('/api/ask', requireBearerAuthAndRateLimit(API_ASK_RATE_LIMIT_POLICY, '/api/ask'));
 app.use('/mcp', requireMcpAuthAndRateLimit());
 
 // ─── MCP transport ───────────────────────────────────────────────────────────
@@ -1707,16 +1824,20 @@ app.get('/api/cards', async (c) => {
 
 // ─── Ask endpoint ────────────────────────────────────────────────────────────
 
+const ASK_QUESTION_MAX_CHARS = 2_000;
+const ASK_HISTORY_MAX_ITEMS = 20;
+const ASK_HISTORY_MESSAGE_MAX_CHARS = 2_000;
+
 const AskRequestSchema = z.object({
-  question: z.string().min(1),
+  question: z.string().min(1).max(ASK_QUESTION_MAX_CHARS),
   history: z
     .array(
       z.object({
         role: z.enum(['user', 'assistant']),
-        content: z.string(),
+        content: z.string().max(ASK_HISTORY_MESSAGE_MAX_CHARS),
       }),
     )
-    .max(20)
+    .max(ASK_HISTORY_MAX_ITEMS)
     .optional(),
   campaignId: z.string().uuid().optional(),
   userId: z.string().uuid().optional(),

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -2,6 +2,7 @@ import type { RedisClientType } from '@redis/client';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  createRateLimiterFromEnv,
   FlexibleRateLimitStore,
   hashRateLimitIdentity,
   InMemoryTokenBucketStore,
@@ -207,5 +208,39 @@ describe('RateLimiter', () => {
     });
     expect(staleClient.destroy).toHaveBeenCalledTimes(1);
     expect(freshClient.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed instead of allowing requests when Redis connect fails', async () => {
+    const failingClient = createFakeRedisClient({
+      connectPromise: new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('redis unavailable')), 0);
+      }),
+    });
+    const freshClient = createFakeRedisClient({});
+    const store = new RedisRateLimitStore('redis://example.test:6379', failingClient, {
+      clientFactory: () => freshClient,
+      operationTimeoutMs: 50,
+    });
+
+    await expect(
+      store.consume({
+        key: 'squire:rate-limit:test',
+        capacity: 10,
+        refillTokens: 10,
+        refillIntervalMs: 3_600_000,
+        cost: 1,
+        nowMs: 0,
+      }),
+    ).rejects.toThrow('redis unavailable');
+    expect(failingClient.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires Redis configuration in production', () => {
+    expect(() =>
+      createRateLimiterFromEnv({
+        NODE_ENV: 'production',
+        SESSION_SECRET: 'rate-limit-unit-test-secret',
+      } as NodeJS.ProcessEnv),
+    ).toThrow('REDIS_URL must be set in production to enable app rate limiting');
   });
 });

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -136,6 +136,7 @@ vi.mock('../src/auth.ts', () => ({
 }));
 
 import { app } from '../src/server.ts';
+import { verifyAccessToken } from '../src/auth.ts';
 import {
   API_ASK_RATE_LIMIT_POLICY,
   API_CARD_SEARCH_RATE_LIMIT_POLICY,
@@ -147,6 +148,8 @@ import {
   type RateLimitConsumeInput,
   type RateLimitDecision,
 } from '../src/rate-limit.ts';
+
+const mockVerifyAccessToken = vi.mocked(verifyAccessToken);
 
 /** Stub bearer header — the mocked `verifyAccessToken` accepts anything. */
 async function auth(): Promise<Record<string, string>> {
@@ -326,6 +329,27 @@ describe('GET /api/search/rules', () => {
     expect(limiter.calls).toEqual([
       { policy: API_RULE_SEARCH_RATE_LIMIT_POLICY, identity: 'client:stub-client' },
       { policy: API_RULE_SEARCH_RATE_LIMIT_POLICY, identity: 'client:stub-client' },
+    ]);
+  });
+
+  it('uses token user identity for rule-search rate limits when present', async () => {
+    const limiter = installOneRequestLimiter();
+    mockVerifyAccessToken.mockResolvedValueOnce({
+      token: 'stub',
+      clientId: 'stub-client',
+      scopes: [],
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      extra: { userId: 'user-123' },
+    });
+
+    const res = await app.request('/api/search/rules?q=loot+action', {
+      headers: await auth(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockSearchRules).toHaveBeenCalledTimes(1);
+    expect(limiter.calls).toEqual([
+      { policy: API_RULE_SEARCH_RATE_LIMIT_POLICY, identity: 'user:user-123' },
     ]);
   });
 

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -11,7 +11,7 @@
  * conflicts, and lets CI reports point at the right owner.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { parseSSE } from './helpers/server-oauth-helpers.ts';
 import { LlmBudgetExceededError } from '../src/llm-budget.ts';
@@ -136,10 +136,59 @@ vi.mock('../src/auth.ts', () => ({
 }));
 
 import { app } from '../src/server.ts';
+import {
+  API_ASK_RATE_LIMIT_POLICY,
+  API_CARD_SEARCH_RATE_LIMIT_POLICY,
+  API_RULE_SEARCH_RATE_LIMIT_POLICY,
+  hashRateLimitIdentity,
+  resetRateLimiterForTesting,
+  setRateLimiterForTesting,
+  type RateLimiter,
+  type RateLimitConsumeInput,
+  type RateLimitDecision,
+} from '../src/rate-limit.ts';
 
 /** Stub bearer header — the mocked `verifyAccessToken` accepts anything. */
 async function auth(): Promise<Record<string, string>> {
   return { Authorization: 'Bearer stub-token' };
+}
+
+function installOneRequestLimiter() {
+  const counts = new Map<string, number>();
+  const calls: RateLimitConsumeInput[] = [];
+
+  const limiter = {
+    async consume(input: RateLimitConsumeInput): Promise<RateLimitDecision> {
+      calls.push(input);
+      const used = (counts.get(input.identity) ?? 0) + 1;
+      counts.set(input.identity, used);
+      const allowed = used <= 1;
+      return {
+        allowed,
+        policy: input.policy,
+        identityHash: hashRateLimitIdentity(input.identity, 'api-rate-limit-test-secret'),
+        remaining: 0,
+        retryAfterSeconds: allowed ? 0 : 30,
+        resetAfterSeconds: 30,
+      };
+    },
+  };
+
+  setRateLimiterForTesting(limiter as unknown as RateLimiter);
+  return { calls };
+}
+
+function installUnavailableLimiter(error = new Error('redis unavailable')) {
+  const calls: RateLimitConsumeInput[] = [];
+  const limiter = {
+    async consume(input: RateLimitConsumeInput): Promise<RateLimitDecision> {
+      calls.push(input);
+      throw error;
+    },
+  };
+
+  setRateLimiterForTesting(limiter as unknown as RateLimiter);
+  return { calls };
 }
 
 function resetRouteMocks() {
@@ -158,6 +207,10 @@ function resetRouteMocks() {
   mockGetCard.mockReset();
   mockRunReadinessChecks.mockReset();
 }
+
+afterEach(() => {
+  resetRateLimiterForTesting();
+});
 
 describe('GET /api/health', () => {
   beforeEach(() => {
@@ -249,6 +302,46 @@ describe('GET /api/search/rules', () => {
     expect(body.results[0]).toHaveProperty('source');
     expect(body.results[0]).toHaveProperty('sourceLabel');
     expect(body.results[0]).toHaveProperty('score');
+  });
+
+  it('rate limits authenticated rule searches before provider-backed work', async () => {
+    const limiter = installOneRequestLimiter();
+
+    const allowed = await app.request('/api/search/rules?q=loot+action', {
+      headers: await auth(),
+    });
+    expect(allowed.status).toBe(200);
+
+    const rejected = await app.request('/api/search/rules?q=loot+action', {
+      headers: await auth(),
+    });
+
+    expect(rejected.status).toBe(429);
+    expect(rejected.headers.get('Retry-After')).toBe('30');
+    await expect(rejected.json()).resolves.toMatchObject({
+      error: 'rate_limited',
+      retry_after_seconds: 30,
+    });
+    expect(mockSearchRules).toHaveBeenCalledTimes(1);
+    expect(limiter.calls).toEqual([
+      { policy: API_RULE_SEARCH_RATE_LIMIT_POLICY, identity: 'client:stub-client' },
+      { policy: API_RULE_SEARCH_RATE_LIMIT_POLICY, identity: 'client:stub-client' },
+    ]);
+  });
+
+  it('fails closed when the rule-search limiter is unavailable', async () => {
+    const limiter = installUnavailableLimiter();
+
+    const res = await app.request('/api/search/rules?q=loot+action', { headers: await auth() });
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchObject({
+      error: 'temporarily_unavailable',
+    });
+    expect(mockSearchRules).not.toHaveBeenCalled();
+    expect(limiter.calls).toEqual([
+      { policy: API_RULE_SEARCH_RATE_LIMIT_POLICY, identity: 'client:stub-client' },
+    ]);
   });
 
   it('passes query and topK to searchRules', async () => {
@@ -351,6 +444,46 @@ describe('GET /api/search/cards', () => {
     expect(body.results[0]).toHaveProperty('type');
     expect(body.results[0]).toHaveProperty('data');
     expect(body.results[0]).toHaveProperty('score');
+  });
+
+  it('rate limits authenticated card searches before card work', async () => {
+    const limiter = installOneRequestLimiter();
+
+    const allowed = await app.request('/api/search/cards?q=algox+archer', {
+      headers: await auth(),
+    });
+    expect(allowed.status).toBe(200);
+
+    const rejected = await app.request('/api/search/cards?q=algox+archer', {
+      headers: await auth(),
+    });
+
+    expect(rejected.status).toBe(429);
+    expect(rejected.headers.get('Retry-After')).toBe('30');
+    await expect(rejected.json()).resolves.toMatchObject({
+      error: 'rate_limited',
+      retry_after_seconds: 30,
+    });
+    expect(mockSearchCards).toHaveBeenCalledTimes(1);
+    expect(limiter.calls).toEqual([
+      { policy: API_CARD_SEARCH_RATE_LIMIT_POLICY, identity: 'client:stub-client' },
+      { policy: API_CARD_SEARCH_RATE_LIMIT_POLICY, identity: 'client:stub-client' },
+    ]);
+  });
+
+  it('fails closed when the card-search limiter is unavailable', async () => {
+    const limiter = installUnavailableLimiter();
+
+    const res = await app.request('/api/search/cards?q=algox+archer', { headers: await auth() });
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchObject({
+      error: 'temporarily_unavailable',
+    });
+    expect(mockSearchCards).not.toHaveBeenCalled();
+    expect(limiter.calls).toEqual([
+      { policy: API_CARD_SEARCH_RATE_LIMIT_POLICY, identity: 'client:stub-client' },
+    ]);
   });
 
   it('passes query and topK to searchCards', async () => {
@@ -554,6 +687,56 @@ describe('POST /api/ask', () => {
     );
   });
 
+  it('rate limits authenticated ask requests before budget and model work', async () => {
+    const limiter = installOneRequestLimiter();
+
+    const allowed = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'What is the loot action?' }),
+    });
+    expect(allowed.status).toBe(200);
+
+    const rejected = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'What is the loot action?' }),
+    });
+
+    expect(rejected.status).toBe(429);
+    expect(rejected.headers.get('Retry-After')).toBe('30');
+    await expect(rejected.json()).resolves.toMatchObject({
+      error: 'rate_limited',
+      retry_after_seconds: 30,
+    });
+    expect(mockEnsureAskBudgetAvailable).toHaveBeenCalledTimes(1);
+    expect(mockAsk).toHaveBeenCalledTimes(1);
+    expect(limiter.calls).toEqual([
+      { policy: API_ASK_RATE_LIMIT_POLICY, identity: 'client:stub-client' },
+      { policy: API_ASK_RATE_LIMIT_POLICY, identity: 'client:stub-client' },
+    ]);
+  });
+
+  it('fails closed when the ask limiter is unavailable', async () => {
+    const limiter = installUnavailableLimiter();
+
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'What is the loot action?' }),
+    });
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchObject({
+      error: 'temporarily_unavailable',
+    });
+    expect(mockEnsureAskBudgetAvailable).not.toHaveBeenCalled();
+    expect(mockAsk).not.toHaveBeenCalled();
+    expect(limiter.calls).toEqual([
+      { policy: API_ASK_RATE_LIMIT_POLICY, identity: 'client:stub-client' },
+    ]);
+  });
+
   it('returns 429 before opening the stream when the LLM budget is exhausted', async () => {
     mockEnsureAskBudgetAvailable.mockRejectedValueOnce(
       new LlmBudgetExceededError({
@@ -572,11 +755,13 @@ describe('POST /api/ask', () => {
     });
 
     expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBeNull();
     expect(res.headers.get('content-type')).toContain('application/json');
     expect(await res.json()).toMatchObject({
       error: 'llm_budget_exceeded',
       error_description: 'Daily LLM budget exhausted. Try again tomorrow.',
     });
+    expect(mockEnsureAskBudgetAvailable).toHaveBeenCalledWith(null);
     expect(mockAsk).not.toHaveBeenCalled();
   });
 
@@ -609,6 +794,17 @@ describe('POST /api/ask', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 400 before budget checks when the question is too large', async () => {
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'x'.repeat(2_001) }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockEnsureAskBudgetAvailable).not.toHaveBeenCalled();
+    expect(mockAsk).not.toHaveBeenCalled();
+  });
+
   it('returns 400 for invalid JSON body', async () => {
     const res = await app.request('/api/ask', {
       method: 'POST',
@@ -629,6 +825,38 @@ describe('POST /api/ask', () => {
       body: JSON.stringify({ question: 'What about traps?', history }),
     });
     expect(mockAsk).toHaveBeenCalledWith('What about traps?', expect.objectContaining({ history }));
+  });
+
+  it('returns 400 before budget checks when history has too many items', async () => {
+    const history = Array.from({ length: 21 }, () => ({
+      role: 'user',
+      content: 'What is loot?',
+    }));
+
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({ question: 'What about traps?', history }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockEnsureAskBudgetAvailable).not.toHaveBeenCalled();
+    expect(mockAsk).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 before budget checks when a history message is too large', async () => {
+    const res = await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({
+        question: 'What about traps?',
+        history: [{ role: 'user', content: 'x'.repeat(2_001) }],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockEnsureAskBudgetAvailable).not.toHaveBeenCalled();
+    expect(mockAsk).not.toHaveBeenCalled();
   });
 
   it('ignores client-supplied userId on the bearer API path', async () => {


### PR DESCRIPTION
## Summary
- Add explicit Redis/Valkey-backed API rate-limit policies for `/api/ask`, `/api/search/rules`, and `/api/search/cards`.
- Fail closed when the app limiter is unavailable and keep budget exhaustion distinct from rate-limit exhaustion.
- Cap `/api/ask` request text and document the final public/expensive route-control matrix.

## Review
- Pre-landing review: no issues found in the SQR-29 diff.

## Validation
- `npm run check`  
  - typecheck, lint, CSS lint, markdownlint, format check
  - Vitest split suite: 112 files passed, 1,441 tests passed

Fixes SQR-29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced per-request rate limits on /api/ask, /api/search/rules, and /api/search/cards; clearer request-size validation for /api/ask (question and history limits).
  * Distinct 429 responses for rate-limit vs. LLM budget exhaustion.

* **Bug Fixes**
  * Requests fail closed with HTTP 503 when the rate-limiter backend is unavailable.

* **Documentation**
  * Updated architecture, security, and production runbook with rate-limit policies, auth contexts, response shapes, and operational behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->