### PR TITLE
test(e2e): add authenticated API agent smoke

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@
 
 # Required for answer generation
 ANTHROPIC_API_KEY=your_key_here
+# Required for rule indexing and retrieval
+VOYAGE_API_KEY=your_key_here
 OPENAI_API_KEY=your_key_here
 
 # Google OAuth (required for web UI login)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,3 +142,57 @@ jobs:
 
       - name: Slow PDF extraction test
         run: npm run test:slow:pdf
+
+  authenticated-api-agent-e2e:
+    name: Authenticated API and agent E2E smoke
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: squire
+          POSTGRES_PASSWORD: squire
+          POSTGRES_DB: squire_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U squire -d squire_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://squire:squire@localhost:5432/squire_test
+      TEST_DATABASE_URL: postgres://squire:squire@localhost:5432/squire_test
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
+      NODE_ENV: development
+      SQUIRE_ENV: e2e
+      SESSION_SECRET: ci-e2e-session-secret-32-characters-minimum
+      GOOGLE_OAUTH_CLIENT_ID: ci-e2e-unused-google-client-id
+      GOOGLE_OAUTH_CLIENT_SECRET: ci-e2e-unused-google-client-secret
+      SQUIRE_ALLOWED_EMAILS: ci-e2e@squire.local
+      SQUIRE_LLM_DAILY_BUDGET_USD: '0.25'
+      PORT: '3000'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Run database migrations
+        run: npm run db:migrate
+
+      - name: Index rule sources
+        run: npm run index
+
+      - name: Seed card and scenario data
+        run: npm run seed
+
+      - name: Authenticated API and agent E2E smoke
+        run: npm run e2e:api-agent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
     name: Authenticated API and agent E2E smoke
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: pgvector/pgvector:pg16

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -16,6 +16,8 @@ Create a `.env` file in the project root:
 ```bash
 # Required
 ANTHROPIC_API_KEY=...
+# Required for rule indexing and retrieval
+VOYAGE_API_KEY=...
 # Required when running OpenAI-backed evals
 OPENAI_API_KEY=...
 
@@ -456,6 +458,7 @@ npm run test:coverage:serial # Previous serial coverage path, useful for compari
 npm run test:slow:pdf # Real scenario/section PDF extraction check
 npm run test:full     # Fast suite plus real scenario/section PDF extraction
 npm run test:watch    # Watch mode
+npm run e2e:api-agent # Scheduled/manual authenticated API + agent smoke
 npm run typecheck     # TypeScript type checking
 npm run lint          # ESLint
 npm run lint:css      # stylelint (CSS, Tailwind v4 aware — SQR-70)
@@ -473,6 +476,16 @@ suite and does not reparse the full scenario/section PDF set. The checked-in
 scenario/section extract has fast regression coverage; `npm run test:slow:pdf`
 and the scheduled/manual CI path run the real PDF parser when that parser or
 source PDFs need verification.
+
+`npm run e2e:api-agent` is the scheduled/manual authenticated API and agent
+smoke from SQR-23. By default it starts `npm run serve`, waits for `/api/live`
+and `/api/health`, mints a real OAuth bearer token, checks `/api/search/rules`
+for Frosthaven and Gloomhaven 2e, makes two live `/api/ask` calls, then inserts
+an over-budget ledger row and verifies `/api/ask` returns the JSON
+`llm_budget_exceeded` 429 before opening an SSE stream. CI runs it only on the
+daily schedule and manual dispatch with `SQUIRE_LLM_DAILY_BUDGET_USD=0.25` so
+provider spend is capped. For an already-running server, set
+`SQUIRE_E2E_START_SERVER=0` and `SQUIRE_E2E_BASE_URL=http://localhost:<port>`.
 
 SQR-148 added an explicit test split for measuring safe parallelism:
 `test/helpers/test-slices.ts` lists the DB-backed test files that use the

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:full": "vitest run",
     "test:coverage:full": "vitest run --coverage",
     "test:watch": "vitest",
+    "e2e:api-agent": "node scripts/e2e-api-agent-smoke.ts",
     "agent:check": "node scripts/check-agent-parity.ts",
     "security:alerts:dry-run": "SECURITY_ALERT_DRY_RUN=1 node scripts/sync-security-alerts-to-linear.ts",
     "security:alerts:validate-config": "node scripts/sync-security-alerts-to-linear.ts --validate-config",

--- a/scripts/e2e-api-agent-smoke.ts
+++ b/scripts/e2e-api-agent-smoke.ts
@@ -1,0 +1,469 @@
+import 'dotenv/config';
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { eq } from 'drizzle-orm';
+
+import { llmBudgetLedger } from '../src/db/schema/budget.ts';
+import { getDb, shutdownServerPool } from '../src/db.ts';
+import { FROSTHAVEN_GAME_ID, GLOOMHAVEN_2E_GAME_ID, type GameId } from '../src/game.ts';
+
+const CODE_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+const CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+const DEFAULT_PORT = '3000';
+const DEFAULT_BUDGET_USD = '0.25';
+const DEFAULT_SERVER_WAIT_MS = 120_000;
+const BUDGET_GUARD_MODEL = 'squire-e2e-budget-guard';
+const OVERRUN_COST_USD_MICROS = 1_000_000;
+
+export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
+type Logger = (message: string) => void;
+
+export interface E2eSmokeGame {
+  game: GameId;
+  label: string;
+  searchQuery: string;
+  askQuestion: string;
+  expectedSourceMarker: string;
+  expectedSourceLabel: string;
+  forbiddenSourceMarker: string;
+  requiredAnswerTerms: string[];
+}
+
+export const E2E_SMOKE_GAMES: readonly E2eSmokeGame[] = [
+  {
+    game: FROSTHAVEN_GAME_ID,
+    label: 'Frosthaven',
+    searchQuery: 'loot',
+    askQuestion: 'In Frosthaven, what does the Loot action do?',
+    expectedSourceMarker: 'fh-',
+    expectedSourceLabel: 'Rulebook',
+    forbiddenSourceMarker: 'gh2-',
+    requiredAnswerTerms: ['loot'],
+  },
+  {
+    game: GLOOMHAVEN_2E_GAME_ID,
+    label: 'Gloomhaven 2e',
+    searchQuery: 'advantage',
+    askQuestion: 'In Gloomhaven 2e, how does Advantage work?',
+    expectedSourceMarker: 'gh2-',
+    expectedSourceLabel: 'Rulebook',
+    forbiddenSourceMarker: 'fh-',
+    requiredAnswerTerms: ['advantage'],
+  },
+];
+
+interface SmokeOptions {
+  baseUrl: string;
+  fetch?: FetchLike;
+  logger?: Logger;
+  clearBudgetExhaustion?: () => Promise<void>;
+  seedBudgetExhaustion?: () => Promise<void>;
+}
+
+export interface SmokeResult {
+  games: GameId[];
+  providerCalls: number;
+  budgetExceededBeforeStream: boolean;
+}
+
+interface SseEvent {
+  event?: string;
+  data: unknown;
+}
+
+interface SearchResult {
+  game?: string;
+  source?: string;
+  sourceRef?: string;
+  sourceLabel?: string;
+}
+
+function log(logger: Logger, message: string) {
+  logger(`[e2e-api-agent] ${message}`);
+}
+
+function normalizeBaseUrl(raw: string): string {
+  return raw.replace(/\/+$/, '');
+}
+
+function urlFor(baseUrl: string, path: string): string {
+  return `${normalizeBaseUrl(baseUrl)}${path}`;
+}
+
+async function readBody(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return '<unreadable body>';
+  }
+}
+
+async function expectStatus(step: string, res: Response, status: number): Promise<void> {
+  if (res.status === status) return;
+  throw new Error(`${step}: expected ${status}, got ${res.status}: ${await readBody(res)}`);
+}
+
+async function expectJson<T>(step: string, res: Response, status: number): Promise<T> {
+  await expectStatus(step, res, status);
+  const contentType = res.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    throw new Error(`${step}: expected JSON response, got ${contentType || '<missing>'}`);
+  }
+  return (await res.json()) as T;
+}
+
+function containsRequiredTerms(answer: string, terms: readonly string[]): boolean {
+  const normalized = answer.toLowerCase();
+  return terms.every((term) => normalized.includes(term.toLowerCase()));
+}
+
+export function parseSseEvents(text: string): SseEvent[] {
+  return text
+    .split(/\n\n+/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0)
+    .map((block) => {
+      const lines = block.split('\n');
+      const event = lines
+        .find((line) => line.startsWith('event:'))
+        ?.slice('event:'.length)
+        .trim();
+      const dataText =
+        lines
+          .filter((line) => line.startsWith('data:'))
+          .map((line) => line.slice('data:'.length).trim())
+          .join('\n') || '{}';
+      let data: unknown;
+      try {
+        data = JSON.parse(dataText);
+      } catch {
+        data = dataText;
+      }
+      return { event, data };
+    });
+}
+
+async function waitForJsonOk(fetchImpl: FetchLike, url: string, timeoutMs: number): Promise<void> {
+  const started = Date.now();
+  let lastError = '';
+
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const res = await fetchImpl(url);
+      if (res.status === 200) return;
+      lastError = `${res.status}: ${await readBody(res)}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(1_000);
+  }
+
+  throw new Error(`Timed out waiting for ${url}. Last error: ${lastError}`);
+}
+
+async function mintBearerToken(baseUrl: string, fetchImpl: FetchLike): Promise<string> {
+  const register = await expectJson<{ client_id: string }>(
+    'oauth register',
+    await fetchImpl(urlFor(baseUrl, '/register'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        redirect_uris: ['http://localhost:8080/callback'],
+        client_name: 'Squire scheduled E2E smoke',
+        token_endpoint_auth_method: 'none',
+      }),
+    }),
+    201,
+  );
+
+  const authorizeParams = new URLSearchParams({
+    client_id: register.client_id,
+    redirect_uri: 'http://localhost:8080/callback',
+    response_type: 'code',
+    code_challenge: CODE_CHALLENGE,
+    code_challenge_method: 'S256',
+  });
+  const authorize = await fetchImpl(urlFor(baseUrl, `/authorize?${authorizeParams}`), {
+    redirect: 'manual',
+  });
+  await expectStatus('oauth authorize', authorize, 302);
+  const redirect = authorize.headers.get('location');
+  if (!redirect) throw new Error('oauth authorize: missing redirect location');
+  const code = new URL(redirect).searchParams.get('code');
+  if (!code) throw new Error('oauth authorize: missing authorization code');
+
+  const token = await expectJson<{ access_token: string; token_type?: string }>(
+    'oauth token',
+    await fetchImpl(urlFor(baseUrl, '/token'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        client_id: register.client_id,
+        code_verifier: CODE_VERIFIER,
+        redirect_uri: 'http://localhost:8080/callback',
+      }).toString(),
+    }),
+    200,
+  );
+
+  if (!token.access_token) throw new Error('oauth token: missing access_token');
+  return token.access_token;
+}
+
+function assertSearchResults(game: E2eSmokeGame, results: SearchResult[]) {
+  if (results.length === 0) {
+    throw new Error(`${game.label} rule search: expected at least one result`);
+  }
+
+  const sourceMetadata = results
+    .flatMap((result) => [result.source, result.sourceRef])
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ')
+    .toLowerCase();
+  if (sourceMetadata.includes(game.forbiddenSourceMarker)) {
+    throw new Error(`${game.label} rule search: result crossed into ${game.forbiddenSourceMarker}`);
+  }
+
+  if (!sourceMetadata.includes(game.expectedSourceMarker)) {
+    throw new Error(`${game.label} rule search: no ${game.expectedSourceMarker} source metadata`);
+  }
+
+  for (const result of results) {
+    if (result.game !== undefined && result.game !== game.game) {
+      throw new Error(`${game.label} rule search: result game was ${result.game}`);
+    }
+  }
+}
+
+async function runRuleSearch(
+  baseUrl: string,
+  fetchImpl: FetchLike,
+  token: string,
+  game: E2eSmokeGame,
+) {
+  const params = new URLSearchParams({
+    q: game.searchQuery,
+    topK: '3',
+    game: game.game,
+  });
+  const body = await expectJson<{ results: SearchResult[] }>(
+    `${game.label} rule search`,
+    await fetchImpl(urlFor(baseUrl, `/api/search/rules?${params}`), {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+    200,
+  );
+  assertSearchResults(game, body.results);
+}
+
+function dataRecord(data: unknown): Record<string, unknown> {
+  return typeof data === 'object' && data !== null ? (data as Record<string, unknown>) : {};
+}
+
+async function runAsk(baseUrl: string, fetchImpl: FetchLike, token: string, game: E2eSmokeGame) {
+  const res = await fetchImpl(urlFor(baseUrl, '/api/ask'), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      question: game.askQuestion,
+      game: game.game,
+    }),
+  });
+  await expectStatus(`${game.label} ask`, res, 200);
+  const contentType = res.headers.get('content-type') ?? '';
+  if (!contentType.includes('text/event-stream')) {
+    throw new Error(`${game.label} ask: expected SSE stream, got ${contentType || '<missing>'}`);
+  }
+
+  const events = parseSseEvents(await res.text());
+  const eventNames = new Set(events.map((event) => event.event));
+  for (const expectedEvent of ['tool_progress', 'tool_result', 'text', 'done']) {
+    if (!eventNames.has(expectedEvent)) {
+      throw new Error(`${game.label} ask: missing SSE event ${expectedEvent}`);
+    }
+  }
+
+  const sourceLabels = events
+    .filter((event) => event.event === 'tool_result')
+    .flatMap((event) => {
+      const sourceBooks = dataRecord(event.data).sourceBooks;
+      return Array.isArray(sourceBooks)
+        ? sourceBooks.filter((value) => typeof value === 'string')
+        : [];
+    });
+  if (sourceLabels.length === 0) {
+    throw new Error(`${game.label} ask: no citation/source labels in tool_result events`);
+  }
+
+  const answer = events
+    .filter((event) => event.event === 'text')
+    .map((event) => dataRecord(event.data).delta)
+    .filter((delta): delta is string => typeof delta === 'string')
+    .join('');
+  if (!containsRequiredTerms(answer, game.requiredAnswerTerms)) {
+    throw new Error(
+      `${game.label} semantic answer check failed: missing ${game.requiredAnswerTerms.join(', ')}`,
+    );
+  }
+}
+
+async function seedBudgetExhaustionLedger() {
+  const { db } = getDb('server');
+  await db.insert(llmBudgetLedger).values({
+    budgetDay: new Date().toISOString().slice(0, 10),
+    userId: null,
+    model: BUDGET_GUARD_MODEL,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    totalTokens: 0,
+    costUsdMicros: OVERRUN_COST_USD_MICROS,
+    createdAt: new Date(),
+  });
+}
+
+async function clearBudgetExhaustionLedger() {
+  const { db } = getDb('server');
+  await db.delete(llmBudgetLedger).where(eq(llmBudgetLedger.model, BUDGET_GUARD_MODEL));
+}
+
+async function runBudgetExhaustionCheck(baseUrl: string, fetchImpl: FetchLike, token: string) {
+  const res = await fetchImpl(urlFor(baseUrl, '/api/ask'), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      question: 'In Frosthaven, what does the Loot action do?',
+      game: FROSTHAVEN_GAME_ID,
+    }),
+  });
+  await expectStatus('budget exhaustion', res, 429);
+  const contentType = res.headers.get('content-type') ?? '';
+  if (contentType.includes('text/event-stream')) {
+    throw new Error('budget exhaustion: opened an SSE stream instead of returning JSON');
+  }
+  const body = await expectJson<{ error?: string }>('budget exhaustion', res, 429);
+  if (body.error !== 'llm_budget_exceeded') {
+    throw new Error(`budget exhaustion: expected llm_budget_exceeded, got ${body.error}`);
+  }
+}
+
+export async function runApiAgentSmoke(options: SmokeOptions): Promise<SmokeResult> {
+  const fetchImpl = options.fetch ?? fetch;
+  const logger = options.logger ?? console.log;
+  const clearBudgetExhaustion = options.clearBudgetExhaustion ?? clearBudgetExhaustionLedger;
+  const seedBudgetExhaustion = options.seedBudgetExhaustion ?? seedBudgetExhaustionLedger;
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+
+  await clearBudgetExhaustion();
+
+  log(logger, `checking liveness at ${baseUrl}`);
+  await expectJson('live check', await fetchImpl(urlFor(baseUrl, '/api/live')), 200);
+  await expectJson('health check', await fetchImpl(urlFor(baseUrl, '/api/health')), 200);
+
+  log(logger, 'minting OAuth bearer token');
+  const token = await mintBearerToken(baseUrl, fetchImpl);
+
+  for (const game of E2E_SMOKE_GAMES) {
+    log(logger, `searching ${game.label} rules`);
+    await runRuleSearch(baseUrl, fetchImpl, token, game);
+    log(logger, `asking ${game.label} agent question`);
+    await runAsk(baseUrl, fetchImpl, token, game);
+  }
+
+  log(logger, 'seeding budget ledger and checking pre-stream 429');
+  await seedBudgetExhaustion();
+  await runBudgetExhaustionCheck(baseUrl, fetchImpl, token);
+
+  return {
+    games: E2E_SMOKE_GAMES.map((game) => game.game),
+    providerCalls: E2E_SMOKE_GAMES.length,
+    budgetExceededBeforeStream: true,
+  };
+}
+
+function serverEnv(baseUrl: string): NodeJS.ProcessEnv {
+  const port = new URL(baseUrl).port || DEFAULT_PORT;
+  return {
+    ...process.env,
+    NODE_ENV: process.env.NODE_ENV ?? 'development',
+    SQUIRE_ENV: process.env.SQUIRE_ENV ?? 'e2e',
+    PORT: process.env.PORT ?? port,
+    SQUIRE_BASE_URL: process.env.SQUIRE_BASE_URL ?? baseUrl,
+    SQUIRE_LLM_DAILY_BUDGET_USD: process.env.SQUIRE_LLM_DAILY_BUDGET_USD ?? DEFAULT_BUDGET_USD,
+  };
+}
+
+function pipeChildOutput(child: ChildProcess) {
+  child.stdout?.on('data', (chunk: Buffer) => process.stdout.write(chunk));
+  child.stderr?.on('data', (chunk: Buffer) => process.stderr.write(chunk));
+}
+
+async function stopServer(child: ChildProcess | null) {
+  if (!child || child.exitCode !== null) return;
+  child.kill('SIGTERM');
+  await Promise.race([
+    new Promise<void>((resolve) => child.once('exit', () => resolve())),
+    sleep(5_000).then(() => {
+      if (child.exitCode === null) child.kill('SIGKILL');
+    }),
+  ]);
+}
+
+async function main() {
+  const baseUrl =
+    process.env.SQUIRE_E2E_BASE_URL ??
+    `http://localhost:${process.env.PORT ?? process.env.SQUIRE_E2E_PORT ?? DEFAULT_PORT}`;
+  const shouldStartServer = process.env.SQUIRE_E2E_START_SERVER !== '0';
+  const logger: Logger = (message) => console.log(message);
+  let server: ChildProcess | null = null;
+
+  try {
+    if (shouldStartServer) {
+      log(logger, `starting server at ${baseUrl}`);
+      server = spawn('npm', ['run', 'serve'], {
+        env: serverEnv(baseUrl),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      pipeChildOutput(server);
+      server.once('exit', (code) => {
+        if (code !== null && code !== 0) {
+          console.error(`[e2e-api-agent] server exited with code ${code}`);
+        }
+      });
+    }
+
+    await waitForJsonOk(fetch, urlFor(baseUrl, '/api/live'), DEFAULT_SERVER_WAIT_MS);
+    await waitForJsonOk(fetch, urlFor(baseUrl, '/api/health'), DEFAULT_SERVER_WAIT_MS);
+    const result = await runApiAgentSmoke({ baseUrl, logger });
+    log(
+      logger,
+      `passed for ${result.games.join(', ')} with ${result.providerCalls} provider calls and budget cap ${process.env.SQUIRE_LLM_DAILY_BUDGET_USD ?? DEFAULT_BUDGET_USD} USD`,
+    );
+  } finally {
+    await shutdownServerPool();
+    await stopServer(server);
+  }
+}
+
+if (
+  process.env.VITEST !== 'true' &&
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/scripts/e2e-api-agent-smoke.ts
+++ b/scripts/e2e-api-agent-smoke.ts
@@ -151,6 +151,7 @@ function containsRequiredTerms(answer: string, terms: readonly string[]): boolea
 
 export function parseSseEvents(text: string): SseEvent[] {
   return text
+    .replace(/\r\n/g, '\n')
     .split(/\n\n+/)
     .map((block) => block.trim())
     .filter((block) => block.length > 0)
@@ -416,7 +417,11 @@ export async function runApiAgentSmoke(options: SmokeOptions): Promise<SmokeResu
 
   log(logger, 'seeding budget ledger and checking pre-stream 429');
   await seedBudgetExhaustion();
-  await runBudgetExhaustionCheck(baseUrl, fetchImpl, token);
+  try {
+    await runBudgetExhaustionCheck(baseUrl, fetchImpl, token);
+  } finally {
+    await clearBudgetExhaustion();
+  }
 
   return {
     games: E2E_SMOKE_GAMES.map((game) => game.game),

--- a/scripts/e2e-api-agent-smoke.ts
+++ b/scripts/e2e-api-agent-smoke.ts
@@ -461,13 +461,25 @@ function pipeChildOutput(child: ChildProcess) {
   child.stderr?.on('data', (chunk: Buffer) => process.stderr.write(chunk));
 }
 
+function signalChild(child: ChildProcess, signal: NodeJS.Signals) {
+  if (child.pid && process.platform !== 'win32') {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // Fall through to signaling the direct child.
+    }
+  }
+  child.kill(signal);
+}
+
 async function stopServer(child: ChildProcess | null) {
   if (!child || child.exitCode !== null) return;
-  child.kill('SIGTERM');
+  signalChild(child, 'SIGTERM');
   await Promise.race([
     new Promise<void>((resolve) => child.once('exit', () => resolve())),
     sleep(5_000).then(() => {
-      if (child.exitCode === null) child.kill('SIGKILL');
+      if (child.exitCode === null) signalChild(child, 'SIGKILL');
     }),
   ]);
 }
@@ -485,6 +497,7 @@ async function main() {
       log(logger, `starting server at ${baseUrl}`);
       server = spawn('npm', ['run', 'serve'], {
         env: serverEnv(baseUrl),
+        detached: process.platform !== 'win32',
         stdio: ['ignore', 'pipe', 'pipe'],
       });
       pipeChildOutput(server);

--- a/scripts/e2e-api-agent-smoke.ts
+++ b/scripts/e2e-api-agent-smoke.ts
@@ -15,6 +15,7 @@ const CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
 const DEFAULT_PORT = '3000';
 const DEFAULT_BUDGET_USD = '0.25';
 const DEFAULT_SERVER_WAIT_MS = 120_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
 const BUDGET_GUARD_MODEL = 'squire-e2e-budget-guard';
 const OVERRUN_COST_USD_MICROS = 1_000_000;
 
@@ -61,6 +62,7 @@ interface SmokeOptions {
   logger?: Logger;
   clearBudgetExhaustion?: () => Promise<void>;
   seedBudgetExhaustion?: () => Promise<void>;
+  requestTimeoutMs?: number;
 }
 
 export interface SmokeResult {
@@ -91,6 +93,33 @@ function normalizeBaseUrl(raw: string): string {
 
 function urlFor(baseUrl: string, path: string): string {
   return `${normalizeBaseUrl(baseUrl)}${path}`;
+}
+
+function createTimedFetch(fetchImpl: FetchLike, timeoutMs: number): FetchLike {
+  return async (url, init = {}) => {
+    const controller = new AbortController();
+    const timeout = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetchImpl(url, {
+        ...init,
+        signal: controller.signal,
+      });
+      const body = await response.arrayBuffer();
+      return new Response(body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new Error(`Timed out after ${timeoutMs}ms fetching ${String(url)}`, { cause: error });
+      }
+      throw error;
+    } finally {
+      globalThis.clearTimeout(timeout);
+    }
+  };
 }
 
 async function readBody(res: Response): Promise<string> {
@@ -360,7 +389,10 @@ async function runBudgetExhaustionCheck(baseUrl: string, fetchImpl: FetchLike, t
 }
 
 export async function runApiAgentSmoke(options: SmokeOptions): Promise<SmokeResult> {
-  const fetchImpl = options.fetch ?? fetch;
+  const fetchImpl = createTimedFetch(
+    options.fetch ?? fetch,
+    options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+  );
   const logger = options.logger ?? console.log;
   const clearBudgetExhaustion = options.clearBudgetExhaustion ?? clearBudgetExhaustionLedger;
   const seedBudgetExhaustion = options.seedBudgetExhaustion ?? seedBudgetExhaustionLedger;
@@ -444,8 +476,9 @@ async function main() {
       });
     }
 
-    await waitForJsonOk(fetch, urlFor(baseUrl, '/api/live'), DEFAULT_SERVER_WAIT_MS);
-    await waitForJsonOk(fetch, urlFor(baseUrl, '/api/health'), DEFAULT_SERVER_WAIT_MS);
+    const timedFetch = createTimedFetch(fetch, DEFAULT_REQUEST_TIMEOUT_MS);
+    await waitForJsonOk(timedFetch, urlFor(baseUrl, '/api/live'), DEFAULT_SERVER_WAIT_MS);
+    await waitForJsonOk(timedFetch, urlFor(baseUrl, '/api/health'), DEFAULT_SERVER_WAIT_MS);
     const result = await runApiAgentSmoke({ baseUrl, logger });
     log(
       logger,

--- a/scripts/e2e-api-agent-smoke.ts
+++ b/scripts/e2e-api-agent-smoke.ts
@@ -98,26 +98,40 @@ function urlFor(baseUrl: string, path: string): string {
 function createTimedFetch(fetchImpl: FetchLike, timeoutMs: number): FetchLike {
   return async (url, init = {}) => {
     const controller = new AbortController();
-    const timeout = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+    let timedOut = false;
+    let timeout: ReturnType<typeof globalThis.setTimeout> | undefined;
+    const timeoutError = new Error(`Timed out after ${timeoutMs}ms fetching ${String(url)}`);
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeout = globalThis.setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+        reject(timeoutError);
+      }, timeoutMs);
+    });
 
     try {
-      const response = await fetchImpl(url, {
-        ...init,
-        signal: controller.signal,
-      });
-      const body = await response.arrayBuffer();
-      return new Response(body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: response.headers,
-      });
+      return await Promise.race([
+        (async () => {
+          const response = await fetchImpl(url, {
+            ...init,
+            signal: controller.signal,
+          });
+          const body = await response.arrayBuffer();
+          return new Response(body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+          });
+        })(),
+        timeoutPromise,
+      ]);
     } catch (error) {
-      if (controller.signal.aborted) {
+      if (timedOut || controller.signal.aborted) {
         throw new Error(`Timed out after ${timeoutMs}ms fetching ${String(url)}`, { cause: error });
       }
       throw error;
     } finally {
-      globalThis.clearTimeout(timeout);
+      if (timeout !== undefined) globalThis.clearTimeout(timeout);
     }
   };
 }

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -97,6 +97,27 @@ describe('deployment configuration', () => {
     expect(workflow).not.toContain('run: npx vitest run --coverage');
   });
 
+  it('defines the scheduled authenticated API and agent smoke command', async () => {
+    const packageJson = JSON.parse(await readProjectFile('package.json')) as {
+      scripts?: Record<string, string>;
+    };
+    const workflow = await readProjectFile('.github/workflows/ci.yml');
+    const development = await readProjectFile('docs/DEVELOPMENT.md');
+
+    expect(packageJson.scripts?.['e2e:api-agent']).toBe('node scripts/e2e-api-agent-smoke.ts');
+    expect(workflow).toContain('name: Authenticated API and agent E2E smoke');
+    expect(workflow).toContain("github.event_name == 'schedule'");
+    expect(workflow).toContain("github.event_name == 'workflow_dispatch'");
+    expect(workflow).toContain('ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}');
+    expect(workflow).toContain('VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}');
+    expect(workflow).toContain("SQUIRE_LLM_DAILY_BUDGET_USD: '0.25'");
+    expect(workflow).toContain('run: npm run e2e:api-agent');
+
+    expect(development).toContain('npm run e2e:api-agent');
+    expect(development).toContain('two live `/api/ask` calls');
+    expect(development).toContain('SQUIRE_LLM_DAILY_BUDGET_USD=0.25');
+  });
+
   it('defines a Fly cron process for expired session cleanup', async () => {
     const flyConfig = await readProjectFile('fly.toml');
     const crontab = await readProjectFile('crontab');

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -111,6 +111,7 @@ describe('deployment configuration', () => {
     expect(workflow).toContain('ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}');
     expect(workflow).toContain('VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}');
     expect(workflow).toContain("SQUIRE_LLM_DAILY_BUDGET_USD: '0.25'");
+    expect(workflow).toContain('timeout-minutes: 15');
     expect(workflow).toContain('run: npm run e2e:api-agent');
 
     expect(development).toContain('npm run e2e:api-agent');

--- a/test/e2e-api-agent-smoke.test.ts
+++ b/test/e2e-api-agent-smoke.test.ts
@@ -146,7 +146,7 @@ describe('scheduled API and agent E2E smoke runner', () => {
   });
 
   it('times out a hung agent request', async () => {
-    const fetch: FetchLike = async (url, init = {}) => {
+    const fetch: FetchLike = async (url) => {
       const parsed = new URL(String(url));
 
       if (parsed.pathname === '/api/live') return jsonResponse({ status: 'ok' });
@@ -184,11 +184,7 @@ describe('scheduled API and agent E2E smoke runner', () => {
         });
       }
       if (parsed.pathname === '/api/ask') {
-        return new Promise<Response>((_, reject) => {
-          init.signal?.addEventListener('abort', () => reject(new Error('aborted')), {
-            once: true,
-          });
-        });
+        return new Promise<Response>(() => undefined);
       }
 
       throw new Error(`Unexpected request: ${parsed.pathname}`);

--- a/test/e2e-api-agent-smoke.test.ts
+++ b/test/e2e-api-agent-smoke.test.ts
@@ -34,6 +34,17 @@ describe('scheduled API and agent E2E smoke runner', () => {
     ]);
   });
 
+  it('parses CRLF-delimited SSE events', () => {
+    expect(
+      parseSseEvents(
+        'event: text\r\ndata: {"delta":"Loot"}\r\n\r\nevent: done\r\ndata: {}\r\n\r\n',
+      ),
+    ).toEqual([
+      { event: 'text', data: { delta: 'Loot' } },
+      { event: 'done', data: {} },
+    ]);
+  });
+
   it('runs health, bearer auth, per-game search, per-game ask, and budget checks', async () => {
     const calls: string[] = [];
     const budgetSteps: string[] = [];
@@ -124,7 +135,7 @@ describe('scheduled API and agent E2E smoke runner', () => {
     expect(result.games).toEqual(['frosthaven', 'gloomhaven-2e']);
     expect(result.providerCalls).toBe(2);
     expect(result.budgetExceededBeforeStream).toBe(true);
-    expect(budgetSteps).toEqual(['clear', 'seed']);
+    expect(budgetSteps).toEqual(['clear', 'seed', 'clear']);
     expect(calls).toContain('GET /api/live');
     expect(calls).toContain('GET /api/health');
     expect(calls).toContain('POST /register');

--- a/test/e2e-api-agent-smoke.test.ts
+++ b/test/e2e-api-agent-smoke.test.ts
@@ -133,4 +133,65 @@ describe('scheduled API and agent E2E smoke runner', () => {
     expect(calls).toContain('GET /api/search/rules?q=advantage&topK=3&game=gloomhaven-2e');
     expect(calls.filter((call) => call === 'POST /api/ask')).toHaveLength(3);
   });
+
+  it('times out a hung agent request', async () => {
+    const fetch: FetchLike = async (url, init = {}) => {
+      const parsed = new URL(String(url));
+
+      if (parsed.pathname === '/api/live') return jsonResponse({ status: 'ok' });
+      if (parsed.pathname === '/api/health') {
+        return jsonResponse({
+          status: 'ok',
+          db: { status: 'ok' },
+          vector: { status: 'ok' },
+          embedder: { status: 'ok' },
+        });
+      }
+      if (parsed.pathname === '/register') {
+        return jsonResponse({ client_id: 'client-1' }, { status: 201 });
+      }
+      if (parsed.pathname === '/authorize') {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: 'http://localhost:8080/callback?code=code-1' },
+        });
+      }
+      if (parsed.pathname === '/token') {
+        return jsonResponse({ access_token: 'token-1', token_type: 'bearer' });
+      }
+      if (parsed.pathname === '/api/search/rules') {
+        const game = parsed.searchParams.get('game');
+        const expected = E2E_SMOKE_GAMES.find((entry) => entry.game === game);
+        return jsonResponse({
+          results: [
+            {
+              game,
+              source: expected?.expectedSourceMarker + 'rule-book.pdf',
+              sourceLabel: expected?.expectedSourceLabel,
+            },
+          ],
+        });
+      }
+      if (parsed.pathname === '/api/ask') {
+        return new Promise<Response>((_, reject) => {
+          init.signal?.addEventListener('abort', () => reject(new Error('aborted')), {
+            once: true,
+          });
+        });
+      }
+
+      throw new Error(`Unexpected request: ${parsed.pathname}`);
+    };
+
+    await expect(
+      runApiAgentSmoke({
+        baseUrl: 'http://localhost:3000',
+        fetch,
+        clearBudgetExhaustion: async () => undefined,
+        seedBudgetExhaustion: async () => undefined,
+        logger: () => undefined,
+        requestTimeoutMs: 5,
+      }),
+    ).rejects.toThrow(/Timed out after 5ms fetching http:\/\/localhost:3000\/api\/ask/);
+  });
 });

--- a/test/e2e-api-agent-smoke.test.ts
+++ b/test/e2e-api-agent-smoke.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  E2E_SMOKE_GAMES,
+  parseSseEvents,
+  runApiAgentSmoke,
+  type FetchLike,
+} from '../scripts/e2e-api-agent-smoke.ts';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...init.headers },
+  });
+}
+
+function sseResponse(events: Array<{ event: string; data: unknown }>) {
+  const body = events
+    .map(({ event, data }) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+    .join('');
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+describe('scheduled API and agent E2E smoke runner', () => {
+  it('parses named SSE events with JSON payloads', () => {
+    expect(
+      parseSseEvents('event: text\ndata: {"delta":"Loot"}\n\n' + 'event: done\ndata: {}\n\n'),
+    ).toEqual([
+      { event: 'text', data: { delta: 'Loot' } },
+      { event: 'done', data: {} },
+    ]);
+  });
+
+  it('runs health, bearer auth, per-game search, per-game ask, and budget checks', async () => {
+    const calls: string[] = [];
+    const budgetSteps: string[] = [];
+    let budgetLedgerSeeded = false;
+
+    const fetch: FetchLike = async (url, init = {}) => {
+      const parsed = new URL(String(url));
+      calls.push(`${init.method ?? 'GET'} ${parsed.pathname}${parsed.search}`);
+
+      if (parsed.pathname === '/api/live') return jsonResponse({ status: 'ok' });
+      if (parsed.pathname === '/api/health') {
+        return jsonResponse({
+          status: 'ok',
+          db: { status: 'ok' },
+          vector: { status: 'ok' },
+          embedder: { status: 'ok' },
+        });
+      }
+      if (parsed.pathname === '/register') {
+        return jsonResponse({ client_id: 'client-1' }, { status: 201 });
+      }
+      if (parsed.pathname === '/authorize') {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: 'http://localhost:8080/callback?code=code-1' },
+        });
+      }
+      if (parsed.pathname === '/token') {
+        return jsonResponse({ access_token: 'token-1', token_type: 'bearer' });
+      }
+      if (parsed.pathname === '/api/search/rules') {
+        const game = parsed.searchParams.get('game');
+        const expected = E2E_SMOKE_GAMES.find((entry) => entry.game === game);
+        return jsonResponse({
+          results: [
+            {
+              text: `Rules result for ${game}`,
+              game,
+              source: expected?.expectedSourceMarker + 'rule-book.pdf',
+              sourceLabel: expected?.expectedSourceLabel,
+              score: 0.9,
+            },
+          ],
+        });
+      }
+      if (parsed.pathname === '/api/ask') {
+        if (budgetLedgerSeeded) {
+          return jsonResponse(
+            {
+              error: 'llm_budget_exceeded',
+              error_description: 'Daily LLM budget exhausted. Try again tomorrow.',
+            },
+            { status: 429 },
+          );
+        }
+        const body = JSON.parse(String(init.body)) as { game: string };
+        const expected = E2E_SMOKE_GAMES.find((entry) => entry.game === body.game)!;
+        return sseResponse([
+          { event: 'tool_progress', data: { toolName: 'search_knowledge' } },
+          {
+            event: 'tool_result',
+            data: {
+              name: 'search_knowledge',
+              sourceBooks: [expected.expectedSourceLabel],
+            },
+          },
+          { event: 'text', data: { delta: expected.requiredAnswerTerms.join(' ') } },
+          { event: 'done', data: {} },
+        ]);
+      }
+
+      throw new Error(`Unexpected request: ${parsed.pathname}`);
+    };
+
+    const result = await runApiAgentSmoke({
+      baseUrl: 'http://localhost:3000',
+      fetch,
+      clearBudgetExhaustion: async () => {
+        budgetSteps.push('clear');
+      },
+      seedBudgetExhaustion: async () => {
+        budgetSteps.push('seed');
+        budgetLedgerSeeded = true;
+      },
+      logger: () => undefined,
+    });
+
+    expect(result.games).toEqual(['frosthaven', 'gloomhaven-2e']);
+    expect(result.providerCalls).toBe(2);
+    expect(result.budgetExceededBeforeStream).toBe(true);
+    expect(budgetSteps).toEqual(['clear', 'seed']);
+    expect(calls).toContain('GET /api/live');
+    expect(calls).toContain('GET /api/health');
+    expect(calls).toContain('POST /register');
+    expect(calls).toContain('POST /token');
+    expect(calls).toContain('GET /api/search/rules?q=loot&topK=3&game=frosthaven');
+    expect(calls).toContain('GET /api/search/rules?q=advantage&topK=3&game=gloomhaven-2e');
+    expect(calls.filter((call) => call === 'POST /api/ask')).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

- add a scheduled/manual authenticated API and agent smoke runner
- cover OAuth bearer minting, `/api/search/rules`, `/api/ask` SSE, cross-game metadata, and pre-stream LLM budget exhaustion
- wire the smoke into the scheduled/manual CI path with bounded provider spend and document the required `ANTHROPIC_API_KEY` / `VOYAGE_API_KEY` repo secrets

## Validation

- `npm run check`
- `SQUIRE_LLM_DAILY_BUDGET_USD=1.00 npm run e2e:api-agent`

Fixes SQR-23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented a required API key for rule indexing and added guidance for the authenticated E2E agent smoke flow.

* **New Features**
  * Added a scheduled/manual authenticated API + agent end-to-end smoke test and a runnable E2E smoke command.

* **Tests**
  * Added comprehensive E2E smoke tests covering registration, rule search, agent ask flows, SSE streaming behavior, timeout handling, and budget-exceeded scenarios.

* **Chores**
  * Added the new API key placeholder to environment examples and CI scheduling for automated E2E runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->