### PR TITLE
Fix Anthropic LangSmith eval preflight

### DIFF
--- a/.github/workflows/langsmith-regression.yml
+++ b/.github/workflows/langsmith-regression.yml
@@ -3,6 +3,14 @@ name: LangSmith Regression
 on:
   schedule:
     - cron: '42 9 * * *'
+  pull_request:
+    paths:
+      - '.github/workflows/langsmith-regression.yml'
+      - 'eval/**'
+      - 'test/deployment-config.test.ts'
+      - 'test/eval-matrix-runtime.test.ts'
+      - 'package-lock.json'
+      - 'package.json'
   workflow_dispatch:
     inputs:
       target:
@@ -57,8 +65,29 @@ permissions:
   attestations: read
 
 jobs:
+  preflight:
+    name: LangSmith eval workflow preflight
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run LangSmith eval preflight tests
+        run: npm test -- test/eval-matrix-runtime.test.ts test/deployment-config.test.ts
+
   regression:
     name: ${{ matrix.label }}
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/eval/matrix-runtime.ts
+++ b/eval/matrix-runtime.ts
@@ -193,7 +193,12 @@ export function createEvalMatrixRunner(
     options.langSmithTracing === false
       ? undefined
       : withEvalTraceEnvironment(createLangSmithTraceWriterFromEnv(env), env);
-  const openAiClient = createOpenAiResponsesClient(env);
+  let openAiClient: OpenAiResponsesClient | undefined;
+
+  function getOpenAiClient(): OpenAiResponsesClient {
+    openAiClient ??= createOpenAiResponsesClient(env);
+    return openAiClient;
+  }
 
   return async (input) => {
     if (input.agentRuntime === 'deep-agents') {
@@ -205,7 +210,7 @@ export function createEvalMatrixRunner(
     }
 
     if (input.providerConfig.provider === 'openai') {
-      return runOpenAiMatrixCase(input, anthropic, traceWriter, openAiClient, env);
+      return runOpenAiMatrixCase(input, anthropic, traceWriter, getOpenAiClient(), env);
     }
 
     throw new Error(`Matrix runner does not support provider ${input.providerConfig.provider}.`);

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -107,11 +107,19 @@ describe('deployment configuration', () => {
 
     expect(parsed.name).toBe('LangSmith Regression');
     expect(workflow).toContain('cron:');
+    expect(workflow).toContain('pull_request:');
+    expect(workflow).toContain('.github/workflows/langsmith-regression.yml');
     expect(workflow).toContain('workflow_dispatch:');
     expect(workflow).toContain('suite: adversarial-boundary');
     expect(workflow).toContain('suite: cross-game-boundary');
     expect(workflow).toContain('game: frosthaven');
     expect(workflow).toContain('game: gloomhaven-2e');
+    expect(workflow).toContain('name: LangSmith eval workflow preflight');
+    expect(workflow).toContain("if: github.event_name == 'pull_request'");
+    expect(workflow).toContain(
+      'npm test -- test/eval-matrix-runtime.test.ts test/deployment-config.test.ts',
+    );
+    expect(workflow).toContain("if: github.event_name != 'pull_request'");
     expect(workflow).toContain('npm run eval --');
     expect(workflow).toContain('--matrix');
     expect(workflow).toContain('--max-estimated-cost-usd=');

--- a/test/eval-matrix-runtime.test.ts
+++ b/test/eval-matrix-runtime.test.ts
@@ -183,6 +183,30 @@ describe('eval matrix runtime adapter', () => {
     });
   });
 
+  it('does not require an OpenAI client for Anthropic-only matrix rows', async () => {
+    mockCreateOpenAiResponsesClient.mockImplementation(() => {
+      throw new Error('OPENAI_API_KEY is required for OpenAI evals.');
+    });
+    mockRunAnthropicEvalCase.mockResolvedValue({
+      answer: 'Spyglass reveals the top card.',
+      trajectory: { toolCalls: [] },
+      durationMs: 1000,
+      toolSurface: 'redesigned',
+      traceId: 'anthropic-trace',
+      trace: trace({ traceId: 'anthropic-trace' }),
+    });
+
+    const runner = createEvalMatrixRunner({}, { langSmithTracing: false });
+    const output = await runner(input('anthropic'));
+
+    expect(mockCreateOpenAiResponsesClient).not.toHaveBeenCalled();
+    expect(output).toMatchObject({
+      ok: true,
+      traceId: 'anthropic-trace',
+      failureClass: 'none',
+    });
+  });
+
   it('runs Haiku through the Anthropic matrix adapter', async () => {
     mockRunAnthropicEvalCase.mockResolvedValue({
       answer: 'Spyglass reveals the top card.',


### PR DESCRIPTION
## Summary
- Lazily initialize the OpenAI eval client so Anthropic-only matrix runs do not require OPENAI_API_KEY.
- Add a PR-only LangSmith eval workflow preflight that runs mocked config/runtime tests without live provider secrets.
- Keep the live LangSmith regression matrix limited to scheduled and manual workflow runs.

## Validation
- npm test -- test/eval-matrix-runtime.test.ts test/deployment-config.test.ts
- npm run lint:actions
- npm run check

Fixes SQR-25