### PR TITLE
feat(web-ui): show elapsed work-log timing

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -242,7 +242,7 @@ SCEN 14` once Phase 4 character state lands. Always visible. One line,
    and a hairline `--rule` between turns. The drop cap appears
    only on the NEWEST `.squire-answer` (position-based selector
    `.squire-answer:not(:has(~ .squire-answer))::first-letter`); past answers
-   render plain. Each answer owns an inline "Working" disclosure above the
+   render plain. Each answer owns an inline work disclosure above the
    answer prose. It is expanded while Squire is working, renders only
    browser-safe events (`tool-start`, `tool-progress`, `tool-result`, or
    `answer-artifact`), and collapses to a compact source/step summary when the
@@ -259,14 +259,16 @@ SCEN 14` once Phase 4 character state lands. Always visible. One line,
    separate `SEARCHING` / `CHECKED` prefixes; use a stable semantic order so
    resolving appears before source search, which appears before checked-source
    rows, even if stream events arrive out of order.
-   The collapsed summary says `Checked 3 sources`; do not add a second
-   provenance footer below the answer. The user can reopen it in place. The
-   disclosure state is driven by the agent state only: open while Squire is
-   working, collapsed when the answer is ready, and open on errors. Do not add
-   display-density toggles, a header bar, plus/minus icons, or borders around
-   the work log. This gives the user the agent-app pattern of visible work
-   without mixing work notes into the answer body. It is not raw private
-   chain-of-thought, not campaign memory, and not page chrome. Phase 5 hosts
+   The disclosure title shows elapsed work time: `Working for 12s` while Squire
+   is active, updating once per second, and `Worked for 8m 33s` after the answer
+   is ready. Do not add a second provenance footer below the answer. The user
+   can reopen it in place. The disclosure state is driven by the agent state
+   only: open while Squire is working, collapsed when the answer is ready, and
+   open on errors. Do not add display-density toggles, a header bar, plus/minus
+   icons, or borders around the work log. This gives the user the agent-app
+   pattern of visible work without mixing work notes into the answer body. It
+   is not raw private chain-of-thought, not campaign memory, and not page
+   chrome. Phase 5 hosts
    two card mockups side-by-side with a
    "Squire recommends" verdict via a side panel or modal — not as a peer
    mode of the transcript.

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -31,6 +31,7 @@ import {
 } from './markdown-styleguide.ts';
 import { DEFAULT_GAME_ID, SUPPORTED_GAME_IDS, SUPPORTED_GAMES } from '../game.ts';
 import {
+  formatWorkLogDuration,
   humanizeWorkLogProgressMessage,
   workLogSourceActionFromProgressMessage,
 } from '../work-log-display.ts';
@@ -482,6 +483,7 @@ interface CompletedAnswerWorkRow {
 interface CompletedAnswerWorkTimeline {
   rows: CompletedAnswerWorkRow[];
   sourceCount: number;
+  durationMs: number | null;
 }
 
 function answerWorkSlug(value: string | undefined, fallback: string): string {
@@ -650,6 +652,7 @@ function countTimelineSourceLabels(rows: CompletedAnswerWorkRow[]): number {
 
 function buildCompletedAnswerWorkTimeline(
   events: readonly ConversationMessagePublicWorkEvent[] | undefined,
+  completedAt: Date,
 ): CompletedAnswerWorkTimeline {
   const rows = new Map<string, CompletedAnswerWorkRow>();
   const successfulSources = new Set<ToolSourceLabel>();
@@ -817,6 +820,7 @@ function buildCompletedAnswerWorkTimeline(
     rows: orderedRows,
     sourceCount:
       successfulSources.size > 0 ? successfulSources.size : countTimelineSourceLabels(orderedRows),
+    durationMs: completedAnswerWorkDurationMs(events, completedAt),
   };
 }
 
@@ -834,7 +838,22 @@ function timelineFromConsultedSources(
       ordinal: index,
     })),
     sourceCount: labels.length,
+    durationMs: null,
   };
+}
+
+function completedAnswerWorkDurationMs(
+  events: readonly ConversationMessagePublicWorkEvent[] | undefined,
+  completedAt: Date,
+): number | null {
+  const firstEvent = (events ?? []).find((event) => event.createdAt instanceof Date);
+  if (!firstEvent) return null;
+  return Math.max(0, completedAt.getTime() - firstEvent.createdAt.getTime());
+}
+
+function completedAnswerWorkStatus(timeline: CompletedAnswerWorkTimeline): string {
+  if (timeline.durationMs === null) return 'Worked';
+  return `Worked for ${formatWorkLogDuration(timeline.durationMs)}`;
 }
 
 function renderCompletedAnswerWorkTimeline(
@@ -847,7 +866,9 @@ function renderCompletedAnswerWorkTimeline(
     data-work-state="complete"
   >
     <summary class="squire-answer-work__summary">
-      <span class="squire-answer-work__status" data-answer-work-status>Finished working</span>
+      <span class="squire-answer-work__status" data-answer-work-status>
+        ${completedAnswerWorkStatus(timeline)}
+      </span>
       <span class="squire-answer-work__summary-caret" aria-hidden="true"></span>
     </summary>
     <div class="squire-answer-work__rows" data-answer-work-rows>
@@ -879,7 +900,10 @@ function renderCompletedAnswerWork(message: ConversationMessage): HtmlEscapedStr
   if (message.isError) {
     return html`` as HtmlEscapedString;
   }
-  const persistedTimeline = buildCompletedAnswerWorkTimeline(message.publicWorkEvents);
+  const persistedTimeline = buildCompletedAnswerWorkTimeline(
+    message.publicWorkEvents,
+    message.createdAt,
+  );
   if (persistedTimeline.rows.length > 0) {
     return renderCompletedAnswerWorkTimeline(persistedTimeline);
   }

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -593,6 +593,78 @@ function answerWorkElements(answerEl) {
   };
 }
 
+function formatWorkLogDuration(durationMs) {
+  var totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+  var seconds = totalSeconds % 60;
+  var totalMinutes = Math.floor(totalSeconds / 60);
+  var minutes = totalMinutes % 60;
+  var hours = Math.floor(totalMinutes / 60);
+
+  if (hours > 0) return hours + 'h ' + minutes + 'm ' + seconds + 's';
+  if (totalMinutes > 0) return totalMinutes + 'm ' + seconds + 's';
+  return seconds + 's';
+}
+
+function answerWorkNowMs() {
+  return Date.now();
+}
+
+function updateAnswerWorkElapsedStatus(elements, state, endMs) {
+  if (!elements || !elements.container || !elements.statusEl) return;
+  var startedAt = Number.parseInt(
+    (elements.container.dataset && elements.container.dataset.answerWorkStartedAtMs) || '',
+    10,
+  );
+  if (!Number.isFinite(startedAt)) {
+    startedAt = answerWorkNowMs();
+    if (elements.container.dataset) {
+      elements.container.dataset.answerWorkStartedAtMs = String(startedAt);
+    }
+  }
+  var elapsed = (endMs == null ? answerWorkNowMs() : endMs) - startedAt;
+  elements.statusEl.textContent =
+    (state === 'complete' ? 'Worked for ' : 'Working for ') + formatWorkLogDuration(elapsed);
+}
+
+function clearAnswerWorkTimer(elements) {
+  if (!elements || !elements.container || !elements.container.dataset) return;
+  var timerId = elements.container.dataset.answerWorkTimerId;
+  if (!timerId) return;
+  if (
+    typeof window !== 'undefined' &&
+    window.clearInterval &&
+    Number.isFinite(Number.parseInt(timerId, 10))
+  ) {
+    window.clearInterval(Number.parseInt(timerId, 10));
+  }
+  delete elements.container.dataset.answerWorkTimerId;
+}
+
+function startAnswerWorkTimer(elements) {
+  if (!elements || !elements.container || !elements.container.dataset) return;
+  if (!elements.container.dataset.answerWorkStartedAtMs) {
+    elements.container.dataset.answerWorkStartedAtMs = String(answerWorkNowMs());
+  }
+  updateAnswerWorkElapsedStatus(elements, 'running');
+  if (elements.container.dataset.answerWorkTimerId) return;
+  if (typeof window === 'undefined' || typeof window.setInterval !== 'function') return;
+  var timerId = window.setInterval(function () {
+    if (elements.container.getAttribute('data-work-state') !== 'running') {
+      clearAnswerWorkTimer(elements);
+      return;
+    }
+    updateAnswerWorkElapsedStatus(elements, 'running');
+  }, 1000);
+  elements.container.dataset.answerWorkTimerId = String(timerId);
+}
+
+function completeAnswerWorkTimer(elements) {
+  if (!elements || !elements.container) return;
+  var endedAt = answerWorkNowMs();
+  clearAnswerWorkTimer(elements);
+  updateAnswerWorkElapsedStatus(elements, 'complete', endedAt);
+}
+
 function resetAnswerWork(elements, entries) {
   if (!elements || !elements.container) return;
   if (elements.rowsEl) {
@@ -607,7 +679,11 @@ function resetAnswerWork(elements, entries) {
   elements.container.hidden = false;
   elements.container.setAttribute('data-work-state', 'running');
   syncAnswerWorkOpenState(elements.container);
-  if (elements.statusEl) elements.statusEl.textContent = 'Working';
+  if (elements.container.dataset) {
+    delete elements.container.dataset.answerWorkStartedAtMs;
+  }
+  clearAnswerWorkTimer(elements);
+  startAnswerWorkTimer(elements);
 }
 
 function setAnswerWorkRunning(elements) {
@@ -615,7 +691,7 @@ function setAnswerWorkRunning(elements) {
   elements.container.hidden = false;
   elements.container.setAttribute('data-work-state', 'running');
   elements.container.open = true;
-  if (elements.statusEl) elements.statusEl.textContent = 'Working';
+  startAnswerWorkTimer(elements);
 }
 
 function baseAnswerWorkId(rowId) {
@@ -1098,6 +1174,7 @@ function completeAnswerWork(elements) {
     elements.container.hidden = true;
     elements.container.open = false;
     elements.container.setAttribute('data-work-state', 'complete');
+    clearAnswerWorkTimer(elements);
     if (elements.statusEl) elements.statusEl.textContent = 'Answered directly';
     return;
   }
@@ -1105,9 +1182,7 @@ function completeAnswerWork(elements) {
   elements.container.hidden = false;
   elements.container.setAttribute('data-work-state', 'complete');
   syncAnswerWorkOpenState(elements.container);
-  if (elements.statusEl) {
-    elements.statusEl.textContent = 'Finished working';
-  }
+  completeAnswerWorkTimer(elements);
 }
 
 function markAnswerWorkError(elements) {
@@ -1115,6 +1190,7 @@ function markAnswerWorkError(elements) {
   elements.container.hidden = false;
   elements.container.open = true;
   elements.container.setAttribute('data-work-state', 'error');
+  clearAnswerWorkTimer(elements);
   if (elements.statusEl) elements.statusEl.textContent = 'Stopped before answer';
 }
 

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -659,7 +659,7 @@ function startAnswerWorkTimer(elements) {
 }
 
 function completeAnswerWorkTimer(elements) {
-  if (!elements || !elements.container) return;
+  if (!elements.container) return;
   var endedAt = answerWorkNowMs();
   clearAnswerWorkTimer(elements);
   updateAnswerWorkElapsedStatus(elements, 'complete', endedAt);

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -1616,8 +1616,9 @@ template#squire-banner-fixtures {
   font-size: 10px;
   font-weight: 650;
   line-height: 1.3;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  letter-spacing: 0;
+  text-transform: none;
+  font-variant-numeric: tabular-nums;
   color: var(--sepia);
   text-align: left;
 }

--- a/src/work-log-display.ts
+++ b/src/work-log-display.ts
@@ -3,6 +3,18 @@ export type WorkLogSourceAction = {
   detail: string;
 };
 
+export function formatWorkLogDuration(durationMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+  const seconds = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const minutes = totalMinutes % 60;
+  const hours = Math.floor(totalMinutes / 60);
+
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`;
+  if (totalMinutes > 0) return `${totalMinutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
 function titleizeSlug(value: string): string {
   return value
     .split(/[\s_-]+/)

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -2577,7 +2577,7 @@ describe('conversation web backend', () => {
     const page = await pageRes.text();
 
     expect(pageRes.status).toBe(200);
-    expect(page).toContain('Finished working');
+    expect(page).toContain('Worked for');
     expect(page).toMatch(/Checked Bandit Archer stat card[\s\S]*Checked the rulebook/);
     expect(page).not.toContain('class="squire-toolcall"');
   });

--- a/test/e2e/sqr-24-chat-game-selection.spec.ts
+++ b/test/e2e/sqr-24-chat-game-selection.spec.ts
@@ -105,7 +105,7 @@ async function expectFinalAnswer(page: Page, expectedAnswer: RegExp): Promise<vo
   );
   await expect(latestAnswer.locator('[data-testid="answer-content"] a')).toBeVisible();
   await expect(latestAnswer.locator('[data-testid="answer-progress"]')).toContainText(
-    'Finished working',
+    /Worked for \d+(?:h \d+m \d+s|m \d+s|s)/,
   );
   await expect(latestAnswer.locator('[data-testid="answer-progress"]')).toContainText(
     'Checked the rulebook',
@@ -209,7 +209,7 @@ test.describe('SQR-24 browser chat game selection', () => {
     await expectFinalAnswer(page, /Closed doors block line-of-sight/);
     await expect(workLog).toHaveAttribute('data-work-state', 'complete');
     await expect(workLog).not.toHaveAttribute('open', '');
-    await expect(workLog).toContainText('Finished working');
+    await expect(workLog).toContainText(/Worked for \d+(?:h \d+m \d+s|m \d+s|s)/);
     await expect(workLog.locator('.squire-answer-work__row-label')).toHaveCount(0);
     await expect(workLog.locator('.squire-answer-work__row-detail')).toContainText(
       'Checked the rulebook',

--- a/test/web-ui-htmx.regression-1.test.ts
+++ b/test/web-ui-htmx.regression-1.test.ts
@@ -56,7 +56,8 @@ describe('squire.js HTMX first-turn submit regression', () => {
     expect(squireJs).toContain("'SEARCHING'");
     expect(squireJs).toContain("'CHECKED'");
     expect(squireJs).toContain('elements.container.open = false;');
-    expect(squireJs).toContain("elements.statusEl.textContent = 'Finished working';");
+    expect(squireJs).toContain("state === 'complete' ? 'Worked for ' : 'Working for '");
+    expect(squireJs).toContain('completeAnswerWorkTimer(elements);');
     expect(squireJs).toContain('function shouldSuppressPreToolDelta(delta) {');
     expect(squireJs).toContain('preToolBuffer += delta;');
     expect(squireJs).toContain('delta = preToolBuffer;');

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -1380,7 +1380,7 @@ describe('GET / — SQR-107 purpose-built landing', () => {
     it('renders a collapsed checked-source work log inside the answer element for a single source', () => {
       const body = renderTranscriptAnswer(answerWith(['search_rules']));
       expect(body).toMatch(
-        /class="squire-turn squire-answer"[\s\S]*<details[^>]*class="squire-answer-work"[^>]*data-work-state="complete"[\s\S]*Finished working[\s\S]*Checked the rulebook[\s\S]*<\/details>/,
+        /class="squire-turn squire-answer"[\s\S]*<details[^>]*class="squire-answer-work"[^>]*data-work-state="complete"[\s\S]*Worked[\s\S]*Checked the rulebook[\s\S]*<\/details>/,
       );
       expect(body).not.toContain('class="squire-answer-work__summary-icon"');
       expect(body).toContain('class="squire-answer-work__row-icon" aria-hidden="true"');
@@ -1452,7 +1452,7 @@ describe('GET / — SQR-107 purpose-built landing', () => {
         }),
       );
 
-      expect(body).toContain('Finished working');
+      expect(body).toContain('Worked for 0s');
       expect(body).toMatch(
         /Checked Bandit Archer stat card[\s\S]*Searched available sources[\s\S]*Checked the rulebook[\s\S]*Checked the section book/,
       );
@@ -1462,6 +1462,36 @@ describe('GET / — SQR-107 purpose-built landing', () => {
       expect(body).not.toContain('class="squire-answer-work__row-note"');
       expect(body).not.toContain(rawRef);
       expect(body).not.toContain('Looked up Bandit Archer');
+    });
+
+    it('renders completed persisted work with the elapsed disclosure title', () => {
+      const body = renderTranscriptAnswer(
+        answerWith(null, {
+          createdAt: new Date('2026-04-20T00:08:34.000Z'),
+          publicWorkEvents: [
+            {
+              sequence: 1,
+              event: 'tool-progress',
+              payload: {
+                id: 'search_knowledge-progress-1',
+                label: 'RULEBOOK',
+                message: 'Searching the rulebook',
+              },
+              createdAt: new Date('2026-04-20T00:00:01.000Z'),
+            },
+            {
+              sequence: 2,
+              event: 'tool-result',
+              payload: { id: 'search_knowledge', labels: ['RULEBOOK'], ok: true },
+              createdAt: new Date('2026-04-20T00:00:03.000Z'),
+            },
+          ],
+        }),
+      );
+
+      expect(body).toContain('Worked for 8m 33s');
+      expect(body).not.toContain('Finished working');
+      expect(body).toContain('Searched the rulebook');
     });
 
     it('replays persisted agent intent rows in the completed work timeline', () => {
@@ -1522,7 +1552,7 @@ describe('GET / — SQR-107 purpose-built landing', () => {
         }),
       );
 
-      expect(body).toContain('Finished working');
+      expect(body).toContain('Worked for 0s');
       expect(body).toMatch(
         /I&#39;ll search the rulebook\.[\s\S]*Searched the rulebook[\s\S]*I&#39;ll search the scenario book\.[\s\S]*Searched the scenario book/,
       );
@@ -1584,7 +1614,7 @@ describe('GET / — SQR-107 purpose-built landing', () => {
         }),
       );
 
-      expect(sectionBody).toContain('Finished working');
+      expect(sectionBody).toContain('Worked for 0s');
       expect(sectionBody).toMatch(
         /I&#39;ll look that up in the section book\.[\s\S]*Looked up section 67.1 in the section book/,
       );
@@ -1633,7 +1663,7 @@ describe('GET / — SQR-107 purpose-built landing', () => {
         }),
       );
 
-      expect(scenarioBody).toContain('Finished working');
+      expect(scenarioBody).toContain('Worked for 0s');
       expect(scenarioBody).toMatch(
         /I&#39;ll look that up in the scenario book\.[\s\S]*Looked up scenario 61 in the scenario book/,
       );
@@ -1675,7 +1705,7 @@ describe('GET / — SQR-107 purpose-built landing', () => {
         }),
       );
 
-      expect(body).toContain('Finished working');
+      expect(body).toContain('Worked for 0s');
       expect(body).toContain('Looked up section 67.1 in the section book');
       expect(body).not.toContain('Opening 67.1');
     });

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -230,9 +230,55 @@ function runSquireScript(pathname: string): Record<string, string> {
   return attributes;
 }
 
-function bootPendingTranscript() {
+function createFakeClock(startMs = 0) {
+  let nowMs = startMs;
+  let nextTimerId = 1;
+  const timers = new Map<number, { callback: () => void; intervalMs: number; nextRunAt: number }>();
+
+  return {
+    Date: class extends Date {
+      constructor(...args: ConstructorParameters<typeof Date>) {
+        if (args.length > 0) {
+          super(...args);
+        } else {
+          super(nowMs);
+        }
+      }
+
+      static now() {
+        return nowMs;
+      }
+    } as DateConstructor,
+    advance(ms: number) {
+      nowMs += ms;
+      let ranTimer = true;
+      while (ranTimer) {
+        ranTimer = false;
+        for (const timer of timers.values()) {
+          if (timer.nextRunAt <= nowMs) {
+            timer.callback();
+            timer.nextRunAt += timer.intervalMs;
+            ranTimer = true;
+          }
+        }
+      }
+    },
+    clearInterval(id: number) {
+      timers.delete(id);
+    },
+    setInterval(callback: () => void, intervalMs: number) {
+      const id = nextTimerId;
+      nextTimerId += 1;
+      timers.set(id, { callback, intervalMs, nextRunAt: nowMs + intervalMs });
+      return id;
+    },
+  };
+}
+
+function bootPendingTranscript(options: { clock?: ReturnType<typeof createFakeClock> } = {}) {
   const listeners = new Map<string, Array<(event?: unknown) => void>>();
   const storedValues = new Map<string, string>();
+  const clock = options.clock ?? createFakeClock();
 
   // SQR-108: setFormPendingState writes to form.dataset and reads back
   // form.querySelector('input[name="question"]'/'button[type="submit"]'),
@@ -332,6 +378,7 @@ function bootPendingTranscript() {
   };
 
   const context = vm.createContext({
+    Date: clock.Date,
     document,
     window: {
       location: { pathname: '/chat/test' },
@@ -349,6 +396,7 @@ function bootPendingTranscript() {
         cb();
         return 0;
       },
+      clearInterval: clock.clearInterval,
       localStorage: {
         getItem(key: string) {
           return storedValues.get(key) ?? null;
@@ -357,6 +405,7 @@ function bootPendingTranscript() {
           storedValues.set(key, value);
         },
       },
+      setInterval: clock.setInterval,
     },
   });
 
@@ -560,7 +609,7 @@ describe('squire.js chat form retargeting', () => {
 
     expect(workEl.open).toBe(true);
     expect(workEl.getAttribute('data-work-state')).toBe('running');
-    expect(workStatusEl.textContent).toBe('Working');
+    expect(workStatusEl.textContent).toBe('Working for 0s');
 
     source.emit('text-delta', { delta: 'Let me ' });
     source.emit('text-delta', { delta: 'look that up carefully before answering.' });
@@ -589,7 +638,7 @@ describe('squire.js chat form retargeting', () => {
     expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
     expect(workEl.open).toBe(false);
     expect(workEl.getAttribute('data-work-state')).toBe('complete');
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
     expect(workRowsEl.children).toHaveLength(1);
     expect(source.closed).toBe(true);
   });
@@ -628,7 +677,7 @@ describe('squire.js chat form retargeting', () => {
     expect(contentEl.innerHTML).toBe('<p>The section is <strong>Locked Down</strong>.</p>');
     expect(workEl.open).toBe(false);
     expect(workEl.getAttribute('data-work-state')).toBe('complete');
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
     expect(workRowsEl.children).toHaveLength(1);
     expect(answerEl.querySelector('.squire-toolcall')).toBeNull();
   });
@@ -639,13 +688,13 @@ describe('squire.js chat form retargeting', () => {
     expect(workEl.hidden).toBe(false);
     expect(workEl.open).toBe(true);
     expect(workEl.getAttribute('data-work-state')).toBe('running');
-    expect(workStatusEl.textContent).toBe('Working');
+    expect(workStatusEl.textContent).toBe('Working for 0s');
 
     source.emit('tool-start', { id: 'search_rules', label: 'RULEBOOK' });
 
     expect(workEl.open).toBe(true);
     expect(workEl.getAttribute('data-work-state')).toBe('running');
-    expect(workStatusEl.textContent).toBe('Working');
+    expect(workStatusEl.textContent).toBe('Working for 0s');
     expect(workRowsEl.children).toHaveLength(0);
 
     source.emit('tool-progress', {
@@ -671,7 +720,27 @@ describe('squire.js chat form retargeting', () => {
     expect(workEl.open).toBe(false);
     expect(workEl.getAttribute('data-work-state')).toBe('complete');
     expect(workRowsEl.children).toHaveLength(1);
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
+  });
+
+  it('updates the work disclosure elapsed time every second and freezes it on done', () => {
+    const clock = createFakeClock();
+    const { source, workStatusEl } = bootPendingTranscript({ clock });
+
+    expect(workStatusEl.textContent).toBe('Working for 0s');
+
+    clock.advance(1_000);
+    expect(workStatusEl.textContent).toBe('Working for 1s');
+
+    clock.advance(512_000);
+    expect(workStatusEl.textContent).toBe('Working for 8m 33s');
+
+    source.emit('tool-result', { id: 'search_rules', labels: ['RULEBOOK'], ok: true });
+    source.emit('done', { html: '<p>Answer.</p>' });
+    expect(workStatusEl.textContent).toBe('Worked for 8m 33s');
+
+    clock.advance(5_000);
+    expect(workStatusEl.textContent).toBe('Worked for 8m 33s');
   });
 
   it('does not render obsolete progress detail controls during an active run', () => {
@@ -743,7 +812,7 @@ describe('squire.js chat form retargeting', () => {
     });
     source.emit('done', { html: '<p>Answer.</p>' });
 
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
     expect(workRowsEl.children).toHaveLength(4);
     expect(workRowMessages(workRowsEl)).toEqual([
       'Checked Bandit Archer stat card',
@@ -853,7 +922,7 @@ describe('squire.js chat form retargeting', () => {
     source.emit('tool-result', { id: 'search_knowledge', labels: ['RULEBOOK'], ok: true });
     source.emit('done', { html: '<p>Loot answer.</p>' });
 
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
     expect(workRowMessages(workRowsEl)).toEqual([
       "I'll search the rulebook.",
       'Searched the rulebook',
@@ -887,7 +956,7 @@ describe('squire.js chat form retargeting', () => {
     source.emit('tool-result', { id: 'search_knowledge', labels: ['SCENARIO BOOK'], ok: true });
     source.emit('done', { html: '<p>Loot answer.</p>' });
 
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
     expect(workRowMessages(workRowsEl)).toEqual([
       "I'll search the rulebook.",
       'Searched the rulebook',
@@ -912,7 +981,7 @@ describe('squire.js chat form retargeting', () => {
     source.emit('tool-result', { id: 'search_knowledge', labels: ['RULEBOOK'], ok: true });
     source.emit('done', { html: '<p>Loot answer.</p>' });
 
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
     expect(workRowMessages(workRowsEl)).toEqual(['Searched the rulebook']);
   });
 
@@ -927,7 +996,7 @@ describe('squire.js chat form retargeting', () => {
     source.emit('tool-result', { id: 'search_knowledge', labels: ['RULEBOOK'], ok: true });
     source.emit('done', { html: '<p>Loot answer.</p>' });
 
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
     expect(workRowMessages(workRowsEl)).toEqual(['Searched the rulebook']);
   });
 
@@ -947,7 +1016,7 @@ describe('squire.js chat form retargeting', () => {
     });
     source.emit('done', { html: '<p>Loot answer.</p>' });
 
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
     expect(workRowMessages(workRowsEl)).toEqual([
       'Searched the rulebook',
       'Checked the scenario book',
@@ -987,7 +1056,7 @@ describe('squire.js chat form retargeting', () => {
     });
     source.emit('done', { html: '<p>Book answer.</p>' });
 
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
     expect(workRowMessages(workRowsEl)).toEqual([
       "I'll look that up in the section book.",
       'Looked up section 67.1 in the section book',
@@ -1015,7 +1084,7 @@ describe('squire.js chat form retargeting', () => {
     });
     source.emit('done', { html: '<p>Section answer.</p>' });
 
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
     expect(workRowMessages(workRowsEl)).toEqual(['Looked up section 67.1 in the section book']);
   });
 
@@ -1044,7 +1113,7 @@ describe('squire.js chat form retargeting', () => {
     });
     source.emit('done', { html: '<p>Scenario answer.</p>' });
 
-    expect(workStatusEl.textContent).toBe('Finished working');
+    expect(workStatusEl.textContent).toBe('Worked for 0s');
     expect(workRowMessages(workRowsEl)).toEqual([
       "I'll look that up in the scenario book.",
       'Looked up scenario 61 in the scenario book',
@@ -1163,7 +1232,7 @@ describe('squire.js chat form retargeting', () => {
 
       expect(workRowsEl.children).toHaveLength(1);
       expect(workRowMessages(workRowsEl)).toEqual(["Couldn't check the rulebook"]);
-      expect(workStatusEl.textContent).toBe('Finished working');
+      expect(workStatusEl.textContent).toBe('Worked for 0s');
     });
 
     it('ignores the REFERENCE fallback label (utility/traversal tools)', () => {

--- a/test/work-log-display.test.ts
+++ b/test/work-log-display.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatWorkLogDuration,
   humanizeWorkLogProgressMessage,
   workLogSourceActionFromProgressMessage,
 } from '../src/work-log-display.ts';
 
 describe('work log display wording', () => {
+  it('formats elapsed work durations like the disclosure title', () => {
+    expect(formatWorkLogDuration(0)).toBe('0s');
+    expect(formatWorkLogDuration(999)).toBe('0s');
+    expect(formatWorkLogDuration(1_000)).toBe('1s');
+    expect(formatWorkLogDuration(65_000)).toBe('1m 5s');
+    expect(formatWorkLogDuration(513_000)).toBe('8m 33s');
+  });
+
   it('turns card implementation refs into physical card checks', () => {
     const message =
       'Opening card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/bandit-archer/0-3';


### PR DESCRIPTION
## Summary

- Shows elapsed work time in the answer work disclosure while Squire is running, updating once per second as `Working for 0s`, `Working for 1s`, etc.
- Freezes completed work disclosures as `Worked for <duration>` instead of `Finished working`, including persisted conversation history.
- Keeps direct-answer turns hidden as `Answered directly`, clears timers on completion/error, and preserves existing grouped work rows.
- Updates the work-log design contract and regression coverage for live timers, persisted timelines, and E2E completion labels.

## Test Coverage

All new code paths have test coverage.

## Pre-Landing Review

Scope Check: CLEAN
Intent: SQR-260 should replace the completed work-log title with elapsed work time and update the active work title every second.
Delivered: The live browser work log, persisted server-rendered work log, CSS title styling, tests, and design docs all use elapsed work timing.

Pre-Landing Review: No issues found.

## Design Review

Design Review: No issues found.

## Eval Results

No prompt-related behavior changed; evals skipped.

## Plan Completion

No plan file detected.

## Verification Results

Manual browser verification passed on the real local app:

- Started `npm run serve` and logged in with the dev login flow.
- Submitted a real chat query.
- Observed the disclosure update from `Working for 0s` to `Working for 2s` while the agent was still running.
- Observed completion freeze at `Worked for 16s`, with the work log collapsed and grouped rows rendered.
- Confirmed no browser console errors during the run.

## Test plan

- [x] `npm run check` (114 files, 1505 tests)
- [x] `npm run check` again after commit hooks (114 files, 1505 tests)
- [x] Manual local app/browser verification

Fixes SQR-260


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Work progress now displays elapsed time that updates live (e.g., "Working for 12s" while active, "Worked for 45s" after completion).
  * Completed work disclosures show elapsed-time titles and can be reopened inline; disclosure state follows agent progress and error states.

* **Style**
  * Improved numeric typography for consistent width in work status text.

* **Documentation**
  * Mobile work-disclosure wording and UI constraints updated.

* **Tests**
  * Updated tests and e2e checks to expect elapsed-time progress text and verify timer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->