### PR TITLE
Add searchable conversation history

### DIFF
--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -40,10 +40,13 @@ export interface ConversationHistoryViewRow {
 export interface ConversationHistoryViewModel {
   rows: ConversationHistoryViewRow[];
   nextCursor: string | null;
+  query?: string;
 }
 
 const DEFAULT_HISTORY_LIMIT = 30;
 const UNTITLED_CHAT_TITLE = 'Untitled chat';
+const HISTORY_QUERY_MAX_LENGTH = 120;
+const HISTORY_TITLE_MAX_LENGTH = 72;
 const gameLabels = new Map<string, string>([
   ...SUPPORTED_GAMES.map((game) => [game.id, game.label] as const),
   ['gloomhaven-2e', 'Gloomhaven 2e'],
@@ -51,6 +54,29 @@ const gameLabels = new Map<string, string>([
 
 function normalizeHistoryText(value: string | null): string {
   return (value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function clampHistoryQuery(value: string | undefined): string {
+  return normalizeHistoryText(value ?? '')
+    .slice(0, HISTORY_QUERY_MAX_LENGTH)
+    .trim();
+}
+
+function deriveHistoryTitle(value: string | null): string {
+  const normalized = normalizeHistoryText(value);
+  if (!normalized) return UNTITLED_CHAT_TITLE;
+  if (normalized.length <= HISTORY_TITLE_MAX_LENGTH) return normalized;
+
+  // SQR-257: titles are deterministic excerpts from user-visible questions,
+  // not model-generated summaries. That keeps first-answer latency unchanged
+  // and prevents the history rail from inventing a misleading label.
+  const clipped = normalized.slice(0, HISTORY_TITLE_MAX_LENGTH + 1);
+  const lastSpace = clipped.lastIndexOf(' ');
+  const title =
+    lastSpace >= 40
+      ? clipped.slice(0, lastSpace).trim()
+      : normalized.slice(0, HISTORY_TITLE_MAX_LENGTH).trim();
+  return `${title.replace(/[,:;.!?\s]+$/, '')}...`;
 }
 
 function gameScopeLabel(gameId: string | null): string | null {
@@ -97,22 +123,33 @@ export async function loadConversationHistory(input: {
   activeStatus?: ConversationHistoryStatus;
   limit?: number;
   cursor?: string;
+  query?: string;
 }): Promise<ConversationHistoryViewModel> {
   const limit = input.limit ?? DEFAULT_HISTORY_LIMIT;
   if (!Number.isInteger(limit) || limit < 1) {
     throw new TypeError(`loadConversationHistory: limit must be a positive integer, got ${limit}`);
   }
+  const query = clampHistoryQuery(input.query);
 
-  const page = await ConversationRepository.listOwnedSummaries({
-    userId: input.userId,
-    limit,
-    cursor: decodeHistoryCursor(input.cursor),
-  });
+  const page =
+    query.length > 0
+      ? await ConversationRepository.searchOwnedSummaries({
+          userId: input.userId,
+          query,
+          limit,
+          cursor: decodeHistoryCursor(input.cursor),
+        })
+      : await ConversationRepository.listOwnedSummaries({
+          userId: input.userId,
+          limit,
+          cursor: decodeHistoryCursor(input.cursor),
+        });
 
   return {
+    query,
     rows: page.rows.map((row) => {
       const active = row.id === input.activeConversationId;
-      const title = normalizeHistoryText(row.firstUserMessageContent) || UNTITLED_CHAT_TITLE;
+      const title = deriveHistoryTitle(row.titleMessageContent);
       const preview = normalizeHistoryText(row.latestMessageContent);
       return {
         id: row.id,

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -79,6 +79,11 @@ function deriveHistoryTitle(value: string | null): string {
   return `${title.replace(/[,:;.!?\s]+$/, '')}...`;
 }
 
+function historyHref(conversationId: string, query: string): string {
+  if (!query) return `/chat/${conversationId}`;
+  return `/chat/${conversationId}?${new URLSearchParams({ historyQuery: query }).toString()}`;
+}
+
 function gameScopeLabel(gameId: string | null): string | null {
   if (!gameId) return null;
   return gameLabels.get(gameId) ?? null;
@@ -153,7 +158,7 @@ export async function loadConversationHistory(input: {
       const preview = normalizeHistoryText(row.latestMessageContent);
       return {
         id: row.id,
-        href: `/chat/${row.id}`,
+        href: historyHref(row.id, query),
         active,
         title,
         preview,

--- a/src/db/repositories/conversation-repository.ts
+++ b/src/db/repositories/conversation-repository.ts
@@ -83,7 +83,8 @@ async function loadOwnedSummaryPage(input: {
         select 1
         from messages search_message
         where search_message.conversation_id = c.id
-          and search_message.content ilike ${searchPattern} escape '\\'
+          and regexp_replace(btrim(search_message.content), '[[:space:]]+', ' ', 'g')
+            ilike ${searchPattern} escape '\\'
       )`
     : sql``;
 

--- a/src/db/repositories/conversation-repository.ts
+++ b/src/db/repositories/conversation-repository.ts
@@ -28,7 +28,7 @@ interface ConversationHistorySummaryRow {
   userId: string;
   createdAt: Date | string;
   lastMessageAt: Date | string;
-  firstUserMessageContent: string | null;
+  titleMessageContent: string | null;
   latestMessageContent: string | null;
   latestMessageRole: string | null;
   latestMessageGame: string | null;
@@ -47,7 +47,7 @@ function toHistorySummary(row: ConversationHistorySummaryRow): ConversationHisto
     userId: row.userId,
     createdAt,
     lastMessageAt,
-    firstUserMessageContent: row.firstUserMessageContent,
+    titleMessageContent: row.titleMessageContent,
     latestMessageContent: row.latestMessageContent,
     latestMessageRole:
       row.latestMessageRole === 'user' || row.latestMessageRole === 'assistant'
@@ -55,6 +55,98 @@ function toHistorySummary(row: ConversationHistorySummaryRow): ConversationHisto
         : null,
     latestMessageGame: row.latestMessageGame,
     latestMessageIsError: row.latestMessageIsError ?? false,
+  };
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (char) => `\\${char}`);
+}
+
+async function loadOwnedSummaryPage(input: {
+  userId: string;
+  limit: number;
+  cursor?: ConversationHistoryCursor | null;
+  query?: string | null;
+}): Promise<ConversationHistoryPage> {
+  if (!Number.isInteger(input.limit) || input.limit < 1) {
+    throw new TypeError(`listOwnedSummaries: limit must be a positive integer, got ${input.limit}`);
+  }
+
+  const { db } = getDb('server');
+  const pageSize = input.limit + 1;
+  const cursorFilter = input.cursor
+    ? sql`and (c.last_message_at, c.id) < (${input.cursor.lastMessageAt}, ${input.cursor.id}::uuid)`
+    : sql``;
+  const searchPattern = input.query ? `%${escapeLikePattern(input.query)}%` : null;
+  const searchFilter = searchPattern
+    ? sql`and exists (
+        select 1
+        from messages search_message
+        where search_message.conversation_id = c.id
+          and search_message.content ilike ${searchPattern} escape '\\'
+      )`
+    : sql``;
+
+  const result = await db.execute(sql`
+    with base as (
+      select c.id, c.user_id, c.created_at, c.last_message_at
+      from conversations c
+      where c.user_id = ${input.userId}
+      ${cursorFilter}
+      ${searchFilter}
+      order by c.last_message_at desc, c.id desc
+      limit ${pageSize}
+    ),
+    title_user as (
+      select distinct on (m.conversation_id)
+        m.conversation_id,
+        m.content,
+        m.game
+      from messages m
+      where m.role = 'user'
+        and length(btrim(m.content)) > 0
+        and m.conversation_id in (select id from base)
+      order by m.conversation_id, m.created_at asc, m.id asc
+    ),
+    latest_message as (
+      select distinct on (m.conversation_id)
+        m.conversation_id,
+        m.content,
+        m.role,
+        m.game,
+        m.is_error
+      from messages m
+      where m.conversation_id in (select id from base)
+      order by m.conversation_id, m.created_at desc, m.id desc
+    )
+    select
+      base.id,
+      base.user_id as "userId",
+      base.created_at as "createdAt",
+      base.last_message_at as "lastMessageAt",
+      title_user.content as "titleMessageContent",
+      latest_message.content as "latestMessageContent",
+      latest_message.role as "latestMessageRole",
+      coalesce(latest_message.game, title_user.game) as "latestMessageGame",
+      latest_message.is_error as "latestMessageIsError"
+    from base
+    left join title_user on title_user.conversation_id = base.id
+    left join latest_message on latest_message.conversation_id = base.id
+    order by base.last_message_at desc, base.id desc
+  `);
+
+  const summaries = result.rows.map((row) =>
+    toHistorySummary(row as unknown as ConversationHistorySummaryRow),
+  );
+  const pageRows = summaries.slice(0, input.limit);
+  const hasNextPage = summaries.length > input.limit;
+  const lastVisible = pageRows[pageRows.length - 1] ?? null;
+  return {
+    rows: pageRows,
+    nextCursor:
+      hasNextPage && lastVisible
+        ? { lastMessageAt: lastVisible.lastMessageAt, id: lastVisible.id }
+        : null,
   };
 }
 
@@ -76,75 +168,16 @@ export async function listOwnedSummaries(input: {
   limit: number;
   cursor?: ConversationHistoryCursor | null;
 }): Promise<ConversationHistoryPage> {
-  if (!Number.isInteger(input.limit) || input.limit < 1) {
-    throw new TypeError(`listOwnedSummaries: limit must be a positive integer, got ${input.limit}`);
-  }
+  return loadOwnedSummaryPage(input);
+}
 
-  const { db } = getDb('server');
-  const pageSize = input.limit + 1;
-  const cursorFilter = input.cursor
-    ? sql`and (c.last_message_at, c.id) < (${input.cursor.lastMessageAt}, ${input.cursor.id}::uuid)`
-    : sql``;
-
-  const result = await db.execute(sql`
-    with base as (
-      select c.id, c.user_id, c.created_at, c.last_message_at
-      from conversations c
-      where c.user_id = ${input.userId}
-      ${cursorFilter}
-      order by c.last_message_at desc, c.id desc
-      limit ${pageSize}
-    ),
-    first_user as (
-      select distinct on (m.conversation_id)
-        m.conversation_id,
-        m.content,
-        m.game
-      from messages m
-      where m.role = 'user'
-        and m.conversation_id in (select id from base)
-      order by m.conversation_id, m.created_at asc, m.id asc
-    ),
-    latest_message as (
-      select distinct on (m.conversation_id)
-        m.conversation_id,
-        m.content,
-        m.role,
-        m.game,
-        m.is_error
-      from messages m
-      where m.conversation_id in (select id from base)
-      order by m.conversation_id, m.created_at desc, m.id desc
-    )
-    select
-      base.id,
-      base.user_id as "userId",
-      base.created_at as "createdAt",
-      base.last_message_at as "lastMessageAt",
-      first_user.content as "firstUserMessageContent",
-      latest_message.content as "latestMessageContent",
-      latest_message.role as "latestMessageRole",
-      coalesce(latest_message.game, first_user.game) as "latestMessageGame",
-      latest_message.is_error as "latestMessageIsError"
-    from base
-    left join first_user on first_user.conversation_id = base.id
-    left join latest_message on latest_message.conversation_id = base.id
-    order by base.last_message_at desc, base.id desc
-  `);
-
-  const summaries = result.rows.map((row) =>
-    toHistorySummary(row as unknown as ConversationHistorySummaryRow),
-  );
-  const pageRows = summaries.slice(0, input.limit);
-  const hasNextPage = summaries.length > input.limit;
-  const lastVisible = pageRows[pageRows.length - 1] ?? null;
-  return {
-    rows: pageRows,
-    nextCursor:
-      hasNextPage && lastVisible
-        ? { lastMessageAt: lastVisible.lastMessageAt, id: lastVisible.id }
-        : null,
-  };
+export async function searchOwnedSummaries(input: {
+  userId: string;
+  query: string;
+  limit: number;
+  cursor?: ConversationHistoryCursor | null;
+}): Promise<ConversationHistoryPage> {
+  return loadOwnedSummaryPage(input);
 }
 
 export async function create(

--- a/src/db/repositories/types.ts
+++ b/src/db/repositories/types.ts
@@ -74,7 +74,7 @@ export interface ConversationHistorySummary {
   userId: string;
   createdAt: Date;
   lastMessageAt: Date;
-  firstUserMessageContent: string | null;
+  titleMessageContent: string | null;
   latestMessageContent: string | null;
   latestMessageRole: 'user' | 'assistant' | null;
   latestMessageGame: string | null;

--- a/src/server.ts
+++ b/src/server.ts
@@ -996,6 +996,11 @@ function buildToolStatusId(name: string): string {
     .replace(/^-|-$/g, '');
 }
 
+function conversationPath(conversationId: string, historyQuery?: string): string {
+  if (!historyQuery) return `/chat/${conversationId}`;
+  return `/chat/${conversationId}?${new URLSearchParams({ historyQuery }).toString()}`;
+}
+
 async function readQuestionForm(
   c: Context,
 ): Promise<{ question: string; idempotencyKey?: string; game?: string; historyQuery?: string }> {
@@ -1150,7 +1155,7 @@ app.post('/chat', async (c) => {
 
     c.header('Cache-Control', 'no-store');
     c.header('Vary', 'Cookie');
-    c.header('HX-Push-Url', `/chat/${pending.conversation.id}`);
+    c.header('HX-Push-Url', conversationPath(pending.conversation.id, historyQuery));
 
     // ADR 0012: the home form swaps `#squire-surface innerHTML` with the
     // full transcript shell (one pending turn). After the swap, squire.js
@@ -1237,8 +1242,8 @@ app.post('/chat/:conversationId/messages', async (c) => {
 
     c.header('Cache-Control', 'no-store');
     c.header('Vary', 'Cookie');
-    // Keep follow-up submissions pinned to the canonical conversation URL.
-    c.header('HX-Push-Url', `/chat/${pending.conversation.id}`);
+    // Keep follow-up submissions pinned to the current conversation URL.
+    c.header('HX-Push-Url', conversationPath(pending.conversation.id, historyQuery));
     const conversationHistory = await loadConversationHistory({
       userId: session.userId,
       activeConversationId: pending.conversation.id,

--- a/src/server.ts
+++ b/src/server.ts
@@ -580,7 +580,10 @@ app.get('/', requirePageSession(), async (c) => {
   // now builds that file before deploy so this fails before runtime.
   try {
     const session = c.get('session')!;
-    const conversationHistory = await loadConversationHistory({ userId: session.userId });
+    const conversationHistory = await loadConversationHistory({
+      userId: session.userId,
+      query: c.req.query('historyQuery'),
+    });
     c.header('Cache-Control', 'no-store');
     c.header('Vary', 'Cookie');
     return c.html(
@@ -995,11 +998,12 @@ function buildToolStatusId(name: string): string {
 
 async function readQuestionForm(
   c: Context,
-): Promise<{ question: string; idempotencyKey?: string; game?: string }> {
+): Promise<{ question: string; idempotencyKey?: string; game?: string; historyQuery?: string }> {
   const form = await c.req.formData();
   const questionValue = form.get('question');
   const idempotencyValue = form.get('idempotencyKey');
   const gameValue = form.get('game');
+  const historyQueryValue = form.get('historyQuery');
 
   return {
     question: typeof questionValue === 'string' ? questionValue.trim() : '',
@@ -1009,6 +1013,10 @@ async function readQuestionForm(
         : undefined,
     game:
       typeof gameValue === 'string' && gameValue.trim().length > 0 ? gameValue.trim() : undefined,
+    historyQuery:
+      typeof historyQueryValue === 'string' && historyQueryValue.trim().length > 0
+        ? historyQueryValue.trim()
+        : undefined,
   };
 }
 
@@ -1092,6 +1100,7 @@ app.get('/chat/:conversationId', async (c) => {
     userId: session.userId,
     activeConversationId: loaded.conversation.id,
     activeStatus: pendingStreamUrls.size > 0 ? 'running' : 'idle',
+    query: c.req.query('historyQuery'),
   });
 
   c.header('Cache-Control', 'no-store');
@@ -1119,7 +1128,7 @@ app.get('/chat/:conversationId/messages/:messageId', async (c) => {
 app.post('/chat', async (c) => {
   const requestId = correlateRequest(c);
   const session = c.get('session')!;
-  const { question, idempotencyKey, game: rawGame } = await readQuestionForm(c);
+  const { question, idempotencyKey, game: rawGame, historyQuery } = await readQuestionForm(c);
 
   if (!question) return badChatRequest(c, 'Question is required');
   if (!idempotencyKey) return badChatRequest(c, 'Idempotency key is required');
@@ -1158,6 +1167,7 @@ app.post('/chat', async (c) => {
         userId: session.userId,
         activeConversationId: loaded.conversation.id,
         activeStatus: pendingStreamUrls.size > 0 ? 'running' : 'idle',
+        query: historyQuery,
       });
       return c.html(
         renderConversationTranscriptWithHistoryOob({
@@ -1173,6 +1183,7 @@ app.post('/chat', async (c) => {
       userId: session.userId,
       activeConversationId: pending.conversation.id,
       activeStatus: 'running',
+      query: historyQuery,
     });
     return c.html(
       renderConversationTranscriptWithHistoryOob({
@@ -1205,7 +1216,7 @@ app.post('/chat', async (c) => {
 app.post('/chat/:conversationId/messages', async (c) => {
   const requestId = correlateRequest(c);
   const session = c.get('session')!;
-  const { question, game: rawGame } = await readQuestionForm(c);
+  const { question, game: rawGame, historyQuery } = await readQuestionForm(c);
   if (!question) return badChatRequest(c, 'Question is required');
   let game: string | undefined;
   try {
@@ -1232,6 +1243,7 @@ app.post('/chat/:conversationId/messages', async (c) => {
       userId: session.userId,
       activeConversationId: pending.conversation.id,
       activeStatus: 'running',
+      query: historyQuery,
     });
     // ADR 0012 E-3: append-fragment swap. The client's form posts with
     // `hx-target=".squire-transcript"` `hx-swap="beforeend"`, so we return

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -101,6 +101,7 @@ export interface LayoutShellOptions {
 const EMPTY_CONVERSATION_HISTORY: ConversationHistoryViewModel = {
   rows: [],
   nextCursor: null,
+  query: '',
 };
 
 interface DocumentOptions {
@@ -185,10 +186,13 @@ function statusLabel(status: ConversationHistoryStatus): string {
   return '';
 }
 
-function renderHistoryRows(rows: ConversationHistoryViewRow[]): HtmlEscapedString {
+function renderHistoryRows(
+  rows: ConversationHistoryViewRow[],
+  options: { query?: string } = {},
+): HtmlEscapedString {
   if (rows.length === 0) {
     return html`<div class="squire-history-empty">
-      <p>No conversations yet.</p>
+      <p>${options.query ? 'No matching conversations.' : 'No conversations yet.'}</p>
     </div>` as HtmlEscapedString;
   }
 
@@ -219,9 +223,33 @@ function renderHistoryRows(rows: ConversationHistoryViewRow[]): HtmlEscapedStrin
   })}` as HtmlEscapedString;
 }
 
+function renderConversationHistorySearch(
+  history: ConversationHistoryViewModel,
+  idSuffix: string,
+): HtmlEscapedString {
+  const query = history.query ?? '';
+  return html`<form class="squire-history-search" method="get" role="search">
+    <label class="sr-only" for="squire-history-search-${idSuffix}">Search history</label>
+    <input
+      id="squire-history-search-${idSuffix}"
+      class="squire-history-search__input"
+      type="search"
+      name="historyQuery"
+      value="${query}"
+      placeholder="Search history"
+      autocomplete="off"
+    />
+    <button class="squire-history-search__submit" type="submit">Search</button>
+  </form>` as HtmlEscapedString;
+}
+
 function renderConversationHistoryList(history: ConversationHistoryViewModel): HtmlEscapedString {
-  return html`<nav class="squire-history-list" aria-label="Recent conversations">
-    ${renderHistoryRows(history.rows)}
+  const query = history.query ?? '';
+  return html`<nav
+    class="squire-history-list"
+    aria-label="${query ? 'Matching conversations' : 'Recent conversations'}"
+  >
+    ${renderHistoryRows(history.rows, { query })}
   </nav>` as HtmlEscapedString;
 }
 
@@ -246,7 +274,7 @@ export function renderConversationHistoryShell(
         </a>
         ${renderNewChatLink('squire-history-new-chat')}
       </div>
-      ${renderConversationHistoryList(history)}
+      ${renderConversationHistorySearch(history, 'rail')} ${renderConversationHistoryList(history)}
     </aside>
     <div class="squire-history-backdrop" data-history-close hidden></div>
     <aside
@@ -271,6 +299,7 @@ export function renderConversationHistoryShell(
         </button>
       </div>
       ${renderNewChatLink('squire-history-new-chat squire-history-new-chat--drawer')}
+      ${renderConversationHistorySearch(history, 'drawer')}
       ${renderConversationHistoryList(history)}
     </aside>
   </div>` as HtmlEscapedString;
@@ -773,9 +802,11 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
   const chatFormHxSwap = options.chatFormHxSwap ?? 'innerHTML';
   const headerContext = options.headerContext ?? 'HAVEN · RULES';
   const columnClassName = options.columnClassName ?? 'squire-column';
+  const historyQuery = conversationHistory?.query ?? '';
   const chatFormHiddenFields = [
     ...(csrfToken ? [{ name: CSRF_FORM_FIELD_NAME, value: csrfToken }] : []),
     { name: 'game', value: DEFAULT_GAME_ID },
+    ...(historyQuery ? [{ name: 'historyQuery', value: historyQuery }] : []),
     ...(options.chatFormHiddenFields ?? []),
   ];
   // SAFETY: `errorBanner.message` is interpolated via hono/html's tagged

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -257,18 +257,19 @@ html {
   border-radius: 6px;
   padding: 0 10px;
   color: var(--parchment);
-  background: var(--ink);
+  background: var(--surface);
   font-family: 'Geist', system-ui, sans-serif;
   font-size: 13px;
 }
 
 .squire-history-search__input::placeholder {
   color: var(--sepia);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-style: italic;
 }
 
 .squire-history-search__input:focus {
   border-color: var(--wax);
-  outline: none;
 }
 
 .squire-history-search__submit {

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -243,6 +243,52 @@ html {
   border-color: var(--wax);
 }
 
+.squire-history-search {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+.squire-history-search__input {
+  min-width: 0;
+  width: 100%;
+  height: 36px;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  padding: 0 10px;
+  color: var(--parchment);
+  background: var(--ink);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 13px;
+}
+
+.squire-history-search__input::placeholder {
+  color: var(--sepia);
+}
+
+.squire-history-search__input:focus {
+  border-color: var(--wax);
+  outline: none;
+}
+
+.squire-history-search__submit {
+  min-height: 36px;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  padding: 0 10px;
+  color: var(--parchment);
+  background: var(--surface-2);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.squire-history-search__submit:hover,
+.squire-history-search__submit:focus-visible {
+  color: var(--wax);
+  border-color: var(--wax);
+}
+
 .squire-history-list {
   display: flex;
   flex-direction: column;

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -407,6 +407,63 @@ describe('conversation history summaries', () => {
     expect(thirdPage.rows.map((row) => row.id)).toEqual([third.conversationId]);
     expect(thirdPage.nextCursor).toBeNull();
   });
+
+  it('searches owned conversation history by visible message text without leaking other users', async () => {
+    const alice = await createAuthContext({ email: 'alice-history-search@example.com' });
+    const bob = await createAuthContext({
+      email: 'bob-history-search@example.com',
+      googleSub: 'google-sub-bob-history-search',
+      name: 'Bob',
+    });
+
+    const matching = await seedHistoryConversation(alice, {
+      firstQuestion: 'How does short resting work?',
+      latestContent: 'Short rests recover one discarded card at random.',
+      lastMessageAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await seedHistoryConversation(alice, {
+      firstQuestion: 'How does poison interact with healing?',
+      latestContent: 'Poison prevents the healing value.',
+      lastMessageAt: new Date('2026-01-03T00:00:00.000Z'),
+    });
+    await seedHistoryConversation(bob, {
+      firstQuestion: 'Bob should not leak',
+      latestContent: 'Short rests recover one discarded card at random.',
+      lastMessageAt: new Date('2026-01-04T00:00:00.000Z'),
+    });
+
+    const history = await loadConversationHistory({
+      userId: alice.userId,
+      query: 'DISCARDED CARD',
+      limit: 30,
+    });
+
+    expect(history.rows.map((row) => row.id)).toEqual([matching.conversationId]);
+    expect(history.rows[0]).toMatchObject({
+      title: 'How does short resting work?',
+      preview: 'Short rests recover one discarded card at random.',
+    });
+  });
+
+  it('uses the first non-empty user-visible question as the history title fallback', async () => {
+    const auth = await createAuthContext({ email: 'history-title-fallback@example.com' });
+    const seeded = await seedConversationWithTurns(auth, [
+      { question: '   ', answer: 'The blank initial question should not become the title.' },
+      { question: 'Can summons loot coins?', answer: 'Summons do not loot coins.' },
+    ]);
+
+    const history = await loadConversationHistory({
+      userId: auth.userId,
+      limit: 30,
+    });
+
+    expect(history.rows).toHaveLength(1);
+    expect(history.rows[0]).toMatchObject({
+      id: seeded.conversationId,
+      title: 'Can summons loot coins?',
+      preview: 'Summons do not loot coins.',
+    });
+  });
 });
 
 describe('conversation web backend', () => {

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -418,7 +418,7 @@ describe('conversation history summaries', () => {
 
     const matching = await seedHistoryConversation(alice, {
       firstQuestion: 'How does short resting work?',
-      latestContent: 'Short rests recover one discarded card at random.',
+      latestContent: 'Short rests recover one discarded\ncard at random.',
       lastMessageAt: new Date('2026-01-01T00:00:00.000Z'),
     });
     await seedHistoryConversation(alice, {
@@ -440,6 +440,7 @@ describe('conversation history summaries', () => {
 
     expect(history.rows.map((row) => row.id)).toEqual([matching.conversationId]);
     expect(history.rows[0]).toMatchObject({
+      href: `/chat/${matching.conversationId}?historyQuery=DISCARDED+CARD`,
       title: 'How does short resting work?',
       preview: 'Short rests recover one discarded card at random.',
     });
@@ -922,6 +923,31 @@ describe('conversation web backend', () => {
     expect(body).toContain('class="squire-transcript"');
   });
 
+  it('preserves filtered history in the pushed URL on the first HTMX chat submit', async () => {
+    const auth = await createAuthContext();
+
+    const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'hx-request': 'true',
+      },
+      body: formBody({
+        question: 'How does long rest recovery work?',
+        idempotencyKey: 'idem-history-filtered-oob-first',
+        historyQuery: 'long rest',
+      }),
+    });
+
+    expect(createRes.status).toBe(200);
+    const pushedUrl = createRes.headers.get('HX-Push-Url');
+    expect(pushedUrl).toMatch(/^\/chat\/[0-9a-f-]+\?historyQuery=long\+rest$/);
+    const body = await createRes.text();
+    expect(body).toContain(`href="${pushedUrl}"`);
+    expect(body).toContain('value="long rest"');
+  });
+
   it('returns an out-of-band history shell on HTMX follow-up submit', async () => {
     const auth = await createAuthContext();
     const seeded = await seedConversationWithTurns(auth, [
@@ -1105,6 +1131,36 @@ describe('conversation web backend', () => {
     expect(response.headers.get('HX-Push-Url')).toBe(`/chat/${seeded.conversationId}`);
     const body = await response.text();
     expect(body).not.toMatch(/<nav[^>]*id="squire-recent-questions"/);
+  });
+
+  it('preserves filtered history in the pushed URL on HTMX follow-up submit', async () => {
+    const auth = await createAuthContext();
+    const seeded = await seedConversationWithTurns(auth, [
+      { question: 'First question', answer: 'First answer' },
+      { question: 'Second question', answer: 'Second answer' },
+    ]);
+
+    const response = await requestWithAuth(
+      auth,
+      `http://localhost:3000/chat/${seeded.conversationId}/messages`,
+      {
+        method: 'POST',
+        csrf: true,
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          'hx-request': 'true',
+          'hx-current-url': `http://localhost:3000/chat/${seeded.conversationId}?historyQuery=first`,
+        },
+        body: formBody({ question: 'Newest question', historyQuery: 'first' }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const pushedUrl = response.headers.get('HX-Push-Url');
+    expect(pushedUrl).toBe(`/chat/${seeded.conversationId}?historyQuery=first`);
+    const body = await response.text();
+    expect(body).toContain(`href="${pushedUrl}"`);
+    expect(body).toContain('value="first"');
   });
 
   it('returns an append-fragment (new question + pending answer skeleton) for HTMX follow-ups (SQR-108 E-3)', async () => {

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -348,6 +348,21 @@ describe('GET / — companion-first layout shell (SQR-65)', () => {
     expect(body).toContain('Frosthaven');
   });
 
+  it('renders a history search affordance in the desktop rail and mobile drawer', async () => {
+    const body = String(
+      await actualLayout.renderHomePage(testSession, testCsrfToken, {
+        conversationHistory: { ...testConversationHistory(), query: 'poison' },
+      }),
+    );
+
+    expect(body).toContain('class="squire-history-search"');
+    expect(body).toContain('name="historyQuery"');
+    expect(body).toContain('placeholder="Search history"');
+    expect(body).toContain('value="poison"');
+    expect(body).toContain('type="hidden" name="historyQuery" value="poison"');
+    expect(body.match(/class="squire-history-search"/g)).toHaveLength(2);
+  });
+
   it('does not render the history toggle when the history shell is disabled', async () => {
     const body = String(
       await actualLayout.layoutShell({


### PR DESCRIPTION
## Summary
- derive deterministic conversation-history titles from the first non-empty user question
- add owner-scoped history search across visible message text
- render compact search controls in the desktop rail and mobile drawer, preserving filtered history through HTMX refreshes

## Validation
- npm test -- --run test/conversation.test.ts -t "conversation history summaries"
- npm test -- --run test/web-ui-layout.test.ts -t "history search affordance"
- npm run check
- manual QA confirmed: dev login/home load, matching history search, no-match state, clear search, new-chat title from question, search by title and answer text, active conversation with filtered history, follow-up submit after history search

Fixes SQR-257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search conversation history by message text via a visible history search form (desktop + mobile); search term is preserved in the URL and across message submissions.
  * History empty-state and results update based on the active search.

* **Bug Fixes**
  * Improved conversation title generation with clearer fallbacks for untitled chats.

* **Style**
  * Added styling for the history search input and button.

* **Tests**
  * Added tests covering history search, URL persistence, and title fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->