### PR TITLE
Persist completed work timelines

### DIFF
--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -4,6 +4,7 @@ import { ask, type HistoryMessage, type EmitFn } from '../service.ts';
 import { getDb } from '../db.ts';
 import * as ConversationRepository from '../db/repositories/conversation-repository.ts';
 import * as MessageRepository from '../db/repositories/message-repository.ts';
+import * as MessageStreamEventRepository from '../db/repositories/message-stream-event-repository.ts';
 import type {
   Conversation,
   ConversationHistoryCursor,
@@ -640,5 +641,28 @@ export async function loadConversation(input: {
     }
   }
 
-  return { conversation, messages };
+  // SQR-261: completed work logs reload from the same browser-safe SSE rows
+  // the live client saw. That keeps persisted timelines inspectable without a
+  // second storage shape for raw tool payloads or hidden reasoning.
+  const responseUserMessageIds = [
+    ...new Set(
+      messages.flatMap((message) =>
+        message.role === 'assistant' && message.responseToMessageId
+          ? [message.responseToMessageId]
+          : [],
+      ),
+    ),
+  ];
+  const publicWorkEventsByUserMessage =
+    await MessageStreamEventRepository.listPublicWorkEventsByUserMessageIds(responseUserMessageIds);
+  const messagesWithPublicWorkEvents = messages.map((message) =>
+    message.role === 'assistant' && message.responseToMessageId
+      ? {
+          ...message,
+          publicWorkEvents: publicWorkEventsByUserMessage.get(message.responseToMessageId) ?? [],
+        }
+      : message,
+  );
+
+  return { conversation, messages: messagesWithPublicWorkEvents };
 }

--- a/src/db/repositories/message-stream-event-repository.ts
+++ b/src/db/repositories/message-stream-event-repository.ts
@@ -1,7 +1,11 @@
-import { and, asc, eq, gt, sql } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, sql } from 'drizzle-orm';
 
 import { getDb } from '../../db.ts';
 import { messageStreamEvents } from '../schema/conversations.ts';
+import type {
+  ConversationMessagePublicWorkEvent,
+  ConversationMessagePublicWorkEventName,
+} from './types.ts';
 
 export type BrowserStreamEventName =
   | 'text-delta'
@@ -20,6 +24,11 @@ export interface MessageStreamEvent {
 }
 
 const TERMINAL_EVENTS = new Set<BrowserStreamEventName>(['done', 'error']);
+const PUBLIC_WORK_EVENTS: ConversationMessagePublicWorkEventName[] = [
+  'tool-progress',
+  'tool-result',
+  'answer-artifact',
+];
 
 function isUniqueViolation(error: unknown): boolean {
   return (
@@ -71,6 +80,41 @@ export async function findTerminal(userMessageId: string): Promise<MessageStream
     .orderBy(asc(messageStreamEvents.sequence));
   const terminal = rows.find((row) => row.event === 'done' || row.event === 'error');
   return terminal ? toDomain(terminal) : null;
+}
+
+export async function listPublicWorkEventsByUserMessageIds(
+  userMessageIds: string[],
+): Promise<Map<string, ConversationMessagePublicWorkEvent[]>> {
+  const eventsByUserMessage = new Map<string, ConversationMessagePublicWorkEvent[]>();
+  if (userMessageIds.length === 0) return eventsByUserMessage;
+
+  const { db } = getDb('server');
+  const rows = await db
+    .select()
+    .from(messageStreamEvents)
+    .where(
+      and(
+        inArray(messageStreamEvents.userMessageId, userMessageIds),
+        inArray(messageStreamEvents.event, PUBLIC_WORK_EVENTS),
+      ),
+    )
+    .orderBy(asc(messageStreamEvents.userMessageId), asc(messageStreamEvents.sequence));
+
+  for (const row of rows) {
+    const event = row.event as ConversationMessagePublicWorkEventName;
+    if (!PUBLIC_WORK_EVENTS.includes(event)) continue;
+    const entry: ConversationMessagePublicWorkEvent = {
+      sequence: row.sequence,
+      event,
+      payload: row.payload,
+      createdAt: row.createdAt,
+    };
+    const existing = eventsByUserMessage.get(row.userMessageId) ?? [];
+    existing.push(entry);
+    eventsByUserMessage.set(row.userMessageId, existing);
+  }
+
+  return eventsByUserMessage;
 }
 
 async function insertNext(input: {

--- a/src/db/repositories/types.ts
+++ b/src/db/repositories/types.ts
@@ -86,6 +86,18 @@ export interface ConversationHistoryPage {
   nextCursor: ConversationHistoryCursor | null;
 }
 
+export type ConversationMessagePublicWorkEventName =
+  | 'tool-progress'
+  | 'tool-result'
+  | 'answer-artifact';
+
+export interface ConversationMessagePublicWorkEvent {
+  sequence: number;
+  event: ConversationMessagePublicWorkEventName;
+  payload: Record<string, unknown>;
+  createdAt: Date;
+}
+
 export interface ConversationMessage {
   id: string;
   conversationId: string;
@@ -112,6 +124,13 @@ export interface ConversationMessage {
    * render time — no migration is needed.
    */
   consultedSources: string[] | null;
+  /**
+   * Completed browser-safe work timeline for this assistant turn, loaded from
+   * `message_stream_events` by conversation-service on page-render paths.
+   * The payloads are the same public SSE payloads the browser already saw,
+   * not raw tool payloads or hidden model reasoning.
+   */
+  publicWorkEvents?: ConversationMessagePublicWorkEvent[];
   createdAt: Date;
 }
 

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -30,7 +30,11 @@ import {
   UNSUPPORTED_MARKDOWN_SPECIMEN,
 } from './markdown-styleguide.ts';
 import { DEFAULT_GAME_ID, SUPPORTED_GAME_IDS, SUPPORTED_GAMES } from '../game.ts';
-import type { ConversationMessage, Session } from '../db/repositories/types.ts';
+import type {
+  ConversationMessage,
+  ConversationMessagePublicWorkEvent,
+  Session,
+} from '../db/repositories/types.ts';
 import type {
   ConversationHistoryStatus,
   ConversationHistoryViewModel,
@@ -436,39 +440,251 @@ function sentenceToolSourceLabel(label: ToolSourceLabel): string {
   return displayToolSourceLabel(label).toLowerCase();
 }
 
-function renderCompletedAnswerWork(message: ConversationMessage): HtmlEscapedString {
-  if (message.isError || !message.consultedSources || message.consultedSources.length === 0) {
-    return html`` as HtmlEscapedString;
+interface CompletedAnswerWorkRow {
+  id: string;
+  detail: string;
+  sourceLabels: ToolSourceLabel[];
+  state: 'complete' | 'error';
+  sort: number;
+  ordinal: number;
+}
+
+interface CompletedAnswerWorkTimeline {
+  rows: CompletedAnswerWorkRow[];
+  sourceCount: number;
+}
+
+function answerWorkSlug(value: string | undefined, fallback: string): string {
+  const slug = (value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || fallback;
+}
+
+function baseAnswerWorkId(rowId: string | undefined): string | undefined {
+  return rowId?.replace(/-progress-\d+$/, '');
+}
+
+function payloadString(payload: Record<string, unknown>, key: string): string | null {
+  const value = payload[key];
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function payloadSourceLabels(value: unknown): ToolSourceLabel[] {
+  if (!Array.isArray(value)) return [];
+  return aggregateSourceLabels(value.filter((entry): entry is string => typeof entry === 'string'));
+}
+
+function payloadSourceLabel(value: unknown): ToolSourceLabel | null {
+  if (typeof value !== 'string') return null;
+  return aggregateSourceLabels([value])[0] ?? null;
+}
+
+function genericAnswerWorkProgressDetail(message: string): string {
+  const resolvingMonster = message.match(/^Resolving\s+(.+?)\s+monster(?:\s+stat(?:\s+card)?)?$/i);
+  if (resolvingMonster) return `Resolving ${resolvingMonster[1]!.trim()} stats`;
+  if (message === 'Searching selected sources') return 'Searching available sources';
+  if (message === 'Searching knowledge') return 'Searching available sources';
+  return message;
+}
+
+function answerWorkProgressRowId(rowId: string | null, detail: string): string {
+  const baseId = baseAnswerWorkId(rowId ?? undefined) ?? 'progress';
+  const normalizedDetail = detail.toLowerCase();
+  if (normalizedDetail.startsWith('resolving ')) {
+    return `progress-resolving-${answerWorkSlug(detail, 'event')}`;
   }
-  const labels = aggregateSourceLabels(message.consultedSources);
-  if (labels.length === 0) {
-    return html`` as HtmlEscapedString;
+  if (normalizedDetail === 'searching available sources') {
+    return 'progress-searching-available-sources';
   }
+  return `${baseId}-progress-${answerWorkSlug(detail, 'event')}`;
+}
+
+function answerWorkProgressSort(detail: string): number {
+  const normalizedDetail = detail.toLowerCase();
+  if (normalizedDetail.startsWith('resolving ')) return 10;
+  if (normalizedDetail === 'searching available sources') return 20;
+  return 30;
+}
+
+function answerWorkCheckedSourceRowId(label: ToolSourceLabel, ok: boolean, index: number): string {
+  return `${ok ? 'checked-source-' : 'failed-source-'}${answerWorkSlug(label, String(index))}`;
+}
+
+function answerWorkProgressMessage(detail: string, sourceLabel: ToolSourceLabel | null): string {
+  if (detail === 'Searching available sources') return detail;
+  if (!sourceLabel) return detail || 'Checking sources';
+
+  const source = sentenceToolSourceLabel(sourceLabel);
+  if (detail && !detail.toLowerCase().includes(source)) {
+    return `${detail} in ${source}`;
+  }
+  return detail || 'Checking sources';
+}
+
+function answerWorkArtifactMessage(title: string, sourceLabel: ToolSourceLabel | null): string {
+  return `Found ${title || 'source'}${sourceLabel ? ` in ${sentenceToolSourceLabel(sourceLabel)}` : ''}`;
+}
+
+function addCompletedAnswerWorkRow(
+  rows: Map<string, CompletedAnswerWorkRow>,
+  input: Omit<CompletedAnswerWorkRow, 'ordinal'>,
+): CompletedAnswerWorkRow {
+  const existing = rows.get(input.id);
+  if (existing) return existing;
+  const row = { ...input, ordinal: rows.size };
+  rows.set(input.id, row);
+  return row;
+}
+
+function countTimelineSourceLabels(rows: CompletedAnswerWorkRow[]): number {
+  const labels = new Set<ToolSourceLabel>();
+  for (const row of rows) {
+    for (const label of row.sourceLabels) labels.add(label);
+  }
+  return labels.size;
+}
+
+function buildCompletedAnswerWorkTimeline(
+  events: readonly ConversationMessagePublicWorkEvent[] | undefined,
+): CompletedAnswerWorkTimeline {
+  const rows = new Map<string, CompletedAnswerWorkRow>();
+  const successfulSources = new Set<ToolSourceLabel>();
+
+  for (const event of events ?? []) {
+    const payload = event.payload ?? {};
+    if (event.event === 'tool-progress') {
+      const rawMessage = payloadString(payload, 'message');
+      if (!rawMessage) continue;
+      const detail = genericAnswerWorkProgressDetail(rawMessage);
+      const sourceLabel = payloadSourceLabel(payload.label);
+      addCompletedAnswerWorkRow(rows, {
+        id: answerWorkProgressRowId(payloadString(payload, 'id'), detail),
+        detail: answerWorkProgressMessage(detail, sourceLabel),
+        sourceLabels: sourceLabel ? [sourceLabel] : [],
+        state: 'complete',
+        sort: answerWorkProgressSort(detail),
+      });
+      continue;
+    }
+
+    if (event.event === 'answer-artifact') {
+      const title = payloadString(payload, 'title');
+      if (!title) continue;
+      const sourceLabel = payloadSourceLabel(payload.sourceLabel);
+      addCompletedAnswerWorkRow(rows, {
+        id: payloadString(payload, 'id') ?? `answer-artifact-${event.sequence}`,
+        detail: answerWorkArtifactMessage(title, sourceLabel),
+        sourceLabels: sourceLabel ? [sourceLabel] : [],
+        state: 'complete',
+        sort: 40,
+      });
+      continue;
+    }
+
+    if (event.event === 'tool-result') {
+      const ok = payload.ok !== false;
+      const labels = payloadSourceLabels(payload.labels);
+      if (labels.length === 0) {
+        if (ok) continue;
+        addCompletedAnswerWorkRow(rows, {
+          id: payloadString(payload, 'id') ?? `failed-source-${event.sequence}`,
+          detail: "Couldn't check source index",
+          sourceLabels: [],
+          state: 'error',
+          sort: 90,
+        });
+        continue;
+      }
+
+      labels.forEach((label, index) => {
+        if (ok) successfulSources.add(label);
+        addCompletedAnswerWorkRow(rows, {
+          id: answerWorkCheckedSourceRowId(label, ok, index),
+          detail: `${ok ? 'Checked' : "Couldn't check"} ${sentenceToolSourceLabel(label)}`,
+          sourceLabels: ok ? [label] : [],
+          state: ok ? 'complete' : 'error',
+          sort: ok ? 50 : 90,
+        });
+      });
+    }
+  }
+
+  const orderedRows = [...rows.values()].sort((left, right) => {
+    if (left.sort !== right.sort) return left.sort - right.sort;
+    return left.ordinal - right.ordinal;
+  });
+
+  return {
+    rows: orderedRows,
+    sourceCount:
+      successfulSources.size > 0 ? successfulSources.size : countTimelineSourceLabels(orderedRows),
+  };
+}
+
+function timelineFromConsultedSources(
+  consultedSources: readonly string[] | null,
+): CompletedAnswerWorkTimeline {
+  const labels = aggregateSourceLabels(consultedSources ?? []);
+  return {
+    rows: labels.map((label, index) => ({
+      id: answerWorkCheckedSourceRowId(label, true, index),
+      detail: `Checked ${sentenceToolSourceLabel(label)}`,
+      sourceLabels: [label],
+      state: 'complete' as const,
+      sort: 50,
+      ordinal: index,
+    })),
+    sourceCount: labels.length,
+  };
+}
+
+function renderCompletedAnswerWorkTimeline(
+  timeline: CompletedAnswerWorkTimeline,
+): HtmlEscapedString {
+  if (timeline.rows.length === 0) return html`` as HtmlEscapedString;
+  const summary =
+    timeline.sourceCount > 0
+      ? `Checked ${timeline.sourceCount} ${timeline.sourceCount === 1 ? 'source' : 'sources'}`
+      : `Recorded ${timeline.rows.length} ${timeline.rows.length === 1 ? 'step' : 'steps'}`;
   return html`<details
     class="squire-answer-work"
     data-testid="answer-progress"
     data-work-state="complete"
   >
     <summary class="squire-answer-work__summary">
-      <span class="squire-answer-work__status" data-answer-work-status
-        >Checked ${labels.length} ${labels.length === 1 ? 'source' : 'sources'}</span
-      >
+      <span class="squire-answer-work__status" data-answer-work-status>${summary}</span>
     </summary>
     <div class="squire-answer-work__rows" data-answer-work-rows>
-      ${labels.map(
-        (label) =>
+      ${timeline.rows.map(
+        (row) =>
           html`<div
-            class="squire-answer-work__row"
-            data-answer-work-source-labels="${label}"
-            data-work-state="complete"
+            class="squire-answer-work__row${row.state === 'error' ? ' is-error' : ''}"
+            data-answer-work-id="${row.id}"
+            ${row.sourceLabels.length > 0
+              ? html`data-answer-work-source-labels="${row.sourceLabels.join('|')}"`
+              : html``}
+            data-work-state="${row.state}"
           >
-            <span class="squire-answer-work__row-detail"
-              >Checked ${sentenceToolSourceLabel(label)}</span
-            >
+            <span class="squire-answer-work__row-detail">${row.detail}</span>
           </div>`,
       )}
     </div>
   </details>` as HtmlEscapedString;
+}
+
+function renderCompletedAnswerWork(message: ConversationMessage): HtmlEscapedString {
+  if (message.isError) {
+    return html`` as HtmlEscapedString;
+  }
+  const persistedTimeline = buildCompletedAnswerWorkTimeline(message.publicWorkEvents);
+  if (persistedTimeline.rows.length > 0) {
+    return renderCompletedAnswerWorkTimeline(persistedTimeline);
+  }
+  return renderCompletedAnswerWorkTimeline(timelineFromConsultedSources(message.consultedSources));
 }
 
 function renderAnswerTurn(message: ConversationMessage): HtmlEscapedString {

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -60,7 +60,7 @@ import {
   loadConversationHistory,
 } from '../src/chat/conversation-service.ts';
 import { users } from '../src/db/schema/core.ts';
-import { conversations, messages } from '../src/db/schema/conversations.ts';
+import { conversations, messages, messageStreamEvents } from '../src/db/schema/conversations.ts';
 
 interface AuthContext {
   cookie: string;
@@ -2318,6 +2318,77 @@ describe('conversation web backend', () => {
     expect(page).not.toContain('<img');
     expect(page).not.toContain('href="javascript:');
     expect(page).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('renders the completed work timeline from stored stream events on reload', async () => {
+    const auth = await createAuthContext();
+    const { db } = getDb('server');
+    const [conversation] = await db
+      .insert(conversations)
+      .values({ userId: auth.userId })
+      .returning();
+    const [userMessage] = await db
+      .insert(messages)
+      .values({
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'How many hit points does a level 2 bandit archer have?',
+      })
+      .returning();
+    await db.insert(messages).values({
+      conversationId: conversation.id,
+      role: 'assistant',
+      content: 'A level 2 Bandit Archer has 6 hit points.',
+      responseToMessageId: userMessage.id,
+      consultedSources: null,
+    });
+    await db.insert(messageStreamEvents).values([
+      {
+        conversationId: conversation.id,
+        userMessageId: userMessage.id,
+        sequence: 1,
+        event: 'tool-result',
+        payload: { id: 'search_cards', labels: ['CARD INDEX'], ok: true },
+      },
+      {
+        conversationId: conversation.id,
+        userMessageId: userMessage.id,
+        sequence: 2,
+        event: 'tool-progress',
+        payload: {
+          id: 'resolve_entity-progress-1',
+          label: 'REFERENCE',
+          message: 'Resolving bandit archer monster stat card',
+        },
+      },
+      {
+        conversationId: conversation.id,
+        userMessageId: userMessage.id,
+        sequence: 3,
+        event: 'tool-result',
+        payload: { id: 'search_rules', labels: ['RULEBOOK'], ok: true },
+      },
+      {
+        conversationId: conversation.id,
+        userMessageId: userMessage.id,
+        sequence: 4,
+        event: 'done',
+        payload: {
+          html: '<p>A level 2 Bandit Archer has 6 hit points.</p>',
+          consultedSources: null,
+        },
+      },
+    ]);
+
+    const pageRes = await requestWithAuth(auth, `http://localhost:3000/chat/${conversation.id}`);
+    const page = await pageRes.text();
+
+    expect(pageRes.status).toBe(200);
+    expect(page).toContain('Checked 2 sources');
+    expect(page).toMatch(
+      /Resolving bandit archer stats[\s\S]*Checked card index[\s\S]*Checked rulebook/,
+    );
+    expect(page).not.toContain('class="squire-toolcall"');
   });
 
   it('keeps hostile streamed content inert until the final sanitized done fragment', async () => {

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -1374,6 +1374,55 @@ describe('GET / — SQR-107 purpose-built landing', () => {
       expect(body).not.toContain('class="squire-toolcall"');
     });
 
+    it('reloads the completed work timeline from persisted browser-safe stream events', () => {
+      const body = renderTranscriptAnswer(
+        answerWith(null, {
+          publicWorkEvents: [
+            {
+              sequence: 1,
+              event: 'tool-result',
+              payload: { id: 'search_cards', labels: ['CARD INDEX'], ok: true },
+              createdAt: new Date('2026-04-20T00:00:01.000Z'),
+            },
+            {
+              sequence: 2,
+              event: 'tool-progress',
+              payload: {
+                id: 'resolve_entity-progress-1',
+                label: 'REFERENCE',
+                message: 'Resolving bandit archer monster',
+              },
+              createdAt: new Date('2026-04-20T00:00:02.000Z'),
+            },
+            {
+              sequence: 3,
+              event: 'tool-progress',
+              payload: {
+                id: 'search_knowledge-progress-1',
+                label: 'REFERENCE',
+                message: 'Searching selected sources',
+              },
+              createdAt: new Date('2026-04-20T00:00:03.000Z'),
+            },
+            {
+              sequence: 4,
+              event: 'tool-result',
+              payload: { id: 'search_rules', labels: ['RULEBOOK', 'SECTION BOOK'], ok: true },
+              createdAt: new Date('2026-04-20T00:00:04.000Z'),
+            },
+          ],
+        }),
+      );
+
+      expect(body).toContain('Checked 3 sources');
+      expect(body).toMatch(
+        /Resolving bandit archer stats[\s\S]*Searching available sources[\s\S]*Checked card index[\s\S]*Checked rulebook[\s\S]*Checked section book/,
+      );
+      expect(body).not.toContain('SEARCHING');
+      expect(body).not.toContain('CHECKED');
+      expect(body).not.toContain('class="squire-toolcall"');
+    });
+
     it('aggregates multiple tool names into deduped labels, preserving insertion order', () => {
       const body = renderTranscriptAnswer(
         answerWith(['search_rules', 'search_cards', 'search_rules', 'get_card', 'get_section']),


### PR DESCRIPTION
## Summary
- Load completed assistant work timelines from browser-safe persisted SSE events.
- Render reload disclosures from the persisted public timeline, with consulted-source fallback for older rows.
- Cover renderer and real /chat reload behavior for persisted work events.

## Verification
- npm run check
- Browser smoke: test-mode server on :3371, /dev/login, reloaded seeded completed conversation; collapsed summary showed `Checked 2 sources`, disclosure opened to `Resolving bandit archer stats`, `Searching available sources`, `Checked card index`, `Checked rulebook`; no console messages or failed app requests.

Fixes SQR-261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversations now display a detailed timeline of assistant work, including tool progress, results, and artifacts
  * Work timeline persists and loads when reopening conversations
  * Improved visual feedback with error state indicators and dynamic summary counts

* **Tests**
  * Added test coverage for work timeline rendering and persistence in conversations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->