### PR TITLE
Stabilize SQR-255 work log events

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -248,19 +248,26 @@ SCEN 14` once Phase 4 character state lands. Always visible. One line,
    `answer-artifact`), and collapses to a compact source/step summary when the
    final answer is ready. Rows are compact one-line entries. Generic progress
    such as "searching selected sources" must be replaced by actual source
-   labels as soon as result labels arrive, e.g. `CHECKED · Rulebook`. If a
+   labels as soon as result labels arrive, e.g. `Checked rulebook`. If a
    single tool result checked multiple books, render one row per source:
-   `CHECKED · Rulebook`, `CHECKED · Section Book`, `CHECKED · Scenario Book`.
+   `Checked rulebook`, `Checked section book`, `Checked scenario book`.
+   Progress rows and checked-source rows are durable events: once a row appears,
+   its wording does not change. Do not rewrite a `Resolving ...` row into a
+   `Checked ...` row, and do not render duplicate checked rows for the same
+   source label in one answer. Generic source-search progress renders as
+   `Searching available sources`. Render rows as standalone messages without
+   separate `SEARCHING` / `CHECKED` prefixes; use a stable semantic order so
+   resolving appears before source search, which appears before checked-source
+   rows, even if stream events arrive out of order.
    The collapsed summary says `Checked 3 sources`; do not add a second
-   provenance footer below the answer. The user can reopen it in place and can
-   choose `Compact`, `Normal`, or `Full` progress detail from the work-log
-   summary. This is a browser-local preference: it changes whether work details
-   default closed, open only while running, or remain open after completion; it
-   never changes final answer prose and never exposes raw private reasoning.
-   This gives the user the agent-app pattern of visible work without mixing work
-   notes into the answer body. It is not raw private chain-of-thought, not
-   campaign memory, and not page chrome. Phase 5 hosts two card mockups
-   side-by-side with a
+   provenance footer below the answer. The user can reopen it in place. The
+   disclosure state is driven by the agent state only: open while Squire is
+   working, collapsed when the answer is ready, and open on errors. Do not add
+   display-density toggles, a header bar, plus/minus icons, or borders around
+   the work log. This gives the user the agent-app pattern of visible work
+   without mixing work notes into the answer body. It is not raw private
+   chain-of-thought, not campaign memory, and not page chrome. Phase 5 hosts
+   two card mockups side-by-side with a
    "Squire recommends" verdict via a side panel or modal — not as a peer
    mode of the transcript.
 3. **Input dock (bottom)** — slim rounded-rectangle input field in `--surface`
@@ -583,7 +590,7 @@ attribute on `<html>`. That's the extent of the per-game theming.
 | 2026-04-22 | **Split home + scrolling-chat IA — supersedes 2026-04-08 current-turn ledger** — `/chat/:id` is a standard scrolling-chat transcript with the drop cap on the newest answer only (position-based selector). `/` is a separate purpose-built landing. The fake recent-questions chip row is deleted.                                                                                                  | The 2026-04-08 current-turn ledger was a novel IA users had to learn; lived-use surfaced four problems (fake home chips, no first-turn history affordance, orphaned selected-message surface, scaffolding desktop rail). Position-based drop cap rarity preserves the signature without forcing one-turn-at-a-time. From SQR-101 / [ADR 0012](docs/adr/0012-split-home-and-scrolling-chat-ia.md), superseded by [ADR 0020](docs/adr/0020-conversation-history-rail.md).                                         |
 | 2026-06-04 | **Conversation-history rail and mobile History drawer** — desktop gets a real owned-conversation history rail; mobile gets a left drawer. Active row may show current browser-known running/error state only for the active stream. Progress panel, history search, generated titles, pins, and campaign/character memory UI are deferred.                                                           | Repeated use showed that Squire needs conversation recovery before deeper progress UI. This rail is not the old placeholder rail: it is backed by real conversation rows and keeps the transcript as the primary reading surface. From office-hours, `/browse` research, CEO review, design review, and [ADR 0020](docs/adr/0020-conversation-history-rail.md).                                                                                                                                                 |
 | 2026-06-05 | **Inline answer-owned work log** — no right-side current-run panel and no bottom consulted footer. Each pending answer owns an expanded `Working` disclosure above answer prose, fed only by safe stream events. It collapses after `done`, stays reopenable, and renders compact one-line rows that merge repeated progress while keeping separate checked-source rows for each source.             | The conversation list solved recovery; the next missing agent-app affordance is seeing what the current answer is checking without confusing work with the final answer. The first panel version hid too much context after completion, the first inline version was too noisy (`Searching selected sources · REFERENCE`), and the bottom `CONSULTED` footer duplicated the collapsed work-log summary. SQR-255 keeps the single conversation surface and uses the work log as the only visible source display. |
-| 2026-06-07 | **Browser-local progress visibility control** — each work-log summary includes `Compact`, `Normal`, and `Full`. `Compact` defaults work details closed, `Normal` opens the active run and collapses completed work, and `Full` keeps details open after completion.                                                                                                                                  | SQR-256 adds the missing user control without changing the answer contract or adding a server setting table. The preference is stored in `localStorage` because it is display density, not account data. The control affects only safe work-log rows, never raw hidden reasoning, prompts, or final answer prose.                                                                                                                                                                                               |
+| 2026-06-07 | **Compact state-driven work-log disclosure** — the `Compact` / `Normal` / `Full` control is removed. Each work log has only a caret summary and compact event rows. It opens while Squire is working, collapses after `done` to `Checked N sources`, stays reopenable, and stays open on errors. No plus/minus icon, header bar, or border treatment ships around the log.                           | The first SQR-255 pass spent too many pixels on mode controls and chrome. The useful information is the event list itself: `Checked rulebook`, `Checked card index`. State-driven disclosure matches how the user reads it at the table: see work while waiting, get a small provenance summary after the answer.                                                                                                                                                                                               |
 
 <!-- markdownlint-enable MD060 -->
 

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -330,7 +330,7 @@ async function renderDocument(options: DocumentOptions): Promise<HtmlEscapedStri
   ]);
 
   return html`<!doctype html>
-    <html lang="en" data-progress-visibility="normal">
+    <html lang="en">
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
@@ -432,43 +432,8 @@ function displayToolSourceLabel(label: ToolSourceLabel): string {
   }
 }
 
-const PROGRESS_VISIBILITY_OPTIONS = [
-  {
-    value: 'compact',
-    label: 'Compact',
-    title: 'Show only the progress summary by default',
-  },
-  {
-    value: 'normal',
-    label: 'Normal',
-    title: 'Show live progress, then collapse it after the answer',
-  },
-  {
-    value: 'expanded',
-    label: 'Full',
-    title: 'Keep progress details open',
-  },
-] as const;
-
-function renderProgressVisibilityControl(): HtmlEscapedString {
-  return html`<span
-    class="squire-answer-work__visibility"
-    role="group"
-    aria-label="Progress detail"
-  >
-    ${PROGRESS_VISIBILITY_OPTIONS.map(
-      (option) =>
-        html`<button
-          type="button"
-          class="squire-answer-work__visibility-button"
-          data-progress-visibility-choice="${option.value}"
-          aria-pressed="${option.value === 'normal' ? 'true' : 'false'}"
-          title="${option.title}"
-        >
-          ${option.label}
-        </button>`,
-    )}
-  </span>` as HtmlEscapedString;
+function sentenceToolSourceLabel(label: ToolSourceLabel): string {
+  return displayToolSourceLabel(label).toLowerCase();
 }
 
 function renderCompletedAnswerWork(message: ConversationMessage): HtmlEscapedString {
@@ -485,11 +450,9 @@ function renderCompletedAnswerWork(message: ConversationMessage): HtmlEscapedStr
     data-work-state="complete"
   >
     <summary class="squire-answer-work__summary">
-      <span class="squire-answer-work__title">Work log</span>
       <span class="squire-answer-work__status" data-answer-work-status
         >Checked ${labels.length} ${labels.length === 1 ? 'source' : 'sources'}</span
       >
-      ${renderProgressVisibilityControl()}
     </summary>
     <div class="squire-answer-work__rows" data-answer-work-rows>
       ${labels.map(
@@ -499,9 +462,9 @@ function renderCompletedAnswerWork(message: ConversationMessage): HtmlEscapedStr
             data-answer-work-source-labels="${label}"
             data-work-state="complete"
           >
-            <span class="squire-answer-work__row-label">CHECKED</span>
-            <span class="squire-answer-work__row-detail">${displayToolSourceLabel(label)}</span>
-            <span class="squire-answer-work__row-source"></span>
+            <span class="squire-answer-work__row-detail"
+              >Checked ${sentenceToolSourceLabel(label)}</span
+            >
           </div>`,
       )}
     </div>
@@ -548,9 +511,7 @@ function renderPendingAnswerSkeleton(streamUrl: string): HtmlEscapedString {
     <h2 class="sr-only" id="${labelId}">Squire answer</h2>
     <details class="squire-answer-work" data-testid="answer-progress" data-work-state="idle" open>
       <summary class="squire-answer-work__summary">
-        <span class="squire-answer-work__title">Working</span>
         <span class="squire-answer-work__status" data-answer-work-status>Waiting</span>
-        ${renderProgressVisibilityControl()}
       </summary>
       <div
         class="squire-answer-work__rows"

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -730,6 +730,7 @@ function answerWorkRowMessage(label, detail, sourceLabel) {
   if (label === 'FOUND') {
     return 'Found ' + (detailText || 'source') + (source ? ' in ' + source : '');
   }
+  if (detailText === 'Searching available sources') return detailText;
   if (source && detailText && detailText.toLowerCase().indexOf(source) === -1) {
     return detailText + ' in ' + source;
   }
@@ -898,7 +899,7 @@ function renderAnswerWorkResult(elements, entries, rowId, labels, ok) {
       ok === false ? 'error' : 'running',
       ok === false ? 90 : 50,
     );
-    rememberAnswerWorkSourceLabels(row, [entry.label]);
+    if (ok !== false) rememberAnswerWorkSourceLabels(row, [entry.label]);
   }
 }
 

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -10,8 +10,6 @@
 // focus is already covered by the global :focus-visible ring.
 var ACTIVE_GAME_STORAGE_KEY = 'squire.activeGame';
 var FALLBACK_DEFAULT_ACTIVE_GAME = 'frosthaven';
-var PROGRESS_VISIBILITY_STORAGE_KEY = 'squire.progressVisibility';
-var DEFAULT_PROGRESS_VISIBILITY = 'normal';
 var fallbackSupportedActiveGames = {
   frosthaven: true,
   'gloomhaven-2e': true,
@@ -20,24 +18,10 @@ var defaultActiveGame = FALLBACK_DEFAULT_ACTIVE_GAME;
 var supportedActiveGames = fallbackSupportedActiveGames;
 var activeGame = defaultActiveGame;
 var activeGameInitialized = false;
-var progressVisibility = DEFAULT_PROGRESS_VISIBILITY;
-var progressVisibilityInitialized = false;
-var supportedProgressVisibility = {
-  compact: true,
-  normal: true,
-  expanded: true,
-};
 
 function isSupportedActiveGame(value) {
   return (
     typeof value === 'string' && Object.prototype.hasOwnProperty.call(supportedActiveGames, value)
-  );
-}
-
-function isSupportedProgressVisibility(value) {
-  return (
-    typeof value === 'string' &&
-    Object.prototype.hasOwnProperty.call(supportedProgressVisibility, value)
   );
 }
 
@@ -158,40 +142,9 @@ function syncActiveGameControls() {
   }
 }
 
-function readStoredProgressVisibility() {
-  try {
-    var stored =
-      window.localStorage && window.localStorage.getItem(PROGRESS_VISIBILITY_STORAGE_KEY);
-    return isSupportedProgressVisibility(stored) ? stored : DEFAULT_PROGRESS_VISIBILITY;
-  } catch {
-    return DEFAULT_PROGRESS_VISIBILITY;
-  }
-}
-
-function persistProgressVisibility(value) {
-  try {
-    if (window.localStorage) window.localStorage.setItem(PROGRESS_VISIBILITY_STORAGE_KEY, value);
-  } catch {
-    // Storage can be blocked in private browsing; keep the in-page setting.
-  }
-}
-
-function setDocumentProgressVisibility(value) {
-  if (!document.documentElement) return;
-  if (typeof document.documentElement.setAttribute === 'function') {
-    document.documentElement.setAttribute('data-progress-visibility', value);
-    return;
-  }
-  if (document.documentElement.dataset) {
-    document.documentElement.dataset.progressVisibility = value;
-  }
-}
-
 function preferredAnswerWorkOpen(container) {
   var state = container && container.getAttribute ? container.getAttribute('data-work-state') : '';
   if (state === 'error') return true;
-  if (progressVisibility === 'expanded') return true;
-  if (progressVisibility === 'compact') return false;
   return state === 'running' || state === 'idle';
 }
 
@@ -200,51 +153,8 @@ function syncAnswerWorkOpenState(container) {
   container.open = preferredAnswerWorkOpen(container);
 }
 
-function syncAnswerWorkOpenStates() {
-  var workLogs = document.querySelectorAll ? document.querySelectorAll('.squire-answer-work') : [];
-  for (var i = 0; i < workLogs.length; i += 1) {
-    syncAnswerWorkOpenState(workLogs[i]);
-  }
-}
-
-function syncProgressVisibilityControls() {
-  if (!progressVisibilityInitialized) {
-    progressVisibility = readStoredProgressVisibility();
-    progressVisibilityInitialized = true;
-  }
-  if (!isSupportedProgressVisibility(progressVisibility)) {
-    progressVisibility = DEFAULT_PROGRESS_VISIBILITY;
-  }
-  setDocumentProgressVisibility(progressVisibility);
-
-  var controls = document.querySelectorAll
-    ? document.querySelectorAll('[data-progress-visibility-choice]')
-    : [];
-  for (var i = 0; i < controls.length; i += 1) {
-    var control = controls[i];
-    var selected =
-      control.dataset && control.dataset.progressVisibilityChoice === progressVisibility;
-    control.setAttribute('aria-pressed', selected ? 'true' : 'false');
-  }
-  syncAnswerWorkOpenStates();
-}
-
-function setProgressVisibility(value, persist) {
-  progressVisibility = isSupportedProgressVisibility(value) ? value : DEFAULT_PROGRESS_VISIBILITY;
-  if (persist) persistProgressVisibility(progressVisibility);
-  syncProgressVisibilityControls();
-}
-
 document.addEventListener('click', function (e) {
   var t = e.target;
-  var progressChoice = t && t.closest ? t.closest('[data-progress-visibility-choice]') : null;
-  if (progressChoice && progressChoice.dataset) {
-    e.preventDefault();
-    if (typeof e.stopPropagation === 'function') e.stopPropagation();
-    setProgressVisibility(progressChoice.dataset.progressVisibilityChoice, true);
-    return;
-  }
-
   var historyToggle = t && t.closest ? t.closest('.squire-history-toggle') : null;
   if (historyToggle) {
     e.preventDefault();
@@ -680,13 +590,15 @@ function answerWorkElements(answerEl) {
     container: container,
     rowsEl: container.querySelector('.squire-answer-work__rows'),
     statusEl: container.querySelector('.squire-answer-work__status'),
-    titleEl: container.querySelector('.squire-answer-work__title'),
   };
 }
 
 function resetAnswerWork(elements, entries) {
   if (!elements || !elements.container) return;
-  if (elements.rowsEl) elements.rowsEl.replaceChildren();
+  if (elements.rowsEl) {
+    elements.rowsEl.replaceChildren();
+    if (elements.rowsEl.dataset) elements.rowsEl.dataset.answerWorkNextOrdinal = '0';
+  }
   if (entries) {
     for (var id in entries) {
       delete entries[id];
@@ -695,7 +607,6 @@ function resetAnswerWork(elements, entries) {
   elements.container.hidden = false;
   elements.container.setAttribute('data-work-state', 'running');
   syncAnswerWorkOpenState(elements.container);
-  if (elements.titleEl) elements.titleEl.textContent = 'Working';
   if (elements.statusEl) elements.statusEl.textContent = 'Working';
 }
 
@@ -703,15 +614,23 @@ function setAnswerWorkRunning(elements) {
   if (!elements || !elements.container) return;
   elements.container.hidden = false;
   elements.container.setAttribute('data-work-state', 'running');
-  if (progressVisibility !== 'compact') {
-    elements.container.open = true;
-  }
-  if (elements.titleEl) elements.titleEl.textContent = 'Working';
-  if (elements.statusEl) elements.statusEl.textContent = 'Checking sources';
+  elements.container.open = true;
+  if (elements.statusEl) elements.statusEl.textContent = 'Working';
 }
 
 function baseAnswerWorkId(rowId) {
   return typeof rowId === 'string' ? rowId.replace(/-progress-\d+$/, '') : rowId;
+}
+
+function answerWorkSlug(value, fallback) {
+  var slug =
+    typeof value === 'string'
+      ? value
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-|-$/g, '')
+      : '';
+  return slug || fallback;
 }
 
 function displaySourceLabel(label) {
@@ -733,6 +652,11 @@ function displaySourceLabel(label) {
   }
 }
 
+function sentenceSourceLabel(label) {
+  var display = displaySourceLabel(label);
+  return display ? display.toLowerCase() : '';
+}
+
 function answerWorkSourceEntries(labels) {
   var entries = [];
   for (var i = 0; i < labels.length; i += 1) {
@@ -751,15 +675,10 @@ function answerWorkSourceEntries(labels) {
   return entries;
 }
 
-function answerWorkSourceRowId(rowId, label, index) {
-  var suffix =
-    typeof label === 'string'
-      ? label
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-')
-          .replace(/^-|-$/g, '')
-      : String(index);
-  return baseAnswerWorkId(rowId) + '-source-' + suffix;
+function answerWorkCheckedSourceRowId(label, ok, index) {
+  return (
+    (ok === false ? 'failed-source-' : 'checked-source-') + answerWorkSlug(label, String(index))
+  );
 }
 
 function rememberAnswerWorkSourceLabels(row, labels) {
@@ -775,9 +694,75 @@ function rememberAnswerWorkSourceLabels(row, labels) {
 }
 
 function genericProgressDetail(message) {
-  if (message === 'Searching selected sources') return 'Source index';
-  if (message === 'Searching knowledge') return 'Knowledge index';
+  var resolvingMonster = message.match(/^Resolving\s+(.+?)\s+monster(?:\s+stat(?:\s+card)?)?$/i);
+  if (resolvingMonster) return 'Resolving ' + resolvingMonster[1].trim() + ' stats';
+  if (message === 'Searching selected sources') return 'Searching available sources';
+  if (message === 'Searching knowledge') return 'Searching available sources';
   return message;
+}
+
+function answerWorkProgressRowId(rowId, detail) {
+  var baseId = baseAnswerWorkId(rowId) || 'progress';
+  var normalizedDetail = typeof detail === 'string' ? detail.toLowerCase() : '';
+  if (normalizedDetail.indexOf('resolving ') === 0) {
+    return 'progress-resolving-' + answerWorkSlug(detail, 'event');
+  }
+  if (normalizedDetail === 'searching available sources') {
+    return 'progress-searching-available-sources';
+  }
+  return baseId + '-progress-' + answerWorkSlug(detail, 'event');
+}
+
+function answerWorkProgressSort(detail) {
+  var normalizedDetail = typeof detail === 'string' ? detail.toLowerCase() : '';
+  if (normalizedDetail.indexOf('resolving ') === 0) return 10;
+  if (normalizedDetail === 'searching available sources') return 20;
+  return 30;
+}
+
+function answerWorkRowMessage(label, detail, sourceLabel) {
+  var source = sentenceSourceLabel(sourceLabel);
+  var detailText = typeof detail === 'string' ? detail : '';
+  if (label === 'CHECKED') return 'Checked ' + (detailText || source || 'source').toLowerCase();
+  if (label === "COULDN'T CHECK") {
+    return "Couldn't check " + (detailText || source || 'source').toLowerCase();
+  }
+  if (label === 'FOUND') {
+    return 'Found ' + (detailText || 'source') + (source ? ' in ' + source : '');
+  }
+  if (source && detailText && detailText.toLowerCase().indexOf(source) === -1) {
+    return detailText + ' in ' + source;
+  }
+  return detailText || 'Checking sources';
+}
+
+function sortAnswerWorkRows(rowsEl) {
+  if (!rowsEl || !rowsEl.children || rowsEl.children.length < 2) return;
+  var rows = Array.prototype.slice.call(rowsEl.children);
+  rows.sort(function (a, b) {
+    var aSort = Number.parseInt((a.dataset && a.dataset.answerWorkSort) || '50', 10);
+    var bSort = Number.parseInt((b.dataset && b.dataset.answerWorkSort) || '50', 10);
+    if (aSort !== bSort) return aSort - bSort;
+    var aOrdinal = Number.parseInt((a.dataset && a.dataset.answerWorkOrdinal) || '0', 10);
+    var bOrdinal = Number.parseInt((b.dataset && b.dataset.answerWorkOrdinal) || '0', 10);
+    return aOrdinal - bOrdinal;
+  });
+  for (var i = 0; i < rows.length; i += 1) {
+    rowsEl.appendChild(rows[i]);
+  }
+}
+
+function setAnswerWorkRowOrder(elements, row, sort) {
+  if (!row || !row.dataset) return;
+  if (!row.dataset.answerWorkOrdinal) {
+    var rowsEl = elements && elements.rowsEl;
+    var nextOrdinal = rowsEl && rowsEl.dataset ? rowsEl.dataset.answerWorkNextOrdinal : '';
+    var ordinal = Number.parseInt(nextOrdinal || '0', 10);
+    row.dataset.answerWorkOrdinal = String(ordinal);
+    if (rowsEl && rowsEl.dataset) rowsEl.dataset.answerWorkNextOrdinal = String(ordinal + 1);
+  }
+  row.dataset.answerWorkSort = String(sort == null ? 50 : sort);
+  if (elements && elements.rowsEl) sortAnswerWorkRows(elements.rowsEl);
 }
 
 function inferredAnswerWorkSourceCount(elements) {
@@ -818,7 +803,6 @@ function completeAnswerWork(elements, sourceCount) {
   elements.container.hidden = false;
   elements.container.setAttribute('data-work-state', 'complete');
   syncAnswerWorkOpenState(elements.container);
-  if (elements.titleEl) elements.titleEl.textContent = 'Work log';
   if (elements.statusEl) {
     var effectiveSourceCount =
       sourceCount > 0 ? sourceCount : inferredAnswerWorkSourceCount(elements);
@@ -840,7 +824,6 @@ function markAnswerWorkError(elements) {
   elements.container.hidden = false;
   elements.container.open = true;
   elements.container.setAttribute('data-work-state', 'error');
-  if (elements.titleEl) elements.titleEl.textContent = 'Work log';
   if (elements.statusEl) elements.statusEl.textContent = 'Stopped before answer';
 }
 
@@ -854,40 +837,35 @@ function ensureAnswerWorkRow(elements, entries, rowId) {
   row.className = 'squire-answer-work__row';
   row.dataset.answerWorkId = baseId;
 
-  var labelEl = document.createElement('span');
-  labelEl.className = 'squire-answer-work__row-label';
-  row.appendChild(labelEl);
-
   var detailEl = document.createElement('span');
   detailEl.className = 'squire-answer-work__row-detail';
   row.appendChild(detailEl);
-
-  var sourceEl = document.createElement('span');
-  sourceEl.className = 'squire-answer-work__row-source';
-  row.appendChild(sourceEl);
 
   entries[baseId] = row;
   elements.rowsEl.appendChild(row);
   return row;
 }
 
-function renderAnswerWorkRow(elements, entries, rowId, label, detail, sourceLabel, state) {
+function renderAnswerWorkRow(elements, entries, rowId, label, detail, sourceLabel, state, sort) {
   var row = ensureAnswerWorkRow(elements, entries, rowId);
   if (!row) return;
+  if (row.dataset && row.dataset.answerWorkFrozen === 'true') {
+    setAnswerWorkRowOrder(elements, row, sort);
+    setAnswerWorkRunning(elements);
+    return row;
+  }
   rememberAnswerWorkSourceLabels(row, [sourceLabel]);
 
   row.dataset.workState = state || 'running';
+  row.dataset.answerWorkFrozen = 'true';
   row.classList.remove('is-error');
   if (state === 'error') row.classList.add('is-error');
 
-  var labelEl = row.querySelector('.squire-answer-work__row-label');
   var detailEl = row.querySelector('.squire-answer-work__row-detail');
-  var sourceEl = row.querySelector('.squire-answer-work__row-source');
 
-  if (labelEl) labelEl.textContent = label || 'CHECKING';
-  if (detailEl) detailEl.textContent = detail || 'Source index';
-  if (sourceEl) sourceEl.textContent = displaySourceLabel(sourceLabel);
+  if (detailEl) detailEl.textContent = answerWorkRowMessage(label, detail, sourceLabel);
 
+  setAnswerWorkRowOrder(elements, row, sort);
   setAnswerWorkRunning(elements);
   return row;
 }
@@ -904,6 +882,7 @@ function renderAnswerWorkResult(elements, entries, rowId, labels, ok) {
       'Source index',
       '',
       ok === false ? 'error' : 'running',
+      ok === false ? 90 : 50,
     );
     return;
   }
@@ -912,11 +891,12 @@ function renderAnswerWorkResult(elements, entries, rowId, labels, ok) {
     var row = renderAnswerWorkRow(
       elements,
       entries,
-      i === 0 ? rowId : answerWorkSourceRowId(rowId, entry.label, i),
+      answerWorkCheckedSourceRowId(entry.label, ok, i),
       ok === false ? "COULDN'T CHECK" : 'CHECKED',
       entry.display,
       '',
       ok === false ? 'error' : 'running',
+      ok === false ? 90 : 50,
     );
     rememberAnswerWorkSourceLabels(row, [entry.label]);
   }
@@ -1136,23 +1116,13 @@ function attachPendingAnswerStream(answerEl) {
   // tool-result sends `labels[]` (actual books hit, post-SQR-105). The
   // asymmetry is intentional: at start time we don't yet know which books
   // search_rules will hit; at result time we do.
-  source.addEventListener('tool-start', function (event) {
+  source.addEventListener('tool-start', function () {
     if (seenFirstDelta) {
       return;
     }
-    var payload = JSON.parse(event.data || '{}');
     preToolBuffer = '';
     toolPhaseStarted = true;
-    if (payload.label === 'REFERENCE') return;
-    renderAnswerWorkRow(
-      answerWork,
-      answerWorkEntries,
-      payload.id,
-      'CHECKING',
-      displaySourceLabel(payload.label) || 'Source index',
-      '',
-      'running',
-    );
+    setAnswerWorkRunning(answerWork);
   });
 
   source.addEventListener('tool-progress', function (event) {
@@ -1163,14 +1133,16 @@ function attachPendingAnswerStream(answerEl) {
     }
     preToolBuffer = '';
     toolPhaseStarted = true;
+    var detail = genericProgressDetail(payload.message);
     renderAnswerWorkRow(
       answerWork,
       answerWorkEntries,
-      payload.id,
+      answerWorkProgressRowId(payload.id, detail),
       'SEARCHING',
-      genericProgressDetail(payload.message),
+      detail,
       payload.label,
       'running',
+      answerWorkProgressSort(detail),
     );
   });
 
@@ -1217,6 +1189,7 @@ function attachPendingAnswerStream(answerEl) {
       payload.title,
       payload.sourceLabel,
       'running',
+      40,
     );
     renderAnswerArtifact(artifactsEl, artifactEntries, payload);
     if (skeletonEl) skeletonEl.hidden = true;
@@ -1396,7 +1369,6 @@ document.addEventListener('htmx:afterSwap', function (event) {
   if (questionInput) questionInput.value = '';
   syncChatFormAction();
   syncActiveGameControls();
-  syncProgressVisibilityControls();
 
   var swapTarget = event.detail && event.detail.target;
   var pending = findActivePendingAnswer(swapTarget) || findActivePendingAnswer(document);
@@ -1427,7 +1399,6 @@ document.addEventListener('htmx:afterSwap', function (event) {
 document.addEventListener('DOMContentLoaded', function () {
   syncChatFormAction();
   syncActiveGameControls();
-  syncProgressVisibilityControls();
   // SQR-108 / ADR 0012 D-2: the browser preserves last scroll natively on
   // back/forward navigation and refresh, so we don't pin or auto-scroll on
   // initial load. We only flag pin on submit (above) and re-evaluate it

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -1518,24 +1518,16 @@ template#squire-banner-fixtures {
 
 .squire-answer-work {
   margin: 0 0 18px;
-  padding: 10px 0 12px 12px;
-  border-left: 2px solid var(--rule);
+  padding: 0;
   color: var(--sepia);
   font-family: 'Geist', system-ui, sans-serif;
 }
 
-.squire-answer-work[data-work-state='running'] {
-  border-left-color: var(--wax);
-}
-
-.squire-answer-work[data-work-state='error'] {
-  border-left-color: var(--amber);
-}
-
 .squire-answer-work__summary {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
+  max-width: 100%;
   min-height: 24px;
   cursor: pointer;
   list-style: none;
@@ -1546,84 +1538,31 @@ template#squire-banner-fixtures {
 }
 
 .squire-answer-work__summary::before {
-  content: '+';
-  display: inline-grid;
-  flex: 0 0 18px;
-  width: 18px;
-  height: 18px;
-  place-items: center;
-  border: 1px solid var(--rule);
-  border-radius: 4px;
+  content: '';
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid currentcolor;
   color: var(--sepia);
-  font-size: 13px;
-  line-height: 1;
+  transform: translateY(-1px);
+  transform-origin: 45% 50%;
 }
 
 .squire-answer-work[open] .squire-answer-work__summary::before {
-  content: '-';
+  transform: rotate(90deg) translateX(-1px);
 }
 
-.squire-answer-work__title,
-.squire-answer-work__status,
-.squire-answer-work__row-label,
-.squire-answer-work__row-source {
+.squire-answer-work__status {
   font-size: 10px;
   font-weight: 650;
   line-height: 1.3;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-}
-
-.squire-answer-work__title {
-  color: var(--parchment-dim);
-}
-
-.squire-answer-work__status {
-  margin-left: auto;
   color: var(--sepia);
-  text-align: right;
-}
-
-.squire-answer-work__visibility {
-  display: inline-flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 2px;
-  min-height: 44px;
-  padding: 2px;
-  border: 1px solid var(--rule);
-  border-radius: 6px;
-  background: rgb(20 16 12 / 0.28);
-}
-
-.squire-answer-work__visibility-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 44px;
-  min-height: 40px;
-  padding: 2px 8px;
-  border: 0;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--sepia);
-  cursor: pointer;
-  font-family: 'Geist', system-ui, sans-serif;
-  font-size: 10px;
-  font-weight: 650;
-  line-height: 1.2;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.squire-answer-work__visibility-button:hover,
-.squire-answer-work__visibility-button:focus-visible {
-  color: var(--parchment);
-}
-
-.squire-answer-work__visibility-button[aria-pressed='true'] {
-  background: var(--rule);
-  color: var(--parchment-dim);
+  text-align: left;
 }
 
 .squire-answer-work[data-work-state='running'] .squire-answer-work__status {
@@ -1636,8 +1575,9 @@ template#squire-banner-fixtures {
 
 .squire-answer-work__rows {
   display: grid;
-  gap: 6px;
-  margin-top: 8px;
+  gap: 4px;
+  margin-top: 6px;
+  padding-left: 17px;
 }
 
 .squire-answer-work__rows:empty {
@@ -1645,26 +1585,11 @@ template#squire-banner-fixtures {
 }
 
 .squire-answer-work__row {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
   min-width: 0;
-  padding-top: 6px;
-  border-top: 1px solid var(--rule);
-}
-
-.squire-answer-work__row:first-child {
-  padding-top: 0;
-  border-top: 0;
-}
-
-.squire-answer-work__row-label,
-.squire-answer-work__row-source {
-  color: var(--sepia);
 }
 
 .squire-answer-work__row-detail {
-  flex: 1 1 auto;
+  display: block;
   min-width: 0;
   color: var(--parchment-dim);
   font-size: 13px;
@@ -1672,42 +1597,18 @@ template#squire-banner-fixtures {
   overflow-wrap: anywhere;
 }
 
-.squire-answer-work__row-source {
-  flex: 0 1 auto;
-}
-
-.squire-answer-work__row-source:not(:empty)::before {
-  content: '·';
-  margin-right: 8px;
-  color: var(--sepia-dim);
-}
-
-.squire-answer-work__row-source:empty {
-  display: none;
-}
-
-.squire-answer-work__row.is-error .squire-answer-work__row-label,
 .squire-answer-work__row.is-error .squire-answer-work__row-detail {
   color: var(--amber);
 }
 
 @media (max-width: 520px) {
   .squire-answer-work__summary {
-    flex-wrap: wrap;
     align-items: center;
   }
 
   .squire-answer-work__status {
-    flex: 1 1 auto;
-    margin-left: 0;
+    min-width: 0;
     text-align: left;
-  }
-
-  .squire-answer-work__visibility {
-    flex-basis: calc(100% - 28px);
-    margin-left: 28px;
-    width: max-content;
-    max-width: calc(100% - 28px);
   }
 }
 

--- a/test/e2e/sqr-24-chat-game-selection.spec.ts
+++ b/test/e2e/sqr-24-chat-game-selection.spec.ts
@@ -107,7 +107,9 @@ async function expectFinalAnswer(page: Page, expectedAnswer: RegExp): Promise<vo
   await expect(latestAnswer.locator('[data-testid="answer-progress"]')).toContainText(
     'Checked 1 source',
   );
-  await expect(latestAnswer.locator('[data-testid="answer-progress"]')).toContainText('Rulebook');
+  await expect(latestAnswer.locator('[data-testid="answer-progress"]')).toContainText(
+    'Checked rulebook',
+  );
   await expect(page.locator('.squire-input-dock')).not.toHaveAttribute('data-submitting', 'true');
 }
 
@@ -179,7 +181,7 @@ test.describe('SQR-24 browser chat game selection', () => {
     await expectFinalAnswer(page, /Gloomhaven 2e resolves poison/);
   });
 
-  test('changes progress detail during an active run and keeps the completed work visible', async ({
+  test('keeps work log expanded while running and collapses it after completion', async ({
     page,
   }) => {
     const releaseStream = await installDelayedDeterministicStream(page, {
@@ -196,23 +198,21 @@ test.describe('SQR-24 browser chat game selection', () => {
     const workLog = latestAnswer.locator('[data-testid="answer-progress"]');
     await expect(workLog).toBeVisible();
     await expect(workLog).toHaveAttribute('data-work-state', 'running');
-
-    await workLog.getByRole('button', { name: 'Full' }).click();
-
-    await expect(page.locator('html')).toHaveAttribute('data-progress-visibility', 'expanded');
-    await expect(workLog.getByRole('button', { name: 'Full' })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
     await expect(workLog).toHaveAttribute('open', '');
+    await expect(workLog.getByRole('button')).toHaveCount(0);
     await expect
       .poll(() => page.evaluate(() => window.localStorage.getItem('squire.progressVisibility')))
-      .toBe('expanded');
+      .toBeNull();
 
     releaseStream();
 
     await expectFinalAnswer(page, /Closed doors block line-of-sight/);
     await expect(workLog).toHaveAttribute('data-work-state', 'complete');
-    await expect(workLog).toHaveAttribute('open', '');
+    await expect(workLog).not.toHaveAttribute('open', '');
+    await expect(workLog).toContainText('Checked 1 source');
+    await expect(workLog.locator('.squire-answer-work__row-label')).toHaveCount(0);
+    await expect(workLog.locator('.squire-answer-work__row-detail')).toContainText(
+      'Checked rulebook',
+    );
   });
 });

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -634,7 +634,7 @@ describe('renderConversationTurnAppendFragment (SQR-108 / ADR 0012 E-3)', () => 
     expect(body).toContain('class="squire-answer-work"');
     expect(body).toContain('data-testid="answer-progress"');
     expect(body).toContain('data-work-state="idle"');
-    expect(body).toContain('<span class="squire-answer-work__title">Working</span>');
+    expect(body).toContain('class="squire-answer-work__status" data-answer-work-status');
     expect(body).toContain('data-answer-work-status');
     expect(body).toContain('data-answer-work-rows');
     expect(body).toMatch(
@@ -1362,19 +1362,14 @@ describe('GET / — SQR-107 purpose-built landing', () => {
       );
     }
 
-    function expectProgressVisibilityDefaults(markup: string): void {
-      expect(markup).toMatch(/data-progress-visibility-choice="compact"\s+aria-pressed="false"/);
-      expect(markup).toMatch(/data-progress-visibility-choice="normal"\s+aria-pressed="true"/);
-      expect(markup).toMatch(/data-progress-visibility-choice="expanded"\s+aria-pressed="false"/);
-    }
-
     it('renders a collapsed checked-source work log inside the answer element for a single source', () => {
       const body = renderTranscriptAnswer(answerWith(['search_rules']));
       expect(body).toMatch(
-        /class="squire-turn squire-answer"[\s\S]*<details[^>]*class="squire-answer-work"[^>]*data-work-state="complete"[\s\S]*Work log[\s\S]*Checked 1 source[\s\S]*CHECKED[\s\S]*Rulebook[\s\S]*<\/details>/,
+        /class="squire-turn squire-answer"[\s\S]*<details[^>]*class="squire-answer-work"[^>]*data-work-state="complete"[\s\S]*Checked 1 source[\s\S]*Checked rulebook[\s\S]*<\/details>/,
       );
-      expect(body).toContain('aria-label="Progress detail"');
-      expectProgressVisibilityDefaults(body);
+      expect(body).not.toContain('Work log');
+      expect(body).not.toContain('aria-label="Progress detail"');
+      expect(body).not.toContain('data-progress-visibility-choice');
       expect(body).not.toContain('CONSULTED');
       expect(body).not.toContain('class="squire-toolcall"');
     });
@@ -1383,14 +1378,12 @@ describe('GET / — SQR-107 purpose-built landing', () => {
       const body = renderTranscriptAnswer(
         answerWith(['search_rules', 'search_cards', 'search_rules', 'get_card', 'get_section']),
       );
-      expect(body).toMatch(
-        /CHECKED[\s\S]*Rulebook[\s\S]*CHECKED[\s\S]*Card Index[\s\S]*CHECKED[\s\S]*Section Book/,
-      );
+      expect(body).toMatch(/Checked rulebook[\s\S]*Checked card index[\s\S]*Checked section book/);
       expect(body).not.toContain('CONSULTED');
       // The RULEBOOK-first ordering is the insertion-order contract — ensure
       // CARD INDEX doesn't leapfrog ahead of RULEBOOK just because more
       // card-family tools were called.
-      expect(body.indexOf('Rulebook')).toBeLessThan(body.indexOf('Card Index'));
+      expect(body.indexOf('Checked rulebook')).toBeLessThan(body.indexOf('Checked card index'));
     });
 
     it('renders no source work log when consultedSources is null (pre-SQR-98 rows)', () => {
@@ -1426,7 +1419,7 @@ describe('GET / — SQR-107 purpose-built landing', () => {
       const body = renderTranscriptAnswer(
         answerWith(['find_scenario', 'get_scenario', 'get_section']),
       );
-      expect(body).toMatch(/CHECKED[\s\S]*Scenario Book[\s\S]*CHECKED[\s\S]*Section Book/);
+      expect(body).toMatch(/Checked scenario book[\s\S]*Checked section book/);
       expect(body).not.toContain('CONSULTED');
     });
 
@@ -1443,8 +1436,9 @@ describe('GET / — SQR-107 purpose-built landing', () => {
       expect(body).toMatch(/squire-answer--pending[\s\S]*class="squire-answer-work"/);
       const pendingAnswer = body.match(/<article[\s\S]*?squire-answer--pending[\s\S]*?<\/article>/);
       expect(pendingAnswer).not.toBeNull();
-      expect(pendingAnswer?.[0]).toContain('aria-label="Progress detail"');
-      expectProgressVisibilityDefaults(pendingAnswer?.[0] ?? '');
+      expect(pendingAnswer?.[0]).toContain('data-answer-work-status');
+      expect(pendingAnswer?.[0]).not.toContain('aria-label="Progress detail"');
+      expect(pendingAnswer?.[0]).not.toContain('data-progress-visibility-choice');
       expect(body).not.toContain('class="squire-toolcall"');
       expect(body).not.toContain('data-testid="consulted-footer"');
     });

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -63,6 +63,10 @@ class FakeElement {
   }
 
   appendChild(child: FakeElement) {
+    if (child.parentNode) {
+      const existingIndex = child.parentNode.children.indexOf(child);
+      if (existingIndex !== -1) child.parentNode.children.splice(existingIndex, 1);
+    }
     child.parentNode = this;
     this.children.push(child);
     return child;
@@ -126,10 +130,6 @@ class FakeElement {
     if (selector.startsWith('.')) {
       const className = selector.slice(1);
       return this.classList.contains(className) || this.className.split(/\s+/).includes(className);
-    }
-
-    if (selector === '[data-progress-visibility-choice]') {
-      return Boolean(this.dataset.progressVisibilityChoice);
     }
 
     return false;
@@ -261,26 +261,13 @@ function bootPendingTranscript() {
   workEl.setAttribute('data-work-state', 'idle');
   const workSummaryEl = new FakeElement('summary');
   workSummaryEl.classList.add('squire-answer-work__summary');
-  const workTitleEl = new FakeElement('span');
-  workTitleEl.classList.add('squire-answer-work__title');
   const workStatusEl = new FakeElement('span');
   workStatusEl.classList.add('squire-answer-work__status');
   workStatusEl.setAttribute('data-answer-work-status', '');
-  const workVisibilityEl = new FakeElement('span');
-  workVisibilityEl.classList.add('squire-answer-work__visibility');
-  const workModeButtons = ['compact', 'normal', 'expanded'].map((mode) => {
-    const button = new FakeElement('button');
-    button.classList.add('squire-answer-work__visibility-button');
-    button.setAttribute('data-progress-visibility-choice', mode);
-    workVisibilityEl.appendChild(button);
-    return button;
-  });
   const workRowsEl = new FakeElement('div');
   workRowsEl.classList.add('squire-answer-work__rows');
   workRowsEl.setAttribute('data-answer-work-rows', '');
-  workSummaryEl.appendChild(workTitleEl);
   workSummaryEl.appendChild(workStatusEl);
-  workSummaryEl.appendChild(workVisibilityEl);
   workEl.appendChild(workSummaryEl);
   workEl.appendChild(workRowsEl);
   const artifactsEl = new FakeElement('div');
@@ -324,9 +311,6 @@ function bootPendingTranscript() {
       return null;
     },
     querySelectorAll(selector: string) {
-      if (selector === '[data-progress-visibility-choice]') {
-        return workModeButtons;
-      }
       if (selector === '.squire-answer-work') {
         return [workEl];
       }
@@ -396,20 +380,17 @@ function bootPendingTranscript() {
     source,
     storedValues,
     workEl,
-    workModeButtons,
     workRowsEl,
     workStatusEl,
-    clickDocument(target: FakeElement) {
-      const event = {
-        target,
-        preventDefault() {},
-        stopPropagation() {},
-      };
-      for (const callback of listeners.get('click') ?? []) {
-        callback(event);
-      }
-    },
   };
+}
+
+function workRowMessage(row: FakeElement): string | undefined {
+  return row.querySelector('.squire-answer-work__row-detail')?.textContent;
+}
+
+function workRowMessages(rowsEl: FakeElement): Array<string | undefined> {
+  return rowsEl.children.map((row) => workRowMessage(row));
 }
 
 describe('squire.js chat form retargeting', () => {
@@ -588,14 +569,12 @@ describe('squire.js chat form retargeting', () => {
 
     source.emit('tool-start', { id: 'search_rules', label: 'RULEBOOK' });
 
-    const row = workRowsEl.children[0];
-    expect(row).toBeTruthy();
-    expect(row.querySelector('.squire-answer-work__row-label')?.textContent).toBe('CHECKING');
-    expect(row.querySelector('.squire-answer-work__row-detail')?.textContent).toBe('Rulebook');
+    expect(workRowsEl.children).toHaveLength(0);
 
     source.emit('tool-result', { id: 'search_rules', labels: ['RULEBOOK'], ok: true });
-    expect(row.querySelector('.squire-answer-work__row-label')?.textContent).toBe('CHECKED');
-    expect(row.querySelector('.squire-answer-work__row-detail')?.textContent).toBe('Rulebook');
+    const row = workRowsEl.children[0];
+    expect(row).toBeTruthy();
+    expect(workRowMessage(row)).toBe('Checked rulebook');
 
     source.emit('text-delta', { delta: 'Loot 2 can reach up to two hexes away.' });
     expect(skeletonEl.hidden).toBe(true);
@@ -631,24 +610,13 @@ describe('squire.js chat form retargeting', () => {
     expect(workEl.getAttribute('data-work-state')).toBe('running');
     expect(workRowsEl.children).toHaveLength(1);
     const progressRow = workRowsEl.children[0];
-    expect(progressRow.querySelector('.squire-answer-work__row-label')?.textContent).toBe(
-      'SEARCHING',
-    );
-    expect(progressRow.querySelector('.squire-answer-work__row-detail')?.textContent).toBe(
-      'Found Locked Down',
-    );
-    expect(progressRow.querySelector('.squire-answer-work__row-source')?.textContent).toBe(
-      'Section Book',
-    );
+    expect(workRowMessage(progressRow)).toBe('Found Locked Down in section book');
 
     source.emit('tool-result', { id: 'follow_links', labels: ['SECTION BOOK'], ok: true });
-    expect(progressRow.querySelector('.squire-answer-work__row-label')?.textContent).toBe(
-      'CHECKED',
-    );
-    expect(progressRow.querySelector('.squire-answer-work__row-detail')?.textContent).toBe(
-      'Section Book',
-    );
-    expect(progressRow.querySelector('.squire-answer-work__row-source')?.textContent).toBe('');
+    expect(workRowMessage(progressRow)).toBe('Found Locked Down in section book');
+    expect(workRowsEl.children).toHaveLength(2);
+    const checkedRow = workRowsEl.children[1];
+    expect(workRowMessage(checkedRow)).toBe('Checked section book');
 
     source.emit('done', {
       html: '<p>The section is <strong>Locked Down</strong>.</p>',
@@ -658,7 +626,7 @@ describe('squire.js chat form retargeting', () => {
     expect(workEl.open).toBe(false);
     expect(workEl.getAttribute('data-work-state')).toBe('complete');
     expect(workStatusEl.textContent).toBe('Checked 1 source');
-    expect(workRowsEl.children).toHaveLength(1);
+    expect(workRowsEl.children).toHaveLength(2);
     expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
   });
 
@@ -674,14 +642,8 @@ describe('squire.js chat form retargeting', () => {
 
     expect(workEl.open).toBe(true);
     expect(workEl.getAttribute('data-work-state')).toBe('running');
-    expect(workStatusEl.textContent).toBe('Checking sources');
-    expect(workRowsEl.children).toHaveLength(1);
-    expect(
-      workRowsEl.children[0].querySelector('.squire-answer-work__row-label')?.textContent,
-    ).toBe('CHECKING');
-    expect(
-      workRowsEl.children[0].querySelector('.squire-answer-work__row-detail')?.textContent,
-    ).toBe('Rulebook');
+    expect(workStatusEl.textContent).toBe('Working');
+    expect(workRowsEl.children).toHaveLength(0);
 
     source.emit('tool-progress', {
       id: 'search_rules-progress-1',
@@ -690,15 +652,7 @@ describe('squire.js chat form retargeting', () => {
     });
 
     expect(workRowsEl.children).toHaveLength(1);
-    expect(
-      workRowsEl.children[0].querySelector('.squire-answer-work__row-label')?.textContent,
-    ).toBe('SEARCHING');
-    expect(
-      workRowsEl.children[0].querySelector('.squire-answer-work__row-detail')?.textContent,
-    ).toBe('Checking line of sight');
-    expect(
-      workRowsEl.children[0].querySelector('.squire-answer-work__row-source')?.textContent,
-    ).toBe('Rulebook');
+    expect(workRowMessage(workRowsEl.children[0])).toBe('Checking line of sight in rulebook');
 
     source.emit('done', { html: '<p>Answer.</p>' });
 
@@ -709,43 +663,88 @@ describe('squire.js chat form retargeting', () => {
     expect(workStatusEl.textContent).toBe('Checked 1 source');
   });
 
-  it('switches progress detail during an active run without losing the stream', () => {
-    const {
-      clickDocument,
-      contentEl,
-      documentElement,
-      source,
-      storedValues,
-      workEl,
-      workModeButtons,
-      workRowsEl,
-    } = bootPendingTranscript();
+  it('does not render obsolete progress detail controls during an active run', () => {
+    const { contentEl, source, storedValues, workEl, workRowsEl } = bootPendingTranscript();
 
     source.emit('tool-start', { id: 'search_rules', label: 'RULEBOOK' });
 
     expect(workEl.open).toBe(true);
-    expect(workRowsEl.children).toHaveLength(1);
-    expect(documentElement.getAttribute('data-progress-visibility')).toBe('normal');
-
-    const expandedButton = workModeButtons.find(
-      (button) => button.dataset.progressVisibilityChoice === 'expanded',
-    );
-    if (!expandedButton) throw new Error('expanded progress button missing from fixture');
-    clickDocument(expandedButton);
-
-    expect(source.closed).toBe(false);
-    expect(workEl.open).toBe(true);
-    expect(documentElement.getAttribute('data-progress-visibility')).toBe('expanded');
-    expect(expandedButton.getAttribute('aria-pressed')).toBe('true');
-    expect(storedValues.get('squire.progressVisibility')).toBe('expanded');
+    expect(workRowsEl.children).toHaveLength(0);
+    expect(workEl.querySelector('.squire-answer-work__visibility')).toBeNull();
+    expect(storedValues.get('squire.progressVisibility')).toBeUndefined();
 
     source.emit('done', { html: '<p>Answer.</p>' });
 
     expect(source.closed).toBe(true);
     expect(contentEl.innerHTML).toBe('<p>Answer.</p>');
     expect(workEl.getAttribute('data-work-state')).toBe('complete');
-    expect(workEl.open).toBe(true);
-    expect(workRowsEl.children).toHaveLength(1);
+    expect(workEl.open).toBe(false);
+    expect(workRowsEl.children).toHaveLength(0);
+  });
+
+  it('keeps progress wording stable and dedupes checked sources', () => {
+    const { source, workRowsEl, workStatusEl } = bootPendingTranscript();
+
+    source.emit('tool-progress', {
+      id: 'search_knowledge-progress-3',
+      label: 'REFERENCE',
+      message: 'Searching selected sources',
+    });
+    source.emit('tool-result', { id: 'search_cards', labels: ['CARD INDEX'], ok: true });
+    source.emit('tool-result', { id: 'get_card', labels: ['CARD INDEX'], ok: true });
+    source.emit('tool-result', {
+      id: 'search_rules',
+      labels: ['RULEBOOK'],
+      ok: true,
+    });
+    source.emit('tool-progress', {
+      id: 'resolve_entity-progress-1',
+      label: 'REFERENCE',
+      message: 'Resolving bandit archer monster',
+    });
+    source.emit('tool-progress', {
+      id: 'resolve_entity-progress-2',
+      label: 'REFERENCE',
+      message: 'Resolving bandit archer monster stat card',
+    });
+    source.emit('tool-result', {
+      id: 'search_sections',
+      labels: ['SECTION BOOK'],
+      ok: true,
+    });
+    source.emit('done', { html: '<p>Answer.</p>' });
+
+    expect(workStatusEl.textContent).toBe('Checked 3 sources');
+    expect(workRowsEl.children).toHaveLength(5);
+    expect(workRowMessages(workRowsEl)).toEqual([
+      'Resolving bandit archer stats',
+      'Searching available sources',
+      'Checked card index',
+      'Checked rulebook',
+      'Checked section book',
+    ]);
+  });
+
+  it('keeps semantic work-log order when resolving and searching arrive after checked rows', () => {
+    const { source, workRowsEl } = bootPendingTranscript();
+
+    source.emit('tool-result', { id: 'search_cards', labels: ['CARD INDEX'], ok: true });
+    source.emit('tool-progress', {
+      id: 'resolve_entity-progress-1',
+      label: 'REFERENCE',
+      message: 'Resolving bandit archer monster',
+    });
+    source.emit('tool-progress', {
+      id: 'search_knowledge-progress-2',
+      label: 'REFERENCE',
+      message: 'Searching selected sources',
+    });
+
+    expect(workRowMessages(workRowsEl)).toEqual([
+      'Resolving bandit archer stats',
+      'Searching available sources',
+      'Checked card index',
+    ]);
   });
 
   it('keeps inline work details open when the stream errors', () => {
@@ -758,7 +757,7 @@ describe('squire.js chat form retargeting', () => {
     expect(workEl.hidden).toBe(false);
     expect(workEl.open).toBe(true);
     expect(workEl.getAttribute('data-work-state')).toBe('error');
-    expect(workRowsEl.children).toHaveLength(1);
+    expect(workRowsEl.children).toHaveLength(0);
     expect(workStatusEl.textContent).toBe('Stopped before answer');
   });
 
@@ -777,14 +776,8 @@ describe('squire.js chat form retargeting', () => {
     expect(contentEl.querySelector('p')).toBeNull();
     expect(workRowsEl.children).toHaveLength(1);
     expect(
-      workRowsEl.children[0].querySelector('.squire-answer-work__row-label')?.textContent,
-    ).toBe('FOUND');
-    expect(
       workRowsEl.children[0].querySelector('.squire-answer-work__row-detail')?.textContent,
-    ).toBe('Locked Down');
-    expect(
-      workRowsEl.children[0].querySelector('.squire-answer-work__row-source')?.textContent,
-    ).toBe('Section Book');
+    ).toBe('Found Locked Down in section book');
     expect(artifactsEl.children).toHaveLength(1);
     const artifact = artifactsEl.children[0];
     expect(artifact.querySelector('.squire-answer__artifact-title')?.textContent).toBe('');
@@ -816,7 +809,7 @@ describe('squire.js chat form retargeting', () => {
   // order, the REFERENCE fallback filter (utility tools shouldn't leak
   // into the work log), and the empty/error paths.
   describe('SQR-98 source work log', () => {
-    it('renders CHECKED Rulebook and CHECKED Card Index in insertion order', () => {
+    it('renders checked source messages in insertion order', () => {
       const { answerEl, source, workRowsEl } = bootPendingTranscript();
 
       source.emit('tool-start', { id: 'search_rules', label: 'RULEBOOK' });
@@ -827,18 +820,7 @@ describe('squire.js chat form retargeting', () => {
 
       expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
       expect(workRowsEl.children).toHaveLength(2);
-      expect(
-        workRowsEl.children[0].querySelector('.squire-answer-work__row-label')?.textContent,
-      ).toBe('CHECKED');
-      expect(
-        workRowsEl.children[0].querySelector('.squire-answer-work__row-detail')?.textContent,
-      ).toBe('Rulebook');
-      expect(
-        workRowsEl.children[1].querySelector('.squire-answer-work__row-label')?.textContent,
-      ).toBe('CHECKED');
-      expect(
-        workRowsEl.children[1].querySelector('.squire-answer-work__row-detail')?.textContent,
-      ).toBe('Card Index');
+      expect(workRowMessages(workRowsEl)).toEqual(['Checked rulebook', 'Checked card index']);
     });
 
     it('dedupes repeated labels and preserves first-seen order', () => {
@@ -851,12 +833,7 @@ describe('squire.js chat form retargeting', () => {
 
       expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
       expect(workRowsEl.children).toHaveLength(2);
-      expect(
-        workRowsEl.children[0].querySelector('.squire-answer-work__row-detail')?.textContent,
-      ).toBe('Rulebook');
-      expect(
-        workRowsEl.children[1].querySelector('.squire-answer-work__row-detail')?.textContent,
-      ).toBe('Card Index');
+      expect(workRowMessages(workRowsEl)).toEqual(['Checked rulebook', 'Checked card index']);
     });
 
     it('excludes labels from failed tool calls', () => {
@@ -868,18 +845,10 @@ describe('squire.js chat form retargeting', () => {
 
       expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
       expect(workRowsEl.children).toHaveLength(2);
-      expect(
-        workRowsEl.children[0].querySelector('.squire-answer-work__row-label')?.textContent,
-      ).toBe("COULDN'T CHECK");
-      expect(
-        workRowsEl.children[0].querySelector('.squire-answer-work__row-detail')?.textContent,
-      ).toBe('Rulebook');
-      expect(
-        workRowsEl.children[1].querySelector('.squire-answer-work__row-label')?.textContent,
-      ).toBe('CHECKED');
-      expect(
-        workRowsEl.children[1].querySelector('.squire-answer-work__row-detail')?.textContent,
-      ).toBe('Card Index');
+      expect(workRowMessages(workRowsEl)).toEqual([
+        'Checked card index',
+        "Couldn't check rulebook",
+      ]);
     });
 
     it('ignores the REFERENCE fallback label (utility/traversal tools)', () => {
@@ -912,21 +881,13 @@ describe('squire.js chat form retargeting', () => {
       source.emit('done', { html: '<p>Answer.</p>' });
 
       expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
-      expect(workRowsEl.children).toHaveLength(2);
-      const rulebookRow = workRowsEl.children[0];
-      const sectionBookRow = workRowsEl.children[1];
-      expect(rulebookRow.querySelector('.squire-answer-work__row-label')?.textContent).toBe(
-        'CHECKED',
-      );
-      expect(rulebookRow.querySelector('.squire-answer-work__row-detail')?.textContent).toBe(
-        'Rulebook',
-      );
-      expect(sectionBookRow.querySelector('.squire-answer-work__row-label')?.textContent).toBe(
-        'CHECKED',
-      );
-      expect(sectionBookRow.querySelector('.squire-answer-work__row-detail')?.textContent).toBe(
-        'Section Book',
-      );
+      expect(workRowsEl.children).toHaveLength(3);
+      const searchRow = workRowsEl.children[0];
+      const rulebookRow = workRowsEl.children[1];
+      const sectionBookRow = workRowsEl.children[2];
+      expect(workRowMessage(searchRow)).toBe('Searching available sources');
+      expect(workRowMessage(rulebookRow)).toBe('Checked rulebook');
+      expect(workRowMessage(sectionBookRow)).toBe('Checked section book');
     });
 
     it('leaves no source UI on done when no tools fired', () => {
@@ -1003,10 +964,7 @@ describe('squire.js chat form retargeting', () => {
 
     const row = workRowsEl.children[0];
     expect(row?.classList.contains('is-error')).toBe(true);
-    expect(row?.querySelector('.squire-answer-work__row-label')?.textContent).toBe(
-      "COULDN'T CHECK",
-    );
-    expect(row?.querySelector('.squire-answer-work__row-detail')?.textContent).toBe('Rulebook');
+    expect(row ? workRowMessage(row) : undefined).toBe("Couldn't check rulebook");
   });
 
   it('ignores late tool-status events once answer prose is already on screen', () => {

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -747,6 +747,18 @@ describe('squire.js chat form retargeting', () => {
     ]);
   });
 
+  it('keeps generic source-search wording exact when the progress event has a source label', () => {
+    const { source, workRowsEl } = bootPendingTranscript();
+
+    source.emit('tool-progress', {
+      id: 'search_rules-progress-1',
+      label: 'RULEBOOK',
+      message: 'Searching selected sources',
+    });
+
+    expect(workRowMessages(workRowsEl)).toEqual(['Searching available sources']);
+  });
+
   it('keeps inline work details open when the stream errors', () => {
     const { answerEl, source, workEl, workRowsEl, workStatusEl } = bootPendingTranscript();
 
@@ -849,6 +861,17 @@ describe('squire.js chat form retargeting', () => {
         'Checked card index',
         "Couldn't check rulebook",
       ]);
+    });
+
+    it('does not count failed-only source checks as checked sources', () => {
+      const { source, workRowsEl, workStatusEl } = bootPendingTranscript();
+
+      source.emit('tool-result', { id: 'search_rules', labels: ['RULEBOOK'], ok: false });
+      source.emit('done', { html: '<p>Answer.</p>' });
+
+      expect(workRowsEl.children).toHaveLength(1);
+      expect(workRowMessages(workRowsEl)).toEqual(["Couldn't check rulebook"]);
+      expect(workStatusEl.textContent).toBe('Recorded 1 step');
     });
 
     it('ignores the REFERENCE fallback label (utility/traversal tools)', () => {


### PR DESCRIPTION
## Summary
- Remove the work-log display-density controls and header chrome so the disclosure is state-driven.
- Render work-log rows as standalone stable messages without `SEARCHING` / `CHECKED` prefixes.
- Deduplicate checked sources and sort events semantically: resolving, source search, then checked sources.
- Update saved-answer rendering, CSS, design notes, and regression coverage.

## Review
- Pre-landing review found one ordering issue in the DOM reorder helper; fixed before commit.
- No remaining review findings after the fix.

## Validation
- `npm run check`
- `npm run e2e:browser:prepare && npx playwright test test/e2e/sqr-24-chat-game-selection.spec.ts -g "keeps work log expanded while running and collapses it after completion" --config=playwright.e2e.config.ts --project=desktop`

## Documentation
- Updated `DESIGN.md` with the state-driven, text-only, stable-order work-log contract.

Fixes SQR-255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/UX Improvements**
  * Work log now opens while the assistant is working, collapses when ready, and stays open on errors.
  * Per-source rows use stable, deduplicated phrasing like “Checked <source>” and deterministic ordering; collapsed summary shows “Checked N sources.”
  * Removed manual progress-density controls and related chrome for a cleaner interface.
  * Updated visuals: tighter row layout, rotated chevron summary icon, and improved mobile alignment.

* **Documentation**
  * Layout and decisions docs updated to reflect the new state-driven work-log behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->