### PR TITLE
SQR-259: Narrate source work in the answer log

### DIFF
--- a/docs/SSE_CONTRACT.md
+++ b/docs/SSE_CONTRACT.md
@@ -33,7 +33,11 @@ The SSE event log is not a durable LangGraph node checkpoint.
   - Payload: `{ "id": string, "label": string }`
 - `tool-result`
   - Marks a tool row complete or failed.
-  - Payload: `{ "id": string, "labels": string[], "ok": boolean }`
+  - Payload:
+    `{ "id": string, "labels": string[], "ok": boolean, "message"?: string }`
+  - `message`, when present, is a user-safe completed-work description already
+    translated away from raw refs. It is rendered in the work log, never
+    appended as answer prose.
 - `tool-plan`
   - Adds a plain-language statement of the agent's next intended lookup.
   - Payload: `{ "id": string, "message": string }`

--- a/docs/SSE_CONTRACT.md
+++ b/docs/SSE_CONTRACT.md
@@ -34,12 +34,19 @@ The SSE event log is not a durable LangGraph node checkpoint.
 - `tool-result`
   - Marks a tool row complete or failed.
   - Payload: `{ "id": string, "labels": string[], "ok": boolean }`
+- `tool-plan`
+  - Adds a plain-language statement of the agent's next intended lookup.
+  - Payload: `{ "id": string, "message": string }`
+  - `message` is user-safe intent text. It is rendered in the work log, never
+    appended as answer prose.
 - `tool-progress`
   - Adds a compact, user-safe progress row for long tool work.
   - Payload: `{ "id": string, "label": string, "message": string }`
   - `label` is safe tool/source metadata such as `SECTION BOOK` or the
     `REFERENCE` fallback. `message` is already filtered by the service as
-    user-safe progress text; it is rendered as metadata, never answer prose.
+    user-safe, display-ready progress text; it is rendered as metadata, never
+    answer prose. Raw canonical refs should be translated into human labels
+    before they become browser-visible.
 - `answer-artifact`
   - Adds a structured, user-safe artifact such as a quoted section block.
   - Payload:
@@ -155,6 +162,8 @@ The conversation service emits Squire-owned internal events. These are typed in
   or raw retrieved fragments must not be emitted as `text`.
 - `tool_call`: a tool lookup or source traversal started.
 - `tool_result`: a tool lookup or source traversal completed.
+- `tool_plan`: optional user-safe statement of the next intended lookup. Routes
+  that expose it must map it to browser `tool-plan`, not `text-delta`.
 - `tool_progress`: optional user-safe progress from inside a long tool. Routes
   that expose it must map it to browser `tool-progress`, not `text-delta`.
 - `artifact`: optional user-safe structured content. Routes that expose it must
@@ -174,6 +183,7 @@ The route, not the provider, owns the final browser ordering guarantees:
 - provider/internal `text` -> browser `text-delta`
 - provider/internal `tool_call` -> browser `tool-start`
 - provider/internal `tool_result` -> browser `tool-result`
+- internal `tool_plan` -> browser `tool-plan`
 - internal `tool_progress` -> browser `tool-progress`
 - internal `artifact` -> browser `answer-artifact`
 - internal `debug` -> no browser event
@@ -190,6 +200,8 @@ Regression tests should assert browser-visible behavior, not only persistence:
   `done.html` fragment
 - tool-planning text and raw tool output from intermediate model turns never
   appear in `text-delta`
+- `tool_plan` appears only as browser `tool-plan`; it is rendered in the work
+  log when present
 - `tool_progress` appears only as browser `tool-progress`; `debug` never appears
   in browser SSE
 - structured artifacts appear only as browser `answer-artifact`, not

--- a/docs/agent/qa.md
+++ b/docs/agent/qa.md
@@ -37,6 +37,48 @@ Also make sure:
 - local commands use Node 24 if your shell defaults to another version
 - the dev server is running on the current worktree's port
 
+## Manual app process lifecycle
+
+When the user asks for a manual test, the agent owns the local app process.
+Do not hand the user a setup recipe unless a missing secret or dependency
+blocks startup.
+
+Use one boring server lifecycle:
+
+1. Check the intended port before starting:
+
+   ```bash
+   lsof -nP -iTCP:<port> -sTCP:LISTEN || true
+   ```
+
+2. If an old server for the same worktree is already listening and the code has
+   changed, stop it first. If another process owns the port, choose a different
+   port and tell the user the new URL.
+3. Start the server in the managed agent terminal with the real app command:
+
+   ```bash
+   PORT=<port> npm run serve
+   ```
+
+   Keep this terminal session attached while the user tests. Do not use
+   `screen`, `tmux`, `nohup`, shell-backgrounded jobs, or detached wrappers for
+   ordinary manual testing; they hide logs and make shutdown unreliable in
+   agent-run sessions.
+
+4. Wait for the server log to show the final listening port and bootstrap
+   readiness.
+5. Verify the live endpoint before giving the URL to the user:
+
+   ```bash
+   curl -fsS http://localhost:<port>/api/live
+   ```
+
+6. Report the exact URL and keep the process alive until the user asks to shut
+   it down. Stop it with Ctrl-C in the same terminal session.
+
+Do not claim the app was restarted unless the currently running server was
+started after the current code change and `/api/live` returned `{"status":"ok"}`.
+
 ## Mandatory regression sweep
 
 Run these in addition to issue-specific QA unless the branch is purely

--- a/eval/langsmith-trace.ts
+++ b/eval/langsmith-trace.ts
@@ -187,7 +187,8 @@ function graphNodeForToolRun(toolName: string): string {
   if (toolName === 'inspect_sources' || toolName === 'schema') return 'classification';
   if (toolName === 'resolve_entity') return 'retrieval_planning';
   if (toolName === 'neighbors') return 'routing';
-  if (toolName === 'open_entity' || toolName.startsWith('get_')) return 'source_verification';
+  if (toolName === 'lookup_entity' || toolName === 'open_entity' || toolName.startsWith('get_'))
+    return 'source_verification';
   return 'tool_execution';
 }
 

--- a/eval/schema.ts
+++ b/eval/schema.ts
@@ -147,6 +147,7 @@ const TOOL_KIND_BY_NAME = new Map<string, ToolKind>([
   ['search_rules', 'search'],
   ['search_cards', 'search'],
   ['list_cards', 'search'],
+  ['lookup_entity', 'open'],
   ['open_entity', 'open'],
   ['get_card', 'open'],
   ['get_scenario', 'open'],

--- a/eval/suites/frosthaven.json
+++ b/eval/suites/frosthaven.json
@@ -294,11 +294,11 @@
     "category": "trajectory",
     "question": "What does item 1 do, and what source ID did you use to open it?",
     "trajectory": {
-      "requiredTools": ["resolve_entity", "open_entity"],
-      "requiredToolKinds": ["resolution", "open"],
+      "requiredTools": ["lookup_entity"],
+      "requiredToolKinds": ["open"],
       "forbiddenTools": ["search_rules"],
       "requiredRefs": ["card:frosthaven/items/gloomhavensecretariat:item/1"],
-      "maxToolCalls": 6
+      "maxToolCalls": 4
     },
     "source": "data/extracted/items.json",
     "game": "frosthaven",

--- a/eval/suites/gloomhaven-2e.json
+++ b/eval/suites/gloomhaven-2e.json
@@ -310,12 +310,12 @@
     "category": "trajectory",
     "question": "What does Gloomhaven 2e item 1 do, and what source ID did you use to open it?",
     "trajectory": {
-      "requiredTools": ["resolve_entity", "open_entity"],
-      "requiredToolKinds": ["resolution", "open"],
+      "requiredTools": ["lookup_entity"],
+      "requiredToolKinds": ["open"],
       "forbiddenTools": ["search_rules"],
       "requiredRefs": ["card:gloomhaven-2e/items/gloomhavensecretariat:item/1"],
-      "maxToolCalls": 6,
-      "notes": "LangGraph node coverage: retrieval planning should resolve the exact item before final_answer."
+      "maxToolCalls": 4,
+      "notes": "LangGraph node coverage: retrieval planning should use the combined exact lookup for direct item questions."
     },
     "source": "data/extracted/gh2/items.json",
     "game": "gloomhaven-2e",

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -64,6 +64,7 @@ const DISCOVERY_ONLY_TOOL_NAMES = new Set([
   'neighbors',
 ]);
 const DIRECT_EVIDENCE_TOOL_NAMES = new Set([
+  'lookup_entity',
   'open_entity',
   'get_card',
   'get_scenario',
@@ -313,6 +314,13 @@ function completedWorkMessageForTool(name: string, input: Record<string, unknown
     return humanizeWorkLogProgressMessage(
       `Opening ${typeof input.ref === 'string' ? input.ref : 'source'}`,
     );
+  if (name === 'lookup_entity') {
+    const query = typeof input.query === 'string' ? input.query.trim() : '';
+    if (query.length === 0) return 'Looked up source';
+    const openingMessage = humanizeWorkLogProgressMessage(`Opening ${query}`);
+    if (openingMessage !== `Opening ${query}`) return openingMessage;
+    return humanizeWorkLogProgressMessage(`Resolving ${query}`);
+  }
   if (name === 'neighbors')
     return humanizeWorkLogProgressMessage(
       `Checking links from ${typeof input.ref === 'string' ? input.ref : 'source'}`,
@@ -337,7 +345,7 @@ function shouldEmitUserFacingPlan(name: string): boolean {
 }
 
 function shouldEmitUserFacingProgress(name: string): boolean {
-  return name !== 'resolve_entity' && name !== 'open_entity';
+  return name !== 'resolve_entity' && name !== 'open_entity' && name !== 'lookup_entity';
 }
 
 function shouldEmitUserFacingResult(name: string, ok: boolean): boolean {
@@ -387,6 +395,9 @@ function planMessageForTool(name: string, input: Record<string, unknown>): strin
     if (ref.length === 0) return undefined;
     return planMessageFromCompletedAction(humanizeWorkLogProgressMessage(`Opening ${ref}`));
   }
+  if (name === 'lookup_entity') {
+    return planMessageFromCompletedAction(completedWorkMessageForTool(name, input));
+  }
   if (name === 'resolve_entity') {
     return planMessageFromCompletedAction(completedWorkMessageForTool(name, input));
   }
@@ -414,7 +425,7 @@ function sectionArtifactFromToolResult(
   toolName: string,
   result: ToolCallResult,
 ): AgentStreamEventMap['artifact'] | undefined {
-  if (toolName !== 'open_entity') return undefined;
+  if (toolName !== 'open_entity' && toolName !== 'lookup_entity') return undefined;
   try {
     const parsed = JSON.parse(result.content) as {
       ok?: unknown;

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -323,6 +323,8 @@ function failedWorkMessageForTool(name: string, input: Record<string, unknown>):
     const ref =
       typeof input.ref === 'string' && input.ref.trim().length > 0 ? input.ref.trim() : 'source';
     const humanized = humanizeWorkLogProgressMessage(`Opening ${ref}`);
+    const searched = humanized.match(/^Searched\s+(.+)$/i);
+    if (searched) return `Couldn't search ${searched[1]!.trim()}`;
     const checked = humanized.match(/^Checked\s+(.+)$/i);
     if (checked) return `Couldn't check ${checked[1]!.trim()}`;
     const lookedUp = humanized.match(/^Looked up\s+(.+)$/i);
@@ -425,6 +427,9 @@ function joinPlanTargets(targets: string[]): string {
 function planMessageFromCompletedAction(action: string): string | undefined {
   const lookedUpInBook = action.match(/^Looked up\s+.+?\s+in the\s+(.+)$/i);
   if (lookedUpInBook) return `I'll look that up in the ${lookedUpInBook[1]!.trim()}.`;
+
+  const lookedUp = action.match(/^Looked up\s+(.+)$/i);
+  if (lookedUp) return `I'll look up ${lookedUp[1]!.trim()}.`;
 
   const checked = action.match(/^Checked\s+(.+)$/i);
   if (checked) {

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -36,6 +36,10 @@ import {
 import type { AgentStreamEventMap, AskOptions, EmitFn } from './service.ts';
 import { requireGameId } from './game.ts';
 import { resolveSquireEnv } from './squire-env.ts';
+import {
+  activeWorkLogProgressMessageFromCompleted,
+  humanizeWorkLogProgressMessage,
+} from './work-log-display.ts';
 
 type Message = Anthropic.Message;
 type MessageParam = Anthropic.MessageParam;
@@ -292,21 +296,89 @@ function threadIdFor(options: AskOptions | undefined): string {
   );
 }
 
-function progressMessageForTool(name: string, input: Record<string, unknown>): string {
+function completedWorkMessageForTool(name: string, input: Record<string, unknown>): string {
   if (name === 'search_knowledge') {
     const scopeLabels = sourceLabelsForSearchScope(input.scope);
-    return `Searching ${scopeLabels.length > 0 ? scopeLabels.join(', ') : 'knowledge'}`;
+    const query = typeof input.query === 'string' ? input.query.trim() : '';
+    if (scopeLabels.length === 1 && query.length > 0) {
+      const target = scopeLabels[0];
+      if (target === 'Rulebook') return 'Searched the rulebook';
+      if (target === 'Scenario Book') return 'Searched the scenario book';
+      if (target === 'Section Book') return 'Searched the section book';
+      if (target === 'Card Index') return 'Searched cards';
+    }
+    return 'Searched available sources';
   }
   if (name === 'open_entity')
-    return `Opening ${typeof input.ref === 'string' ? input.ref : 'source'}`;
+    return humanizeWorkLogProgressMessage(
+      `Opening ${typeof input.ref === 'string' ? input.ref : 'source'}`,
+    );
   if (name === 'neighbors')
-    return `Checking links from ${typeof input.ref === 'string' ? input.ref : 'source'}`;
-  if (name === 'resolve_entity')
-    return `Resolving ${typeof input.query === 'string' ? input.query : 'reference'}`;
-  if (name === 'inspect_sources') return 'Inspecting available sources';
+    return humanizeWorkLogProgressMessage(
+      `Checking links from ${typeof input.ref === 'string' ? input.ref : 'source'}`,
+    );
+  if (name === 'resolve_entity') {
+    return humanizeWorkLogProgressMessage(
+      `Resolving ${typeof input.query === 'string' ? input.query : 'reference'}`,
+    );
+  }
+  if (name === 'inspect_sources') return 'Inspected available sources';
   if (name === 'schema')
-    return `Checking ${typeof input.kind === 'string' ? input.kind : 'source'} schema`;
-  return `Running ${name}`;
+    return `Checked ${typeof input.kind === 'string' ? input.kind : 'source'} schema`;
+  return `Ran ${name}`;
+}
+
+function progressMessageForTool(name: string, input: Record<string, unknown>): string {
+  return activeWorkLogProgressMessageFromCompleted(completedWorkMessageForTool(name, input));
+}
+
+function sourcePlanTarget(label: string): string {
+  if (label === 'Rulebook') return 'the rulebook';
+  if (label === 'Scenario Book') return 'the scenario book';
+  if (label === 'Section Book') return 'the section book';
+  if (label === 'Card Index') return 'the cards';
+  return label.toLowerCase();
+}
+
+function joinPlanTargets(targets: string[]): string {
+  if (targets.length <= 1) return targets[0] ?? 'available sources';
+  if (targets.length === 2) return `${targets[0]} and ${targets[1]}`;
+  return `${targets.slice(0, -1).join(', ')}, and ${targets[targets.length - 1]}`;
+}
+
+function planMessageFromCompletedAction(action: string): string | undefined {
+  const lookedUpInBook = action.match(/^Looked up\s+.+?\s+in the\s+(.+)$/i);
+  if (lookedUpInBook) return `I'll look that up in the ${lookedUpInBook[1]!.trim()}.`;
+
+  const checked = action.match(/^Checked\s+(.+)$/i);
+  if (checked) {
+    const target = checked[1]!.trim();
+    if (/stat card$/i.test(target)) return "I'll check that stat card.";
+    if (/card$/i.test(target)) return "I'll check that card.";
+    return `I'll check ${target.toLowerCase().startsWith('the ') ? target : `the ${target}`}.`;
+  }
+
+  const searched = action.match(/^Searched\s+(.+)$/i);
+  if (searched) return `I'll search ${searched[1]!.trim()}.`;
+  return undefined;
+}
+
+function planMessageForTool(name: string, input: Record<string, unknown>): string | undefined {
+  if (name === 'search_knowledge') {
+    const scopeLabels = sourceLabelsForSearchScope(input.scope);
+    if (scopeLabels.length === 0) return "I'll search available sources.";
+    if (scopeLabels.length === 1 && scopeLabels[0] === 'Card Index') return "I'll check the cards.";
+    return `I'll search ${joinPlanTargets(scopeLabels.map(sourcePlanTarget))}.`;
+  }
+  if (name === 'open_entity') {
+    const ref = typeof input.ref === 'string' ? input.ref.trim() : '';
+    if (ref.length === 0) return undefined;
+    return planMessageFromCompletedAction(humanizeWorkLogProgressMessage(`Opening ${ref}`));
+  }
+  if (name === 'resolve_entity') {
+    return planMessageFromCompletedAction(completedWorkMessageForTool(name, input));
+  }
+  return undefined;
 }
 
 function sourceLabelsForSearchScope(scope: unknown): string[] {
@@ -550,6 +622,13 @@ async function runLangGraphAgentLoop(
         }
 
         if (emit) {
+          const planMessage = planMessageForTool(block.name, input);
+          if (planMessage) {
+            await emit('tool_plan', {
+              message: planMessage,
+              toolName: block.name,
+            });
+          }
           await emit('tool_progress', {
             message: progressMessageForTool(block.name, input),
             toolName: block.name,
@@ -599,6 +678,7 @@ async function runLangGraphAgentLoop(
           await emit('tool_result', {
             name: block.name,
             ok: toolOk,
+            message: completedWorkMessageForTool(block.name, input),
             sourceBooks: toolResult.sourceBooks,
           });
           const artifact = sectionArtifactFromToolResult(block.name, toolResult);

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -297,7 +297,54 @@ function threadIdFor(options: AskOptions | undefined): string {
   );
 }
 
-function completedWorkMessageForTool(name: string, input: Record<string, unknown>): string {
+function parsedToolResultContent(result: ToolCallResult | undefined): {
+  ok?: unknown;
+  entity?: { ref?: unknown };
+} | null {
+  if (!result) return null;
+  try {
+    return JSON.parse(result.content) as {
+      ok?: unknown;
+      entity?: { ref?: unknown };
+    };
+  } catch {
+    return null;
+  }
+}
+
+function openedEntityRefFromToolResult(result: ToolCallResult | undefined): string | undefined {
+  const ref = parsedToolResultContent(result)?.entity?.ref;
+  return typeof ref === 'string' && ref.trim().length > 0 ? ref.trim() : undefined;
+}
+
+function failedWorkMessageForTool(name: string, input: Record<string, unknown>): string {
+  if (name === 'search_knowledge') return "Couldn't search available sources";
+  if (name === 'open_entity') {
+    const ref =
+      typeof input.ref === 'string' && input.ref.trim().length > 0 ? input.ref.trim() : 'source';
+    return `Couldn't look up ${ref}`;
+  }
+  if (name === 'lookup_entity' || name === 'resolve_entity') {
+    const query =
+      typeof input.query === 'string' && input.query.trim().length > 0
+        ? input.query.trim()
+        : 'source';
+    return `Couldn't look up ${query}`;
+  }
+  if (name === 'neighbors') return "Couldn't follow links";
+  if (name === 'inspect_sources') return "Couldn't inspect available sources";
+  if (name === 'schema') return "Couldn't check source schema";
+  return `Couldn't run ${name}`;
+}
+
+function completedWorkMessageForTool(
+  name: string,
+  input: Record<string, unknown>,
+  toolResult?: ToolCallResult,
+  toolOk = true,
+): string {
+  if (!toolOk) return failedWorkMessageForTool(name, input);
+
   if (name === 'search_knowledge') {
     const scopeLabels = sourceLabelsForSearchScope(input.scope);
     const query = typeof input.query === 'string' ? input.query.trim() : '';
@@ -310,11 +357,15 @@ function completedWorkMessageForTool(name: string, input: Record<string, unknown
     }
     return 'Searched available sources';
   }
-  if (name === 'open_entity')
+  if (name === 'open_entity') {
+    const openedRef = openedEntityRefFromToolResult(toolResult);
     return humanizeWorkLogProgressMessage(
-      `Opening ${typeof input.ref === 'string' ? input.ref : 'source'}`,
+      `Opening ${openedRef ?? (typeof input.ref === 'string' ? input.ref : 'source')}`,
     );
+  }
   if (name === 'lookup_entity') {
+    const openedRef = openedEntityRefFromToolResult(toolResult);
+    if (openedRef) return humanizeWorkLogProgressMessage(`Opening ${openedRef}`);
     const query = typeof input.query === 'string' ? input.query.trim() : '';
     if (query.length === 0) return 'Looked up source';
     const openingMessage = humanizeWorkLogProgressMessage(`Opening ${query}`);
@@ -704,7 +755,7 @@ async function runLangGraphAgentLoop(
             await emit('tool_result', {
               name: block.name,
               ok: toolOk,
-              message: completedWorkMessageForTool(block.name, input),
+              message: completedWorkMessageForTool(block.name, input, toolResult, toolOk),
               sourceBooks: toolResult.sourceBooks,
             });
           }

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -332,6 +332,18 @@ function progressMessageForTool(name: string, input: Record<string, unknown>): s
   return activeWorkLogProgressMessageFromCompleted(completedWorkMessageForTool(name, input));
 }
 
+function shouldEmitUserFacingPlan(name: string): boolean {
+  return name !== 'resolve_entity';
+}
+
+function shouldEmitUserFacingProgress(name: string): boolean {
+  return name !== 'resolve_entity' && name !== 'open_entity';
+}
+
+function shouldEmitUserFacingResult(name: string, ok: boolean): boolean {
+  return name !== 'resolve_entity' || !ok;
+}
+
 function sourcePlanTarget(label: string): string {
   if (label === 'Rulebook') return 'the rulebook';
   if (label === 'Scenario Book') return 'the scenario book';
@@ -623,16 +635,18 @@ async function runLangGraphAgentLoop(
 
         if (emit) {
           const planMessage = planMessageForTool(block.name, input);
-          if (planMessage) {
+          if (planMessage && shouldEmitUserFacingPlan(block.name)) {
             await emit('tool_plan', {
               message: planMessage,
               toolName: block.name,
             });
           }
-          await emit('tool_progress', {
-            message: progressMessageForTool(block.name, input),
-            toolName: block.name,
-          });
+          if (shouldEmitUserFacingProgress(block.name)) {
+            await emit('tool_progress', {
+              message: progressMessageForTool(block.name, input),
+              toolName: block.name,
+            });
+          }
           await emit('tool_call', { name: block.name, input: block.input });
         }
 
@@ -675,12 +689,14 @@ async function runLangGraphAgentLoop(
         }
 
         if (emit) {
-          await emit('tool_result', {
-            name: block.name,
-            ok: toolOk,
-            message: completedWorkMessageForTool(block.name, input),
-            sourceBooks: toolResult.sourceBooks,
-          });
+          if (shouldEmitUserFacingResult(block.name, toolOk)) {
+            await emit('tool_result', {
+              name: block.name,
+              ok: toolOk,
+              message: completedWorkMessageForTool(block.name, input),
+              sourceBooks: toolResult.sourceBooks,
+            });
+          }
           const artifact = sectionArtifactFromToolResult(block.name, toolResult);
           if (artifact) await emit('artifact', artifact);
         }

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -322,6 +322,11 @@ function failedWorkMessageForTool(name: string, input: Record<string, unknown>):
   if (name === 'open_entity') {
     const ref =
       typeof input.ref === 'string' && input.ref.trim().length > 0 ? input.ref.trim() : 'source';
+    const humanized = humanizeWorkLogProgressMessage(`Opening ${ref}`);
+    const checked = humanized.match(/^Checked\s+(.+)$/i);
+    if (checked) return `Couldn't check ${checked[1]!.trim()}`;
+    const lookedUp = humanized.match(/^Looked up\s+(.+)$/i);
+    if (lookedUp) return `Couldn't look up ${lookedUp[1]!.trim()}`;
     return `Couldn't look up ${ref}`;
   }
   if (name === 'lookup_entity' || name === 'resolve_entity') {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -120,24 +120,18 @@ Guidelines:
 - For Gloomhaven (2nd Edition) correction, errata, campaign sheet, "current section," or outdated-reference questions, search current FAQ/errata rule passages before opening a section ref. A missing section ref is not enough to answer a correction question.
 - For core rule or condition-definition questions, search rules passages directly. If FAQ/errata hits only discuss edge cases, keep searching for the rulebook definition before answering.
 - Cite FAQ or errata when you rely on it. Rulebook-only answers are allowed when no current-source clarification applies.
-- Use inspect_sources and schema when you need to discover available kinds, filters, refs, or relations
-- Use lookup_entity to resolve and open one exact natural reference in a single call
-- Use resolve_entity to turn natural references into opener-ready scenario, section, card type, or card refs when you need candidates or traversal refs
-- Prefer search_knowledge for broad discovery across rules, scenarios, sections, and cards
-- Use open_entity when you have an exact canonical ref
-- Use neighbors to traverse explicit scenario/section links from a canonical ref
-- Use find_scenario when the user names a scenario number or scenario title
-- Use get_scenario once you know the exact canonical scenario ref
-- Use get_section for exact section refs or when a traversal link points to a section
-- Use follow_links to inspect explicit scenario/section reference chains
-- For chained scenario/section questions, keep following explicit references until you reach the exact grounded text you need
-- Prefer explicit scenario/section references over search_rules when the question already names a scenario number, scenario title, or section ref
-- Use search_rules for fuzzy book-corpus questions (rules, mechanics, open-ended discovery, or when traversal runs out)
-- Use search_cards for questions about specific cards, monsters, items, or abilities
-- Use get_card for precise lookups only when you know the card type and canonical sourceId
-- If you only know a natural card reference such as a name or number, use resolve_entity, search_cards, or list_cards first to find the canonical sourceId
-- Use list_card_types to discover what data is available
-- Use list_cards to browse or filter cards of a specific type
+- Use find_scenario when the user names a scenario number or scenario title.
+- Use get_scenario once you know the exact canonical scenario ref.
+- Use get_section for exact section refs or when a traversal link points to a section.
+- Use follow_links to inspect explicit scenario/section reference chains.
+- For chained scenario/section questions, keep following explicit references until you reach the exact grounded text you need.
+- Prefer explicit scenario/section references over search_rules when the question already names a scenario number, scenario title, or section ref.
+- Use search_rules for fuzzy book-corpus questions (rules, mechanics, open-ended discovery, or when traversal runs out).
+- Use search_cards for questions about specific cards, monsters, items, or abilities.
+- Use get_card for precise lookups only when you know the card type and canonical sourceId.
+- If you only know a natural card reference such as a name or number, use search_cards or list_cards first to find the canonical sourceId.
+- Use list_card_types to discover what data is available.
+- Use list_cards to browse or filter cards of a specific type.
 - You may call multiple tools or call the same tool multiple times to gather enough context
 - Answer accurately based on the retrieved data. If the data doesn't contain enough information, say so.
 - Do not invent rules, stats, or item numbers.
@@ -888,9 +882,11 @@ function sourceLabelsFromResult(value: unknown): string[] {
   if (!value || typeof value !== 'object') return labels;
   const result = value as {
     citations?: Array<{ sourceLabel?: unknown }>;
+    entity?: { sourceLabel?: unknown };
     results?: Array<{ citations?: Array<{ sourceLabel?: unknown }> }>;
   };
 
+  add(result.entity?.sourceLabel);
   for (const citation of result.citations ?? []) add(citation.sourceLabel);
   for (const hit of result.results ?? []) {
     for (const citation of hit.citations ?? []) add(citation.sourceLabel);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,6 +17,7 @@ import {
   inspectSources,
   getSchema,
   resolveEntity,
+  lookupEntity,
   openEntity,
   findScenario,
   getScenario,
@@ -83,9 +84,10 @@ Grounding rules:
 - Cite FAQ or errata when you rely on it. Rulebook-only answers are allowed when no current-source clarification applies.
 - For Gloomhaven (2nd Edition) correction, errata, campaign sheet, "current section," or outdated-reference questions, search current FAQ/errata rule passages before opening a section ref. A missing section ref is not enough to answer a correction question.
 - For core rule or condition-definition questions, search rules passages directly. If FAQ/errata hits only discuss edge cases, keep searching for the rulebook definition before answering.
-- Resolve natural user language to refs when exact records are needed, then open or traverse those refs.
+- Use lookup_entity when the user asks for the content, stats, details, or source for one exact natural reference such as a scenario, section, item, monster stat card, or named card.
+- Use resolve_entity when the user asks to find candidates, compare possible records, disambiguate, or when you need only a canonical ref for traversal.
 - For scenario/section relationship questions, resolve the named scenario or section first, then open or traverse the canonical ref.
-- For named or numbered card-data records such as item 1, Spyglass, monsters, buildings, events, battle goals, personal quests, and character mats, resolve the record first and then open the exact canonical ref returned by resolve_entity.
+- For named or numbered card-data records such as item 1, Spyglass, monsters, buildings, events, battle goals, personal quests, and character mats, use lookup_entity for direct detail questions.
 - When an exact record has null or empty fields, state that the field is not available in the checked-in data. Do not recommend physical components, community knowledge, memory, or likely values as a substitute for missing tool data.
 - For building records, treat a cost object as known no-cost only when every numeric cost field is 0, including prosperity when present. If resources are 0 but prosperity is non-zero, say there is no resource cost but there is still a prosperity requirement.
 - If the user asks you to resolve something, call resolve_entity before opening or answering.
@@ -119,7 +121,8 @@ Guidelines:
 - For core rule or condition-definition questions, search rules passages directly. If FAQ/errata hits only discuss edge cases, keep searching for the rulebook definition before answering.
 - Cite FAQ or errata when you rely on it. Rulebook-only answers are allowed when no current-source clarification applies.
 - Use inspect_sources and schema when you need to discover available kinds, filters, refs, or relations
-- Use resolve_entity to turn natural references into opener-ready scenario, section, card type, or card refs
+- Use lookup_entity to resolve and open one exact natural reference in a single call
+- Use resolve_entity to turn natural references into opener-ready scenario, section, card type, or card refs when you need candidates or traversal refs
 - Prefer search_knowledge for broad discovery across rules, scenarios, sections, and cards
 - Use open_entity when you have an exact canonical ref
 - Use neighbors to traverse explicit scenario/section links from a canonical ref
@@ -198,6 +201,31 @@ export const AGENT_TOOLS = [
           minimum: 1,
           maximum: 20,
           description: 'Maximum candidates (1-20, default 6)',
+          default: 6,
+        },
+        game: GAME_INPUT_SCHEMA,
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'lookup_entity',
+    description:
+      'Resolve and open one exact natural reference in a single call. Use for direct questions about the content, stats, details, or source for a scenario, section, item, monster stat card, or named card. Do not use when the user asks to find candidates or compare possible records; use resolve_entity for those.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Natural-language entity reference to open' },
+        kinds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional kind filters returned by inspect_sources, plus common aliases',
+        },
+        limit: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 20,
+          description: 'Maximum candidates to consider before opening one (1-20, default 6)',
           default: 6,
         },
         game: GAME_INPUT_SCHEMA,
@@ -936,6 +964,20 @@ export async function executeToolCall(
           null,
           2,
         ),
+      };
+    }
+    case 'lookup_entity': {
+      const kinds = Array.isArray(input.kinds)
+        ? input.kinds.filter((kind): kind is string => typeof kind === 'string')
+        : undefined;
+      const result = await lookupEntity(input.query as string, {
+        kinds,
+        limit: input.limit as number | undefined,
+        ...gameOpts,
+      });
+      return {
+        content: JSON.stringify(result, null, 2),
+        sourceBooks: sourceLabelsFromResult(result),
       };
     }
     case 'search_rules': {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -84,10 +84,10 @@ Grounding rules:
 - Cite FAQ or errata when you rely on it. Rulebook-only answers are allowed when no current-source clarification applies.
 - For Gloomhaven (2nd Edition) correction, errata, campaign sheet, "current section," or outdated-reference questions, search current FAQ/errata rule passages before opening a section ref. A missing section ref is not enough to answer a correction question.
 - For core rule or condition-definition questions, search rules passages directly. If FAQ/errata hits only discuss edge cases, keep searching for the rulebook definition before answering.
-- Use lookup_entity when the user asks for the content, stats, details, or source for one exact natural reference such as a scenario, section, item, monster stat card, or named card.
+- Use lookup_entity when the user asks for the content, stats, details, or source for one exact openable record such as scenario 61, section 67.1, item 1, Spyglass, a monster stat card, or a named card.
 - Use resolve_entity when the user asks to find candidates, compare possible records, disambiguate, or when you need only a canonical ref for traversal.
 - For scenario/section relationship questions, resolve the named scenario or section first, then open or traverse the canonical ref.
-- For named or numbered card-data records such as item 1, Spyglass, monsters, buildings, events, battle goals, personal quests, and character mats, use lookup_entity for direct detail questions.
+- For named or numbered card-data records such as item 1, Spyglass, one monster stat card, one building card, one event card, one battle goal, one personal quest, or one character mat, use lookup_entity for direct detail questions.
 - When an exact record has null or empty fields, state that the field is not available in the checked-in data. Do not recommend physical components, community knowledge, memory, or likely values as a substitute for missing tool data.
 - For building records, treat a cost object as known no-cost only when every numeric cost field is 0, including prosperity when present. If resources are 0 but prosperity is non-zero, say there is no resource cost but there is still a prosperity requirement.
 - If the user asks you to resolve something, call resolve_entity before opening or answering.

--- a/src/db/repositories/message-stream-event-repository.ts
+++ b/src/db/repositories/message-stream-event-repository.ts
@@ -10,6 +10,7 @@ import type {
 export type BrowserStreamEventName =
   | 'text-delta'
   | 'tool-start'
+  | 'tool-plan'
   | 'tool-result'
   | 'tool-progress'
   | 'answer-artifact'
@@ -25,6 +26,7 @@ export interface MessageStreamEvent {
 
 const TERMINAL_EVENTS = new Set<BrowserStreamEventName>(['done', 'error']);
 const PUBLIC_WORK_EVENTS: ConversationMessagePublicWorkEventName[] = [
+  'tool-plan',
   'tool-progress',
   'tool-result',
   'answer-artifact',

--- a/src/db/repositories/types.ts
+++ b/src/db/repositories/types.ts
@@ -87,6 +87,7 @@ export interface ConversationHistoryPage {
 }
 
 export type ConversationMessagePublicWorkEventName =
+  | 'tool-plan'
   | 'tool-progress'
   | 'tool-result'
   | 'answer-artifact';

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -12,6 +12,7 @@ import {
   inspectSources,
   getSchema,
   resolveEntity,
+  lookupEntity,
   openEntity,
   neighbors,
 } from './tools.ts';
@@ -89,6 +90,30 @@ export function createMcpServer(): McpServer {
     async ({ query, kinds, limit, game }) => {
       const result = await resolveEntity(query, { kinds, limit, ...gameOpts(game) });
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    'lookup_entity',
+    {
+      description:
+        'Resolve and open one exact natural reference in a single call. Use for direct questions about scenario, section, item, monster stat, or named card details.',
+      inputSchema: {
+        query: z.string().describe('Natural-language entity reference to open'),
+        kinds: z
+          .array(z.string())
+          .optional()
+          .describe('Optional kind filters returned by inspect_sources, plus common aliases'),
+        limit: z.number().int().min(1).max(20).default(6).describe('Maximum candidates'),
+        game: gameSchema,
+      },
+    },
+    async ({ query, kinds, limit, game }) => {
+      const result = await lookupEntity(query, { kinds, limit, ...gameOpts(game) });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        isError: !result.ok,
+      };
     },
   );
 

--- a/src/server-start.ts
+++ b/src/server-start.ts
@@ -43,6 +43,7 @@ export async function startHttpServer({
       const server = createAdaptorServer({ fetch: appFetch });
       try {
         await listen(server, claim.port, config.host);
+        server.ref();
         server.once('close', () => {
           void claim.release();
         });
@@ -59,6 +60,7 @@ export async function startHttpServer({
 
   const server = createAdaptorServer({ fetch: appFetch });
   await listen(server, configuredPort, config.host);
+  server.ref();
   startBootstrapLifecycle();
   log(`Squire server listening on port ${configuredPort}`);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,6 +48,7 @@ import {
   retrievalSourceLabelToFooterLabel,
   isToolSourceLabel,
 } from './web-ui/consulted-footer.ts';
+import { humanizeWorkLogProgressMessage } from './work-log-display.ts';
 import { claimWorktreePort } from './worktree-runtime.ts';
 import { searchRules, searchCards, listCardTypes, listCards, getCard } from './tools.ts';
 import type { CardType } from './schemas.ts';
@@ -1316,6 +1317,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
   // and persists the same sources. This handler just translates agent
   // events to wire events.
   return streamSSE(c, async (stream) => {
+    let planSequence = 0;
     let progressSequence = 0;
     let artifactSequence = 0;
     let replayCursor = lastEventSequence;
@@ -1476,6 +1478,21 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
           return;
         }
 
+        if (event === 'tool_plan') {
+          const payload = data as { message?: unknown; toolName?: string };
+          const message = typeof payload.message === 'string' ? payload.message.trim() : '';
+          if (message.length === 0) {
+            return;
+          }
+          const name = payload.toolName ?? 'tool';
+          planSequence += 1;
+          await persistAndWrite('tool-plan', {
+            id: `${buildToolStatusId(name)}-plan-${planSequence}`,
+            message,
+          });
+          return;
+        }
+
         if (event === 'tool_progress') {
           const payload = data as { message?: unknown; toolName?: string };
           const message = typeof payload.message === 'string' ? payload.message.trim() : '';
@@ -1483,10 +1500,11 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
             return;
           }
           const name = payload.toolName ?? 'tool';
+          const label = toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL;
           progressSequence += 1;
           await persistAndWrite('tool-progress', {
             id: `${buildToolStatusId(name)}-progress-${progressSequence}`,
-            label: toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL,
+            label,
             message,
           });
           return;
@@ -1527,8 +1545,14 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
         }
 
         if (event === 'tool_result') {
-          const payload = data as { name?: string; ok?: boolean; sourceBooks?: string[] };
+          const payload = data as {
+            name?: string;
+            ok?: boolean;
+            message?: unknown;
+            sourceBooks?: string[];
+          };
           const name = payload.name ?? 'tool';
+          const message = typeof payload.message === 'string' ? payload.message.trim() : '';
           // Use the actual books hit when available (search_rules always sets
           // sourceBooks, even to [] on no results); fall back to the static
           // label for tools that don't set sourceBooks at all.
@@ -1542,6 +1566,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
             id: buildToolStatusId(name),
             labels: labels.length > 0 ? labels : [TOOL_SOURCE_FALLBACK_LABEL],
             ok: payload.ok ?? true,
+            message: message.length > 0 ? humanizeWorkLogProgressMessage(message) : undefined,
           });
           return;
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1556,15 +1556,17 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
           // Use the actual books hit when available (search_rules always sets
           // sourceBooks, even to [] on no results); fall back to the static
           // label for tools that don't set sourceBooks at all.
-          const labels: string[] =
-            payload.sourceBooks !== undefined
-              ? payload.sourceBooks
+          const staticLabel = toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL;
+          const mappedLabels =
+            payload.sourceBooks === undefined
+              ? null
+              : payload.sourceBooks
                   .map(retrievalSourceLabelToFooterLabel)
-                  .filter((l): l is NonNullable<typeof l> => l !== null)
-              : [toolSourceLabel(name) ?? TOOL_SOURCE_FALLBACK_LABEL];
+                  .filter((l): l is NonNullable<typeof l> => l !== null);
+          const labels = mappedLabels && mappedLabels.length > 0 ? mappedLabels : [staticLabel];
           await persistAndWrite('tool-result', {
             id: buildToolStatusId(name),
-            labels: labels.length > 0 ? labels : [TOOL_SOURCE_FALLBACK_LABEL],
+            labels,
             ok: payload.ok ?? true,
             message: message.length > 0 ? humanizeWorkLogProgressMessage(message) : undefined,
           });

--- a/src/service.ts
+++ b/src/service.ts
@@ -520,7 +520,14 @@ export interface AgentStreamEventMap {
   /** A tool lookup or source traversal started. */
   tool_call: { name: string; input?: unknown };
   /** A tool lookup or source traversal completed. */
-  tool_result: { name: string; ok: boolean; sourceBooks?: string[] | undefined };
+  tool_result: {
+    name: string;
+    ok: boolean;
+    message?: string | undefined;
+    sourceBooks?: string[] | undefined;
+  };
+  /** User-safe plain-language statement of the agent's next intended lookup. */
+  tool_plan: { message: string; toolName?: string | undefined };
   /** User-safe progress from a long tool. Trace-only until explicitly mapped by a route. */
   tool_progress: { message: string; toolName?: string | undefined };
   /** User-safe structured artifact content. Routes must render this outside answer prose. */

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -185,6 +185,10 @@ export type EntityResolutionResult =
       candidates: [];
     };
 
+const LOOKUP_LOW_CONFIDENCE_THRESHOLD = 0.8;
+const LOOKUP_TIE_MARGIN = 0.02;
+const LOOKUP_LOW_CONFIDENCE_MARGIN = 0.08;
+
 export type KnowledgeEntityKind = 'rules_passage' | 'scenario' | 'section' | 'card';
 
 export interface KnowledgeEntitySummary {
@@ -1419,6 +1423,92 @@ export async function resolveEntity(
       .sort((a, b) => b.confidence - a.confidence || a.entity.title.localeCompare(b.entity.title))
       .slice(0, limit),
   };
+}
+
+function summaryFromResolutionCandidate(candidate: EntityCandidate): KnowledgeEntitySummary | null {
+  if (candidate.entity.kind === 'card_type') return null;
+  return {
+    kind: candidate.entity.kind,
+    ref: candidate.entity.ref,
+    title: candidate.entity.title,
+    sourceLabel: candidate.entity.sourceLabel,
+  };
+}
+
+function ambiguousLookupCandidates(candidates: EntityCandidate[]): KnowledgeEntitySummary[] {
+  return candidates
+    .map(summaryFromResolutionCandidate)
+    .filter((candidate): candidate is KnowledgeEntitySummary => candidate !== null);
+}
+
+function lookupNeedsClarification(candidates: EntityCandidate[]): boolean {
+  const [top, second] = candidates;
+  if (!top) return false;
+  if (top.confidence < LOOKUP_LOW_CONFIDENCE_THRESHOLD) return true;
+  if (!second) return false;
+
+  const confidenceGap = top.confidence - second.confidence;
+  return (
+    confidenceGap <= LOOKUP_TIE_MARGIN ||
+    (top.confidence < 0.9 && confidenceGap <= LOOKUP_LOW_CONFIDENCE_MARGIN)
+  );
+}
+
+export async function lookupEntity(
+  query: string,
+  options: EntityResolutionOptions = {},
+): Promise<KnowledgeOpenResult> {
+  const resolution = await resolveEntity(query, options);
+  if (!resolution.ok) {
+    return {
+      ok: false,
+      error: {
+        code: 'invalid_filter',
+        message: resolution.hint,
+        hint: resolution.hint,
+        candidates: [],
+      },
+    };
+  }
+
+  const candidates = resolution.candidates;
+  if (candidates.length === 0) {
+    return {
+      ok: false,
+      error: {
+        code: 'not_found',
+        message: `No entity found for: ${query}`,
+        hint: 'Try a more specific scenario, section, item, monster, or card name.',
+      },
+    };
+  }
+
+  if (lookupNeedsClarification(candidates)) {
+    return {
+      ok: false,
+      error: {
+        code: 'ambiguous',
+        message: `Multiple possible matches for: ${query}`,
+        hint: 'Ask again with the exact scenario, section, item number, card name, monster level, or source type.',
+        candidates: ambiguousLookupCandidates(candidates),
+      },
+    };
+  }
+
+  const top = candidates[0];
+  if (!top || top.entity.kind === 'card_type') {
+    return {
+      ok: false,
+      error: {
+        code: 'invalid_ref',
+        message: `The resolved entity is not directly openable: ${query}`,
+        hint: 'Ask for a specific scenario, section, item, monster stat card, or other card record.',
+        candidates: ambiguousLookupCandidates(candidates),
+      },
+    };
+  }
+
+  return openEntity(top.entity.ref, { game: normalizeToolGame(options.game) });
 }
 
 /**

--- a/src/web-ui/consulted-footer.ts
+++ b/src/web-ui/consulted-footer.ts
@@ -56,6 +56,7 @@ const TOOL_SOURCE_LABELS: Record<AgentToolName, ToolSourceLabel | null> = {
   inspect_sources: null,
   schema: null,
   resolve_entity: null,
+  lookup_entity: null,
   open_entity: null,
   search_knowledge: null,
   neighbors: null,

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -542,7 +542,7 @@ function answerWorkProgressSort(detail: string): number {
 }
 
 function answerWorkPlanRowId(rowId: string | null, detail: string): string {
-  return `plan-${answerWorkSlug(detail.length > 0 ? detail : (rowId ?? undefined), 'event')}`;
+  return `plan-${answerWorkSlug(rowId ?? (detail.length > 0 ? detail : undefined), 'event')}`;
 }
 
 function answerWorkPlanSort(detail: string): number {
@@ -789,9 +789,14 @@ function buildCompletedAnswerWorkTimeline(
 
       labels.forEach((label, index) => {
         if (ok) successfulSources.add(label);
-        if (ok && sourceActionRowIdsByLabel.has(label)) return;
         const id = answerWorkCheckedSourceRowId(label, ok, index);
-        if (ok) checkedRowIdsByLabel.set(label, id);
+        const previousCheckedRowId = checkedRowIdsByLabel.get(label);
+        if (previousCheckedRowId && previousCheckedRowId !== id) rows.delete(previousCheckedRowId);
+        if (ok && sourceActionRowIdsByLabel.has(label)) {
+          checkedRowIdsByLabel.delete(label);
+          return;
+        }
+        checkedRowIdsByLabel.set(label, id);
         addCompletedAnswerWorkRow(rows, {
           id,
           detail: `${ok ? 'Checked' : "Couldn't check"} ${physicalToolSourceLabel(label)}`,

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -30,6 +30,10 @@ import {
   UNSUPPORTED_MARKDOWN_SPECIMEN,
 } from './markdown-styleguide.ts';
 import { DEFAULT_GAME_ID, SUPPORTED_GAME_IDS, SUPPORTED_GAMES } from '../game.ts';
+import {
+  humanizeWorkLogProgressMessage,
+  workLogSourceActionFromProgressMessage,
+} from '../work-log-display.ts';
 import type {
   ConversationMessage,
   ConversationMessagePublicWorkEvent,
@@ -450,23 +454,19 @@ function renderMarkdownSpecimenCard(options: {
   </section>` as HtmlEscapedString;
 }
 
-function displayToolSourceLabel(label: ToolSourceLabel): string {
+function physicalToolSourceLabel(label: ToolSourceLabel): string {
   switch (label) {
     case 'RULEBOOK':
-      return 'Rulebook';
+      return 'the rulebook';
     case 'PUZZLE BOOK':
-      return 'Puzzle Book';
+      return 'the puzzle book';
     case 'CARD INDEX':
-      return 'Card Index';
+      return 'the cards';
     case 'SCENARIO BOOK':
-      return 'Scenario Book';
+      return 'the scenario book';
     case 'SECTION BOOK':
-      return 'Section Book';
+      return 'the section book';
   }
-}
-
-function sentenceToolSourceLabel(label: ToolSourceLabel): string {
-  return displayToolSourceLabel(label).toLowerCase();
 }
 
 interface CompletedAnswerWorkRow {
@@ -474,6 +474,7 @@ interface CompletedAnswerWorkRow {
   detail: string;
   sourceLabels: ToolSourceLabel[];
   state: 'complete' | 'error';
+  variant?: 'narrative';
   sort: number;
   ordinal: number;
 }
@@ -513,29 +514,55 @@ function payloadSourceLabel(value: unknown): ToolSourceLabel | null {
 }
 
 function genericAnswerWorkProgressDetail(message: string): string {
-  const resolvingMonster = message.match(/^Resolving\s+(.+?)\s+monster(?:\s+stat(?:\s+card)?)?$/i);
-  if (resolvingMonster) return `Resolving ${resolvingMonster[1]!.trim()} stats`;
-  if (message === 'Searching selected sources') return 'Searching available sources';
-  if (message === 'Searching knowledge') return 'Searching available sources';
-  return message;
+  return humanizeWorkLogProgressMessage(message);
 }
 
 function answerWorkProgressRowId(rowId: string | null, detail: string): string {
   const baseId = baseAnswerWorkId(rowId ?? undefined) ?? 'progress';
   const normalizedDetail = detail.toLowerCase();
-  if (normalizedDetail.startsWith('resolving ')) {
+  if (normalizedDetail.startsWith('resolving ') || normalizedDetail.startsWith('looked up ')) {
     return `progress-resolving-${answerWorkSlug(detail, 'event')}`;
   }
-  if (normalizedDetail === 'searching available sources') {
-    return 'progress-searching-available-sources';
+  if (
+    normalizedDetail === 'searching available sources' ||
+    normalizedDetail === 'searched available sources'
+  ) {
+    return 'progress-searched-available-sources';
   }
   return `${baseId}-progress-${answerWorkSlug(detail, 'event')}`;
 }
 
 function answerWorkProgressSort(detail: string): number {
   const normalizedDetail = detail.toLowerCase();
+  if (normalizedDetail.startsWith('looked up ')) return 10;
+  if (normalizedDetail.startsWith('checked ') && normalizedDetail.includes(' card')) return 10;
   if (normalizedDetail.startsWith('resolving ')) return 10;
-  if (normalizedDetail === 'searching available sources') return 20;
+  if (normalizedDetail === 'searched available sources') return 20;
+  return 30;
+}
+
+function answerWorkPlanRowId(rowId: string | null, detail: string): string {
+  return `plan-${answerWorkSlug(detail.length > 0 ? detail : (rowId ?? undefined), 'event')}`;
+}
+
+function answerWorkPlanSort(detail: string): number {
+  const normalizedDetail = detail.toLowerCase();
+  if (
+    normalizedDetail.startsWith("i'll look that up ") ||
+    normalizedDetail.startsWith("i'll look up ") ||
+    normalizedDetail.startsWith("i'm looking up ") ||
+    normalizedDetail.startsWith("i'm checking ") ||
+    normalizedDetail.includes(' stat card')
+  ) {
+    return 9;
+  }
+  if (
+    normalizedDetail.includes('available sources') ||
+    normalizedDetail.includes(',') ||
+    normalizedDetail.includes(' and ')
+  ) {
+    return 20;
+  }
   return 30;
 }
 
@@ -544,10 +571,11 @@ function answerWorkCheckedSourceRowId(label: ToolSourceLabel, ok: boolean, index
 }
 
 function answerWorkProgressMessage(detail: string, sourceLabel: ToolSourceLabel | null): string {
-  if (detail === 'Searching available sources') return detail;
+  if (detail === 'Searched available sources' || detail === 'Searching available sources')
+    return detail;
   if (!sourceLabel) return detail || 'Checking sources';
 
-  const source = sentenceToolSourceLabel(sourceLabel);
+  const source = physicalToolSourceLabel(sourceLabel);
   if (detail && !detail.toLowerCase().includes(source)) {
     return `${detail} in ${source}`;
   }
@@ -555,7 +583,7 @@ function answerWorkProgressMessage(detail: string, sourceLabel: ToolSourceLabel 
 }
 
 function answerWorkArtifactMessage(title: string, sourceLabel: ToolSourceLabel | null): string {
-  return `Found ${title || 'source'}${sourceLabel ? ` in ${sentenceToolSourceLabel(sourceLabel)}` : ''}`;
+  return `Found ${title || 'source'}${sourceLabel ? ` in ${physicalToolSourceLabel(sourceLabel)}` : ''}`;
 }
 
 function addCompletedAnswerWorkRow(
@@ -567,6 +595,49 @@ function addCompletedAnswerWorkRow(
   const row = { ...input, ordinal: rows.size };
   rows.set(input.id, row);
   return row;
+}
+
+function genericLookupSubject(detail: string): string | null {
+  const match = detail.match(/^Look(?:ed|ing) up\s+(.+)$/i);
+  if (!match || /\s+in the\s+/i.test(detail)) return null;
+  const subject = match[1]!.trim().toLowerCase();
+  return subject.length > 0 ? subject : null;
+}
+
+function sourceActionSupersedesGenericLookup(
+  action: { detail: string },
+  lookup: { id: string; detail: string },
+): boolean {
+  const subject = genericLookupSubject(lookup.detail);
+  if (!subject) return false;
+  return action.detail.toLowerCase().includes(subject);
+}
+
+function removeSupersededGenericLookupRows(
+  rows: Map<string, CompletedAnswerWorkRow>,
+  genericLookupRows: Array<{ id: string; detail: string }>,
+  action: { detail: string },
+): Array<{ id: string; detail: string }> {
+  const remaining: Array<{ id: string; detail: string }> = [];
+  for (const lookup of genericLookupRows) {
+    if (sourceActionSupersedesGenericLookup(action, lookup)) {
+      rows.delete(lookup.id);
+    } else {
+      remaining.push(lookup);
+    }
+  }
+  return remaining;
+}
+
+function removeArtifactRowsForSourceAction(
+  rows: Map<string, CompletedAnswerWorkRow>,
+  artifactRowIdsByLabel: Map<ToolSourceLabel, string[]>,
+  label: ToolSourceLabel,
+): void {
+  const artifactRows = artifactRowIdsByLabel.get(label);
+  if (!artifactRows) return;
+  for (const rowId of artifactRows) rows.delete(rowId);
+  artifactRowIdsByLabel.delete(label);
 }
 
 function countTimelineSourceLabels(rows: CompletedAnswerWorkRow[]): number {
@@ -582,21 +653,69 @@ function buildCompletedAnswerWorkTimeline(
 ): CompletedAnswerWorkTimeline {
   const rows = new Map<string, CompletedAnswerWorkRow>();
   const successfulSources = new Set<ToolSourceLabel>();
+  const sourceActionRowIdsByLabel = new Map<ToolSourceLabel, string>();
+  const checkedRowIdsByLabel = new Map<ToolSourceLabel, string>();
+  const artifactRowIdsByLabel = new Map<ToolSourceLabel, string[]>();
+  let genericLookupRows: Array<{ id: string; detail: string }> = [];
 
   for (const event of events ?? []) {
     const payload = event.payload ?? {};
+    if (event.event === 'tool-plan') {
+      const detail = payloadString(payload, 'message');
+      if (!detail) continue;
+      addCompletedAnswerWorkRow(rows, {
+        id: answerWorkPlanRowId(payloadString(payload, 'id'), detail),
+        detail,
+        sourceLabels: [],
+        state: 'complete',
+        variant: 'narrative',
+        sort: answerWorkPlanSort(detail),
+      });
+      continue;
+    }
+
     if (event.event === 'tool-progress') {
       const rawMessage = payloadString(payload, 'message');
       if (!rawMessage) continue;
       const detail = genericAnswerWorkProgressDetail(rawMessage);
       const sourceLabel = payloadSourceLabel(payload.label);
+      const sourceAction = workLogSourceActionFromProgressMessage(detail, sourceLabel);
+      if (sourceAction) {
+        const label = sourceAction.label as ToolSourceLabel;
+        genericLookupRows = removeSupersededGenericLookupRows(
+          rows,
+          genericLookupRows,
+          sourceAction,
+        );
+        removeArtifactRowsForSourceAction(rows, artifactRowIdsByLabel, label);
+        const checkedRowId = checkedRowIdsByLabel.get(label);
+        if (checkedRowId) {
+          rows.delete(checkedRowId);
+          checkedRowIdsByLabel.delete(label);
+        }
+        const id = `source-action-${answerWorkSlug(label, 'source')}-${answerWorkSlug(
+          sourceAction.detail,
+          'event',
+        )}`;
+        sourceActionRowIdsByLabel.set(label, id);
+        addCompletedAnswerWorkRow(rows, {
+          id,
+          detail: sourceAction.detail,
+          sourceLabels: [label],
+          state: 'complete',
+          sort: answerWorkProgressSort(detail),
+        });
+        continue;
+      }
+      const id = answerWorkProgressRowId(payloadString(payload, 'id'), detail);
       addCompletedAnswerWorkRow(rows, {
-        id: answerWorkProgressRowId(payloadString(payload, 'id'), detail),
+        id,
         detail: answerWorkProgressMessage(detail, sourceLabel),
         sourceLabels: sourceLabel ? [sourceLabel] : [],
         state: 'complete',
         sort: answerWorkProgressSort(detail),
       });
+      if (genericLookupSubject(detail)) genericLookupRows.push({ id, detail });
       continue;
     }
 
@@ -604,19 +723,58 @@ function buildCompletedAnswerWorkTimeline(
       const title = payloadString(payload, 'title');
       if (!title) continue;
       const sourceLabel = payloadSourceLabel(payload.sourceLabel);
+      if (sourceLabel && sourceActionRowIdsByLabel.has(sourceLabel)) continue;
+      const id = payloadString(payload, 'id') ?? `answer-artifact-${event.sequence}`;
       addCompletedAnswerWorkRow(rows, {
-        id: payloadString(payload, 'id') ?? `answer-artifact-${event.sequence}`,
+        id,
         detail: answerWorkArtifactMessage(title, sourceLabel),
         sourceLabels: sourceLabel ? [sourceLabel] : [],
         state: 'complete',
         sort: 40,
       });
+      if (sourceLabel) {
+        artifactRowIdsByLabel.set(sourceLabel, [
+          ...(artifactRowIdsByLabel.get(sourceLabel) ?? []),
+          id,
+        ]);
+      }
       continue;
     }
 
     if (event.event === 'tool-result') {
       const ok = payload.ok !== false;
       const labels = payloadSourceLabels(payload.labels);
+      const resultDetail = payloadString(payload, 'message');
+      const resultSourceAction = resultDetail
+        ? workLogSourceActionFromProgressMessage(resultDetail, labels[0])
+        : null;
+      if (ok && resultSourceAction) {
+        const label = resultSourceAction.label as ToolSourceLabel;
+        successfulSources.add(label);
+        genericLookupRows = removeSupersededGenericLookupRows(
+          rows,
+          genericLookupRows,
+          resultSourceAction,
+        );
+        removeArtifactRowsForSourceAction(rows, artifactRowIdsByLabel, label);
+        const checkedRowId = checkedRowIdsByLabel.get(label);
+        if (checkedRowId) {
+          rows.delete(checkedRowId);
+          checkedRowIdsByLabel.delete(label);
+        }
+        const id = `source-action-${answerWorkSlug(label, 'source')}-${answerWorkSlug(
+          resultSourceAction.detail,
+          'event',
+        )}`;
+        sourceActionRowIdsByLabel.set(label, id);
+        addCompletedAnswerWorkRow(rows, {
+          id,
+          detail: resultSourceAction.detail,
+          sourceLabels: [label],
+          state: 'complete',
+          sort: answerWorkProgressSort(resultSourceAction.detail),
+        });
+      }
       if (labels.length === 0) {
         if (ok) continue;
         addCompletedAnswerWorkRow(rows, {
@@ -631,9 +789,12 @@ function buildCompletedAnswerWorkTimeline(
 
       labels.forEach((label, index) => {
         if (ok) successfulSources.add(label);
+        if (ok && sourceActionRowIdsByLabel.has(label)) return;
+        const id = answerWorkCheckedSourceRowId(label, ok, index);
+        if (ok) checkedRowIdsByLabel.set(label, id);
         addCompletedAnswerWorkRow(rows, {
-          id: answerWorkCheckedSourceRowId(label, ok, index),
-          detail: `${ok ? 'Checked' : "Couldn't check"} ${sentenceToolSourceLabel(label)}`,
+          id,
+          detail: `${ok ? 'Checked' : "Couldn't check"} ${physicalToolSourceLabel(label)}`,
           sourceLabels: ok ? [label] : [],
           state: ok ? 'complete' : 'error',
           sort: ok ? 50 : 90,
@@ -661,7 +822,7 @@ function timelineFromConsultedSources(
   return {
     rows: labels.map((label, index) => ({
       id: answerWorkCheckedSourceRowId(label, true, index),
-      detail: `Checked ${sentenceToolSourceLabel(label)}`,
+      detail: `Checked ${physicalToolSourceLabel(label)}`,
       sourceLabels: [label],
       state: 'complete' as const,
       sort: 50,
@@ -675,29 +836,33 @@ function renderCompletedAnswerWorkTimeline(
   timeline: CompletedAnswerWorkTimeline,
 ): HtmlEscapedString {
   if (timeline.rows.length === 0) return html`` as HtmlEscapedString;
-  const summary =
-    timeline.sourceCount > 0
-      ? `Checked ${timeline.sourceCount} ${timeline.sourceCount === 1 ? 'source' : 'sources'}`
-      : `Recorded ${timeline.rows.length} ${timeline.rows.length === 1 ? 'step' : 'steps'}`;
   return html`<details
     class="squire-answer-work"
     data-testid="answer-progress"
     data-work-state="complete"
   >
     <summary class="squire-answer-work__summary">
-      <span class="squire-answer-work__status" data-answer-work-status>${summary}</span>
+      <span class="squire-answer-work__status" data-answer-work-status>Finished working</span>
+      <span class="squire-answer-work__summary-caret" aria-hidden="true"></span>
     </summary>
     <div class="squire-answer-work__rows" data-answer-work-rows>
       ${timeline.rows.map(
         (row) =>
           html`<div
-            class="squire-answer-work__row${row.state === 'error' ? ' is-error' : ''}"
+            class="${row.variant === 'narrative'
+              ? 'squire-answer-work__row squire-answer-work__row--narrative'
+              : `squire-answer-work__row squire-answer-work__row--event${
+                  row.state === 'error' ? ' is-error' : ''
+                }`}"
             data-answer-work-id="${row.id}"
             ${row.sourceLabels.length > 0
               ? html`data-answer-work-source-labels="${row.sourceLabels.join('|')}"`
               : html``}
             data-work-state="${row.state}"
           >
+            ${row.variant === 'narrative'
+              ? html``
+              : html`<span class="squire-answer-work__row-icon" aria-hidden="true"></span>`}
             <span class="squire-answer-work__row-detail">${row.detail}</span>
           </div>`,
       )}
@@ -756,7 +921,8 @@ function renderPendingAnswerSkeleton(streamUrl: string): HtmlEscapedString {
     <h2 class="sr-only" id="${labelId}">Squire answer</h2>
     <details class="squire-answer-work" data-testid="answer-progress" data-work-state="idle" open>
       <summary class="squire-answer-work__summary">
-        <span class="squire-answer-work__status" data-answer-work-status>Waiting</span>
+        <span class="squire-answer-work__status" data-answer-work-status>Working</span>
+        <span class="squire-answer-work__summary-caret" aria-hidden="true"></span>
       </summary>
       <div
         class="squire-answer-work__rows"

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -1344,7 +1344,6 @@ function renderAnswerWorkResult(elements, entries, context, rowId, labels, ok, d
       resultAction.detail,
       'complete',
     );
-    return;
   }
   if (ok !== false && entries && entries['progress-searched-available-sources']) {
     var genericSearchRow = entries['progress-searched-available-sources'];

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -693,44 +693,369 @@ function rememberAnswerWorkSourceLabels(row, labels) {
   row.dataset.answerWorkSourceLabels = existing.join('|');
 }
 
+function titleizeWorkLogSlug(value) {
+  return String(value || '')
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map(function (part) {
+      return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+    })
+    .join(' ');
+}
+
+function displayWorkLogScenarioNumber(value) {
+  return String(value || '').replace(/^0+(\d)/, '$1');
+}
+
+function removeLeadingWorkLogArticle(value) {
+  return String(value || '').replace(/^the\s+/i, '');
+}
+
+function humanizeWorkLogCardRef(ref) {
+  var match = String(ref || '').match(/^card:[^/]+\/([^/]+)\/gloomhavensecretariat:([^/]+)\/(.+)$/);
+  if (!match) return null;
+  var type = match[1];
+  var sourceKind = match[2];
+  var path = match[3];
+  var pathParts = path.split('/').filter(Boolean);
+  if (pathParts.length === 0) return null;
+
+  if (type === 'monster-stats' && sourceKind === 'monster-stat') {
+    var nameParts = pathParts.slice(0, -1);
+    var name = titleizeWorkLogSlug((nameParts.length > 0 ? nameParts : pathParts).join('-'));
+    return 'the ' + name + ' stat card';
+  }
+
+  var lastPathPart = pathParts[pathParts.length - 1];
+  var fallbackName = titleizeWorkLogSlug(lastPathPart || pathParts.join('-'));
+  if (type === 'items') {
+    return /^\d+$/.test(fallbackName)
+      ? 'the item ' + fallbackName + ' card'
+      : 'the ' + fallbackName + ' item card';
+  }
+  if (type === 'monster-abilities') return 'the ' + fallbackName + ' monster ability card';
+  if (type === 'character-abilities') return 'the ' + fallbackName + ' ability card';
+  if (type === 'buildings') return 'the ' + fallbackName + ' building card';
+  return 'the ' + fallbackName + ' card';
+}
+
+function workLogSourceActionFromRef(ref) {
+  var bareSection = String(ref || '').match(/^(?:section\s+)?(\d+(?:\.\d+)+)$/i);
+  if (bareSection) {
+    return {
+      label: 'SECTION BOOK',
+      detail: 'Looked up section ' + bareSection[1].trim() + ' in the section book',
+    };
+  }
+
+  var bareScenario = String(ref || '').match(/^(?:scenario\s+)?(\d+)$/i);
+  if (bareScenario) {
+    return {
+      label: 'SCENARIO BOOK',
+      detail:
+        'Looked up scenario ' +
+        displayWorkLogScenarioNumber(bareScenario[1].trim()) +
+        ' in the scenario book',
+    };
+  }
+
+  var card = humanizeWorkLogCardRef(ref);
+  if (card) return { label: 'CARD INDEX', detail: 'Checked ' + removeLeadingWorkLogArticle(card) };
+
+  var scenario = String(ref || '').match(/^scenario:[^/]+\/(.+)$/);
+  if (scenario) {
+    return {
+      label: 'SCENARIO BOOK',
+      detail:
+        'Looked up scenario ' +
+        displayWorkLogScenarioNumber(scenario[1].trim()) +
+        ' in the scenario book',
+    };
+  }
+
+  var legacyScenario = String(ref || '').match(/^gloomhavensecretariat:scenario\/(.+)$/);
+  if (legacyScenario) {
+    return {
+      label: 'SCENARIO BOOK',
+      detail:
+        'Looked up scenario ' +
+        displayWorkLogScenarioNumber(legacyScenario[1].trim()) +
+        ' in the scenario book',
+    };
+  }
+
+  var section = String(ref || '').match(/^section:[^/]+\/(.+)$/);
+  if (section) {
+    return {
+      label: 'SECTION BOOK',
+      detail: 'Looked up section ' + section[1].trim() + ' in the section book',
+    };
+  }
+
+  var rules = String(ref || '').match(/^rules:[^/]+\/(.+)#chunk=\d+$/);
+  if (rules) {
+    var source = rules[1].toLowerCase();
+    if (source.indexOf('puzzle') !== -1) {
+      return { label: 'PUZZLE BOOK', detail: 'Checked the puzzle book' };
+    }
+    if (source.indexOf('section') !== -1) {
+      return { label: 'SECTION BOOK', detail: 'Checked the section book' };
+    }
+    if (source.indexOf('scenario') !== -1) {
+      return { label: 'SCENARIO BOOK', detail: 'Checked the scenario book' };
+    }
+    return { label: 'RULEBOOK', detail: 'Checked the rulebook' };
+  }
+
+  return null;
+}
+
+function workLogSearchActionFromBookLabel(label) {
+  var normalized = removeLeadingWorkLogArticle(
+    String(label || '')
+      .trim()
+      .toLowerCase(),
+  );
+  if (normalized === 'rulebook') {
+    return { label: 'RULEBOOK', detail: 'Searched the rulebook' };
+  }
+  if (normalized === 'puzzle book') {
+    return { label: 'PUZZLE BOOK', detail: 'Searched the puzzle book' };
+  }
+  if (normalized === 'scenario book') {
+    return { label: 'SCENARIO BOOK', detail: 'Searched the scenario book' };
+  }
+  if (normalized === 'section book') {
+    return { label: 'SECTION BOOK', detail: 'Searched the section book' };
+  }
+  if (normalized === 'card index' || normalized === 'cards') {
+    return { label: 'CARD INDEX', detail: 'Searched cards' };
+  }
+  return null;
+}
+
 function genericProgressDetail(message) {
+  var checkingCard = message.match(/^Checking\s+the\s+(.+\s+card)$/i);
+  if (checkingCard) return 'Checked ' + checkingCard[1].trim();
+
+  var lookingUpSectionInBook = message.match(
+    /^Looking up\s+section\s+(.+?)\s+in the section book$/i,
+  );
+  if (lookingUpSectionInBook) {
+    return 'Looked up section ' + lookingUpSectionInBook[1].trim() + ' in the section book';
+  }
+  var lookingUpScenarioInBook = message.match(
+    /^Looking up\s+scenario\s+(.+?)\s+in the scenario book$/i,
+  );
+  if (lookingUpScenarioInBook) {
+    return (
+      'Looked up scenario ' +
+      displayWorkLogScenarioNumber(lookingUpScenarioInBook[1].trim()) +
+      ' in the scenario book'
+    );
+  }
+  if (/^Looking up\s+.+\s+in the rulebook$/i.test(message)) return 'Searched the rulebook';
+  if (/^Looking up\s+.+\s+in the puzzle book$/i.test(message)) return 'Searched the puzzle book';
+  if (/^Looking up\s+.+\s+in the scenario book$/i.test(message)) {
+    return 'Searched the scenario book';
+  }
+  if (/^Looking up\s+.+\s+in the section book$/i.test(message)) {
+    return 'Searched the section book';
+  }
+
+  var opening = message.match(/^Opening\s+(.+)$/i);
+  if (opening) {
+    var openedSource = workLogSourceActionFromRef(opening[1].trim());
+    if (openedSource) return openedSource.detail;
+  }
+  var checkingLinks = message.match(/^Checking links from\s+(.+)$/i);
+  if (checkingLinks) {
+    var linkedSource = workLogSourceActionFromRef(checkingLinks[1].trim());
+    if (linkedSource)
+      return 'Followed links from ' + linkedSource.detail.replace(/^Checked\s+/, '');
+  }
+  var checking = message.match(/^Checking\s+(.+)$/i);
+  if (checking) return 'Checked ' + checking[1].trim();
   var resolvingMonster = message.match(/^Resolving\s+(.+?)\s+monster(?:\s+stat(?:\s+card)?)?$/i);
-  if (resolvingMonster) return 'Resolving ' + resolvingMonster[1].trim() + ' stats';
-  if (message === 'Searching selected sources') return 'Searching available sources';
-  if (message === 'Searching knowledge') return 'Searching available sources';
+  if (resolvingMonster) {
+    return 'Checked ' + titleizeWorkLogSlug(resolvingMonster[1].trim()) + ' stat card';
+  }
+  var resolvingStats = message.match(/^Resolving\s+(.+?)\s+stats$/i);
+  if (resolvingStats) {
+    return 'Checked ' + titleizeWorkLogSlug(resolvingStats[1].trim()) + ' stat card';
+  }
+  var resolving = message.match(/^Resolving\s+(.+)$/i);
+  if (resolving) return 'Looked up ' + resolving[1].trim();
+  var searchingBook = message.match(/^Searching\s+(.+)$/i);
+  if (searchingBook) {
+    var searchAction = workLogSearchActionFromBookLabel(searchingBook[1]);
+    if (searchAction) return searchAction.detail;
+    if (searchingBook[1].indexOf(',') !== -1) return 'Searched available sources';
+  }
+  if (message === 'Searching selected sources') return 'Searched available sources';
+  if (message === 'Searching knowledge') return 'Searched available sources';
   return message;
+}
+
+function activeProgressDetail(message) {
+  var checked = String(message || '').match(/^Checked\s+(.+)$/i);
+  if (checked) return 'Checking ' + checked[1].trim();
+  var searched = String(message || '').match(/^Searched\s+(.+)$/i);
+  if (searched) return 'Searching ' + searched[1].trim();
+  var lookedUp = String(message || '').match(/^Looked up\s+(.+)$/i);
+  if (lookedUp) return 'Looking up ' + lookedUp[1].trim();
+  var followedLinks = String(message || '').match(/^Followed links from\s+(.+)$/i);
+  if (followedLinks) return 'Following links from ' + followedLinks[1].trim();
+  return message;
+}
+
+function answerWorkSourceActionFromProgress(detail, sourceLabel) {
+  if (/^Checked .+ card$/i.test(detail) || detail === 'Searched cards') {
+    return { label: 'CARD INDEX', detail: detail };
+  }
+  if (
+    detail === 'Searched the rulebook' ||
+    detail === 'Checked the rulebook' ||
+    / in the rulebook$/i.test(detail)
+  ) {
+    return { label: 'RULEBOOK', detail: detail };
+  }
+  if (
+    detail === 'Searched the puzzle book' ||
+    detail === 'Checked the puzzle book' ||
+    / in the puzzle book$/i.test(detail)
+  ) {
+    return { label: 'PUZZLE BOOK', detail: detail };
+  }
+  if (
+    detail === 'Searched the scenario book' ||
+    detail === 'Checked the scenario book' ||
+    / in the scenario book$/i.test(detail)
+  ) {
+    return { label: 'SCENARIO BOOK', detail: detail };
+  }
+  if (
+    detail === 'Searched the section book' ||
+    detail === 'Checked the section book' ||
+    / in the section book$/i.test(detail)
+  ) {
+    return { label: 'SECTION BOOK', detail: detail };
+  }
+  var sectionLookup = detail.match(/^Looked up\s+section\s+(.+)$/i);
+  if (sectionLookup) {
+    return {
+      label: 'SECTION BOOK',
+      detail: 'Looked up section ' + sectionLookup[1].trim() + ' in the section book',
+    };
+  }
+  var scenarioLookup = detail.match(/^Looked up\s+scenario\s+(.+)$/i);
+  if (scenarioLookup) {
+    return {
+      label: 'SCENARIO BOOK',
+      detail:
+        'Looked up scenario ' +
+        displayWorkLogScenarioNumber(scenarioLookup[1].trim()) +
+        ' in the scenario book',
+    };
+  }
+  if (sourceLabel === 'RULEBOOK' && detail !== 'Searched available sources') {
+    return { label: 'RULEBOOK', detail: detail + ' in the rulebook' };
+  }
+  if (sourceLabel === 'PUZZLE BOOK' && detail !== 'Searched available sources') {
+    return { label: 'PUZZLE BOOK', detail: detail + ' in the puzzle book' };
+  }
+  if (sourceLabel === 'SCENARIO BOOK' && detail !== 'Searched available sources') {
+    return { label: 'SCENARIO BOOK', detail: detail + ' in the scenario book' };
+  }
+  if (sourceLabel === 'SECTION BOOK' && detail !== 'Searched available sources') {
+    return { label: 'SECTION BOOK', detail: detail + ' in the section book' };
+  }
+  return null;
+}
+
+function answerWorkPhysicalSourceLabel(label) {
+  switch (label) {
+    case 'RULEBOOK':
+      return 'the rulebook';
+    case 'PUZZLE BOOK':
+      return 'the puzzle book';
+    case 'CARD INDEX':
+      return 'the cards';
+    case 'SCENARIO BOOK':
+      return 'the scenario book';
+    case 'SECTION BOOK':
+      return 'the section book';
+    default:
+      return sentenceSourceLabel(label);
+  }
 }
 
 function answerWorkProgressRowId(rowId, detail) {
   var baseId = baseAnswerWorkId(rowId) || 'progress';
   var normalizedDetail = typeof detail === 'string' ? detail.toLowerCase() : '';
-  if (normalizedDetail.indexOf('resolving ') === 0) {
+  if (
+    normalizedDetail.indexOf('resolving ') === 0 ||
+    normalizedDetail.indexOf('looked up ') === 0
+  ) {
     return 'progress-resolving-' + answerWorkSlug(detail, 'event');
   }
-  if (normalizedDetail === 'searching available sources') {
-    return 'progress-searching-available-sources';
+  if (
+    normalizedDetail === 'searching available sources' ||
+    normalizedDetail === 'searched available sources'
+  ) {
+    return 'progress-searched-available-sources';
   }
   return baseId + '-progress-' + answerWorkSlug(detail, 'event');
 }
 
 function answerWorkProgressSort(detail) {
   var normalizedDetail = typeof detail === 'string' ? detail.toLowerCase() : '';
+  if (normalizedDetail.indexOf('looked up ') === 0) return 10;
+  if (normalizedDetail.indexOf('checked ') === 0 && normalizedDetail.indexOf(' card') !== -1) {
+    return 10;
+  }
   if (normalizedDetail.indexOf('resolving ') === 0) return 10;
-  if (normalizedDetail === 'searching available sources') return 20;
+  if (normalizedDetail === 'searched available sources') return 20;
+  return 30;
+}
+
+function answerWorkPlanRowId(rowId, detail) {
+  return 'plan-' + answerWorkSlug(detail || rowId, 'event');
+}
+
+function answerWorkPlanSort(detail) {
+  var normalizedDetail = typeof detail === 'string' ? detail.toLowerCase() : '';
+  if (
+    normalizedDetail.indexOf("i'll look that up ") === 0 ||
+    normalizedDetail.indexOf("i'll look up ") === 0 ||
+    normalizedDetail.indexOf("i'm looking up ") === 0 ||
+    normalizedDetail.indexOf("i'm checking ") === 0 ||
+    normalizedDetail.indexOf(' stat card') !== -1
+  ) {
+    return 9;
+  }
+  if (
+    normalizedDetail.indexOf('available sources') !== -1 ||
+    normalizedDetail.indexOf(',') !== -1 ||
+    normalizedDetail.indexOf(' and ') !== -1
+  ) {
+    return 20;
+  }
   return 30;
 }
 
 function answerWorkRowMessage(label, detail, sourceLabel) {
-  var source = sentenceSourceLabel(sourceLabel);
+  var source = answerWorkPhysicalSourceLabel(sourceLabel);
   var detailText = typeof detail === 'string' ? detail : '';
-  if (label === 'CHECKED') return 'Checked ' + (detailText || source || 'source').toLowerCase();
+  if (label === 'CHECKED') return 'Checked ' + (detailText || source || 'source');
   if (label === "COULDN'T CHECK") {
-    return "Couldn't check " + (detailText || source || 'source').toLowerCase();
+    return "Couldn't check " + (detailText || source || 'source');
   }
   if (label === 'FOUND') {
     return 'Found ' + (detailText || 'source') + (source ? ' in ' + source : '');
   }
-  if (detailText === 'Searching available sources') return detailText;
+  if (detailText === 'Searched available sources' || detailText === 'Searching available sources')
+    return detailText;
   if (source && detailText && detailText.toLowerCase().indexOf(source) === -1) {
     return detailText + ' in ' + source;
   }
@@ -766,31 +1091,7 @@ function setAnswerWorkRowOrder(elements, row, sort) {
   if (elements && elements.rowsEl) sortAnswerWorkRows(elements.rowsEl);
 }
 
-function inferredAnswerWorkSourceCount(elements) {
-  if (!elements.rowsEl || !elements.rowsEl.children) return 0;
-  var labels = new Map();
-  for (var i = 0; i < elements.rowsEl.children.length; i += 1) {
-    var row = elements.rowsEl.children[i];
-    var rowLabels =
-      row.dataset && row.dataset.answerWorkSourceLabels
-        ? row.dataset.answerWorkSourceLabels.split('|').filter(Boolean)
-        : [];
-    for (var rowLabelIndex = 0; rowLabelIndex < rowLabels.length; rowLabelIndex += 1) {
-      var rowLabel = rowLabels[rowLabelIndex];
-      if (isKnownConsultedLabel(rowLabel) && !labels.has(rowLabel)) labels.set(rowLabel, true);
-    }
-    var detailEl = row.querySelector ? row.querySelector('.squire-answer-work__row-detail') : null;
-    var sourceEl = row.querySelector ? row.querySelector('.squire-answer-work__row-source') : null;
-    var candidates = [detailEl ? detailEl.textContent : '', sourceEl ? sourceEl.textContent : ''];
-    for (var j = 0; j < candidates.length; j += 1) {
-      var label = candidates[j];
-      if (isKnownConsultedLabel(label) && !labels.has(label)) labels.set(label, true);
-    }
-  }
-  return labels.size;
-}
-
-function completeAnswerWork(elements, sourceCount) {
+function completeAnswerWork(elements) {
   if (!elements || !elements.container) return;
   var rowCount = elements.rowsEl ? elements.rowsEl.children.length : 0;
   if (rowCount === 0) {
@@ -805,18 +1106,7 @@ function completeAnswerWork(elements, sourceCount) {
   elements.container.setAttribute('data-work-state', 'complete');
   syncAnswerWorkOpenState(elements.container);
   if (elements.statusEl) {
-    var effectiveSourceCount =
-      sourceCount > 0 ? sourceCount : inferredAnswerWorkSourceCount(elements);
-    if (effectiveSourceCount > 0) {
-      elements.statusEl.textContent =
-        'Checked ' +
-        effectiveSourceCount +
-        ' ' +
-        (effectiveSourceCount === 1 ? 'source' : 'sources');
-    } else {
-      elements.statusEl.textContent =
-        'Recorded ' + rowCount + ' ' + (rowCount === 1 ? 'step' : 'steps');
-    }
+    elements.statusEl.textContent = 'Finished working';
   }
 }
 
@@ -847,10 +1137,122 @@ function ensureAnswerWorkRow(elements, entries, rowId) {
   return row;
 }
 
+function ensureAnswerWorkRowIcon(row) {
+  if (!row || !row.querySelector) return;
+  if (row.querySelector('.squire-answer-work__row-icon')) return;
+  var detailEl = row.querySelector('.squire-answer-work__row-detail');
+  var iconEl = document.createElement('span');
+  iconEl.className = 'squire-answer-work__row-icon';
+  iconEl.setAttribute('aria-hidden', 'true');
+  if (detailEl && typeof row.insertBefore === 'function') {
+    row.insertBefore(iconEl, detailEl);
+  } else {
+    row.appendChild(iconEl);
+  }
+}
+
+function removeAnswerWorkRowIcon(row) {
+  if (!row || !row.querySelector) return;
+  var iconEl = row.querySelector('.squire-answer-work__row-icon');
+  if (iconEl && iconEl.parentNode && typeof iconEl.parentNode.removeChild === 'function') {
+    iconEl.parentNode.removeChild(iconEl);
+  }
+}
+
+function removeAnswerWorkRow(elements, entries, rowId) {
+  var baseId = baseAnswerWorkId(rowId);
+  if (!baseId || !entries || !entries[baseId]) return;
+  var row = entries[baseId];
+  if (row.parentNode && typeof row.parentNode.removeChild === 'function') {
+    row.parentNode.removeChild(row);
+  } else if (row.parentNode && row.parentNode.children) {
+    var index = row.parentNode.children.indexOf(row);
+    if (index !== -1) row.parentNode.children.splice(index, 1);
+    row.parentNode = null;
+  } else if (elements && elements.rowsEl && elements.rowsEl.children) {
+    var fallbackIndex = elements.rowsEl.children.indexOf(row);
+    if (fallbackIndex !== -1) elements.rowsEl.children.splice(fallbackIndex, 1);
+  }
+  delete entries[baseId];
+}
+
+function answerWorkSourceActionRowId(action) {
+  return (
+    'source-action-' +
+    answerWorkSlug(action && action.label, 'source') +
+    '-' +
+    answerWorkSlug(action && action.detail, 'event')
+  );
+}
+
+function answerWorkGenericLookupSubject(detail) {
+  var match = String(detail || '').match(/^Look(?:ed|ing) up\s+(.+)$/i);
+  if (!match || /\s+in the\s+/i.test(detail)) return '';
+  return match[1].trim().toLowerCase();
+}
+
+function sourceActionSupersedesGenericLookup(action, lookup) {
+  var subject = answerWorkGenericLookupSubject(lookup && lookup.detail);
+  if (!subject) return false;
+  return (
+    String(action && action.detail)
+      .toLowerCase()
+      .indexOf(subject) !== -1
+  );
+}
+
+function rememberGenericLookupRow(context, rowId, detail) {
+  if (!context) return;
+  if (!answerWorkGenericLookupSubject(detail)) return;
+  context.genericLookupRows.push({ rowId: rowId, detail: detail });
+}
+
+function removeSupersededGenericLookupRows(elements, entries, context, action) {
+  if (!context || !context.genericLookupRows.length) return;
+  var remaining = [];
+  for (var i = 0; i < context.genericLookupRows.length; i += 1) {
+    var lookup = context.genericLookupRows[i];
+    if (sourceActionSupersedesGenericLookup(action, lookup)) {
+      removeAnswerWorkRow(elements, entries, lookup.rowId);
+    } else {
+      remaining.push(lookup);
+    }
+  }
+  context.genericLookupRows = remaining;
+}
+
+function rememberArtifactRow(context, rowId, sourceLabel) {
+  if (!context || !isKnownConsultedLabel(sourceLabel)) return;
+  if (!context.artifactRowsByLabel[sourceLabel]) context.artifactRowsByLabel[sourceLabel] = [];
+  context.artifactRowsByLabel[sourceLabel].push(rowId);
+}
+
+function removeArtifactRowsForSourceAction(elements, entries, context, action) {
+  if (!context || !action || !context.artifactRowsByLabel[action.label]) return;
+  var rows = context.artifactRowsByLabel[action.label];
+  for (var i = 0; i < rows.length; i += 1) {
+    removeAnswerWorkRow(elements, entries, rows[i]);
+  }
+  delete context.artifactRowsByLabel[action.label];
+}
+
 function renderAnswerWorkRow(elements, entries, rowId, label, detail, sourceLabel, state, sort) {
   var row = ensureAnswerWorkRow(elements, entries, rowId);
   if (!row) return;
   if (row.dataset && row.dataset.answerWorkFrozen === 'true') {
+    if (state === 'complete' || state === 'error') {
+      var frozenDetailEl = row.querySelector('.squire-answer-work__row-detail');
+      row.dataset.workState = state;
+      if (row.classList && typeof row.classList.remove === 'function') {
+        row.classList.remove('squire-answer-work__row--narrative');
+        row.classList.add('squire-answer-work__row--event');
+        row.classList.remove('is-error');
+        if (state === 'error') row.classList.add('is-error');
+      }
+      ensureAnswerWorkRowIcon(row);
+      if (frozenDetailEl)
+        frozenDetailEl.textContent = answerWorkRowMessage(label, detail, sourceLabel);
+    }
     setAnswerWorkRowOrder(elements, row, sort);
     setAnswerWorkRunning(elements);
     return row;
@@ -859,6 +1261,16 @@ function renderAnswerWorkRow(elements, entries, rowId, label, detail, sourceLabe
 
   row.dataset.workState = state || 'running';
   row.dataset.answerWorkFrozen = 'true';
+  if (row.classList && typeof row.classList.remove === 'function') {
+    row.classList.remove('squire-answer-work__row--narrative');
+    row.classList.add('squire-answer-work__row--event');
+  } else {
+    row.className = row.className.replace(/\bsquire-answer-work__row--narrative\b/g, '').trim();
+    if (row.className.indexOf('squire-answer-work__row--event') === -1) {
+      row.className += ' squire-answer-work__row--event';
+    }
+  }
+  ensureAnswerWorkRowIcon(row);
   row.classList.remove('is-error');
   if (state === 'error') row.classList.add('is-error');
 
@@ -871,8 +1283,77 @@ function renderAnswerWorkRow(elements, entries, rowId, label, detail, sourceLabe
   return row;
 }
 
-function renderAnswerWorkResult(elements, entries, rowId, labels, ok) {
+function renderAnswerWorkNarrative(elements, entries, rowId, detail, sort) {
+  var row = ensureAnswerWorkRow(elements, entries, rowId);
+  if (!row) return null;
+  if (row.classList && typeof row.classList.add === 'function') {
+    row.classList.remove('squire-answer-work__row--event');
+    row.classList.add('squire-answer-work__row--narrative');
+  } else {
+    row.className = row.className.replace(/\bsquire-answer-work__row--event\b/g, '').trim();
+    if (row.className.indexOf('squire-answer-work__row--narrative') === -1) {
+      row.className += ' squire-answer-work__row--narrative';
+    }
+  }
+  row.dataset.workState = 'running';
+  row.dataset.answerWorkFrozen = 'true';
+  removeAnswerWorkRowIcon(row);
+  var detailEl = row.querySelector('.squire-answer-work__row-detail');
+  if (detailEl) detailEl.textContent = detail;
+  setAnswerWorkRowOrder(elements, row, sort);
+  setAnswerWorkRunning(elements);
+  return row;
+}
+
+function rememberAnswerWorkSourceAction(elements, entries, context, action, sort, detail, state) {
+  if (!action || !isKnownConsultedLabel(action.label)) return null;
+  removeSupersededGenericLookupRows(elements, entries, context, action);
+  removeArtifactRowsForSourceAction(elements, entries, context, action);
+  if (context && context.checkedRowsByLabel[action.label]) {
+    removeAnswerWorkRow(elements, entries, context.checkedRowsByLabel[action.label]);
+    delete context.checkedRowsByLabel[action.label];
+  }
+  var rowId = answerWorkSourceActionRowId(action);
+  var row = renderAnswerWorkRow(
+    elements,
+    entries,
+    rowId,
+    'SEARCHING',
+    detail || action.detail,
+    '',
+    state || 'running',
+    sort,
+  );
+  if (row) rememberAnswerWorkSourceLabels(row, [action.label]);
+  if (context) context.sourceActionRowsByLabel[action.label] = rowId;
+  return row;
+}
+
+function renderAnswerWorkResult(elements, entries, context, rowId, labels, ok, detail) {
   var sourceEntries = answerWorkSourceEntries(labels);
+  var resultAction = detail
+    ? answerWorkSourceActionFromProgress(genericProgressDetail(detail))
+    : null;
+  if (ok !== false && resultAction) {
+    rememberAnswerWorkSourceAction(
+      elements,
+      entries,
+      context,
+      resultAction,
+      answerWorkProgressSort(resultAction.detail),
+      resultAction.detail,
+      'complete',
+    );
+    return;
+  }
+  if (ok !== false && entries && entries['progress-searched-available-sources']) {
+    var genericSearchRow = entries['progress-searched-available-sources'];
+    var genericSearchDetailEl = genericSearchRow.querySelector
+      ? genericSearchRow.querySelector('.squire-answer-work__row-detail')
+      : null;
+    if (genericSearchDetailEl) genericSearchDetailEl.textContent = 'Searched available sources';
+    genericSearchRow.dataset.workState = 'complete';
+  }
   if (sourceEntries.length === 0) {
     if (ok !== false) return;
     renderAnswerWorkRow(
@@ -889,16 +1370,39 @@ function renderAnswerWorkResult(elements, entries, rowId, labels, ok) {
   }
   for (var i = 0; i < sourceEntries.length; i += 1) {
     var entry = sourceEntries[i];
+    if (ok !== false && context && context.sourceActionRowsByLabel[entry.label]) {
+      var actionRow = entries[baseAnswerWorkId(context.sourceActionRowsByLabel[entry.label])];
+      if (actionRow) {
+        var actionDetailEl = actionRow.querySelector
+          ? actionRow.querySelector('.squire-answer-work__row-detail')
+          : null;
+        var completedDetail = actionDetailEl
+          ? genericProgressDetail(actionDetailEl.textContent || '')
+          : '';
+        var completedAction = completedDetail
+          ? answerWorkSourceActionFromProgress(completedDetail, entry.label)
+          : null;
+        if (completedAction) completedDetail = completedAction.detail;
+        if (completedDetail && actionDetailEl) {
+          actionDetailEl.textContent = completedDetail;
+          actionRow.dataset.workState = 'complete';
+        }
+        rememberAnswerWorkSourceLabels(actionRow, [entry.label]);
+      }
+      continue;
+    }
+    var checkedRowId = answerWorkCheckedSourceRowId(entry.label, ok, i);
     var row = renderAnswerWorkRow(
       elements,
       entries,
-      answerWorkCheckedSourceRowId(entry.label, ok, i),
+      checkedRowId,
       ok === false ? "COULDN'T CHECK" : 'CHECKED',
-      entry.display,
+      answerWorkPhysicalSourceLabel(entry.label),
       '',
       ok === false ? 'error' : 'running',
       ok === false ? 90 : 50,
     );
+    if (context && ok !== false) context.checkedRowsByLabel[entry.label] = checkedRowId;
     if (ok !== false) rememberAnswerWorkSourceLabels(row, [entry.label]);
   }
 }
@@ -1038,6 +1542,12 @@ function attachPendingAnswerStream(answerEl) {
   var seenFirstDelta = false;
   var toolPhaseStarted = false;
   var artifactEntries = {};
+  var answerWorkContext = {
+    sourceActionRowsByLabel: {},
+    checkedRowsByLabel: {},
+    artifactRowsByLabel: {},
+    genericLookupRows: [],
+  };
   // Ordered-dedup set of provenance labels collected from tool-result
   // events during this turn. `Map` preserves insertion order, which we
   // use for the completed work-log source count and replay fallback.
@@ -1126,6 +1636,23 @@ function attachPendingAnswerStream(answerEl) {
     setAnswerWorkRunning(answerWork);
   });
 
+  source.addEventListener('tool-plan', function (event) {
+    var payload = JSON.parse(event.data || '{}');
+    if (!payload.message) return;
+    if (seenFirstDelta) {
+      return;
+    }
+    preToolBuffer = '';
+    toolPhaseStarted = true;
+    renderAnswerWorkNarrative(
+      answerWork,
+      answerWorkEntries,
+      answerWorkPlanRowId(payload.id, payload.message),
+      payload.message,
+      answerWorkPlanSort(payload.message),
+    );
+  });
+
   source.addEventListener('tool-progress', function (event) {
     var payload = JSON.parse(event.data || '{}');
     if (!payload.message) return;
@@ -1135,16 +1662,35 @@ function attachPendingAnswerStream(answerEl) {
     preToolBuffer = '';
     toolPhaseStarted = true;
     var detail = genericProgressDetail(payload.message);
-    renderAnswerWorkRow(
-      answerWork,
-      answerWorkEntries,
-      answerWorkProgressRowId(payload.id, detail),
-      'SEARCHING',
-      detail,
-      payload.label,
-      'running',
-      answerWorkProgressSort(detail),
-    );
+    var activeDetail = activeProgressDetail(detail);
+    var sourceAction = answerWorkSourceActionFromProgress(detail, payload.label);
+    if (sourceAction) {
+      rememberAnswerWorkSourceAction(
+        answerWork,
+        answerWorkEntries,
+        answerWorkContext,
+        sourceAction,
+        answerWorkProgressSort(detail),
+        activeDetail,
+        'running',
+      );
+    } else {
+      renderAnswerWorkRow(
+        answerWork,
+        answerWorkEntries,
+        answerWorkProgressRowId(payload.id, detail),
+        'SEARCHING',
+        activeDetail,
+        payload.label,
+        'running',
+        answerWorkProgressSort(detail),
+      );
+      rememberGenericLookupRow(
+        answerWorkContext,
+        answerWorkProgressRowId(payload.id, detail),
+        activeDetail,
+      );
+    }
   });
 
   source.addEventListener('tool-result', function (event) {
@@ -1173,7 +1719,15 @@ function attachPendingAnswerStream(answerEl) {
         }
       }
     }
-    renderAnswerWorkResult(answerWork, answerWorkEntries, payload.id, resultLabels, payload.ok);
+    renderAnswerWorkResult(
+      answerWork,
+      answerWorkEntries,
+      answerWorkContext,
+      payload.id,
+      resultLabels,
+      payload.ok,
+      payload.message,
+    );
   });
 
   source.addEventListener('answer-artifact', function (event) {
@@ -1182,16 +1736,19 @@ function attachPendingAnswerStream(answerEl) {
     if (!payload.id || payload.kind !== 'section-quote' || !payload.title || !payload.body) return;
     preToolBuffer = '';
     toolPhaseStarted = true;
-    renderAnswerWorkRow(
-      answerWork,
-      answerWorkEntries,
-      payload.id,
-      'FOUND',
-      payload.title,
-      payload.sourceLabel,
-      'running',
-      40,
-    );
+    if (!answerWorkContext.sourceActionRowsByLabel[payload.sourceLabel]) {
+      renderAnswerWorkRow(
+        answerWork,
+        answerWorkEntries,
+        payload.id,
+        'FOUND',
+        payload.title,
+        payload.sourceLabel,
+        'running',
+        40,
+      );
+      rememberArtifactRow(answerWorkContext, payload.id, payload.sourceLabel);
+    }
     renderAnswerArtifact(artifactsEl, artifactEntries, payload);
     if (skeletonEl) skeletonEl.hidden = true;
     if (pinToBottom) scrollToBottom();
@@ -1268,10 +1825,17 @@ function attachPendingAnswerStream(answerEl) {
           answerWork.rowsEl &&
           answerWork.rowsEl.children.length === 0
         ) {
-          renderAnswerWorkResult(answerWork, answerWorkEntries, 'persisted-sources', labels, true);
+          renderAnswerWorkResult(
+            answerWork,
+            answerWorkEntries,
+            answerWorkContext,
+            'persisted-sources',
+            labels,
+            true,
+          );
         }
       }
-      completeAnswerWork(answerWork, labels.length);
+      completeAnswerWork(answerWork);
       if (pinToBottom) scrollToBottom();
       var clearAriaBusy = function () {
         answerEl.setAttribute('aria-busy', 'false');

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -1020,7 +1020,7 @@ function answerWorkProgressSort(detail) {
 }
 
 function answerWorkPlanRowId(rowId, detail) {
-  return 'plan-' + answerWorkSlug(detail || rowId, 'event');
+  return 'plan-' + answerWorkSlug(rowId || detail, 'event');
 }
 
 function answerWorkPlanSort(detail) {
@@ -1369,6 +1369,15 @@ function renderAnswerWorkResult(elements, entries, context, rowId, labels, ok, d
   }
   for (var i = 0; i < sourceEntries.length; i += 1) {
     var entry = sourceEntries[i];
+    var checkedRowId = answerWorkCheckedSourceRowId(entry.label, ok, i);
+    if (
+      context &&
+      context.checkedRowsByLabel[entry.label] &&
+      context.checkedRowsByLabel[entry.label] !== checkedRowId
+    ) {
+      removeAnswerWorkRow(elements, entries, context.checkedRowsByLabel[entry.label]);
+      delete context.checkedRowsByLabel[entry.label];
+    }
     if (ok !== false && context && context.sourceActionRowsByLabel[entry.label]) {
       var actionRow = entries[baseAnswerWorkId(context.sourceActionRowsByLabel[entry.label])];
       if (actionRow) {
@@ -1388,9 +1397,9 @@ function renderAnswerWorkResult(elements, entries, context, rowId, labels, ok, d
         }
         rememberAnswerWorkSourceLabels(actionRow, [entry.label]);
       }
+      if (context) delete context.checkedRowsByLabel[entry.label];
       continue;
     }
-    var checkedRowId = answerWorkCheckedSourceRowId(entry.label, ok, i);
     var row = renderAnswerWorkRow(
       elements,
       entries,
@@ -1401,7 +1410,7 @@ function renderAnswerWorkResult(elements, entries, context, rowId, labels, ok, d
       ok === false ? 'error' : 'running',
       ok === false ? 90 : 50,
     );
-    if (context && ok !== false) context.checkedRowsByLabel[entry.label] = checkedRowId;
+    if (context) context.checkedRowsByLabel[entry.label] = checkedRowId;
     if (ok !== false) rememberAnswerWorkSourceLabels(row, [entry.label]);
   }
 }

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -1179,9 +1179,9 @@ function removeAnswerWorkRow(elements, entries, rowId) {
 function answerWorkSourceActionRowId(action) {
   return (
     'source-action-' +
-    answerWorkSlug(action && action.label, 'source') +
+    answerWorkSlug(action.label, 'source') +
     '-' +
-    answerWorkSlug(action && action.detail, 'event')
+    answerWorkSlug(action.detail, 'event')
   );
 }
 
@@ -1397,7 +1397,7 @@ function renderAnswerWorkResult(elements, entries, context, rowId, labels, ok, d
         }
         rememberAnswerWorkSourceLabels(actionRow, [entry.label]);
       }
-      if (context) delete context.checkedRowsByLabel[entry.label];
+      delete context.checkedRowsByLabel[entry.label];
       continue;
     }
     var row = renderAnswerWorkRow(

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -1564,16 +1564,18 @@ template#squire-banner-fixtures {
 }
 
 .squire-answer-work {
-  margin: 0 0 18px;
+  margin: 0 0 24px;
   padding: 0;
   color: var(--sepia);
   font-family: 'Geist', system-ui, sans-serif;
 }
 
 .squire-answer-work__summary {
-  display: inline-flex;
+  display: grid;
+  grid-template-columns: minmax(0, max-content) 10px;
   align-items: center;
   gap: 8px;
+  width: fit-content;
   max-width: 100%;
   min-height: 24px;
   cursor: pointer;
@@ -1585,6 +1587,14 @@ template#squire-banner-fixtures {
 }
 
 .squire-answer-work__summary::before {
+  content: none;
+}
+
+.squire-answer-work__summary-icon {
+  display: none;
+}
+
+.squire-answer-work__summary-caret {
   content: '';
   display: inline-block;
   flex: 0 0 auto;
@@ -1598,7 +1608,7 @@ template#squire-banner-fixtures {
   transform-origin: 45% 50%;
 }
 
-.squire-answer-work[open] .squire-answer-work__summary::before {
+.squire-answer-work[open] .squire-answer-work__summary-caret {
   transform: rotate(90deg) translateX(-1px);
 }
 
@@ -1616,15 +1626,23 @@ template#squire-banner-fixtures {
   color: var(--wax);
 }
 
+.squire-answer-work[data-work-state='running'] .squire-answer-work__summary-caret {
+  color: var(--wax);
+}
+
 .squire-answer-work[data-work-state='error'] .squire-answer-work__status {
+  color: var(--amber);
+}
+
+.squire-answer-work[data-work-state='error'] .squire-answer-work__summary-caret {
   color: var(--amber);
 }
 
 .squire-answer-work__rows {
   display: grid;
-  gap: 4px;
-  margin-top: 6px;
-  padding-left: 17px;
+  gap: 8px;
+  margin-top: 10px;
+  padding-left: 0;
 }
 
 .squire-answer-work__rows:empty {
@@ -1635,13 +1653,59 @@ template#squire-banner-fixtures {
   min-width: 0;
 }
 
+.squire-answer-work__row--event {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  align-items: start;
+  column-gap: 8px;
+}
+
+.squire-answer-work__row--narrative + .squire-answer-work__row--event {
+  margin-top: 4px;
+}
+
+.squire-answer-work__row-icon {
+  position: relative;
+  display: inline-block;
+  width: 13px;
+  height: 13px;
+  margin-top: 2px;
+  color: var(--sepia);
+  border: 1px solid currentcolor;
+  border-radius: 3px;
+  opacity: 0.9;
+}
+
+.squire-answer-work__row-icon::before {
+  content: '';
+  position: absolute;
+  left: 3px;
+  top: 4px;
+  width: 5px;
+  height: 1px;
+  background: currentcolor;
+  box-shadow: 0 4px 0 currentcolor;
+}
+
 .squire-answer-work__row-detail {
   display: block;
   min-width: 0;
-  color: var(--parchment-dim);
+  color: var(--sepia);
   font-size: 13px;
+  font-weight: 500;
   line-height: 1.35;
   overflow-wrap: anywhere;
+}
+
+.squire-answer-work__row--narrative .squire-answer-work__row-icon {
+  display: none;
+}
+
+.squire-answer-work__row--narrative .squire-answer-work__row-detail {
+  color: var(--parchment);
+  font-size: inherit;
+  font-weight: 400;
+  line-height: 1.55;
 }
 
 .squire-answer-work__row.is-error .squire-answer-work__row-detail {

--- a/src/work-log-display.ts
+++ b/src/work-log-display.ts
@@ -1,0 +1,273 @@
+export type WorkLogSourceAction = {
+  label: 'RULEBOOK' | 'PUZZLE BOOK' | 'CARD INDEX' | 'SCENARIO BOOK' | 'SECTION BOOK';
+  detail: string;
+};
+
+function titleizeSlug(value: string): string {
+  return value
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
+function displayScenarioNumber(value: string): string {
+  return value.replace(/^0+(\d)/, '$1');
+}
+
+function removeLeadingArticle(value: string): string {
+  return value.replace(/^the\s+/i, '');
+}
+
+function humanizeCardRef(ref: string): string | null {
+  const match = ref.match(/^card:[^/]+\/([^/]+)\/gloomhavensecretariat:([^/]+)\/(.+)$/);
+  if (!match) return null;
+
+  const [, type, sourceKind, path] = match;
+  const pathParts = path.split('/').filter(Boolean);
+  if (pathParts.length === 0) return null;
+
+  if (type === 'monster-stats' && sourceKind === 'monster-stat') {
+    const nameParts = pathParts.slice(0, -1);
+    const name = titleizeSlug((nameParts.length > 0 ? nameParts : pathParts).join('-'));
+    return `the ${name} stat card`;
+  }
+
+  const lastPathPart = pathParts.at(-1);
+  const name = titleizeSlug(lastPathPart ?? pathParts.join('-'));
+  if (type === 'items')
+    return /^\d+$/.test(name) ? `the item ${name} card` : `the ${name} item card`;
+  if (type === 'monster-abilities') return `the ${name} monster ability card`;
+  if (type === 'character-abilities') return `the ${name} ability card`;
+  if (type === 'buildings') return `the ${name} building card`;
+  return `the ${name} card`;
+}
+
+function sourceActionFromRef(ref: string): WorkLogSourceAction | null {
+  const bareSection = ref.match(/^(?:section\s+)?(\d+(?:\.\d+)+)$/i);
+  if (bareSection) {
+    return {
+      label: 'SECTION BOOK',
+      detail: `Looked up section ${bareSection[1]!.trim()} in the section book`,
+    };
+  }
+
+  const bareScenario = ref.match(/^(?:scenario\s+)?(\d+)$/i);
+  if (bareScenario) {
+    return {
+      label: 'SCENARIO BOOK',
+      detail: `Looked up scenario ${displayScenarioNumber(bareScenario[1]!.trim())} in the scenario book`,
+    };
+  }
+
+  const card = humanizeCardRef(ref);
+  if (card) return { label: 'CARD INDEX', detail: `Checked ${removeLeadingArticle(card)}` };
+
+  const scenario = ref.match(/^scenario:[^/]+\/(.+)$/);
+  if (scenario) {
+    return {
+      label: 'SCENARIO BOOK',
+      detail: `Looked up scenario ${displayScenarioNumber(scenario[1]!.trim())} in the scenario book`,
+    };
+  }
+
+  const legacyScenario = ref.match(/^gloomhavensecretariat:scenario\/(.+)$/);
+  if (legacyScenario) {
+    return {
+      label: 'SCENARIO BOOK',
+      detail: `Looked up scenario ${displayScenarioNumber(legacyScenario[1]!.trim())} in the scenario book`,
+    };
+  }
+
+  const section = ref.match(/^section:[^/]+\/(.+)$/);
+  if (section) {
+    return {
+      label: 'SECTION BOOK',
+      detail: `Looked up section ${section[1]!.trim()} in the section book`,
+    };
+  }
+
+  const rules = ref.match(/^rules:[^/]+\/(.+)#chunk=\d+$/);
+  if (rules) {
+    const source = rules[1]!.toLowerCase();
+    if (source.includes('puzzle'))
+      return { label: 'PUZZLE BOOK', detail: 'Checked the puzzle book' };
+    if (source.includes('section'))
+      return { label: 'SECTION BOOK', detail: 'Checked the section book' };
+    if (source.includes('scenario'))
+      return { label: 'SCENARIO BOOK', detail: 'Checked the scenario book' };
+    return { label: 'RULEBOOK', detail: 'Checked the rulebook' };
+  }
+
+  return null;
+}
+
+function searchActionFromBookLabel(label: string): WorkLogSourceAction | null {
+  const normalized = removeLeadingArticle(label.trim().toLowerCase());
+  if (normalized === 'rulebook') {
+    return { label: 'RULEBOOK', detail: 'Searched the rulebook' };
+  }
+  if (normalized === 'puzzle book') {
+    return { label: 'PUZZLE BOOK', detail: 'Searched the puzzle book' };
+  }
+  if (normalized === 'scenario book') {
+    return { label: 'SCENARIO BOOK', detail: 'Searched the scenario book' };
+  }
+  if (normalized === 'section book') {
+    return { label: 'SECTION BOOK', detail: 'Searched the section book' };
+  }
+  if (normalized === 'card index' || normalized === 'cards') {
+    return { label: 'CARD INDEX', detail: 'Searched cards' };
+  }
+  return null;
+}
+
+export function humanizeWorkLogProgressMessage(message: string): string {
+  const checkingCard = message.match(/^Checking\s+the\s+(.+\s+card)$/i);
+  if (checkingCard) return `Checked ${checkingCard[1]!.trim()}`;
+
+  const lookingUpSectionInBook = message.match(
+    /^Looking up\s+section\s+(.+?)\s+in the section book$/i,
+  );
+  if (lookingUpSectionInBook) {
+    return `Looked up section ${lookingUpSectionInBook[1]!.trim()} in the section book`;
+  }
+
+  const lookingUpScenarioInBook = message.match(
+    /^Looking up\s+scenario\s+(.+?)\s+in the scenario book$/i,
+  );
+  if (lookingUpScenarioInBook) {
+    return `Looked up scenario ${displayScenarioNumber(lookingUpScenarioInBook[1]!.trim())} in the scenario book`;
+  }
+
+  if (/^Looking up\s+.+\s+in the rulebook$/i.test(message)) return 'Searched the rulebook';
+  if (/^Looking up\s+.+\s+in the puzzle book$/i.test(message)) return 'Searched the puzzle book';
+  if (/^Looking up\s+.+\s+in the scenario book$/i.test(message))
+    return 'Searched the scenario book';
+  if (/^Looking up\s+.+\s+in the section book$/i.test(message)) return 'Searched the section book';
+
+  const opening = message.match(/^Opening\s+(.+)$/i);
+  if (opening) {
+    const action = sourceActionFromRef(opening[1]!.trim());
+    if (action) return action.detail;
+  }
+
+  const checkingLinks = message.match(/^Checking links from\s+(.+)$/i);
+  if (checkingLinks) {
+    const action = sourceActionFromRef(checkingLinks[1]!.trim());
+    if (action) return `Followed links from ${action.detail.replace(/^Checked\s+/, '')}`;
+  }
+
+  const checking = message.match(/^Checking\s+(.+)$/i);
+  if (checking) return `Checked ${checking[1]!.trim()}`;
+
+  const resolvingMonster = message.match(/^Resolving\s+(.+?)\s+monster(?:\s+stat(?:\s+card)?)?$/i);
+  if (resolvingMonster) {
+    return `Checked ${titleizeSlug(resolvingMonster[1]!.trim())} stat card`;
+  }
+  const resolvingStats = message.match(/^Resolving\s+(.+?)\s+stats$/i);
+  if (resolvingStats) return `Checked ${titleizeSlug(resolvingStats[1]!.trim())} stat card`;
+  const resolving = message.match(/^Resolving\s+(.+)$/i);
+  if (resolving) return `Looked up ${resolving[1]!.trim()}`;
+
+  const searchingBook = message.match(/^Searching\s+(.+)$/i);
+  if (searchingBook) {
+    const action = searchActionFromBookLabel(searchingBook[1]!);
+    if (action) return action.detail;
+    if (searchingBook[1]!.includes(',')) return 'Searched available sources';
+  }
+
+  if (message === 'Searching selected sources') return 'Searched available sources';
+  if (message === 'Searching knowledge') return 'Searched available sources';
+  return message;
+}
+
+export function activeWorkLogProgressMessageFromCompleted(message: string): string {
+  const checked = message.match(/^Checked\s+(.+)$/i);
+  if (checked) return `Checking ${checked[1]!.trim()}`;
+
+  const searched = message.match(/^Searched\s+(.+)$/i);
+  if (searched) return `Searching ${searched[1]!.trim()}`;
+
+  const lookedUp = message.match(/^Looked up\s+(.+)$/i);
+  if (lookedUp) return `Looking up ${lookedUp[1]!.trim()}`;
+
+  const followedLinks = message.match(/^Followed links from\s+(.+)$/i);
+  if (followedLinks) return `Following links from ${followedLinks[1]!.trim()}`;
+
+  const inspected = message.match(/^Inspected\s+(.+)$/i);
+  if (inspected) return `Inspecting ${inspected[1]!.trim()}`;
+
+  const ran = message.match(/^Ran\s+(.+)$/i);
+  if (ran) return `Running ${ran[1]!.trim()}`;
+
+  return message;
+}
+
+export function workLogSourceActionFromProgressMessage(
+  message: string,
+  sourceLabel?: string | null,
+): WorkLogSourceAction | null {
+  const detail = humanizeWorkLogProgressMessage(message);
+  if (/^Checked .+ card$/i.test(detail) || detail === 'Searched cards') {
+    return { label: 'CARD INDEX', detail };
+  }
+  if (
+    detail === 'Searched the rulebook' ||
+    detail === 'Checked the rulebook' ||
+    / in the rulebook$/i.test(detail)
+  ) {
+    return { label: 'RULEBOOK', detail };
+  }
+  if (
+    detail === 'Searched the puzzle book' ||
+    detail === 'Checked the puzzle book' ||
+    / in the puzzle book$/i.test(detail)
+  ) {
+    return { label: 'PUZZLE BOOK', detail };
+  }
+  if (
+    detail === 'Searched the scenario book' ||
+    detail === 'Checked the scenario book' ||
+    / in the scenario book$/i.test(detail)
+  ) {
+    return { label: 'SCENARIO BOOK', detail };
+  }
+  if (
+    detail === 'Searched the section book' ||
+    detail === 'Checked the section book' ||
+    / in the section book$/i.test(detail)
+  ) {
+    return { label: 'SECTION BOOK', detail };
+  }
+
+  const sectionLookup = detail.match(/^Looked up\s+section\s+(.+)$/i);
+  if (sectionLookup) {
+    return {
+      label: 'SECTION BOOK',
+      detail: `Looked up section ${sectionLookup[1]!.trim()} in the section book`,
+    };
+  }
+
+  const scenarioLookup = detail.match(/^Looked up\s+scenario\s+(.+)$/i);
+  if (scenarioLookup) {
+    return {
+      label: 'SCENARIO BOOK',
+      detail: `Looked up scenario ${displayScenarioNumber(scenarioLookup[1]!.trim())} in the scenario book`,
+    };
+  }
+
+  if (sourceLabel === 'RULEBOOK' && detail !== 'Searched available sources') {
+    return { label: 'RULEBOOK', detail: `${detail} in the rulebook` };
+  }
+  if (sourceLabel === 'PUZZLE BOOK' && detail !== 'Searched available sources') {
+    return { label: 'PUZZLE BOOK', detail: `${detail} in the puzzle book` };
+  }
+  if (sourceLabel === 'SCENARIO BOOK' && detail !== 'Searched available sources') {
+    return { label: 'SCENARIO BOOK', detail: `${detail} in the scenario book` };
+  }
+  if (sourceLabel === 'SECTION BOOK' && detail !== 'Searched available sources') {
+    return { label: 'SECTION BOOK', detail: `${detail} in the section book` };
+  }
+  return null;
+}

--- a/src/work-log-display.ts
+++ b/src/work-log-display.ts
@@ -271,7 +271,7 @@ export function workLogSourceActionFromProgressMessage(
         detail: `Checked ${removeLeadingArticle(lookedUpCard[1]!.trim())}`,
       };
     }
-    return { label: 'CARD INDEX', detail: `${detail} in the card index` };
+    return { label: 'CARD INDEX', detail };
   }
   if (sourceLabel === 'SCENARIO BOOK' && detail !== 'Searched available sources') {
     return { label: 'SCENARIO BOOK', detail: `${detail} in the scenario book` };

--- a/src/work-log-display.ts
+++ b/src/work-log-display.ts
@@ -263,6 +263,16 @@ export function workLogSourceActionFromProgressMessage(
   if (sourceLabel === 'PUZZLE BOOK' && detail !== 'Searched available sources') {
     return { label: 'PUZZLE BOOK', detail: `${detail} in the puzzle book` };
   }
+  if (sourceLabel === 'CARD INDEX' && detail !== 'Searched available sources') {
+    const lookedUpCard = detail.match(/^Looked up\s+(.+\s+card)$/i);
+    if (lookedUpCard) {
+      return {
+        label: 'CARD INDEX',
+        detail: `Checked ${removeLeadingArticle(lookedUpCard[1]!.trim())}`,
+      };
+    }
+    return { label: 'CARD INDEX', detail: `${detail} in the card index` };
+  }
   if (sourceLabel === 'SCENARIO BOOK' && detail !== 'Searched available sources') {
     return { label: 'SCENARIO BOOK', detail: `${detail} in the scenario book` };
   }

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -360,6 +360,63 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
     ]);
   });
 
+  it('emits generic lookup intent before exact lookup results are known', async () => {
+    const cardRef = 'card:gloomhaven-2e/items/gloomhavensecretariat:item/001';
+    mockMessagesCreate.mockResolvedValueOnce(
+      toolUseResponse('lookup_entity', {
+        query: 'Spyglass',
+        kinds: ['item'],
+      }),
+    );
+    mockMessagesStream.mockReturnValueOnce(
+      mockStream(textResponse('Spyglass is item 1.'), ['Spyglass is item 1.']),
+    );
+    mockLookupEntity.mockResolvedValueOnce({
+      ok: true,
+      entity: {
+        kind: 'card',
+        ref: cardRef,
+        title: 'Spyglass',
+        sourceLabel: 'Card Index',
+        data: { name: 'Spyglass' },
+      },
+      citations: [{ sourceRef: 'cards.json', sourceLabel: 'Card Index', locator: cardRef }],
+      links: [],
+      related: [],
+    });
+    const emitted: Array<[AgentStreamEventName, unknown]> = [];
+
+    const result = await runLangGraphAgentLoopWithTrajectory('What is Spyglass?', {
+      emit: async (event, data) => {
+        emitted.push([event, data]);
+      },
+      toolSurface: 'redesigned',
+      userMessageId: 'message-spyglass-card',
+    });
+
+    expect(result.answer).toBe('Spyglass is item 1.');
+    expect(
+      emitted.filter(([event]) => ['tool_plan', 'tool_progress', 'tool_result'].includes(event)),
+    ).toEqual([
+      [
+        'tool_plan',
+        {
+          message: "I'll look up Spyglass.",
+          toolName: 'lookup_entity',
+        },
+      ],
+      [
+        'tool_result',
+        {
+          name: 'lookup_entity',
+          ok: true,
+          message: 'Checked item 001 card',
+          sourceBooks: ['Card Index'],
+        },
+      ],
+    ]);
+  });
+
   it('keeps scenario resolution silent until the scenario book is opened', async () => {
     mockMessagesCreate
       .mockResolvedValueOnce(

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -436,6 +436,42 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
     ]);
   });
 
+  it('humanizes failed open_entity work rows', async () => {
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('open_entity', { ref: 'scenario:frosthaven/061' }, 'tool_open_scenario'),
+      )
+      .mockResolvedValueOnce(textResponse("I couldn't find scenario 61."));
+    mockMessagesStream.mockReturnValueOnce(
+      mockStream(textResponse("I couldn't find scenario 61."), ["I couldn't find scenario 61."]),
+    );
+    mockOpenEntity.mockResolvedValueOnce({ ok: false, error: 'Not found' });
+    const emitted: Array<[AgentStreamEventName, unknown]> = [];
+
+    const result = await runLangGraphAgentLoopWithTrajectory('What is scenario 61?', {
+      emit: async (event, data) => {
+        emitted.push([event, data]);
+      },
+      toolSurface: 'redesigned',
+      userMessageId: 'message-scenario-61-failed-open',
+    });
+
+    expect(result.answer).toBe("I couldn't find scenario 61.");
+    const displayedWorkRows = emitted.filter(([event]) =>
+      ['tool_plan', 'tool_progress', 'tool_result'].includes(event),
+    );
+    expect(JSON.stringify(displayedWorkRows)).not.toContain('scenario:frosthaven/061');
+    expect(emitted).toContainEqual([
+      'tool_result',
+      {
+        name: 'open_entity',
+        ok: false,
+        message: "Couldn't look up scenario 61 in the scenario book",
+        sourceBooks: [],
+      },
+    ]);
+  });
+
   it('continues after neighbors before finalizing answers that need target content', async () => {
     mockMessagesCreate
       .mockResolvedValueOnce(toolUseResponse('neighbors', { ref: 'scenario:frosthaven/060' }))

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -6,6 +6,7 @@ const {
   mockSearchKnowledge,
   mockListCards,
   mockResolveEntity,
+  mockLookupEntity,
   mockNeighbors,
   mockOpenEntity,
   mockStartedSpans,
@@ -16,6 +17,7 @@ const {
   mockSearchKnowledge: vi.fn(),
   mockListCards: vi.fn(),
   mockResolveEntity: vi.fn(),
+  mockLookupEntity: vi.fn(),
   mockNeighbors: vi.fn(),
   mockOpenEntity: vi.fn(),
   mockStartedSpans: [] as Array<{ name: string; span: { attributes: Record<string, unknown> } }>,
@@ -65,6 +67,7 @@ vi.mock('../src/tools.ts', () => ({
   inspectSources: vi.fn(),
   getSchema: vi.fn(),
   resolveEntity: mockResolveEntity,
+  lookupEntity: mockLookupEntity,
   openEntity: mockOpenEntity,
   searchKnowledge: mockSearchKnowledge,
   neighbors: mockNeighbors,
@@ -281,44 +284,29 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
   it('emits card lookup intent before the card work row can render', async () => {
     const cardRef =
       'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/bandit-archer/0-3';
-    mockMessagesCreate
-      .mockResolvedValueOnce(
-        toolUseResponse('resolve_entity', {
-          query: 'Bandit Archer monster stat card',
-          kinds: ['card'],
-        }),
-      )
-      .mockResolvedValueOnce(toolUseResponse('open_entity', { ref: cardRef }, 'tool_open_card'));
+    mockMessagesCreate.mockResolvedValueOnce(
+      toolUseResponse('lookup_entity', {
+        query: 'Bandit Archer monster stat card',
+        kinds: ['monster-stat'],
+      }),
+    );
     mockMessagesStream.mockReturnValueOnce(
       mockStream(textResponse('An elite level 3 Bandit Archer has 10 hit points.'), [
         'An elite level 3 Bandit Archer has 10 hit points.',
       ]),
     );
-    mockResolveEntity.mockResolvedValueOnce({
-      ok: true,
-      query: 'Bandit Archer monster stat card',
-      candidates: [
-        {
-          entity: {
-            kind: 'card',
-            ref: cardRef,
-            title: 'Bandit Archer',
-            sourceLabel: 'Card Index',
-          },
-          confidence: 0.99,
-          matchReason: 'Exact card match',
-        },
-      ],
-    });
-    mockOpenEntity.mockResolvedValueOnce({
+    mockLookupEntity.mockResolvedValueOnce({
       ok: true,
       entity: {
         kind: 'card',
         ref: cardRef,
         title: 'Bandit Archer',
+        sourceLabel: 'Card Index',
         data: { normal: { hp: 6 }, elite: { hp: 10 } },
       },
-      citations: [{ sourceRef: 'cards.json', sourceLabel: 'Card Index' }],
+      citations: [{ sourceRef: 'cards.json', sourceLabel: 'Card Index', locator: cardRef }],
+      links: [],
+      related: [],
     });
     const emitted: Array<[AgentStreamEventName, unknown]> = [];
 
@@ -334,10 +322,7 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
     );
 
     expect(result.answer).toBe('An elite level 3 Bandit Archer has 10 hit points.');
-    expect(result.trajectory.toolCalls.map((call) => call.name)).toEqual([
-      'resolve_entity',
-      'open_entity',
-    ]);
+    expect(result.trajectory.toolCalls.map((call) => call.name)).toEqual(['lookup_entity']);
     const visibleEvents = emitted.filter(([event]) => event !== 'debug');
     expect(visibleEvents).not.toContainEqual([
       'tool_plan',
@@ -360,13 +345,13 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
         'tool_plan',
         {
           message: "I'll check that stat card.",
-          toolName: 'open_entity',
+          toolName: 'lookup_entity',
         },
       ],
       [
         'tool_result',
         {
-          name: 'open_entity',
+          name: 'lookup_entity',
           ok: true,
           message: 'Checked Bandit Archer stat card',
           sourceBooks: ['Card Index'],

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -339,19 +339,113 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
       'open_entity',
     ]);
     const visibleEvents = emitted.filter(([event]) => event !== 'debug');
-    expect(visibleEvents.slice(0, 2)).toEqual([
+    expect(visibleEvents).not.toContainEqual([
+      'tool_plan',
+      expect.objectContaining({ toolName: 'resolve_entity' }),
+    ]);
+    expect(visibleEvents).not.toContainEqual([
+      'tool_progress',
+      expect.objectContaining({ toolName: 'resolve_entity' }),
+    ]);
+    expect(visibleEvents).not.toContainEqual([
+      'tool_result',
+      expect.objectContaining({ name: 'resolve_entity' }),
+    ]);
+    expect(
+      visibleEvents.filter(([event]) =>
+        ['tool_plan', 'tool_progress', 'tool_result'].includes(event),
+      ),
+    ).toEqual([
       [
         'tool_plan',
         {
           message: "I'll check that stat card.",
-          toolName: 'resolve_entity',
+          toolName: 'open_entity',
         },
       ],
       [
-        'tool_progress',
+        'tool_result',
         {
-          message: 'Checking Bandit Archer stat card',
-          toolName: 'resolve_entity',
+          name: 'open_entity',
+          ok: true,
+          message: 'Checked Bandit Archer stat card',
+          sourceBooks: ['Card Index'],
+        },
+      ],
+    ]);
+  });
+
+  it('keeps scenario resolution silent until the scenario book is opened', async () => {
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('resolve_entity', {
+          query: 'scenario 61',
+          kinds: ['scenario'],
+        }),
+      )
+      .mockResolvedValueOnce(
+        toolUseResponse('open_entity', { ref: 'scenario:frosthaven/061' }, 'tool_open_scenario'),
+      );
+    mockMessagesStream.mockReturnValueOnce(
+      mockStream(textResponse('Scenario 61 is Dangerous Grove.'), [
+        'Scenario 61 ',
+        'is Dangerous Grove.',
+      ]),
+    );
+    mockResolveEntity.mockResolvedValueOnce({
+      query: 'scenario 61',
+      candidates: [
+        {
+          entity: {
+            kind: 'scenario',
+            ref: 'scenario:frosthaven/061',
+            title: 'Scenario 61',
+            sourceLabel: 'Scenario Book',
+          },
+          confidence: 0.99,
+          matchReason: 'Exact scenario match',
+        },
+      ],
+    });
+    mockOpenEntity.mockResolvedValueOnce({
+      ok: true,
+      entity: {
+        kind: 'scenario',
+        ref: 'scenario:frosthaven/061',
+        title: 'Scenario 61',
+        data: { name: 'Dangerous Grove' },
+      },
+      citations: [{ sourceRef: 'scenario-book.json', sourceLabel: 'Scenario Book' }],
+    });
+    const emitted: Array<[AgentStreamEventName, unknown]> = [];
+
+    const result = await runLangGraphAgentLoopWithTrajectory('What is scenario 61?', {
+      emit: async (event, data) => {
+        emitted.push([event, data]);
+      },
+      toolSurface: 'redesigned',
+      userMessageId: 'message-scenario-61',
+    });
+
+    expect(result.answer).toBe('Scenario 61 is Dangerous Grove.');
+    const workEvents = emitted.filter(([event]) =>
+      ['tool_plan', 'tool_progress', 'tool_result'].includes(event),
+    );
+    expect(workEvents).toEqual([
+      [
+        'tool_plan',
+        {
+          message: "I'll look that up in the scenario book.",
+          toolName: 'open_entity',
+        },
+      ],
+      [
+        'tool_result',
+        {
+          name: 'open_entity',
+          ok: true,
+          message: 'Looked up scenario 61 in the scenario book',
+          sourceBooks: ['Scenario Book'],
         },
       ],
     ]);

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -5,6 +5,7 @@ const {
   mockMessagesStream,
   mockSearchKnowledge,
   mockListCards,
+  mockResolveEntity,
   mockNeighbors,
   mockOpenEntity,
   mockStartedSpans,
@@ -14,6 +15,7 @@ const {
   mockMessagesStream: vi.fn(),
   mockSearchKnowledge: vi.fn(),
   mockListCards: vi.fn(),
+  mockResolveEntity: vi.fn(),
   mockNeighbors: vi.fn(),
   mockOpenEntity: vi.fn(),
   mockStartedSpans: [] as Array<{ name: string; span: { attributes: Record<string, unknown> } }>,
@@ -62,7 +64,7 @@ vi.mock('@anthropic-ai/sdk', () => ({
 vi.mock('../src/tools.ts', () => ({
   inspectSources: vi.fn(),
   getSchema: vi.fn(),
-  resolveEntity: vi.fn(),
+  resolveEntity: mockResolveEntity,
   openEntity: mockOpenEntity,
   searchKnowledge: mockSearchKnowledge,
   neighbors: mockNeighbors,
@@ -209,9 +211,13 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
     const userVisibleEvents = emitted.filter(([event]) => event !== 'debug');
     expect(userVisibleEvents).toEqual([
       [
-        'tool_progress',
-        { message: 'Searching Rulebook, Section Book, Card Index', toolName: 'search_knowledge' },
+        'tool_plan',
+        {
+          message: "I'll search the rulebook, the section book, and the cards.",
+          toolName: 'search_knowledge',
+        },
       ],
+      ['tool_progress', { message: 'Searching available sources', toolName: 'search_knowledge' }],
       [
         'tool_call',
         {
@@ -219,7 +225,15 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
           input: { query: 'loot', scope: ['rules_passage', 'section', 'card'] },
         },
       ],
-      ['tool_result', { name: 'search_knowledge', ok: true, sourceBooks: ['Rulebook'] }],
+      [
+        'tool_result',
+        {
+          name: 'search_knowledge',
+          ok: true,
+          message: 'Searched available sources',
+          sourceBooks: ['Rulebook'],
+        },
+      ],
       ['text', { delta: 'Use loot abilities ' }],
       ['text', { delta: 'to pick up loot tokens.' }],
       ['done', {}],
@@ -264,6 +278,85 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
     expect(mockMessagesCreate).toHaveBeenCalledTimes(3);
   });
 
+  it('emits card lookup intent before the card work row can render', async () => {
+    const cardRef =
+      'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/bandit-archer/0-3';
+    mockMessagesCreate
+      .mockResolvedValueOnce(
+        toolUseResponse('resolve_entity', {
+          query: 'Bandit Archer monster stat card',
+          kinds: ['card'],
+        }),
+      )
+      .mockResolvedValueOnce(toolUseResponse('open_entity', { ref: cardRef }, 'tool_open_card'));
+    mockMessagesStream.mockReturnValueOnce(
+      mockStream(textResponse('An elite level 3 Bandit Archer has 10 hit points.'), [
+        'An elite level 3 Bandit Archer has 10 hit points.',
+      ]),
+    );
+    mockResolveEntity.mockResolvedValueOnce({
+      ok: true,
+      query: 'Bandit Archer monster stat card',
+      candidates: [
+        {
+          entity: {
+            kind: 'card',
+            ref: cardRef,
+            title: 'Bandit Archer',
+            sourceLabel: 'Card Index',
+          },
+          confidence: 0.99,
+          matchReason: 'Exact card match',
+        },
+      ],
+    });
+    mockOpenEntity.mockResolvedValueOnce({
+      ok: true,
+      entity: {
+        kind: 'card',
+        ref: cardRef,
+        title: 'Bandit Archer',
+        data: { normal: { hp: 6 }, elite: { hp: 10 } },
+      },
+      citations: [{ sourceRef: 'cards.json', sourceLabel: 'Card Index' }],
+    });
+    const emitted: Array<[AgentStreamEventName, unknown]> = [];
+
+    const result = await runLangGraphAgentLoopWithTrajectory(
+      'How many hit points does an elite level 3 Bandit Archer have?',
+      {
+        emit: async (event, data) => {
+          emitted.push([event, data]);
+        },
+        toolSurface: 'redesigned',
+        userMessageId: 'message-bandit-card',
+      },
+    );
+
+    expect(result.answer).toBe('An elite level 3 Bandit Archer has 10 hit points.');
+    expect(result.trajectory.toolCalls.map((call) => call.name)).toEqual([
+      'resolve_entity',
+      'open_entity',
+    ]);
+    const visibleEvents = emitted.filter(([event]) => event !== 'debug');
+    expect(visibleEvents.slice(0, 2)).toEqual([
+      [
+        'tool_plan',
+        {
+          message: "I'll check that stat card.",
+          toolName: 'resolve_entity',
+        },
+      ],
+      [
+        'tool_progress',
+        {
+          message: 'Checking Bandit Archer stat card',
+          toolName: 'resolve_entity',
+        },
+      ],
+    ]);
+  });
+
   it('continues after neighbors before finalizing answers that need target content', async () => {
     mockMessagesCreate
       .mockResolvedValueOnce(toolUseResponse('neighbors', { ref: 'scenario:frosthaven/060' }))
@@ -276,11 +369,14 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
         'Scenario 61.',
       ]),
     );
+    const emitted: Array<[AgentStreamEventName, unknown]> = [];
 
     const result = await runLangGraphAgentLoopWithTrajectory(
       'What is the text of the section that unlocks scenario 61?',
       {
-        emit: async () => undefined,
+        emit: async (event, data) => {
+          emitted.push([event, data]);
+        },
         toolSurface: 'redesigned',
         userMessageId: 'message-neighbors',
       },
@@ -292,6 +388,13 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
     expect(result.trajectory.toolCalls.map((call) => call.name)).toEqual([
       'neighbors',
       'open_entity',
+    ]);
+    expect(emitted).toContainEqual([
+      'tool_plan',
+      {
+        message: "I'll look that up in the section book.",
+        toolName: 'open_entity',
+      },
     ]);
   });
 

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -10,6 +10,7 @@ const {
   mockSearchKnowledge,
   mockListCardTypes,
   mockOpenEntity,
+  mockLookupEntity,
   mockInspectSources,
   mockGetSchema,
   mockResolveEntity,
@@ -62,6 +63,7 @@ const {
     mockSearchKnowledge: vi.fn(),
     mockListCardTypes: vi.fn(),
     mockOpenEntity: vi.fn(),
+    mockLookupEntity: vi.fn(),
     mockInspectSources: vi.fn(),
     mockGetSchema: vi.fn(),
     mockResolveEntity: vi.fn(),
@@ -97,6 +99,7 @@ vi.mock('../src/tools.ts', () => ({
   searchKnowledge: mockSearchKnowledge,
   listCardTypes: mockListCardTypes,
   openEntity: mockOpenEntity,
+  lookupEntity: mockLookupEntity,
   inspectSources: mockInspectSources,
   getSchema: mockGetSchema,
   resolveEntity: mockResolveEntity,
@@ -435,6 +438,7 @@ describe('runAgentLoop', () => {
       'inspect_sources',
       'schema',
       'resolve_entity',
+      'lookup_entity',
       'open_entity',
       'search_knowledge',
       'neighbors',
@@ -1398,6 +1402,43 @@ describe('executeToolCall', () => {
     expect(mockOpenEntity).toHaveBeenCalledWith('section:frosthaven/67.1', { game: 'gh2' });
     expect(JSON.parse(result.content).entity.ref).toBe('section:frosthaven/67.1');
     expect(result.sourceBooks).toEqual(['Section Book 62-81']);
+  });
+
+  it('dispatches lookup_entity and collects citation source labels', async () => {
+    mockLookupEntity.mockResolvedValueOnce({
+      ok: true,
+      entity: {
+        kind: 'card',
+        ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+        title: 'Spyglass',
+        sourceLabel: 'Card Index',
+        data: {},
+      },
+      citations: [
+        {
+          sourceRef: 'source:frosthaven/cards/items',
+          sourceLabel: 'Card Index',
+          locator: 'gloomhavensecretariat:item/1',
+        },
+      ],
+      links: [],
+      related: [],
+    });
+    const result = await executeToolCall(
+      'lookup_entity',
+      { query: 'item 1', kinds: ['item'], limit: 2 },
+      { game: 'gh2' },
+    );
+
+    expect(mockLookupEntity).toHaveBeenCalledWith('item 1', {
+      kinds: ['item'],
+      limit: 2,
+      game: 'gh2',
+    });
+    expect(JSON.parse(result.content).entity.ref).toBe(
+      'card:frosthaven/items/gloomhavensecretariat:item/1',
+    );
+    expect(result.sourceBooks).toEqual(['Card Index']);
   });
 
   it('dispatches list_card_types', async () => {

--- a/test/consulted-footer.test.ts
+++ b/test/consulted-footer.test.ts
@@ -36,6 +36,7 @@ describe('toolSourceLabel', () => {
   });
 
   it('returns null for tools whose dynamic results carry source labels', () => {
+    expect(toolSourceLabel('lookup_entity')).toBeNull();
     expect(toolSourceLabel('open_entity')).toBeNull();
     expect(toolSourceLabel('search_knowledge')).toBeNull();
   });

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -1950,7 +1950,7 @@ describe('conversation web backend', () => {
       await options?.emit?.('tool_result', {
         name: 'search_cards',
         ok: true,
-        message: 'Checked Bandit Archer stat card',
+        message: `Opening ${rawRef}`,
         sourceBooks: ['Card Index'],
       });
       await options?.emit?.('text', {

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -1935,6 +1935,86 @@ describe('conversation web backend', () => {
     ]);
   });
 
+  it('streams richer browser-safe work events without narration payloads', async () => {
+    const rawRef =
+      'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/bandit-archer/0-3';
+    mockAsk.mockImplementationOnce(async (_question, options) => {
+      await options?.emit?.('tool_plan', {
+        toolName: 'open_entity',
+        message: "I'll check the Bandit Archer stat card.",
+      });
+      await options?.emit?.('tool_progress', {
+        toolName: 'open_entity',
+        message: 'Checking Bandit Archer stat card',
+      });
+      await options?.emit?.('tool_result', {
+        name: 'search_cards',
+        ok: true,
+        message: 'Checked Bandit Archer stat card',
+        sourceBooks: ['Card Index'],
+      });
+      await options?.emit?.('text', {
+        delta: 'A level 3 elite Bandit Archer has 10 hit points.',
+      });
+      await options?.emit?.('done', {});
+      return 'A level 3 elite Bandit Archer has 10 hit points.';
+    });
+
+    const auth = await createAuthContext();
+    const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
+      method: 'POST',
+      csrf: true,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'hx-request': 'true',
+      },
+      body: formBody({
+        question: 'How many hit points does an elite level 3 Bandit Archer have?',
+        idempotencyKey: 'idem-stream-work-event-text',
+      }),
+    });
+
+    const body = await createRes.text();
+    const streamUrl = body.match(/data-stream-url="([^"]+)"/)?.[1];
+    expect(streamUrl).toBeTruthy();
+
+    const streamRes = await requestWithAuth(auth, `http://localhost:3000${streamUrl}`);
+    const events = parseSse(await streamRes.text());
+    expect(events).toContainEqual({
+      event: 'tool-plan',
+      data: {
+        id: 'open_entity-plan-1',
+        message: "I'll check the Bandit Archer stat card.",
+      },
+    });
+    expect(events).toContainEqual({
+      event: 'tool-progress',
+      data: {
+        id: 'open_entity-progress-1',
+        label: 'REFERENCE',
+        message: 'Checking Bandit Archer stat card',
+      },
+    });
+    expect(events).toContainEqual({
+      event: 'tool-result',
+      data: {
+        id: 'card-index',
+        labels: ['CARD INDEX'],
+        message: 'Checked Bandit Archer stat card',
+        ok: true,
+      },
+    });
+    expect(JSON.stringify(events)).not.toContain(rawRef);
+    expect(JSON.stringify(events)).not.toContain('"note"');
+    expect(JSON.stringify(events)).not.toContain('"notes"');
+    const doneEvent = events.find((event) => event.event === 'done');
+    expect(doneEvent?.data).toEqual(
+      expect.objectContaining({
+        html: '<p>A level 3 elite Bandit Archer has 10 hit points.</p>\n',
+      }),
+    );
+  });
+
   it('replays stored stream events after Last-Event-ID without re-running the agent', async () => {
     mockAsk.mockImplementationOnce(async (_question, options) => {
       await options?.emit?.('tool_call', { name: 'search_rules' });
@@ -2497,10 +2577,8 @@ describe('conversation web backend', () => {
     const page = await pageRes.text();
 
     expect(pageRes.status).toBe(200);
-    expect(page).toContain('Checked 2 sources');
-    expect(page).toMatch(
-      /Resolving bandit archer stats[\s\S]*Checked card index[\s\S]*Checked rulebook/,
-    );
+    expect(page).toContain('Finished working');
+    expect(page).toMatch(/Checked Bandit Archer stat card[\s\S]*Checked the rulebook/);
     expect(page).not.toContain('class="squire-toolcall"');
   });
 

--- a/test/e2e/sqr-24-chat-game-selection.spec.ts
+++ b/test/e2e/sqr-24-chat-game-selection.spec.ts
@@ -105,10 +105,10 @@ async function expectFinalAnswer(page: Page, expectedAnswer: RegExp): Promise<vo
   );
   await expect(latestAnswer.locator('[data-testid="answer-content"] a')).toBeVisible();
   await expect(latestAnswer.locator('[data-testid="answer-progress"]')).toContainText(
-    'Checked 1 source',
+    'Finished working',
   );
   await expect(latestAnswer.locator('[data-testid="answer-progress"]')).toContainText(
-    'Checked rulebook',
+    'Checked the rulebook',
   );
   await expect(page.locator('.squire-input-dock')).not.toHaveAttribute('data-submitting', 'true');
 }
@@ -209,10 +209,10 @@ test.describe('SQR-24 browser chat game selection', () => {
     await expectFinalAnswer(page, /Closed doors block line-of-sight/);
     await expect(workLog).toHaveAttribute('data-work-state', 'complete');
     await expect(workLog).not.toHaveAttribute('open', '');
-    await expect(workLog).toContainText('Checked 1 source');
+    await expect(workLog).toContainText('Finished working');
     await expect(workLog.locator('.squire-answer-work__row-label')).toHaveCount(0);
     await expect(workLog.locator('.squire-answer-work__row-detail')).toContainText(
-      'Checked rulebook',
+      'Checked the rulebook',
     );
   });
 });

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -268,6 +268,16 @@ describe('eval dataset', () => {
     expect(evalCase?.trajectory?.requiredTools).not.toContain('open_entity');
   });
 
+  it('uses the combined lookup tool for exact item-open trajectory checks', () => {
+    const exactItemCase = cases.find((candidate) => candidate.id === 'traj-exact-item-open');
+    const gh2ExactItemCase = cases.find((candidate) => candidate.id === 'gh2-traj-exact-item-open');
+
+    for (const evalCase of [exactItemCase, gh2ExactItemCase]) {
+      expect(evalCase?.trajectory?.requiredTools).toEqual(['lookup_entity']);
+      expect(evalCase?.trajectory?.requiredToolKinds).toEqual(['open']);
+    }
+  });
+
   it('keeps SQR-137 final-answer expectations aligned with checked-in data', () => {
     const byId = new Map(cases.map((evalCase) => [evalCase.id, evalCase]));
 

--- a/test/eval-openai-runner.test.ts
+++ b/test/eval-openai-runner.test.ts
@@ -91,6 +91,7 @@ describe('OpenAI Responses eval runner', () => {
       'inspect_sources',
       'schema',
       'resolve_entity',
+      'lookup_entity',
       'open_entity',
       'search_knowledge',
       'neighbors',

--- a/test/eval-openai-schema.test.ts
+++ b/test/eval-openai-schema.test.ts
@@ -98,6 +98,7 @@ describe('OpenAI strict tool schema renderer', () => {
     expect(byName.search_cards.required).toEqual(['query', 'topK', 'game']);
     expect(byName.search_knowledge.required).toEqual(['query', 'scope', 'limit', 'game']);
     expect(byName.resolve_entity.required).toEqual(['query', 'kinds', 'limit', 'game']);
+    expect(byName.lookup_entity.required).toEqual(['query', 'kinds', 'limit', 'game']);
     expect(byName.neighbors.required).toEqual(['ref', 'relation', 'limit', 'game']);
     expect(byName.neighbors.properties.relation.enum).toContain(null);
     expect(byName.list_cards.required).toEqual(['type', 'filter', 'game']);

--- a/test/eval-openai-schema.test.ts
+++ b/test/eval-openai-schema.test.ts
@@ -21,6 +21,7 @@ vi.mock('../src/tools.ts', () => ({
   inspectSources: vi.fn(),
   getSchema: vi.fn(),
   resolveEntity: vi.fn(),
+  lookupEntity: vi.fn(),
   openEntity: vi.fn(),
   findScenario: vi.fn(),
   getScenario: vi.fn(),

--- a/test/eval-trajectory.test.ts
+++ b/test/eval-trajectory.test.ts
@@ -6,18 +6,18 @@ describe('scoreTrajectory', () => {
   it('passes flexible required tools, kinds, refs, and budget checks', () => {
     const result = scoreTrajectory(
       {
-        requiredTools: ['resolve_entity', 'open_entity'],
-        requiredToolKinds: ['resolution', 'open'],
+        requiredTools: ['lookup_entity'],
+        requiredToolKinds: ['open'],
         forbiddenTools: ['search_rules'],
         forbiddenToolKinds: ['traversal'],
         requiredRefs: ['card:frosthaven/items/gloomhavensecretariat:item/1'],
         maxToolCalls: 3,
       },
       [
-        { name: 'resolve_entity', input: { query: 'item 1' } },
         {
-          name: 'open_entity',
-          input: { ref: 'card:frosthaven/items/gloomhavensecretariat:item/1' },
+          name: 'lookup_entity',
+          input: { query: 'item 1', kinds: ['item'] },
+          canonicalRefs: ['card:frosthaven/items/gloomhavensecretariat:item/1'],
         },
       ],
     );

--- a/test/mcp-in-process.test.ts
+++ b/test/mcp-in-process.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const {
   mockSearchKnowledge,
   mockOpenEntity,
+  mockLookupEntity,
   mockInspectSources,
   mockGetSchema,
   mockResolveEntity,
@@ -10,6 +11,7 @@ const {
 } = vi.hoisted(() => ({
   mockSearchKnowledge: vi.fn(),
   mockOpenEntity: vi.fn(),
+  mockLookupEntity: vi.fn(),
   mockInspectSources: vi.fn(),
   mockGetSchema: vi.fn(),
   mockResolveEntity: vi.fn(),
@@ -19,6 +21,7 @@ const {
 vi.mock('../src/tools.ts', () => ({
   searchKnowledge: mockSearchKnowledge,
   openEntity: mockOpenEntity,
+  lookupEntity: mockLookupEntity,
   inspectSources: mockInspectSources,
   getSchema: mockGetSchema,
   resolveEntity: mockResolveEntity,
@@ -38,6 +41,19 @@ describe('in-process MCP client', () => {
     });
     mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
     mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
+    mockLookupEntity.mockResolvedValue({
+      ok: true,
+      entity: {
+        kind: 'card',
+        ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+        title: 'Spyglass',
+        sourceLabel: 'Card Index',
+        data: {},
+      },
+      citations: [],
+      links: [],
+      related: [],
+    });
     mockSearchKnowledge.mockResolvedValue({ ok: true, query: 'loot', results: [] });
     mockOpenEntity.mockResolvedValue({
       ok: true,
@@ -77,6 +93,7 @@ describe('in-process MCP client', () => {
       'inspect_sources',
       'schema',
       'resolve_entity',
+      'lookup_entity',
       'open_entity',
       'search_knowledge',
       'neighbors',

--- a/test/mcp-transport.test.ts
+++ b/test/mcp-transport.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const {
   mockSearchKnowledge,
   mockOpenEntity,
+  mockLookupEntity,
   mockInspectSources,
   mockGetSchema,
   mockResolveEntity,
@@ -11,6 +12,7 @@ const {
 } = vi.hoisted(() => ({
   mockSearchKnowledge: vi.fn(),
   mockOpenEntity: vi.fn(),
+  mockLookupEntity: vi.fn(),
   mockInspectSources: vi.fn(),
   mockGetSchema: vi.fn(),
   mockResolveEntity: vi.fn(),
@@ -21,6 +23,7 @@ const {
 vi.mock('../src/tools.ts', () => ({
   searchKnowledge: mockSearchKnowledge,
   openEntity: mockOpenEntity,
+  lookupEntity: mockLookupEntity,
   inspectSources: mockInspectSources,
   getSchema: mockGetSchema,
   resolveEntity: mockResolveEntity,
@@ -183,6 +186,7 @@ describe('MCP over Streamable HTTP', () => {
       'inspect_sources',
       'schema',
       'resolve_entity',
+      'lookup_entity',
       'open_entity',
       'search_knowledge',
       'neighbors',

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const {
   mockSearchKnowledge,
   mockOpenEntity,
+  mockLookupEntity,
   mockInspectSources,
   mockGetSchema,
   mockResolveEntity,
@@ -10,6 +11,7 @@ const {
 } = vi.hoisted(() => ({
   mockSearchKnowledge: vi.fn(),
   mockOpenEntity: vi.fn(),
+  mockLookupEntity: vi.fn(),
   mockInspectSources: vi.fn(),
   mockGetSchema: vi.fn(),
   mockResolveEntity: vi.fn(),
@@ -19,6 +21,7 @@ const {
 vi.mock('../src/tools.ts', () => ({
   searchKnowledge: mockSearchKnowledge,
   openEntity: mockOpenEntity,
+  lookupEntity: mockLookupEntity,
   inspectSources: mockInspectSources,
   getSchema: mockGetSchema,
   resolveEntity: mockResolveEntity,
@@ -57,6 +60,19 @@ describe('MCP redesigned tool registration', () => {
     });
     mockGetSchema.mockReturnValue({ ok: true, kind: 'card', fields: [] });
     mockResolveEntity.mockResolvedValue({ ok: true, query: 'Spyglass', candidates: [] });
+    mockLookupEntity.mockResolvedValue({
+      ok: true,
+      entity: {
+        kind: 'card',
+        ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+        title: 'Spyglass',
+        sourceLabel: 'Card Index',
+        data: {},
+      },
+      citations: [],
+      links: [],
+      related: [],
+    });
     mockOpenEntity.mockResolvedValue({
       ok: true,
       entity: {
@@ -92,6 +108,7 @@ describe('MCP redesigned tool registration', () => {
       'inspect_sources',
       'schema',
       'resolve_entity',
+      'lookup_entity',
       'open_entity',
       'search_knowledge',
       'neighbors',
@@ -134,6 +151,18 @@ describe('MCP redesigned tool registration', () => {
     expect(mockResolveEntity).toHaveBeenCalledWith('Spyglass', {
       kinds: ['card'],
       limit: 3,
+      game: 'gh2',
+    });
+
+    await expect(
+      client.callTool({
+        name: 'lookup_entity',
+        arguments: { query: 'item 1', kinds: ['item'], limit: 2, game: 'gh2' },
+      }),
+    ).resolves.toBeDefined();
+    expect(mockLookupEntity).toHaveBeenCalledWith('item 1', {
+      kinds: ['item'],
+      limit: 2,
       game: 'gh2',
     });
   });

--- a/test/start-server.test.ts
+++ b/test/start-server.test.ts
@@ -3,12 +3,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 class FakeServer extends EventEmitter {
   listenCalls: number[] = [];
+  refCalls = 0;
 
   listen(port: number, _host?: string): this {
     this.listenCalls.push(port);
     queueMicrotask(() => {
       this.emit('listening');
     });
+    return this;
+  }
+
+  ref(): this {
+    this.refCalls += 1;
     return this;
   }
 }
@@ -191,6 +197,7 @@ describe.sequential('startServer', () => {
     await configured.startServer();
 
     expect(configured.fakeServer.listenCalls).toContain(4123);
+    expect(configured.fakeServer.refCalls).toBe(1);
     expect(configured.startBootstrapLifecycle).toHaveBeenCalled();
 
     const claimed = await loadStartServer({
@@ -201,6 +208,7 @@ describe.sequential('startServer', () => {
 
     expect(claimed.claimWorktreePort).toHaveBeenCalled();
     expect(claimed.fakeServer.listenCalls).toContain(4555);
+    expect(claimed.fakeServer.refCalls).toBe(1);
     expect(claimed.startBootstrapLifecycle).toHaveBeenCalled();
   }, 30_000);
 });

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -40,6 +40,7 @@ import {
   inspectSources,
   getSchema,
   resolveEntity,
+  lookupEntity,
   findScenario,
   getScenario,
   getSection,
@@ -1751,6 +1752,52 @@ describe('knowledge discovery tools', () => {
       ok: true,
       query: '   ',
       candidates: [],
+    });
+  });
+
+  it('lookupEntity resolves and opens exact item queries in one call', async () => {
+    const result = await lookupEntity('item 1', { kinds: ['item'] });
+
+    expect(result).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'card',
+        ref: 'card:frosthaven/items/gloomhavensecretariat:item/1',
+        data: {
+          number: '001',
+          sourceId: 'gloomhavensecretariat:item/1',
+          displayName: 'Spyglass',
+        },
+      },
+      citations: [
+        {
+          sourceRef: 'source:frosthaven/cards/items',
+          sourceLabel: 'Card Index',
+          locator: 'gloomhavensecretariat:item/1',
+        },
+      ],
+    });
+  });
+
+  it('lookupEntity asks for clarification instead of opening tied monster records', async () => {
+    const result = await lookupEntity('Living Spirit monster', {
+      kinds: ['monster'],
+      game: 'gloomhaven-2e',
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: 'ambiguous',
+        candidates: expect.arrayContaining([
+          expect.objectContaining({
+            ref: 'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/living-spirit/0-3',
+          }),
+          expect.objectContaining({
+            ref: 'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/living-spirit/4-7',
+          }),
+        ]),
+      },
     });
   });
 });

--- a/test/web-ui-htmx.regression-1.test.ts
+++ b/test/web-ui-htmx.regression-1.test.ts
@@ -50,13 +50,13 @@ describe('squire.js HTMX first-turn submit regression', () => {
     expect(squireJs).toContain('function renderAnswerWorkResult(');
     expect(squireJs).toContain('function baseAnswerWorkId(rowId) {');
     expect(squireJs).toContain('function answerWorkSourceEntries(labels) {');
-    expect(squireJs).toContain('function completeAnswerWork(elements, sourceCount) {');
+    expect(squireJs).toContain('function completeAnswerWork(elements) {');
     expect(squireJs).toContain('var toolPhaseStarted = false;');
     expect(squireJs).toContain("var preToolBuffer = '';");
     expect(squireJs).toContain("'SEARCHING'");
     expect(squireJs).toContain("'CHECKED'");
     expect(squireJs).toContain('elements.container.open = false;');
-    expect(squireJs).toContain('inferredAnswerWorkSourceCount(elements)');
+    expect(squireJs).toContain("elements.statusEl.textContent = 'Finished working';");
     expect(squireJs).toContain('function shouldSuppressPreToolDelta(delta) {');
     expect(squireJs).toContain('preToolBuffer += delta;');
     expect(squireJs).toContain('delta = preToolBuffer;');

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -1380,8 +1380,11 @@ describe('GET / — SQR-107 purpose-built landing', () => {
     it('renders a collapsed checked-source work log inside the answer element for a single source', () => {
       const body = renderTranscriptAnswer(answerWith(['search_rules']));
       expect(body).toMatch(
-        /class="squire-turn squire-answer"[\s\S]*<details[^>]*class="squire-answer-work"[^>]*data-work-state="complete"[\s\S]*Checked 1 source[\s\S]*Checked rulebook[\s\S]*<\/details>/,
+        /class="squire-turn squire-answer"[\s\S]*<details[^>]*class="squire-answer-work"[^>]*data-work-state="complete"[\s\S]*Finished working[\s\S]*Checked the rulebook[\s\S]*<\/details>/,
       );
+      expect(body).not.toContain('class="squire-answer-work__summary-icon"');
+      expect(body).toContain('class="squire-answer-work__row-icon" aria-hidden="true"');
+      expect(body).toContain('class="squire-answer-work__summary-caret" aria-hidden="true"');
       expect(body).not.toContain('Work log');
       expect(body).not.toContain('aria-label="Progress detail"');
       expect(body).not.toContain('data-progress-visibility-choice');
@@ -1390,13 +1393,19 @@ describe('GET / — SQR-107 purpose-built landing', () => {
     });
 
     it('reloads the completed work timeline from persisted browser-safe stream events', () => {
+      const rawRef =
+        'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/bandit-archer/0-3';
       const body = renderTranscriptAnswer(
         answerWith(null, {
           publicWorkEvents: [
             {
               sequence: 1,
               event: 'tool-result',
-              payload: { id: 'search_cards', labels: ['CARD INDEX'], ok: true },
+              payload: {
+                id: 'search_cards',
+                labels: ['CARD INDEX'],
+                ok: true,
+              },
               createdAt: new Date('2026-04-20T00:00:01.000Z'),
             },
             {
@@ -1405,7 +1414,7 @@ describe('GET / — SQR-107 purpose-built landing', () => {
               payload: {
                 id: 'resolve_entity-progress-1',
                 label: 'REFERENCE',
-                message: 'Resolving bandit archer monster',
+                message: 'Resolving Bandit Archer',
               },
               createdAt: new Date('2026-04-20T00:00:02.000Z'),
             },
@@ -1421,33 +1430,268 @@ describe('GET / — SQR-107 purpose-built landing', () => {
             },
             {
               sequence: 4,
+              event: 'tool-progress',
+              payload: {
+                id: 'open_entity-progress-1',
+                label: 'REFERENCE',
+                message: `Opening ${rawRef}`,
+              },
+              createdAt: new Date('2026-04-20T00:00:04.000Z'),
+            },
+            {
+              sequence: 5,
               event: 'tool-result',
-              payload: { id: 'search_rules', labels: ['RULEBOOK', 'SECTION BOOK'], ok: true },
+              payload: {
+                id: 'search_rules',
+                labels: ['RULEBOOK', 'SECTION BOOK'],
+                ok: true,
+              },
+              createdAt: new Date('2026-04-20T00:00:05.000Z'),
+            },
+          ],
+        }),
+      );
+
+      expect(body).toContain('Finished working');
+      expect(body).toMatch(
+        /Checked Bandit Archer stat card[\s\S]*Searched available sources[\s\S]*Checked the rulebook[\s\S]*Checked the section book/,
+      );
+      expect(body).not.toContain('SEARCHING');
+      expect(body).not.toContain('CHECKED');
+      expect(body).not.toContain('class="squire-toolcall"');
+      expect(body).not.toContain('class="squire-answer-work__row-note"');
+      expect(body).not.toContain(rawRef);
+      expect(body).not.toContain('Looked up Bandit Archer');
+    });
+
+    it('replays persisted agent intent rows in the completed work timeline', () => {
+      const body = renderTranscriptAnswer(
+        answerWith(null, {
+          publicWorkEvents: [
+            {
+              sequence: 1,
+              event: 'tool-plan',
+              payload: {
+                id: 'search_knowledge-plan-1',
+                message: "I'll search the rulebook.",
+              },
+              createdAt: new Date('2026-04-20T00:00:01.000Z'),
+            },
+            {
+              sequence: 2,
+              event: 'tool-progress',
+              payload: {
+                id: 'search_knowledge-progress-1',
+                label: 'RULEBOOK',
+                message: 'Looking up loot in the rulebook',
+              },
+              createdAt: new Date('2026-04-20T00:00:02.000Z'),
+            },
+            {
+              sequence: 3,
+              event: 'tool-result',
+              payload: { id: 'search_knowledge', labels: ['RULEBOOK'], ok: true },
+              createdAt: new Date('2026-04-20T00:00:03.000Z'),
+            },
+            {
+              sequence: 4,
+              event: 'tool-plan',
+              payload: {
+                id: 'search_knowledge-plan-2',
+                message: "I'll search the scenario book.",
+              },
+              createdAt: new Date('2026-04-20T00:00:04.000Z'),
+            },
+            {
+              sequence: 5,
+              event: 'tool-progress',
+              payload: {
+                id: 'search_knowledge-progress-2',
+                label: 'SCENARIO BOOK',
+                message: 'Looking up loot reminders in the scenario book',
+              },
+              createdAt: new Date('2026-04-20T00:00:05.000Z'),
+            },
+            {
+              sequence: 6,
+              event: 'tool-result',
+              payload: { id: 'search_knowledge', labels: ['SCENARIO BOOK'], ok: true },
+              createdAt: new Date('2026-04-20T00:00:06.000Z'),
+            },
+          ],
+        }),
+      );
+
+      expect(body).toContain('Finished working');
+      expect(body).toMatch(
+        /I&#39;ll search the rulebook\.[\s\S]*Searched the rulebook[\s\S]*I&#39;ll search the scenario book\.[\s\S]*Searched the scenario book/,
+      );
+      expect(body).toContain('squire-answer-work__row--narrative');
+    });
+
+    it('reloads section and scenario lookups as one source-action row', () => {
+      const sectionBody = renderTranscriptAnswer(
+        answerWith(null, {
+          publicWorkEvents: [
+            {
+              sequence: 1,
+              event: 'tool-progress',
+              payload: {
+                id: 'resolve_entity-progress-1',
+                label: 'REFERENCE',
+                message: 'Resolving section 67.1',
+              },
+              createdAt: new Date('2026-04-20T00:00:01.000Z'),
+            },
+            {
+              sequence: 2,
+              event: 'tool-plan',
+              payload: {
+                id: 'open_entity-plan-1',
+                message: "I'll look that up in the section book.",
+              },
+              createdAt: new Date('2026-04-20T00:00:02.000Z'),
+            },
+            {
+              sequence: 3,
+              event: 'tool-progress',
+              payload: {
+                id: 'open_entity-progress-1',
+                label: 'REFERENCE',
+                message: 'Opening section:gloomhaven-2e/67.1',
+              },
+              createdAt: new Date('2026-04-20T00:00:03.000Z'),
+            },
+            {
+              sequence: 4,
+              event: 'answer-artifact',
+              payload: {
+                id: 'section-quote-1',
+                kind: 'section-quote',
+                title: 'Section 67.1',
+                body: 'Conclusion',
+                sourceLabel: 'SECTION BOOK',
+              },
+              createdAt: new Date('2026-04-20T00:00:04.000Z'),
+            },
+            {
+              sequence: 5,
+              event: 'tool-result',
+              payload: { id: 'open_entity', labels: ['SECTION BOOK'], ok: true },
+              createdAt: new Date('2026-04-20T00:00:05.000Z'),
+            },
+          ],
+        }),
+      );
+
+      expect(sectionBody).toContain('Finished working');
+      expect(sectionBody).toMatch(
+        /I&#39;ll look that up in the section book\.[\s\S]*Looked up section 67.1 in the section book/,
+      );
+      expect(sectionBody).not.toContain('Found Section 67.1');
+      expect(sectionBody).not.toContain('Checked the section book');
+
+      const scenarioBody = renderTranscriptAnswer(
+        answerWith(null, {
+          publicWorkEvents: [
+            {
+              sequence: 1,
+              event: 'tool-progress',
+              payload: {
+                id: 'resolve_entity-progress-1',
+                label: 'REFERENCE',
+                message: 'Resolving scenario 61',
+              },
+              createdAt: new Date('2026-04-20T00:00:01.000Z'),
+            },
+            {
+              sequence: 2,
+              event: 'tool-plan',
+              payload: {
+                id: 'open_entity-plan-1',
+                message: "I'll look that up in the scenario book.",
+              },
+              createdAt: new Date('2026-04-20T00:00:02.000Z'),
+            },
+            {
+              sequence: 3,
+              event: 'tool-progress',
+              payload: {
+                id: 'open_entity-progress-1',
+                label: 'REFERENCE',
+                message: 'Opening gloomhavensecretariat:scenario/061',
+              },
+              createdAt: new Date('2026-04-20T00:00:03.000Z'),
+            },
+            {
+              sequence: 4,
+              event: 'tool-result',
+              payload: { id: 'open_entity', labels: ['SCENARIO BOOK'], ok: true },
               createdAt: new Date('2026-04-20T00:00:04.000Z'),
             },
           ],
         }),
       );
 
-      expect(body).toContain('Checked 3 sources');
-      expect(body).toMatch(
-        /Resolving bandit archer stats[\s\S]*Searching available sources[\s\S]*Checked card index[\s\S]*Checked rulebook[\s\S]*Checked section book/,
+      expect(scenarioBody).toContain('Finished working');
+      expect(scenarioBody).toMatch(
+        /I&#39;ll look that up in the scenario book\.[\s\S]*Looked up scenario 61 in the scenario book/,
       );
-      expect(body).not.toContain('SEARCHING');
-      expect(body).not.toContain('CHECKED');
-      expect(body).not.toContain('class="squire-toolcall"');
+      expect(scenarioBody).not.toContain('Checked the scenario book');
+      expect(scenarioBody).not.toContain('gloomhavensecretariat:scenario/061');
+    });
+
+    it('replays bare section open progress as the same section lookup row', () => {
+      const body = renderTranscriptAnswer(
+        answerWith(null, {
+          publicWorkEvents: [
+            {
+              sequence: 1,
+              event: 'tool-progress',
+              payload: {
+                id: 'resolve_entity-progress-1',
+                label: 'REFERENCE',
+                message: 'Looked up section 67.1',
+              },
+              createdAt: new Date('2026-04-20T00:00:01.000Z'),
+            },
+            {
+              sequence: 2,
+              event: 'tool-progress',
+              payload: {
+                id: 'open_entity-progress-2',
+                label: 'REFERENCE',
+                message: 'Opening 67.1',
+              },
+              createdAt: new Date('2026-04-20T00:00:02.000Z'),
+            },
+            {
+              sequence: 3,
+              event: 'tool-result',
+              payload: { id: 'open_entity', labels: ['SECTION BOOK'], ok: true },
+              createdAt: new Date('2026-04-20T00:00:03.000Z'),
+            },
+          ],
+        }),
+      );
+
+      expect(body).toContain('Finished working');
+      expect(body).toContain('Looked up section 67.1 in the section book');
+      expect(body).not.toContain('Opening 67.1');
     });
 
     it('aggregates multiple tool names into deduped labels, preserving insertion order', () => {
       const body = renderTranscriptAnswer(
         answerWith(['search_rules', 'search_cards', 'search_rules', 'get_card', 'get_section']),
       );
-      expect(body).toMatch(/Checked rulebook[\s\S]*Checked card index[\s\S]*Checked section book/);
+      expect(body).toMatch(
+        /Checked the rulebook[\s\S]*Checked the cards[\s\S]*Checked the section book/,
+      );
       expect(body).not.toContain('CONSULTED');
       // The RULEBOOK-first ordering is the insertion-order contract — ensure
-      // CARD INDEX doesn't leapfrog ahead of RULEBOOK just because more
+      // card-source labels don't leapfrog ahead of RULEBOOK just because more
       // card-family tools were called.
-      expect(body.indexOf('Checked rulebook')).toBeLessThan(body.indexOf('Checked card index'));
+      expect(body.indexOf('Checked the rulebook')).toBeLessThan(body.indexOf('Checked the cards'));
     });
 
     it('renders no source work log when consultedSources is null (pre-SQR-98 rows)', () => {
@@ -1483,7 +1727,7 @@ describe('GET / — SQR-107 purpose-built landing', () => {
       const body = renderTranscriptAnswer(
         answerWith(['find_scenario', 'get_scenario', 'get_section']),
       );
-      expect(body).toMatch(/Checked scenario book[\s\S]*Checked section book/);
+      expect(body).toMatch(/Checked the scenario book[\s\S]*Checked the section book/);
       expect(body).not.toContain('CONSULTED');
     });
 

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -931,6 +931,29 @@ describe('squire.js chat form retargeting', () => {
     expect(workRowMessages(workRowsEl)).toEqual(['Searched the rulebook']);
   });
 
+  it('keeps additional result sources visible when a rulebook search hits another book', () => {
+    const { source, workRowsEl, workStatusEl } = bootPendingTranscript();
+
+    source.emit('tool-progress', {
+      id: 'search_knowledge-progress-1',
+      label: 'RULEBOOK',
+      message: 'Searching the rulebook',
+    });
+    source.emit('tool-result', {
+      id: 'search_knowledge',
+      labels: ['RULEBOOK', 'SCENARIO BOOK'],
+      message: 'Searched the rulebook',
+      ok: true,
+    });
+    source.emit('done', { html: '<p>Loot answer.</p>' });
+
+    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workRowMessages(workRowsEl)).toEqual([
+      'Searched the rulebook',
+      'Checked the scenario book',
+    ]);
+  });
+
   it('collapses section resolve, open, and artifact rows into one lookup row', () => {
     const { source, workRowsEl, workStatusEl } = bootPendingTranscript();
 

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -574,7 +574,7 @@ describe('squire.js chat form retargeting', () => {
     source.emit('tool-result', { id: 'search_rules', labels: ['RULEBOOK'], ok: true });
     const row = workRowsEl.children[0];
     expect(row).toBeTruthy();
-    expect(workRowMessage(row)).toBe('Checked rulebook');
+    expect(workRowMessage(row)).toBe('Checked the rulebook');
 
     source.emit('text-delta', { delta: 'Loot 2 can reach up to two hexes away.' });
     expect(skeletonEl.hidden).toBe(true);
@@ -589,7 +589,7 @@ describe('squire.js chat form retargeting', () => {
     expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
     expect(workEl.open).toBe(false);
     expect(workEl.getAttribute('data-work-state')).toBe('complete');
-    expect(workStatusEl.textContent).toBe('Checked 1 source');
+    expect(workStatusEl.textContent).toBe('Finished working');
     expect(workRowsEl.children).toHaveLength(1);
     expect(source.closed).toBe(true);
   });
@@ -610,13 +610,16 @@ describe('squire.js chat form retargeting', () => {
     expect(workEl.getAttribute('data-work-state')).toBe('running');
     expect(workRowsEl.children).toHaveLength(1);
     const progressRow = workRowsEl.children[0];
-    expect(workRowMessage(progressRow)).toBe('Found Locked Down in section book');
+    expect(workRowMessage(progressRow)).toBe('Found Locked Down');
 
-    source.emit('tool-result', { id: 'follow_links', labels: ['SECTION BOOK'], ok: true });
-    expect(workRowMessage(progressRow)).toBe('Found Locked Down in section book');
-    expect(workRowsEl.children).toHaveLength(2);
-    const checkedRow = workRowsEl.children[1];
-    expect(workRowMessage(checkedRow)).toBe('Checked section book');
+    source.emit('tool-result', {
+      id: 'follow_links',
+      labels: ['SECTION BOOK'],
+      message: 'Found Locked Down in the section book',
+      ok: true,
+    });
+    expect(workRowMessage(progressRow)).toBe('Found Locked Down in the section book');
+    expect(workRowsEl.children).toHaveLength(1);
 
     source.emit('done', {
       html: '<p>The section is <strong>Locked Down</strong>.</p>',
@@ -625,8 +628,8 @@ describe('squire.js chat form retargeting', () => {
     expect(contentEl.innerHTML).toBe('<p>The section is <strong>Locked Down</strong>.</p>');
     expect(workEl.open).toBe(false);
     expect(workEl.getAttribute('data-work-state')).toBe('complete');
-    expect(workStatusEl.textContent).toBe('Checked 1 source');
-    expect(workRowsEl.children).toHaveLength(2);
+    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workRowsEl.children).toHaveLength(1);
     expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
   });
 
@@ -652,7 +655,15 @@ describe('squire.js chat form retargeting', () => {
     });
 
     expect(workRowsEl.children).toHaveLength(1);
-    expect(workRowMessage(workRowsEl.children[0])).toBe('Checking line of sight in rulebook');
+    expect(workRowMessage(workRowsEl.children[0])).toBe('Checking line of sight');
+
+    source.emit('tool-result', {
+      id: 'search_rules',
+      labels: ['RULEBOOK'],
+      message: 'Checked line of sight in the rulebook',
+      ok: true,
+    });
+    expect(workRowMessage(workRowsEl.children[0])).toBe('Checked line of sight in the rulebook');
 
     source.emit('done', { html: '<p>Answer.</p>' });
 
@@ -660,7 +671,7 @@ describe('squire.js chat form retargeting', () => {
     expect(workEl.open).toBe(false);
     expect(workEl.getAttribute('data-work-state')).toBe('complete');
     expect(workRowsEl.children).toHaveLength(1);
-    expect(workStatusEl.textContent).toBe('Checked 1 source');
+    expect(workStatusEl.textContent).toBe('Finished working');
   });
 
   it('does not render obsolete progress detail controls during an active run', () => {
@@ -690,11 +701,28 @@ describe('squire.js chat form retargeting', () => {
       label: 'REFERENCE',
       message: 'Searching selected sources',
     });
-    source.emit('tool-result', { id: 'search_cards', labels: ['CARD INDEX'], ok: true });
-    source.emit('tool-result', { id: 'get_card', labels: ['CARD INDEX'], ok: true });
+    source.emit('tool-result', {
+      id: 'search_knowledge',
+      labels: [],
+      message: 'Searched available sources',
+      ok: true,
+    });
+    source.emit('tool-result', {
+      id: 'search_cards',
+      labels: ['CARD INDEX'],
+      message: 'Checked Bandit Archer stat card',
+      ok: true,
+    });
+    source.emit('tool-result', {
+      id: 'get_card',
+      labels: ['CARD INDEX'],
+      message: 'Checked Bandit Archer stat card',
+      ok: true,
+    });
     source.emit('tool-result', {
       id: 'search_rules',
       labels: ['RULEBOOK'],
+      message: 'Checked the rulebook',
       ok: true,
     });
     source.emit('tool-progress', {
@@ -710,25 +738,30 @@ describe('squire.js chat form retargeting', () => {
     source.emit('tool-result', {
       id: 'search_sections',
       labels: ['SECTION BOOK'],
+      message: 'Checked the section book',
       ok: true,
     });
     source.emit('done', { html: '<p>Answer.</p>' });
 
-    expect(workStatusEl.textContent).toBe('Checked 3 sources');
-    expect(workRowsEl.children).toHaveLength(5);
+    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workRowsEl.children).toHaveLength(4);
     expect(workRowMessages(workRowsEl)).toEqual([
-      'Resolving bandit archer stats',
-      'Searching available sources',
-      'Checked card index',
-      'Checked rulebook',
-      'Checked section book',
+      'Checked Bandit Archer stat card',
+      'Searched available sources',
+      'Checked the rulebook',
+      'Checked the section book',
     ]);
   });
 
   it('keeps semantic work-log order when resolving and searching arrive after checked rows', () => {
     const { source, workRowsEl } = bootPendingTranscript();
 
-    source.emit('tool-result', { id: 'search_cards', labels: ['CARD INDEX'], ok: true });
+    source.emit('tool-result', {
+      id: 'search_cards',
+      labels: ['CARD INDEX'],
+      message: 'Checked Bandit Archer stat card',
+      ok: true,
+    });
     source.emit('tool-progress', {
       id: 'resolve_entity-progress-1',
       label: 'REFERENCE',
@@ -739,12 +772,49 @@ describe('squire.js chat form retargeting', () => {
       label: 'REFERENCE',
       message: 'Searching selected sources',
     });
+    source.emit('tool-result', {
+      id: 'search_knowledge',
+      labels: [],
+      message: 'Searched available sources',
+      ok: true,
+    });
 
     expect(workRowMessages(workRowsEl)).toEqual([
-      'Resolving bandit archer stats',
-      'Searching available sources',
-      'Checked card index',
+      'Checked Bandit Archer stat card',
+      'Searched available sources',
     ]);
+  });
+
+  it('collapses card lookup bookkeeping into one table-action row', () => {
+    const { contentEl, source, workRowsEl } = bootPendingTranscript();
+    const rawRef =
+      'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/bandit-archer/0-3';
+
+    source.emit('tool-progress', {
+      id: 'resolve_entity-progress-1',
+      label: 'REFERENCE',
+      message: 'Resolving Bandit Archer',
+    });
+    source.emit('tool-progress', {
+      id: 'open_entity-progress-2',
+      label: 'REFERENCE',
+      message: `Opening ${rawRef}`,
+    });
+    source.emit('tool-result', {
+      id: 'search_cards',
+      labels: ['CARD INDEX'],
+      message: 'Checked Bandit Archer stat card',
+      ok: true,
+    });
+    source.emit('done', {
+      html: '<p>An elite level 3 Bandit Archer has 10 hit points.</p>',
+    });
+
+    expect(workRowMessages(workRowsEl)).toEqual(['Checked Bandit Archer stat card']);
+    expect(workRowsEl.querySelector('.squire-answer-work__row-note')).toBeNull();
+    expect(workRowMessages(workRowsEl).join('\n')).not.toContain(rawRef);
+    expect(workRowMessages(workRowsEl).join('\n')).not.toContain('Looked up Bandit Archer');
+    expect(contentEl.innerHTML).toBe('<p>An elite level 3 Bandit Archer has 10 hit points.</p>');
   });
 
   it('keeps generic source-search wording exact when the progress event has a source label', () => {
@@ -757,6 +827,205 @@ describe('squire.js chat form retargeting', () => {
     });
 
     expect(workRowMessages(workRowsEl)).toEqual(['Searching available sources']);
+
+    source.emit('tool-result', {
+      id: 'search_rules',
+      labels: [],
+      message: 'Searched available sources',
+      ok: true,
+    });
+
+    expect(workRowMessages(workRowsEl)).toEqual(['Searched available sources']);
+  });
+
+  it('renders agent intent as a narrative row before source work', () => {
+    const { source, workRowsEl, workStatusEl } = bootPendingTranscript();
+
+    source.emit('tool-plan', {
+      id: 'search_knowledge-plan-1',
+      message: "I'll search the rulebook.",
+    });
+    source.emit('tool-progress', {
+      id: 'search_knowledge-progress-1',
+      label: 'RULEBOOK',
+      message: 'Looking up loot in the rulebook',
+    });
+    source.emit('tool-result', { id: 'search_knowledge', labels: ['RULEBOOK'], ok: true });
+    source.emit('done', { html: '<p>Loot answer.</p>' });
+
+    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workRowMessages(workRowsEl)).toEqual([
+      "I'll search the rulebook.",
+      'Searched the rulebook',
+    ]);
+    expect(workRowsEl.children[0].className).toContain('squire-answer-work__row--narrative');
+  });
+
+  it('keeps later source-search intent interspersed with later source work', () => {
+    const { source, workRowsEl, workStatusEl } = bootPendingTranscript();
+
+    source.emit('tool-plan', {
+      id: 'search_knowledge-plan-1',
+      message: "I'll search the rulebook.",
+    });
+    source.emit('tool-progress', {
+      id: 'search_knowledge-progress-1',
+      label: 'RULEBOOK',
+      message: 'Looking up loot in the rulebook',
+    });
+    source.emit('tool-result', { id: 'search_knowledge', labels: ['RULEBOOK'], ok: true });
+
+    source.emit('tool-plan', {
+      id: 'search_knowledge-plan-2',
+      message: "I'll search the scenario book.",
+    });
+    source.emit('tool-progress', {
+      id: 'search_knowledge-progress-2',
+      label: 'SCENARIO BOOK',
+      message: 'Looking up loot reminders in the scenario book',
+    });
+    source.emit('tool-result', { id: 'search_knowledge', labels: ['SCENARIO BOOK'], ok: true });
+    source.emit('done', { html: '<p>Loot answer.</p>' });
+
+    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workRowMessages(workRowsEl)).toEqual([
+      "I'll search the rulebook.",
+      'Searched the rulebook',
+      "I'll search the scenario book.",
+      'Searched the scenario book',
+    ]);
+  });
+
+  it('uses rulebook lookup wording without adding a duplicate checked row', () => {
+    const { source, workRowsEl, workStatusEl } = bootPendingTranscript();
+
+    source.emit('tool-progress', {
+      id: 'search_knowledge-progress-1',
+      label: 'RULEBOOK',
+      message: 'Looking up loot in the rulebook',
+    });
+    source.emit('tool-progress', {
+      id: 'search_knowledge-progress-2',
+      label: 'RULEBOOK',
+      message: 'Looking up end of turn looting loot tokens monsters drop in the rulebook',
+    });
+    source.emit('tool-result', { id: 'search_knowledge', labels: ['RULEBOOK'], ok: true });
+    source.emit('done', { html: '<p>Loot answer.</p>' });
+
+    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workRowMessages(workRowsEl)).toEqual(['Searched the rulebook']);
+  });
+
+  it('collapses rulebook search progress and checked result into one source row', () => {
+    const { source, workRowsEl, workStatusEl } = bootPendingTranscript();
+
+    source.emit('tool-progress', {
+      id: 'search_knowledge-progress-1',
+      label: 'RULEBOOK',
+      message: 'Searching the rulebook',
+    });
+    source.emit('tool-result', { id: 'search_knowledge', labels: ['RULEBOOK'], ok: true });
+    source.emit('done', { html: '<p>Loot answer.</p>' });
+
+    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workRowMessages(workRowsEl)).toEqual(['Searched the rulebook']);
+  });
+
+  it('collapses section resolve, open, and artifact rows into one lookup row', () => {
+    const { source, workRowsEl, workStatusEl } = bootPendingTranscript();
+
+    source.emit('tool-plan', {
+      id: 'open_entity-plan-1',
+      message: "I'll look that up in the section book.",
+    });
+    source.emit('tool-progress', {
+      id: 'resolve_entity-progress-1',
+      label: 'REFERENCE',
+      message: 'Resolving section 67.1',
+    });
+    source.emit('tool-progress', {
+      id: 'open_entity-progress-2',
+      label: 'REFERENCE',
+      message: 'Opening section:gloomhaven-2e/67.1',
+    });
+    source.emit('answer-artifact', {
+      id: 'section-quote-1',
+      kind: 'section-quote',
+      title: 'Section 67.1',
+      body: 'Conclusion',
+      sourceLabel: 'SECTION BOOK',
+      ref: 'section:frosthaven/67.1',
+    });
+    source.emit('tool-result', {
+      id: 'open_entity',
+      labels: ['SECTION BOOK'],
+      message: 'Looked up section 67.1 in the section book',
+      ok: true,
+    });
+    source.emit('done', { html: '<p>Book answer.</p>' });
+
+    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workRowMessages(workRowsEl)).toEqual([
+      "I'll look that up in the section book.",
+      'Looked up section 67.1 in the section book',
+    ]);
+  });
+
+  it('collapses bare section open progress into the section lookup row', () => {
+    const { source, workRowsEl, workStatusEl } = bootPendingTranscript();
+
+    source.emit('tool-progress', {
+      id: 'resolve_entity-progress-1',
+      label: 'REFERENCE',
+      message: 'Looked up section 67.1',
+    });
+    source.emit('tool-progress', {
+      id: 'open_entity-progress-2',
+      label: 'REFERENCE',
+      message: 'Opening 67.1',
+    });
+    source.emit('tool-result', {
+      id: 'open_entity',
+      labels: ['SECTION BOOK'],
+      message: 'Looked up section 67.1 in the section book',
+      ok: true,
+    });
+    source.emit('done', { html: '<p>Section answer.</p>' });
+
+    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workRowMessages(workRowsEl)).toEqual(['Looked up section 67.1 in the section book']);
+  });
+
+  it('collapses scenario resolve and legacy open refs into one lookup row', () => {
+    const { source, workRowsEl, workStatusEl } = bootPendingTranscript();
+
+    source.emit('tool-plan', {
+      id: 'open_entity-plan-1',
+      message: "I'll look that up in the scenario book.",
+    });
+    source.emit('tool-progress', {
+      id: 'resolve_entity-progress-1',
+      label: 'REFERENCE',
+      message: 'Resolving scenario 61',
+    });
+    source.emit('tool-progress', {
+      id: 'open_entity-progress-1',
+      label: 'REFERENCE',
+      message: 'Opening gloomhavensecretariat:scenario/061',
+    });
+    source.emit('tool-result', {
+      id: 'open_entity',
+      labels: ['SCENARIO BOOK'],
+      message: 'Looked up scenario 61 in the scenario book',
+      ok: true,
+    });
+    source.emit('done', { html: '<p>Scenario answer.</p>' });
+
+    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workRowMessages(workRowsEl)).toEqual([
+      "I'll look that up in the scenario book.",
+      'Looked up scenario 61 in the scenario book',
+    ]);
   });
 
   it('keeps inline work details open when the stream errors', () => {
@@ -789,7 +1058,7 @@ describe('squire.js chat form retargeting', () => {
     expect(workRowsEl.children).toHaveLength(1);
     expect(
       workRowsEl.children[0].querySelector('.squire-answer-work__row-detail')?.textContent,
-    ).toBe('Found Locked Down in section book');
+    ).toBe('Found Locked Down in the section book');
     expect(artifactsEl.children).toHaveLength(1);
     const artifact = artifactsEl.children[0];
     expect(artifact.querySelector('.squire-answer__artifact-title')?.textContent).toBe('');
@@ -832,7 +1101,7 @@ describe('squire.js chat form retargeting', () => {
 
       expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
       expect(workRowsEl.children).toHaveLength(2);
-      expect(workRowMessages(workRowsEl)).toEqual(['Checked rulebook', 'Checked card index']);
+      expect(workRowMessages(workRowsEl)).toEqual(['Checked the rulebook', 'Checked the cards']);
     });
 
     it('dedupes repeated labels and preserves first-seen order', () => {
@@ -845,7 +1114,7 @@ describe('squire.js chat form retargeting', () => {
 
       expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
       expect(workRowsEl.children).toHaveLength(2);
-      expect(workRowMessages(workRowsEl)).toEqual(['Checked rulebook', 'Checked card index']);
+      expect(workRowMessages(workRowsEl)).toEqual(['Checked the rulebook', 'Checked the cards']);
     });
 
     it('excludes labels from failed tool calls', () => {
@@ -858,8 +1127,8 @@ describe('squire.js chat form retargeting', () => {
       expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
       expect(workRowsEl.children).toHaveLength(2);
       expect(workRowMessages(workRowsEl)).toEqual([
-        'Checked card index',
-        "Couldn't check rulebook",
+        'Checked the cards',
+        "Couldn't check the rulebook",
       ]);
     });
 
@@ -870,8 +1139,8 @@ describe('squire.js chat form retargeting', () => {
       source.emit('done', { html: '<p>Answer.</p>' });
 
       expect(workRowsEl.children).toHaveLength(1);
-      expect(workRowMessages(workRowsEl)).toEqual(["Couldn't check rulebook"]);
-      expect(workStatusEl.textContent).toBe('Recorded 1 step');
+      expect(workRowMessages(workRowsEl)).toEqual(["Couldn't check the rulebook"]);
+      expect(workStatusEl.textContent).toBe('Finished working');
     });
 
     it('ignores the REFERENCE fallback label (utility/traversal tools)', () => {
@@ -908,9 +1177,9 @@ describe('squire.js chat form retargeting', () => {
       const searchRow = workRowsEl.children[0];
       const rulebookRow = workRowsEl.children[1];
       const sectionBookRow = workRowsEl.children[2];
-      expect(workRowMessage(searchRow)).toBe('Searching available sources');
-      expect(workRowMessage(rulebookRow)).toBe('Checked rulebook');
-      expect(workRowMessage(sectionBookRow)).toBe('Checked section book');
+      expect(workRowMessage(searchRow)).toBe('Searched available sources');
+      expect(workRowMessage(rulebookRow)).toBe('Checked the rulebook');
+      expect(workRowMessage(sectionBookRow)).toBe('Checked the section book');
     });
 
     it('leaves no source UI on done when no tools fired', () => {
@@ -987,7 +1256,7 @@ describe('squire.js chat form retargeting', () => {
 
     const row = workRowsEl.children[0];
     expect(row?.classList.contains('is-error')).toBe(true);
-    expect(row ? workRowMessage(row) : undefined).toBe("Couldn't check rulebook");
+    expect(row ? workRowMessage(row) : undefined).toBe("Couldn't check the rulebook");
   });
 
   it('ignores late tool-status events once answer prose is already on screen', () => {

--- a/test/work-log-display.test.ts
+++ b/test/work-log-display.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  humanizeWorkLogProgressMessage,
+  workLogSourceActionFromProgressMessage,
+} from '../src/work-log-display.ts';
+
+describe('work log display wording', () => {
+  it('turns card implementation refs into physical card checks', () => {
+    const message =
+      'Opening card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/bandit-archer/0-3';
+
+    expect(humanizeWorkLogProgressMessage(message)).toBe('Checked Bandit Archer stat card');
+    expect(workLogSourceActionFromProgressMessage(message)).toEqual({
+      label: 'CARD INDEX',
+      detail: 'Checked Bandit Archer stat card',
+    });
+  });
+
+  it('turns scenario and section refs into book-opening actions', () => {
+    expect(humanizeWorkLogProgressMessage('Opening scenario:gloomhaven-2e/061')).toBe(
+      'Looked up scenario 61 in the scenario book',
+    );
+    expect(humanizeWorkLogProgressMessage('Opening gloomhavensecretariat:scenario/061')).toBe(
+      'Looked up scenario 61 in the scenario book',
+    );
+    expect(humanizeWorkLogProgressMessage('Opening section:gloomhaven-2e/67.1')).toBe(
+      'Looked up section 67.1 in the section book',
+    );
+    expect(humanizeWorkLogProgressMessage('Opening 67.1')).toBe(
+      'Looked up section 67.1 in the section book',
+    );
+    expect(humanizeWorkLogProgressMessage('Opening scenario 061')).toBe(
+      'Looked up scenario 61 in the scenario book',
+    );
+  });
+
+  it('uses lookup language for rulebook searches and entity resolution', () => {
+    expect(humanizeWorkLogProgressMessage('Searching Rulebook')).toBe('Searched the rulebook');
+    expect(humanizeWorkLogProgressMessage('Searching the rulebook')).toBe('Searched the rulebook');
+    expect(humanizeWorkLogProgressMessage('Looking up loot in the rulebook')).toBe(
+      'Searched the rulebook',
+    );
+    expect(humanizeWorkLogProgressMessage('Searching Rulebook, Section Book, Card Index')).toBe(
+      'Searched available sources',
+    );
+    expect(humanizeWorkLogProgressMessage('Resolving bandit archer monster stat card')).toBe(
+      'Checked Bandit Archer stat card',
+    );
+    expect(humanizeWorkLogProgressMessage('Resolving loot')).toBe('Looked up loot');
+    expect(workLogSourceActionFromProgressMessage('Resolving section 67.1')).toEqual({
+      label: 'SECTION BOOK',
+      detail: 'Looked up section 67.1 in the section book',
+    });
+    expect(workLogSourceActionFromProgressMessage('Resolving scenario 61')).toEqual({
+      label: 'SCENARIO BOOK',
+      detail: 'Looked up scenario 61 in the scenario book',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add agent intent events before user-facing source work and keep the work log focused on physical table actions.
- Collapse resolve/open/source bookkeeping into one durable row per source action, including combined entity lookup results.
- Keep manual-test server lifecycle notes in repo docs and preserve extra source rows when a completed search reports more books than its initial progress row.

## Checks
- npm run check
- live eval: traj-exact-item-open
- live eval: gh2-traj-exact-item-open
- live eval: traj-ambiguous-algox-archer
- live eval: traj-scenario-neighbors

Fixes SQR-259


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-call lookup tool for exact content lookups.
  * New "plan" event and richer result messages so the assistant surfaces concise next-step plans and humanized completion notes in the work log.

* **UI / UX**
  * Work timeline now shows “Finished working”, narrative plan rows, and clearer “Checked …”/source rows.
  * Refined streaming work-log rendering, layout, and styling for improved readability and replay.

* **Documentation**
  * SSE contract and QA manual app-process guidance updated.

* **Tests**
  * Expanded suites and e2e checks covering lookup workflows, streaming events, and updated UI wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->