### PR TITLE
ci(eval): pass Voyage key to LangSmith regression

### DIFF
--- a/.github/workflows/langsmith-regression.yml
+++ b/.github/workflows/langsmith-regression.yml
@@ -103,6 +103,7 @@ jobs:
       LANGSMITH_PROJECT: ${{ vars.LANGSMITH_PROJECT || 'squire-evals' }}
       LANGSMITH_TRACING: 'true'
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       TARGET_INPUT: ${{ inputs.target || 'all' }}
       PROVIDER_INPUT: ${{ inputs.provider || 'anthropic' }}
@@ -145,6 +146,9 @@ jobs:
           [[ -n "$LANGSMITH_API_KEY" ]] || missing+=("LANGSMITH_API_KEY")
           if [[ -z "$ANTHROPIC_API_KEY" ]]; then
             missing+=("ANTHROPIC_API_KEY")
+          fi
+          if [[ -z "$VOYAGE_API_KEY" ]]; then
+            missing+=("VOYAGE_API_KEY")
           fi
           if [[ "$PROVIDER_INPUT" == "openai" && -z "$OPENAI_API_KEY" ]]; then
             missing+=("OPENAI_API_KEY")

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -115,9 +115,13 @@ describe('deployment configuration', () => {
     expect(workflow).toContain('npm run eval --');
     expect(workflow).toContain('--matrix');
     expect(workflow).toContain('--max-estimated-cost-usd=');
-    expect(workflow).toContain('LANGSMITH_API_KEY');
-    expect(workflow).toContain('ANTHROPIC_API_KEY');
-    expect(workflow).toContain('OPENAI_API_KEY');
+    expect(workflow).toContain('LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}');
+    expect(workflow).toContain('ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}');
+    expect(workflow).toContain('VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}');
+    expect(workflow).toContain('OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}');
+    expect(workflow).toContain('missing+=("LANGSMITH_API_KEY")');
+    expect(workflow).toContain('missing+=("ANTHROPIC_API_KEY")');
+    expect(workflow).toContain('missing+=("VOYAGE_API_KEY")');
     expect(workflow).toContain('cat "$REPORT_MD" >> "$GITHUB_STEP_SUMMARY"');
     expect(workflow).toContain('actions/upload-artifact');
   });


### PR DESCRIPTION
## Summary
- Pass VOYAGE_API_KEY into the LangSmith regression matrix job so npm run index can build retrieval indexes.
- Add VOYAGE_API_KEY to the workflow credential preflight so missing secrets fail before indexing.
- Tighten the deployment config test to assert the eval workflow secret mappings and preflight checks.

## Root cause
The scheduled LangSmith regression jobs all failed in the shared Build retrieval indexes step. The repo secret existed, but .github/workflows/langsmith-regression.yml did not map secrets.VOYAGE_API_KEY into the job env, so src/voyage-retrieval.ts rejected indexing.

## Validation
- npm test -- test/deployment-config.test.ts
- actionlint .github/workflows/langsmith-regression.yml
- npm run check

Fixes SQR-25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added Voyage API key environment variable support to regression testing workflow, enabling expanded testing capabilities
  * Implemented validation checks to ensure Voyage API key is properly configured alongside other required API credentials
  * Updated test suite to verify complete environment variable setup for all integrated API services and authentication mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->