### PR TITLE
feat(auth): caller identity propagation for campaign state (SQR-20)

### DIFF
--- a/src/campaign/identity.ts
+++ b/src/campaign/identity.ts
@@ -1,0 +1,65 @@
+/**
+ * Caller identity for campaign-state access (Phase 4, SQR-20).
+ *
+ * ADR 0021 requires every campaign-scoped operation to know WHO is asking,
+ * on every channel. This module is the one place that turns channel
+ * mechanics (web session, OAuth bearer token, in-process call) into a typed
+ * `CallerIdentity`, and the one place that enforces the user-bound-token
+ * rule: client-credentials tokens carry no `userId` and are structurally
+ * rejected from campaign state — there is no client-identity fallback here,
+ * unlike rate limiting, where falling back to the OAuth client id is fine.
+ *
+ * Identity is not authorization: membership and permission checks happen in
+ * the campaign service layer against the SQR-28 contract. This type just
+ * guarantees the checks have a real user to evaluate.
+ */
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+
+export type CallerChannel = 'web' | 'mcp' | 'rest' | 'system';
+
+export interface CallerIdentity {
+  userId: string;
+  channel: CallerChannel;
+}
+
+/**
+ * Structured rejection for tokens that identify a client but not a user.
+ * State surfaces translate this into their channel's error shape (HTTP 403
+ * JSON, MCP tool error payload) — never a silent fallback.
+ */
+export class UserIdentityRequiredError extends Error {
+  readonly code = 'user_identity_required';
+
+  constructor(channel: CallerChannel) {
+    super(
+      `Campaign state requires a user-bound token on the ${channel} channel; ` +
+        `client-credentials tokens have no user identity`,
+    );
+    this.name = 'UserIdentityRequiredError';
+  }
+}
+
+/** Extract the token's user id, if the token is user-bound. */
+export function userIdFromAuthInfo(authInfo: AuthInfo | undefined): string | null {
+  const userId = authInfo?.extra?.userId;
+  return typeof userId === 'string' && userId.trim().length > 0 ? userId : null;
+}
+
+/**
+ * The hard gate for state surfaces (ADR 0021, plan constraint: hard-reject
+ * client-only tokens). Throws `UserIdentityRequiredError` when the token is
+ * absent or client-only.
+ */
+export function requireIdentityFromAuthInfo(
+  authInfo: AuthInfo | undefined,
+  channel: CallerChannel,
+): CallerIdentity {
+  const userId = userIdFromAuthInfo(authInfo);
+  if (!userId) throw new UserIdentityRequiredError(channel);
+  return { userId, channel };
+}
+
+/** In-process callers (web conversation agent) carry identity without auth. */
+export function identityFromSessionUser(userId: string): CallerIdentity {
+  return { userId, channel: 'web' };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import './instrumentation.ts';
 import { randomUUID } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 import { Hono, type Context, type MiddlewareHandler } from 'hono';
+import { userIdFromAuthInfo } from './campaign/identity.ts';
 import { html } from 'hono/html';
 import { streamSSE } from 'hono/streaming';
 import {
@@ -1692,11 +1693,15 @@ app.use('/mcp', requireMcpAuthAndRateLimit());
 
 app.all('/mcp', async (c) => {
   const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: undefined, // Stateless mode — auth added later
+    sessionIdGenerator: undefined, // Stateless mode
   });
   const server = createMcpServer();
   await server.connect(transport);
-  return transport.handleRequest(c.req.raw);
+  // Thread the verified bearer token into tool handlers as `extra.authInfo`
+  // so identity-requiring tools (campaign state, SQR-20/269) can resolve the
+  // caller. Knowledge tools ignore it.
+  const authInfo = c.get('authInfo');
+  return transport.handleRequest(c.req.raw, authInfo ? { authInfo } : undefined);
 });
 
 // ─── Error handling ──────────────────────────────────────────────────────────
@@ -1942,9 +1947,15 @@ app.post('/api/ask', async (c) => {
     const message = error instanceof Error ? error.message : String(error);
     return c.json(jsonError(message, 400), 400);
   }
+  // Identity comes from the verified bearer token, never the request body
+  // (SQR-20 / ADR 0021): a body-supplied userId is discarded, and client-
+  // credentials tokens (no userId) simply get no personalization or
+  // per-user budget attribution on this read path.
   delete options.userId;
+  const tokenUserId = userIdFromAuthInfo(c.get('authInfo'));
+  if (tokenUserId) options.userId = tokenUserId;
   try {
-    await ensureAskBudgetAvailable(null);
+    await ensureAskBudgetAvailable(tokenUserId);
   } catch (error) {
     if (error instanceof LlmBudgetExceededError) return budgetExceededResponse(c, error);
     throw error;

--- a/test/campaign-identity.test.ts
+++ b/test/campaign-identity.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Caller identity resolution for campaign state (SQR-20, ADR 0021).
+ *
+ * The user-bound-token rule: client-credentials tokens identify a client,
+ * not a user, and are structurally rejected from campaign-state access —
+ * no client-identity fallback exists on state surfaces.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import {
+  identityFromSessionUser,
+  requireIdentityFromAuthInfo,
+  UserIdentityRequiredError,
+  userIdFromAuthInfo,
+} from '../src/campaign/identity.ts';
+
+function authInfo(extra?: Record<string, unknown>): AuthInfo {
+  return {
+    token: 'raw-token',
+    clientId: 'client-123',
+    scopes: [],
+    extra,
+  };
+}
+
+describe('campaign caller identity (SQR-20)', () => {
+  it('resolves the user id from a user-bound token', () => {
+    const identity = requireIdentityFromAuthInfo(authInfo({ userId: 'user-1' }), 'mcp');
+    expect(identity).toEqual({ userId: 'user-1', channel: 'mcp' });
+  });
+
+  it('hard-rejects client-credentials tokens (no userId) with a structured error', () => {
+    expect(() => requireIdentityFromAuthInfo(authInfo(), 'rest')).toThrow(
+      UserIdentityRequiredError,
+    );
+    try {
+      requireIdentityFromAuthInfo(authInfo({ userId: '   ' }), 'mcp');
+      expect.unreachable('blank userId must not resolve');
+    } catch (error) {
+      expect(error).toBeInstanceOf(UserIdentityRequiredError);
+      expect((error as UserIdentityRequiredError).code).toBe('user_identity_required');
+    }
+  });
+
+  it('hard-rejects a missing token entirely', () => {
+    expect(() => requireIdentityFromAuthInfo(undefined, 'mcp')).toThrow(UserIdentityRequiredError);
+  });
+
+  it('never falls back to the client id', () => {
+    expect(userIdFromAuthInfo(authInfo({ somethingElse: true }))).toBeNull();
+  });
+
+  it('wraps in-process session users as web-channel identity', () => {
+    expect(identityFromSessionUser('user-9')).toEqual({ userId: 'user-9', channel: 'web' });
+  });
+});

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -711,6 +711,48 @@ describe('POST /api/ask', () => {
     );
   });
 
+  // SQR-20 / ADR 0021: identity comes from the verified bearer token, never
+  // the request body, and client-credentials tokens get no user identity.
+  it('derives ask identity from a user-bound token and ignores body userId', async () => {
+    mockVerifyAccessToken.mockResolvedValueOnce({
+      token: 'stub',
+      clientId: 'stub-client',
+      scopes: [],
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      extra: { userId: 'token-user-1' },
+    });
+
+    await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({
+        question: 'What items can I afford?',
+        userId: '00000000-0000-4000-8000-00000000dead',
+      }),
+    });
+
+    expect(mockAsk).toHaveBeenCalledWith(
+      'What items can I afford?',
+      expect.objectContaining({ userId: 'token-user-1' }),
+    );
+    expect(mockEnsureAskBudgetAvailable).toHaveBeenCalledWith('token-user-1');
+  });
+
+  it('passes no user identity for client-credentials tokens', async () => {
+    await app.request('/api/ask', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      body: JSON.stringify({
+        question: 'What is the loot action?',
+        userId: '00000000-0000-4000-8000-00000000beef',
+      }),
+    });
+
+    const options = mockAsk.mock.calls[0][1] as Record<string, unknown>;
+    expect(options.userId).toBeUndefined();
+    expect(mockEnsureAskBudgetAvailable).toHaveBeenCalledWith(null);
+  });
+
   it('rate limits authenticated ask requests before budget and model work', async () => {
     const limiter = installOneRequestLimiter();
 


### PR DESCRIPTION
## Summary

Identity plumbing per ADR 0021 and the plan's constraints 1–2:

- **`src/campaign/identity.ts`** — typed `CallerIdentity` (`userId` + channel), `requireIdentityFromAuthInfo` as the hard gate for state surfaces (`UserIdentityRequiredError`, code `user_identity_required`, for client-credentials tokens — there is deliberately no client-id fallback here, unlike rate limiting), and `identityFromSessionUser` for in-process web calls.
- **`/api/ask`** — identity now comes from the verified bearer token, never the body: body `userId` is discarded unconditionally, token `userId` flows into `ask()` options (LangGraph trace metadata picks it up) and into the LLM budget precheck for per-user attribution. Client-only tokens proceed un-personalized.
- **`/mcp`** — the verified `authInfo` is now passed to `WebStandardStreamableHTTPServerTransport.handleRequest`, so MCP tool handlers receive `extra.authInfo`. This is the hook the campaign state tools (SQR-269/271/287) require.

## Validation

- 5 new unit tests on the identity module (user-bound resolution, client-only hard reject incl. blank userId, missing token, no client fallback, session wrapper)
- 2 new `/api/ask` route tests: token identity wins over a body-supplied UUID; client-credentials tokens yield no `userId` and `null` budget attribution
- `npm run check` green: 1,512 tests / 115 files

## Notes

End-to-end proof that `extra.authInfo` reaches a real identity-requiring MCP tool lands with the first such tool (SQR-269) — no MCP state codepaths exist yet to test against; the SDK's typed `HandleRequestOptions.authInfo` contract covers the pass-through until then.

Fixes SQR-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication validation requiring verified user identity for accessing campaign state and operations.

* **Bug Fixes**
  * Enhanced security by deriving user identity from verified authentication tokens rather than request body data, improving request attribution and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->