### PR TITLE
feat(campaign): campaign CRUD + membership service and REST API (SQR-21)

### DIFF
--- a/src/campaign/campaign-service.ts
+++ b/src/campaign/campaign-service.ts
@@ -1,0 +1,366 @@
+/**
+ * Campaign lifecycle + membership service (Phase 4, SQR-21).
+ *
+ * This is the ADR 0021 enforcement point for campaign-scoped operations:
+ * every function takes a `CallerIdentity` and decides visibility/permission
+ * against the contract's matrix BEFORE touching repositories. Routes stay
+ * thin — they translate typed errors into HTTP shapes and never make
+ * authorization decisions themselves.
+ *
+ * Non-members (and invited/departed members) get `CampaignNotFoundError` on
+ * campaign-scoped reads and writes — indistinguishable from an absent id
+ * (ADR 0021 §Non-member access). Members hitting owner-only mutations get
+ * `CampaignForbiddenError`: the campaign's existence is already known to
+ * them, so a 403 leaks nothing.
+ *
+ * The allowlist is checked at campaign create, invite AND join time
+ * (ADR 0021 §Invites): a lapsed allowlist entry blocks the join even when
+ * the invite row still exists.
+ */
+import { getAllowedEmails } from '../auth/google.ts';
+import { getDb } from '../db.ts';
+import * as CampaignRepository from '../db/repositories/campaign-repository.ts';
+import * as CampaignMemberRepository from '../db/repositories/campaign-member-repository.ts';
+import * as UserRepository from '../db/repositories/user-repository.ts';
+import type {
+  Campaign,
+  CampaignMember,
+  CampaignMemberStatus,
+  CampaignRole,
+  UpdateCampaignSharedStateInput,
+} from '../db/repositories/types.ts';
+import { normalizeGameId } from '../game.ts';
+import type { CallerIdentity } from './identity.ts';
+
+// ─── Typed errors (routes map these to HTTP shapes) ─────────────────────────
+
+/** Absent id and non-member access are deliberately the same error. */
+export class CampaignNotFoundError extends Error {
+  readonly code = 'not_found';
+
+  constructor() {
+    super('Not found');
+    this.name = 'CampaignNotFoundError';
+  }
+}
+
+/** A real member attempting a mutation outside their role's matrix cells. */
+export class CampaignForbiddenError extends Error {
+  readonly code = 'forbidden';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'CampaignForbiddenError';
+  }
+}
+
+export class NotAllowlistedError extends Error {
+  readonly code = 'not_allowlisted';
+
+  constructor() {
+    super('That email is not on the invite allowlist');
+    this.name = 'NotAllowlistedError';
+  }
+}
+
+/**
+ * ADR 0021: the last member cannot leave, and the single owner cannot leave
+ * while the campaign exists — both resolve to "delete the campaign instead"
+ * (ownership transfer is future work). Since the owner can never leave, the
+ * sole-member case is always the owner and this one error covers both rules.
+ */
+export class OwnerCannotLeaveError extends Error {
+  readonly code = 'owner_cannot_leave';
+
+  constructor() {
+    super('The owner cannot leave a campaign; delete the campaign instead');
+    this.name = 'OwnerCannotLeaveError';
+  }
+}
+
+export class AlreadyInvitedError extends Error {
+  readonly code = 'already_invited';
+
+  constructor(status: CampaignMemberStatus) {
+    super(status === 'active' ? 'Already a member' : 'Already invited');
+    this.name = 'AlreadyInvitedError';
+  }
+}
+
+export class UnsupportedGameError extends Error {
+  readonly code = 'unsupported_game';
+
+  constructor(game: string) {
+    super(`Unsupported game: ${game}`);
+    this.name = 'UnsupportedGameError';
+  }
+}
+
+// ─── Views ───────────────────────────────────────────────────────────────────
+
+/** Roster entry: membership facts are shared-tier data among members. */
+export interface RosterMember {
+  memberId: string;
+  userId: string | null;
+  email: string;
+  name: string | null;
+  role: CampaignRole;
+  status: CampaignMemberStatus;
+  joinedAt: Date | null;
+}
+
+export interface CampaignDetail {
+  campaign: Campaign;
+  members: RosterMember[];
+  self: { memberId: string; role: CampaignRole };
+}
+
+/** The invite carve-out record: minimal, only via the invitee's own list. */
+export interface PendingInvite {
+  memberId: string;
+  campaignName: string;
+  game: string;
+  inviterName: string | null;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function assertAllowlisted(email: string): void {
+  if (!getAllowedEmails().includes(email.toLowerCase())) {
+    throw new NotAllowlistedError();
+  }
+}
+
+/** The membership gate on every campaign-scoped operation. */
+async function requireActiveMember(campaignId: string, userId: string): Promise<CampaignMember> {
+  const member = await CampaignMemberRepository.findActiveMember(campaignId, userId);
+  if (!member) throw new CampaignNotFoundError();
+  return member;
+}
+
+async function requireUser(userId: string) {
+  const user = await UserRepository.findById(userId);
+  // Identities come from verified sessions/tokens, so a missing user row
+  // means a deleted account still holding credentials — treat as not found.
+  if (!user) throw new CampaignNotFoundError();
+  return user;
+}
+
+async function rosterFor(campaignId: string): Promise<RosterMember[]> {
+  const members = await CampaignMemberRepository.listMembers(campaignId);
+  const roster: RosterMember[] = [];
+  for (const member of members) {
+    const user = member.userId ? await UserRepository.findById(member.userId) : null;
+    roster.push({
+      memberId: member.id,
+      userId: member.userId,
+      email: member.inviteEmail,
+      name: user?.name ?? null,
+      role: member.role,
+      status: member.status,
+      joinedAt: member.joinedAt,
+    });
+  }
+  return roster;
+}
+
+// ─── Campaign lifecycle ──────────────────────────────────────────────────────
+
+export async function createCampaign(
+  identity: CallerIdentity,
+  input: { name: string; game: string; modules?: string[] },
+): Promise<Campaign> {
+  const user = await requireUser(identity.userId);
+  assertAllowlisted(user.email);
+
+  const game = normalizeGameId(input.game);
+  if (!game) throw new UnsupportedGameError(input.game);
+
+  const { db } = getDb('server');
+  return db.transaction(async (tx) => {
+    const campaign = await CampaignRepository.create(tx, {
+      name: input.name,
+      game,
+      modules: input.modules,
+    });
+    await CampaignMemberRepository.createOwner(tx, {
+      campaignId: campaign.id,
+      userId: user.id,
+      email: user.email,
+    });
+    return campaign;
+  });
+}
+
+export async function listMyCampaigns(identity: CallerIdentity): Promise<Campaign[]> {
+  return CampaignMemberRepository.listCampaignsForUser(identity.userId);
+}
+
+export async function getCampaignDetail(
+  identity: CallerIdentity,
+  campaignId: string,
+): Promise<CampaignDetail> {
+  const member = await requireActiveMember(campaignId, identity.userId);
+  const campaign = await CampaignRepository.findById(campaignId);
+  if (!campaign) throw new CampaignNotFoundError();
+  return {
+    campaign,
+    members: await rosterFor(campaignId),
+    self: { memberId: member.id, role: member.role },
+  };
+}
+
+/**
+ * Shared-state CAS write (E3). Any member may edit shared state; the
+ * destructive subset (scenario un-play, prosperity decrease) joins the
+ * propose→confirm gate when the pending-mutations mechanism lands.
+ * TODO(SQR-279): route un-play / prosperity-decrease through proposals.
+ */
+export async function updateSharedState(
+  identity: CallerIdentity,
+  campaignId: string,
+  input: UpdateCampaignSharedStateInput,
+): Promise<Campaign> {
+  await requireActiveMember(campaignId, identity.userId);
+  const { db } = getDb('server');
+  return CampaignRepository.updateSharedState(db, campaignId, input);
+}
+
+/** Owner-only; cascades domain rows while audit rows survive (ADR 0021). */
+export async function deleteCampaign(identity: CallerIdentity, campaignId: string): Promise<void> {
+  const member = await requireActiveMember(campaignId, identity.userId);
+  if (member.role !== 'owner') {
+    throw new CampaignForbiddenError('Only the owner can delete a campaign');
+  }
+  // TODO(SQR-279): destructive — route through propose→confirm once the
+  // pending-mutations mechanism exists.
+  const { db } = getDb('server');
+  await CampaignRepository.remove(db, campaignId);
+}
+
+// ─── Membership ──────────────────────────────────────────────────────────────
+
+export async function inviteMember(
+  identity: CallerIdentity,
+  campaignId: string,
+  rawEmail: string,
+): Promise<RosterMember> {
+  const actor = await requireActiveMember(campaignId, identity.userId);
+  if (actor.role !== 'owner') {
+    throw new CampaignForbiddenError('Only the owner can invite members');
+  }
+
+  const email = rawEmail.trim().toLowerCase();
+  assertAllowlisted(email);
+
+  const members = await CampaignMemberRepository.listMembers(campaignId);
+  const existing = members.find((m) => m.inviteEmail.toLowerCase() === email);
+  const { db } = getDb('server');
+
+  let invite: CampaignMember;
+  if (!existing) {
+    invite = await CampaignMemberRepository.createInvite(db, {
+      campaignId,
+      inviteEmail: email,
+      invitedByUserId: identity.userId,
+    });
+  } else if (existing.status === 'departed') {
+    // Rejoin keeps the user binding so character ownership survives; the
+    // accept path still runs (consent + join-time allowlist re-check).
+    const revived = await CampaignMemberRepository.reinviteDeparted(
+      db,
+      existing.id,
+      identity.userId,
+    );
+    if (!revived) throw new AlreadyInvitedError(existing.status);
+    invite = revived;
+  } else {
+    throw new AlreadyInvitedError(existing.status);
+  }
+
+  const user = invite.userId ? await UserRepository.findById(invite.userId) : null;
+  return {
+    memberId: invite.id,
+    userId: invite.userId,
+    email: invite.inviteEmail,
+    name: user?.name ?? null,
+    role: invite.role,
+    status: invite.status,
+    joinedAt: invite.joinedAt,
+  };
+}
+
+/** The invitee's own invite list — the only non-member campaign visibility. */
+export async function listMyInvites(identity: CallerIdentity): Promise<PendingInvite[]> {
+  const user = await requireUser(identity.userId);
+  const invites = await CampaignMemberRepository.listPendingInvitesForEmail(
+    user.email.toLowerCase(),
+  );
+  const views: PendingInvite[] = [];
+  for (const invite of invites) {
+    const campaign = await CampaignRepository.findById(invite.campaignId);
+    if (!campaign) continue;
+    const inviter = invite.invitedByUserId
+      ? await UserRepository.findById(invite.invitedByUserId)
+      : null;
+    views.push({
+      memberId: invite.id,
+      campaignName: campaign.name,
+      game: campaign.game,
+      inviterName: inviter?.name ?? null,
+    });
+  }
+  return views;
+}
+
+export async function acceptInvite(identity: CallerIdentity, memberId: string): Promise<Campaign> {
+  const user = await requireUser(identity.userId);
+  // Join-time allowlist re-check: a lapsed entry blocks the join even though
+  // the invite row exists (ADR 0021 §Invites).
+  assertAllowlisted(user.email);
+
+  const { db } = getDb('server');
+  const activated = await CampaignMemberRepository.activateInvite(db, memberId, {
+    userId: user.id,
+    email: user.email.toLowerCase(),
+  });
+  // Wrong member id, someone else's invite, or already accepted — all the
+  // same indistinguishable not-found.
+  if (!activated) throw new CampaignNotFoundError();
+
+  const campaign = await CampaignRepository.findById(activated.campaignId);
+  if (!campaign) throw new CampaignNotFoundError();
+  return campaign;
+}
+
+export async function leaveCampaign(identity: CallerIdentity, campaignId: string): Promise<void> {
+  const member = await requireActiveMember(campaignId, identity.userId);
+  if (member.role === 'owner') throw new OwnerCannotLeaveError();
+  const { db } = getDb('server');
+  await CampaignMemberRepository.markDeparted(db, member.id);
+}
+
+export async function removeMember(
+  identity: CallerIdentity,
+  campaignId: string,
+  targetMemberId: string,
+): Promise<void> {
+  const actor = await requireActiveMember(campaignId, identity.userId);
+  if (actor.role !== 'owner') {
+    throw new CampaignForbiddenError('Only the owner can remove members');
+  }
+  if (actor.id === targetMemberId) {
+    throw new CampaignForbiddenError('Owners cannot remove themselves; delete the campaign');
+  }
+
+  const members = await CampaignMemberRepository.listMembers(campaignId);
+  const target = members.find((m) => m.id === targetMemberId);
+  // A member id from another campaign is indistinguishable from absent.
+  if (!target) throw new CampaignNotFoundError();
+  if (target.status === 'departed') return; // idempotent
+
+  // TODO(SQR-279): destructive — route through propose→confirm once the
+  // pending-mutations mechanism exists.
+  const { db } = getDb('server');
+  await CampaignMemberRepository.markDeparted(db, target.id);
+}

--- a/src/campaign/campaign-service.ts
+++ b/src/campaign/campaign-service.ts
@@ -131,6 +131,14 @@ function assertAllowlisted(email: string): void {
   }
 }
 
+/** Drizzle wraps PG errors as DrizzleQueryError with the original in `cause`. */
+function isUniqueViolation(error: unknown): boolean {
+  const cause = (error as { cause?: unknown })?.cause ?? error;
+  return (
+    typeof cause === 'object' && cause !== null && (cause as { code?: string }).code === '23505'
+  );
+}
+
 /** The membership gate on every campaign-scoped operation. */
 async function requireActiveMember(campaignId: string, userId: string): Promise<CampaignMember> {
   const member = await CampaignMemberRepository.findActiveMember(campaignId, userId);
@@ -259,11 +267,19 @@ export async function inviteMember(
 
   let invite: CampaignMember;
   if (!existing) {
-    invite = await CampaignMemberRepository.createInvite(db, {
-      campaignId,
-      inviteEmail: email,
-      invitedByUserId: identity.userId,
-    });
+    try {
+      invite = await CampaignMemberRepository.createInvite(db, {
+        campaignId,
+        inviteEmail: email,
+        invitedByUserId: identity.userId,
+      });
+    } catch (error) {
+      // Read-then-write race: a concurrent invite for the same email won
+      // the (campaign_id, invite_email) unique index. Same outcome as
+      // having seen the row up front.
+      if (isUniqueViolation(error)) throw new AlreadyInvitedError('invited');
+      throw error;
+    }
   } else if (existing.status === 'departed') {
     // Rejoin keeps the user binding so character ownership survives; the
     // accept path still runs (consent + join-time allowlist re-check).

--- a/src/db/repositories/campaign-member-repository.ts
+++ b/src/db/repositories/campaign-member-repository.ts
@@ -178,6 +178,24 @@ export async function markDeparted(handle: DbOrTx, memberId: string): Promise<bo
   return updated.length > 0;
 }
 
+/**
+ * Re-invite a departed member: the row flips back to 'invited' (keeping its
+ * user binding) so the rejoin rides the normal accept path — including the
+ * join-time allowlist re-check (ADR 0021 §Invites).
+ */
+export async function reinviteDeparted(
+  handle: DbOrTx,
+  memberId: string,
+  invitedByUserId: string,
+): Promise<CampaignMember | null> {
+  const [row] = await handle
+    .update(campaignMembers)
+    .set({ status: 'invited', invitedByUserId, joinedAt: null })
+    .where(and(eq(campaignMembers.id, memberId), eq(campaignMembers.status, 'departed')))
+    .returning();
+  return row ? toDomain(row) : null;
+}
+
 /** Rejoin: reactivate a departed membership (ownership of characters is user-bound). */
 export async function reactivateDeparted(
   handle: DbOrTx,

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -89,6 +89,20 @@ export const API_ASK_RATE_LIMIT_POLICY: RateLimitPolicy = {
   windowMs: 60 * 1000,
 };
 
+/** Campaign-state reads, per user (ADR 0018 inventory, eng decision E7). */
+export const CAMPAIGN_READ_RATE_LIMIT_POLICY: RateLimitPolicy = {
+  name: 'campaign_read',
+  limit: 120,
+  windowMs: 60 * 1000,
+};
+
+/** Campaign-state writes, per user (ADR 0018 inventory, eng decision E7). */
+export const CAMPAIGN_WRITE_RATE_LIMIT_POLICY: RateLimitPolicy = {
+  name: 'campaign_write',
+  limit: 60,
+  windowMs: 60 * 1000,
+};
+
 export const API_RULE_SEARCH_RATE_LIMIT_POLICY: RateLimitPolicy = {
   name: 'api_search_rules',
   limit: 60,

--- a/src/server.ts
+++ b/src/server.ts
@@ -2088,6 +2088,10 @@ function requireCampaignUser(route: string): MiddlewareHandler {
       return apiRateLimitedResponse(c, { decision, identityKind: 'user' }, route);
     }
 
+    // Per-user JSON must never be cacheable — these routes also serve
+    // cookie-authenticated browser reads, where a shared cache would happily
+    // reuse one member's roster for another without this.
+    c.header('Cache-Control', 'no-store');
     c.set('callerIdentity', auth.identity);
     await next();
   };
@@ -2197,16 +2201,22 @@ app.patch('/api/campaigns/:id', async (c) => {
   } catch (error) {
     if (error instanceof VersionConflictError) {
       // E3: 409 + the current state so the client can re-read and retry.
-      const detail = await CampaignService.getCampaignDetail(identity, campaignId);
-      return c.json(
-        {
-          error: 'version_conflict',
-          currentVersion: detail.campaign.version,
-          campaign: detail.campaign,
-          status: 409,
-        },
-        409,
-      );
+      // The follow-up read can itself lose a race (campaign deleted, caller
+      // removed) — map that outcome instead of letting it become a 500.
+      try {
+        const detail = await CampaignService.getCampaignDetail(identity, campaignId);
+        return c.json(
+          {
+            error: 'version_conflict',
+            currentVersion: detail.campaign.version,
+            campaign: detail.campaign,
+            status: 409,
+          },
+          409,
+        );
+      } catch (readError) {
+        return campaignErrorResponse(c, readError);
+      }
     }
     return campaignErrorResponse(c, error);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,10 +8,18 @@ import 'dotenv/config';
 // before service.ts transitively loads db.ts, otherwise Postgres spans never
 // reach LangSmith in production. Same pattern as query.ts and eval/run.ts.
 import './instrumentation.ts';
-import { randomUUID } from 'node:crypto';
+import { randomUUID, timingSafeEqual } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 import { Hono, type Context, type MiddlewareHandler } from 'hono';
-import { userIdFromAuthInfo } from './campaign/identity.ts';
+import {
+  identityFromSessionUser,
+  requireIdentityFromAuthInfo,
+  userIdFromAuthInfo,
+  UserIdentityRequiredError,
+  type CallerIdentity,
+} from './campaign/identity.ts';
+import * as CampaignService from './campaign/campaign-service.ts';
+import { VersionConflictError } from './db/repositories/types.ts';
 import { html } from 'hono/html';
 import { streamSSE } from 'hono/streaming';
 import {
@@ -33,6 +41,8 @@ import {
   API_ASK_RATE_LIMIT_POLICY,
   API_CARD_SEARCH_RATE_LIMIT_POLICY,
   API_RULE_SEARCH_RATE_LIMIT_POLICY,
+  CAMPAIGN_READ_RATE_LIMIT_POLICY,
+  CAMPAIGN_WRITE_RATE_LIMIT_POLICY,
   GOOGLE_OAUTH_CALLBACK_RATE_LIMIT_POLICY,
   GOOGLE_OAUTH_START_RATE_LIMIT_POLICY,
   getDefaultRateLimiter,
@@ -74,7 +84,8 @@ import {
   GoogleAuthError,
   resolveGoogleRedirectUri,
 } from './auth/google.ts';
-import { getSessionSecret } from './auth/session-middleware.ts';
+import { getSessionSecret, SESSION_COOKIE_NAME } from './auth/session-middleware.ts';
+import { CSRF_HEADER_NAME } from './web-ui/csrf.ts';
 import * as SessionRepository from './db/repositories/session-repository.ts';
 import { writeAuditEvent } from './auth/audit.ts';
 import {
@@ -1978,6 +1989,298 @@ app.post('/api/ask', async (c) => {
       });
     }
   });
+});
+
+// ─── Campaign state API (SQR-21, ADR 0021) ──────────────────────────────────
+//
+// Dual-channel auth: a user-bound OAuth bearer token (API/MCP clients) or the
+// web session cookie (browser fetch/HTMX, with a CSRF header on writes).
+// Client-credentials tokens are structurally rejected — campaign state always
+// needs a real user (SQR-20). Authorization itself (membership, roles, the
+// permission matrix) lives in campaign-service, not here.
+
+type CampaignAuthResult =
+  | { ok: true; identity: CallerIdentity }
+  | { ok: false; response: Response };
+
+function timingSafeEqualStrings(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+async function authenticateCampaignRequest(c: Context): Promise<CampaignAuthResult> {
+  if (c.req.header('authorization')) {
+    const authResult = await authenticateBearer(c);
+    if (!authResult.ok) return { ok: false, response: bearerAuthFailureResponse(c, authResult) };
+    c.set('authInfo', authResult.authInfo);
+    try {
+      return { ok: true, identity: requireIdentityFromAuthInfo(authResult.authInfo, 'rest') };
+    } catch (error) {
+      if (error instanceof UserIdentityRequiredError) {
+        writeSecurityLog({
+          event: 'campaign_client_token_rejected',
+          fields: {
+            route: c.req.path,
+            method: c.req.method,
+            client_id: authResult.authInfo.clientId,
+          },
+        });
+        return {
+          ok: false,
+          response: c.json({ error: error.code, message: error.message, status: 403 }, 403),
+        };
+      }
+      throw error;
+    }
+  }
+
+  const sessionId = await getSignedCookie(c, getSessionSecret(), SESSION_COOKIE_NAME);
+  if (!sessionId) {
+    if (sessionId === false) deleteCookie(c, SESSION_COOKIE_NAME, { path: '/' });
+    return { ok: false, response: c.json(jsonError('Authentication required', 401), 401) };
+  }
+  const session = await SessionRepository.findById(sessionId);
+  if (!session) {
+    deleteCookie(c, SESSION_COOKIE_NAME, { path: '/' });
+    return { ok: false, response: c.json(jsonError('Session expired', 401), 401) };
+  }
+  c.set('session', session);
+
+  // Cookie-authenticated writes need the CSRF header (JSON API: header only,
+  // no form-field fallback — HTMX/fetch callers set `x-csrf-token`).
+  if (!['GET', 'HEAD'].includes(c.req.method)) {
+    const provided = c.req.header(CSRF_HEADER_NAME);
+    if (!provided || !timingSafeEqualStrings(provided, createCsrfToken(session.id))) {
+      return {
+        ok: false,
+        response: c.json(
+          jsonError('Security check failed. Refresh the page and try again.', 403),
+          403,
+        ),
+      };
+    }
+  }
+
+  return { ok: true, identity: identityFromSessionUser(session.userId) };
+}
+
+function requireCampaignUser(route: string): MiddlewareHandler {
+  return async (c, next) => {
+    const auth = await authenticateCampaignRequest(c);
+    if (!auth.ok) return auth.response;
+
+    const policy =
+      c.req.method === 'GET' || c.req.method === 'HEAD'
+        ? CAMPAIGN_READ_RATE_LIMIT_POLICY
+        : CAMPAIGN_WRITE_RATE_LIMIT_POLICY;
+    let decision: RateLimitDecision;
+    try {
+      decision = await getDefaultRateLimiter().consume({
+        policy,
+        identity: `user:${auth.identity.userId}`,
+      });
+    } catch (error) {
+      return apiRateLimitUnavailableResponse(c, error, route, policy);
+    }
+    if (!decision.allowed) {
+      return apiRateLimitedResponse(c, { decision, identityKind: 'user' }, route);
+    }
+
+    c.set('callerIdentity', auth.identity);
+    await next();
+  };
+}
+
+// `/*` also matches the bare path in Hono 4 — one registration per prefix,
+// or the rate limiter would consume twice per request.
+app.use('/api/campaigns/*', requireCampaignUser('/api/campaigns'));
+app.use('/api/invites/*', requireCampaignUser('/api/invites'));
+
+/** Map campaign-service errors to HTTP; rethrow anything unrecognized. */
+function campaignErrorResponse(c: Context, error: unknown): Response {
+  if (error instanceof CampaignService.CampaignNotFoundError) {
+    return c.json(jsonError('Not found', 404), 404);
+  }
+  if (error instanceof CampaignService.CampaignForbiddenError) {
+    return c.json({ error: error.code, message: error.message, status: 403 }, 403);
+  }
+  if (error instanceof CampaignService.NotAllowlistedError) {
+    return c.json({ error: error.code, message: error.message, status: 403 }, 403);
+  }
+  if (error instanceof CampaignService.OwnerCannotLeaveError) {
+    return c.json({ error: error.code, message: error.message, status: 409 }, 409);
+  }
+  if (error instanceof CampaignService.AlreadyInvitedError) {
+    return c.json({ error: error.code, message: error.message, status: 409 }, 409);
+  }
+  if (error instanceof CampaignService.UnsupportedGameError) {
+    return c.json({ error: error.code, message: error.message, status: 400 }, 400);
+  }
+  throw error;
+}
+
+/**
+ * Malformed ids return the same not-found as absent ids: a 400 on a
+ * non-UUID would distinguish "bad id" from "real id you cannot see"
+ * (ADR 0021 §Non-member access).
+ */
+function campaignRouteId(c: Context, param: string): string | null {
+  const value = c.req.param(param);
+  return value !== undefined && z.string().uuid().safeParse(value).success ? value : null;
+}
+
+const CreateCampaignRequestSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  game: z.string().trim().min(1).max(100),
+  modules: z.array(z.string().trim().min(1).max(100)).max(20).optional(),
+});
+
+const InviteRequestSchema = z.object({
+  email: z.string().trim().email().max(320),
+});
+
+const StateKeyArraySchema = z.array(z.string().trim().min(1).max(200)).max(1000);
+
+const UpdateCampaignRequestSchema = z
+  .object({
+    expectedVersion: z.number().int().min(0),
+    name: z.string().trim().min(1).max(200).optional(),
+    prosperity: z.number().int().min(0).max(100).optional(),
+    activeScenario: z.string().trim().min(1).max(200).nullable().optional(),
+    playedScenarios: StateKeyArraySchema.optional(),
+    drawnScenarios: StateKeyArraySchema.optional(),
+    unlockedClasses: StateKeyArraySchema.optional(),
+    unlockedItems: StateKeyArraySchema.optional(),
+    unlockedBuildings: StateKeyArraySchema.optional(),
+  })
+  .refine((body) => Object.keys(body).length > 1, {
+    message: 'At least one field to update is required',
+  });
+
+app.post('/api/campaigns', async (c) => {
+  const body = CreateCampaignRequestSchema.safeParse(await c.req.json().catch(() => null));
+  if (!body.success) return c.json(jsonError('Invalid request body', 400), 400);
+  try {
+    const campaign = await CampaignService.createCampaign(c.get('callerIdentity')!, body.data);
+    return c.json({ campaign }, 201);
+  } catch (error) {
+    return campaignErrorResponse(c, error);
+  }
+});
+
+app.get('/api/campaigns', async (c) => {
+  const campaigns = await CampaignService.listMyCampaigns(c.get('callerIdentity')!);
+  return c.json({ campaigns });
+});
+
+app.get('/api/campaigns/:id', async (c) => {
+  const campaignId = campaignRouteId(c, 'id');
+  if (!campaignId) return c.json(jsonError('Not found', 404), 404);
+  try {
+    return c.json(await CampaignService.getCampaignDetail(c.get('callerIdentity')!, campaignId));
+  } catch (error) {
+    return campaignErrorResponse(c, error);
+  }
+});
+
+app.patch('/api/campaigns/:id', async (c) => {
+  const campaignId = campaignRouteId(c, 'id');
+  if (!campaignId) return c.json(jsonError('Not found', 404), 404);
+  const body = UpdateCampaignRequestSchema.safeParse(await c.req.json().catch(() => null));
+  if (!body.success) return c.json(jsonError('Invalid request body', 400), 400);
+  const identity = c.get('callerIdentity')!;
+  try {
+    const campaign = await CampaignService.updateSharedState(identity, campaignId, body.data);
+    return c.json({ campaign });
+  } catch (error) {
+    if (error instanceof VersionConflictError) {
+      // E3: 409 + the current state so the client can re-read and retry.
+      const detail = await CampaignService.getCampaignDetail(identity, campaignId);
+      return c.json(
+        {
+          error: 'version_conflict',
+          currentVersion: detail.campaign.version,
+          campaign: detail.campaign,
+          status: 409,
+        },
+        409,
+      );
+    }
+    return campaignErrorResponse(c, error);
+  }
+});
+
+app.delete('/api/campaigns/:id', async (c) => {
+  const campaignId = campaignRouteId(c, 'id');
+  if (!campaignId) return c.json(jsonError('Not found', 404), 404);
+  try {
+    await CampaignService.deleteCampaign(c.get('callerIdentity')!, campaignId);
+    return c.body(null, 204);
+  } catch (error) {
+    return campaignErrorResponse(c, error);
+  }
+});
+
+app.post('/api/campaigns/:id/invites', async (c) => {
+  const campaignId = campaignRouteId(c, 'id');
+  if (!campaignId) return c.json(jsonError('Not found', 404), 404);
+  const body = InviteRequestSchema.safeParse(await c.req.json().catch(() => null));
+  if (!body.success) return c.json(jsonError('Invalid request body', 400), 400);
+  try {
+    const member = await CampaignService.inviteMember(
+      c.get('callerIdentity')!,
+      campaignId,
+      body.data.email,
+    );
+    return c.json({ member }, 201);
+  } catch (error) {
+    return campaignErrorResponse(c, error);
+  }
+});
+
+app.post('/api/campaigns/:id/leave', async (c) => {
+  const campaignId = campaignRouteId(c, 'id');
+  if (!campaignId) return c.json(jsonError('Not found', 404), 404);
+  try {
+    await CampaignService.leaveCampaign(c.get('callerIdentity')!, campaignId);
+    return c.body(null, 204);
+  } catch (error) {
+    return campaignErrorResponse(c, error);
+  }
+});
+
+app.delete('/api/campaigns/:id/members/:memberId', async (c) => {
+  const campaignId = campaignRouteId(c, 'id');
+  const memberId = campaignRouteId(c, 'memberId');
+  if (!campaignId || !memberId) return c.json(jsonError('Not found', 404), 404);
+  try {
+    await CampaignService.removeMember(c.get('callerIdentity')!, campaignId, memberId);
+    return c.body(null, 204);
+  } catch (error) {
+    return campaignErrorResponse(c, error);
+  }
+});
+
+app.get('/api/invites', async (c) => {
+  try {
+    const invites = await CampaignService.listMyInvites(c.get('callerIdentity')!);
+    return c.json({ invites });
+  } catch (error) {
+    return campaignErrorResponse(c, error);
+  }
+});
+
+app.post('/api/invites/:memberId/accept', async (c) => {
+  const memberId = campaignRouteId(c, 'memberId');
+  if (!memberId) return c.json(jsonError('Not found', 404), 404);
+  try {
+    const campaign = await CampaignService.acceptInvite(c.get('callerIdentity')!, memberId);
+    return c.json({ campaign });
+  } catch (error) {
+    return campaignErrorResponse(c, error);
+  }
 });
 
 // ─── Server startup ──────────────────────────────────────────────────────────

--- a/src/types/hono.d.ts
+++ b/src/types/hono.d.ts
@@ -12,6 +12,7 @@
 
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 
+import type { CallerIdentity } from '../campaign/identity.ts';
 import type { Session } from '../db/repositories/types.ts';
 
 export {};
@@ -20,5 +21,7 @@ declare module 'hono' {
   interface ContextVariableMap {
     authInfo: AuthInfo | undefined;
     session: Session | undefined;
+    /** Set by requireCampaignUser() on campaign-state routes (SQR-21). */
+    callerIdentity: CallerIdentity | undefined;
   }
 }

--- a/test/campaign-api.test.ts
+++ b/test/campaign-api.test.ts
@@ -1,0 +1,538 @@
+/**
+ * Campaign CRUD + membership API integration tests (SQR-21, ADR 0021).
+ *
+ * Runs against the real test Postgres (ADR 0007). Covers the SQR-21
+ * acceptance criteria: 404-indistinguishability for non-members, allowlist
+ * rejection at create/invite/join, optimistic-version conflicts, rate-limit
+ * denial, the permission matrix's "no" cells, and both auth channels
+ * (session cookie + CSRF, bearer tokens with client-only rejection).
+ */
+import { generateSignedCookie } from 'hono/cookie';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+process.env.SESSION_SECRET = 'test-session-secret-must-be-at-least-32-characters-long';
+
+import { app } from '../src/server.ts';
+import { getDb, shutdownServerPool } from '../src/db.ts';
+import { createCsrfToken } from '../src/auth/csrf.ts';
+import { SESSION_COOKIE_NAME, getSessionSecret } from '../src/auth/session-middleware.ts';
+import * as SessionRepository from '../src/db/repositories/session-repository.ts';
+import { SESSION_LIFETIME_MS } from '../src/db/repositories/session-repository.ts';
+import * as CampaignMemberRepository from '../src/db/repositories/campaign-member-repository.ts';
+import { hashSecret } from '../src/security/hashing.ts';
+import {
+  hashRateLimitIdentity,
+  resetRateLimiterForTesting,
+  setRateLimiterForTesting,
+  type RateLimiter,
+  type RateLimitConsumeInput,
+  type RateLimitDecision,
+} from '../src/rate-limit.ts';
+import { users } from '../src/db/schema/core.ts';
+import { oauthTokens } from '../src/db/schema/auth.ts';
+import { makeAuthHelpers } from './helpers/server-oauth-helpers.ts';
+import { resetTestDb, setupTestDb, teardownTestDb } from './helpers/db.ts';
+
+interface TestUser {
+  cookie: string;
+  sessionId: string;
+  userId: string;
+  email: string;
+}
+
+const OWNER_EMAIL = 'owner@example.com';
+const MEMBER_EMAIL = 'member@example.com';
+const OUTSIDER_EMAIL = 'outsider@example.com';
+const ALL_EMAILS = [OWNER_EMAIL, MEMBER_EMAIL, OUTSIDER_EMAIL].join(',');
+
+const { getTestToken, resetTestToken } = makeAuthHelpers(app);
+
+async function createTestUser(email: string, name = email.split('@')[0]): Promise<TestUser> {
+  const { db } = getDb('server');
+  const [user] = await db
+    .insert(users)
+    .values({ email, googleSub: `google-sub-${email}`, name })
+    .returning();
+  const { sessionId } = await SessionRepository.create(db, { userId: user.id });
+  const signedCookie = await generateSignedCookie(
+    SESSION_COOKIE_NAME,
+    sessionId,
+    getSessionSecret(),
+    {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+      maxAge: SESSION_LIFETIME_MS / 1000,
+    },
+  );
+  return { cookie: signedCookie.split(';')[0], sessionId, userId: user.id, email };
+}
+
+async function request(
+  user: TestUser | null,
+  method: string,
+  url: string,
+  body?: unknown,
+): Promise<Response> {
+  const headers = new Headers();
+  if (user) {
+    headers.set('Cookie', user.cookie);
+    if (!['GET', 'HEAD'].includes(method)) {
+      headers.set('x-csrf-token', createCsrfToken(user.sessionId));
+    }
+  }
+  if (body !== undefined) headers.set('Content-Type', 'application/json');
+  return app.request(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function createCampaign(
+  user: TestUser,
+  overrides: Record<string, unknown> = {},
+): Promise<{ id: string; version: number }> {
+  const res = await request(user, 'POST', '/api/campaigns', {
+    name: 'Thursday Night Frosthaven',
+    game: 'frosthaven',
+    modules: ['fh'],
+    ...overrides,
+  });
+  expect(res.status).toBe(201);
+  const { campaign } = (await res.json()) as { campaign: { id: string; version: number } };
+  return campaign;
+}
+
+/** Invite + accept in one step: returns the activated member id. */
+async function addMember(owner: TestUser, campaignId: string, member: TestUser): Promise<string> {
+  const inviteRes = await request(owner, 'POST', `/api/campaigns/${campaignId}/invites`, {
+    email: member.email,
+  });
+  expect(inviteRes.status).toBe(201);
+  const { member: invite } = (await inviteRes.json()) as { member: { memberId: string } };
+  const acceptRes = await request(member, 'POST', `/api/invites/${invite.memberId}/accept`);
+  expect(acceptRes.status).toBe(200);
+  return invite.memberId;
+}
+
+beforeAll(async () => {
+  await setupTestDb();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  resetTestToken();
+  process.env.SQUIRE_ALLOWED_EMAILS = ALL_EMAILS;
+});
+
+afterEach(() => {
+  resetRateLimiterForTesting();
+});
+
+afterAll(async () => {
+  delete process.env.SQUIRE_ALLOWED_EMAILS;
+  await teardownTestDb();
+  await shutdownServerPool();
+});
+
+describe('campaign API auth channels', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await request(null, 'GET', '/api/campaigns');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects session writes without the CSRF header', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const headers = new Headers({ Cookie: owner.cookie, 'Content-Type': 'application/json' });
+    const res = await app.request('/api/campaigns', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ name: 'No CSRF', game: 'frosthaven' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects client-credentials bearer tokens structurally (no user identity)', async () => {
+    const token = await getTestToken();
+    const res = await app.request('/api/campaigns', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('user_identity_required');
+  });
+
+  it('accepts a user-bound bearer token', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const campaign = await createCampaign(owner);
+
+    // Bind a fresh token to the owner the way the provider stores them: the
+    // DB holds only the SHA-256 hash of the raw token. getTestToken()
+    // registers an OAuth client whose id the user-bound row reuses.
+    await getTestToken();
+    const { db } = getDb('server');
+    const [{ clientId }] = await db
+      .select({ clientId: oauthTokens.clientId })
+      .from(oauthTokens)
+      .limit(1);
+    const rawToken = 'user-bound-test-token';
+    await db.insert(oauthTokens).values({
+      tokenHash: hashSecret(rawToken),
+      clientId,
+      userId: owner.userId,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    const res = await app.request(`/api/campaigns/${campaign.id}`, {
+      headers: { Authorization: `Bearer ${rawToken}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { campaign: { id: string } };
+    expect(body.campaign.id).toBe(campaign.id);
+  });
+
+  it('denies requests over the rate limit with 429', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const counts = new Map<string, number>();
+    const limiter = {
+      async consume(input: RateLimitConsumeInput): Promise<RateLimitDecision> {
+        const used = (counts.get(input.identity) ?? 0) + 1;
+        counts.set(input.identity, used);
+        return {
+          allowed: used <= 1,
+          policy: input.policy,
+          identityHash: hashRateLimitIdentity(input.identity, 'campaign-rate-limit-test'),
+          remaining: 0,
+          retryAfterSeconds: used <= 1 ? 0 : 30,
+          resetAfterSeconds: 30,
+        };
+      },
+    };
+    setRateLimiterForTesting(limiter as unknown as RateLimiter);
+
+    const first = await request(owner, 'GET', '/api/campaigns');
+    expect(first.status).toBe(200);
+    const second = await request(owner, 'GET', '/api/campaigns');
+    expect(second.status).toBe(429);
+    expect(second.headers.get('Retry-After')).toBe('30');
+  });
+});
+
+describe('campaign lifecycle', () => {
+  it('creates a campaign with the creator as owner and lists it', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const res = await request(owner, 'POST', '/api/campaigns', {
+      name: 'GH2e Tuesday',
+      game: 'gh2e', // alias normalizes to canonical id
+      modules: ['gh2e', 'solo2e'],
+    });
+    expect(res.status).toBe(201);
+    const { campaign } = (await res.json()) as {
+      campaign: { id: string; game: string; version: number };
+    };
+    expect(campaign.game).toBe('gloomhaven-2e');
+    expect(campaign.version).toBe(1);
+
+    const listRes = await request(owner, 'GET', '/api/campaigns');
+    const { campaigns } = (await listRes.json()) as { campaigns: Array<{ id: string }> };
+    expect(campaigns.map((c) => c.id)).toEqual([campaign.id]);
+
+    const detailRes = await request(owner, 'GET', `/api/campaigns/${campaign.id}`);
+    expect(detailRes.status).toBe(200);
+    const detail = (await detailRes.json()) as {
+      members: Array<{ role: string; email: string; status: string }>;
+      self: { role: string };
+    };
+    expect(detail.self.role).toBe('owner');
+    expect(detail.members).toEqual([
+      expect.objectContaining({ role: 'owner', email: OWNER_EMAIL, status: 'active' }),
+    ]);
+  });
+
+  it('rejects campaign creation for non-allowlisted creators', async () => {
+    process.env.SQUIRE_ALLOWED_EMAILS = 'someone-else@example.com';
+    const owner = await createTestUser(OWNER_EMAIL);
+    const res = await request(owner, 'POST', '/api/campaigns', {
+      name: 'Nope',
+      game: 'frosthaven',
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe('not_allowlisted');
+  });
+
+  it('rejects unsupported games', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const res = await request(owner, 'POST', '/api/campaigns', {
+      name: 'Wrong game',
+      game: 'monopoly',
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe('unsupported_game');
+  });
+
+  it('deletes a campaign (owner only)', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const member = await createTestUser(MEMBER_EMAIL);
+    const campaign = await createCampaign(owner);
+    await addMember(owner, campaign.id, member);
+
+    const memberDelete = await request(member, 'DELETE', `/api/campaigns/${campaign.id}`);
+    expect(memberDelete.status).toBe(403);
+
+    const ownerDelete = await request(owner, 'DELETE', `/api/campaigns/${campaign.id}`);
+    expect(ownerDelete.status).toBe(204);
+
+    const after = await request(owner, 'GET', `/api/campaigns/${campaign.id}`);
+    expect(after.status).toBe(404);
+  });
+});
+
+describe('404 indistinguishability (ADR 0021)', () => {
+  it('non-members, invitees, malformed ids, and absent ids are identical', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const outsider = await createTestUser(OUTSIDER_EMAIL);
+    const campaign = await createCampaign(owner);
+
+    const absent = await request(
+      outsider,
+      'GET',
+      '/api/campaigns/00000000-0000-4000-8000-000000000000',
+    );
+    const nonMember = await request(outsider, 'GET', `/api/campaigns/${campaign.id}`);
+    const malformed = await request(outsider, 'GET', '/api/campaigns/not-a-uuid');
+
+    expect(nonMember.status).toBe(404);
+    expect(await nonMember.json()).toEqual(await absent.json());
+    expect(malformed.status).toBe(404);
+
+    // An invited-but-not-joined user gets the same 404 on campaign routes;
+    // their only visibility is their own invite list (the carve-out).
+    await request(owner, 'POST', `/api/campaigns/${campaign.id}/invites`, {
+      email: OUTSIDER_EMAIL,
+    });
+    const invited = await request(outsider, 'GET', `/api/campaigns/${campaign.id}`);
+    expect(invited.status).toBe(404);
+
+    // Mutations are indistinguishable too.
+    const patch = await request(outsider, 'PATCH', `/api/campaigns/${campaign.id}`, {
+      expectedVersion: 0,
+      prosperity: 5,
+    });
+    expect(patch.status).toBe(404);
+    const del = await request(outsider, 'DELETE', `/api/campaigns/${campaign.id}`);
+    expect(del.status).toBe(404);
+  });
+});
+
+describe('shared-state writes (optimistic CAS, E3)', () => {
+  it('applies member edits and bumps the version', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const member = await createTestUser(MEMBER_EMAIL);
+    const campaign = await createCampaign(owner);
+    await addMember(owner, campaign.id, member);
+
+    const res = await request(member, 'PATCH', `/api/campaigns/${campaign.id}`, {
+      expectedVersion: 1,
+      playedScenarios: ['fh:1'],
+      prosperity: 2,
+    });
+    expect(res.status).toBe(200);
+    const { campaign: updated } = (await res.json()) as {
+      campaign: { version: number; playedScenarios: string[]; prosperity: number };
+    };
+    expect(updated.version).toBe(2);
+    expect(updated.playedScenarios).toEqual(['fh:1']);
+    expect(updated.prosperity).toBe(2);
+  });
+
+  it('returns 409 with the current state on version conflict', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const campaign = await createCampaign(owner);
+
+    const first = await request(owner, 'PATCH', `/api/campaigns/${campaign.id}`, {
+      expectedVersion: 1,
+      prosperity: 1,
+    });
+    expect(first.status).toBe(200);
+
+    const stale = await request(owner, 'PATCH', `/api/campaigns/${campaign.id}`, {
+      expectedVersion: 1,
+      prosperity: 9,
+    });
+    expect(stale.status).toBe(409);
+    const body = (await stale.json()) as {
+      error: string;
+      currentVersion: number;
+      campaign: { prosperity: number };
+    };
+    expect(body.error).toBe('version_conflict');
+    expect(body.currentVersion).toBe(2);
+    expect(body.campaign.prosperity).toBe(1);
+  });
+});
+
+describe('invites and joining', () => {
+  it('owner invites an allowlisted email; invitee sees and accepts it', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const member = await createTestUser(MEMBER_EMAIL);
+    const campaign = await createCampaign(owner);
+
+    const inviteRes = await request(owner, 'POST', `/api/campaigns/${campaign.id}/invites`, {
+      email: MEMBER_EMAIL.toUpperCase(), // normalized at the boundary
+    });
+    expect(inviteRes.status).toBe(201);
+
+    const listRes = await request(member, 'GET', '/api/invites');
+    const { invites } = (await listRes.json()) as {
+      invites: Array<{
+        memberId: string;
+        campaignName: string;
+        game: string;
+        inviterName: string | null;
+      }>;
+    };
+    expect(invites).toEqual([
+      {
+        memberId: expect.any(String),
+        campaignName: 'Thursday Night Frosthaven',
+        game: 'frosthaven',
+        inviterName: 'owner',
+      },
+    ]);
+
+    const acceptRes = await request(member, 'POST', `/api/invites/${invites[0].memberId}/accept`);
+    expect(acceptRes.status).toBe(200);
+
+    const detail = await request(member, 'GET', `/api/campaigns/${campaign.id}`);
+    expect(detail.status).toBe(200);
+    const { self } = (await detail.json()) as { self: { role: string } };
+    expect(self.role).toBe('member');
+  });
+
+  it('rejects invites for non-allowlisted emails', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const campaign = await createCampaign(owner);
+    const res = await request(owner, 'POST', `/api/campaigns/${campaign.id}/invites`, {
+      email: 'stranger@example.com',
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe('not_allowlisted');
+  });
+
+  it('re-checks the allowlist at join time (lapsed entry blocks the join)', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const member = await createTestUser(MEMBER_EMAIL);
+    const campaign = await createCampaign(owner);
+    const inviteRes = await request(owner, 'POST', `/api/campaigns/${campaign.id}/invites`, {
+      email: MEMBER_EMAIL,
+    });
+    const { member: invite } = (await inviteRes.json()) as { member: { memberId: string } };
+
+    process.env.SQUIRE_ALLOWED_EMAILS = OWNER_EMAIL; // member's entry lapses
+    const acceptRes = await request(member, 'POST', `/api/invites/${invite.memberId}/accept`);
+    expect(acceptRes.status).toBe(403);
+    expect(((await acceptRes.json()) as { error: string }).error).toBe('not_allowlisted');
+  });
+
+  it('only the owner can invite; duplicates conflict; foreign invites are 404', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const member = await createTestUser(MEMBER_EMAIL);
+    const campaign = await createCampaign(owner);
+    await addMember(owner, campaign.id, member);
+
+    const memberInvite = await request(member, 'POST', `/api/campaigns/${campaign.id}/invites`, {
+      email: OUTSIDER_EMAIL,
+    });
+    expect(memberInvite.status).toBe(403);
+
+    const duplicate = await request(owner, 'POST', `/api/campaigns/${campaign.id}/invites`, {
+      email: MEMBER_EMAIL,
+    });
+    expect(duplicate.status).toBe(409);
+
+    // Accepting an invite addressed to someone else is indistinguishable
+    // from a nonexistent invite id.
+    const inviteRes = await request(owner, 'POST', `/api/campaigns/${campaign.id}/invites`, {
+      email: OUTSIDER_EMAIL,
+    });
+    const { member: invite } = (await inviteRes.json()) as { member: { memberId: string } };
+    const theft = await request(member, 'POST', `/api/invites/${invite.memberId}/accept`);
+    expect(theft.status).toBe(404);
+  });
+});
+
+describe('leave, remove, rejoin', () => {
+  it('a member can leave; the owner cannot', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const member = await createTestUser(MEMBER_EMAIL);
+    const campaign = await createCampaign(owner);
+    await addMember(owner, campaign.id, member);
+
+    const ownerLeave = await request(owner, 'POST', `/api/campaigns/${campaign.id}/leave`);
+    expect(ownerLeave.status).toBe(409);
+    expect(((await ownerLeave.json()) as { error: string }).error).toBe('owner_cannot_leave');
+
+    const memberLeave = await request(member, 'POST', `/api/campaigns/${campaign.id}/leave`);
+    expect(memberLeave.status).toBe(204);
+
+    // Departed members lose access — same 404 as a non-member.
+    const after = await request(member, 'GET', `/api/campaigns/${campaign.id}`);
+    expect(after.status).toBe(404);
+  });
+
+  it('the sole member (the owner) cannot leave — directed to delete', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const campaign = await createCampaign(owner);
+    const res = await request(owner, 'POST', `/api/campaigns/${campaign.id}/leave`);
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toBe('owner_cannot_leave');
+  });
+
+  it('owner removes a member; members cannot remove anyone', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const member = await createTestUser(MEMBER_EMAIL);
+    const outsider = await createTestUser(OUTSIDER_EMAIL);
+    const campaign = await createCampaign(owner);
+    const memberId = await addMember(owner, campaign.id, member);
+    const outsiderMemberId = await addMember(owner, campaign.id, outsider);
+
+    const memberRemove = await request(
+      member,
+      'DELETE',
+      `/api/campaigns/${campaign.id}/members/${outsiderMemberId}`,
+    );
+    expect(memberRemove.status).toBe(403);
+
+    const ownerRemove = await request(
+      owner,
+      'DELETE',
+      `/api/campaigns/${campaign.id}/members/${memberId}`,
+    );
+    expect(ownerRemove.status).toBe(204);
+
+    const after = await request(member, 'GET', `/api/campaigns/${campaign.id}`);
+    expect(after.status).toBe(404);
+  });
+
+  it('re-inviting a departed member reactivates their row on accept (rejoin)', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const member = await createTestUser(MEMBER_EMAIL);
+    const campaign = await createCampaign(owner);
+    const originalMemberId = await addMember(owner, campaign.id, member);
+    await request(member, 'POST', `/api/campaigns/${campaign.id}/leave`);
+
+    const reinvite = await request(owner, 'POST', `/api/campaigns/${campaign.id}/invites`, {
+      email: MEMBER_EMAIL,
+    });
+    expect(reinvite.status).toBe(201);
+    const { member: revived } = (await reinvite.json()) as { member: { memberId: string } };
+    expect(revived.memberId).toBe(originalMemberId); // same row, user binding kept
+
+    const accept = await request(member, 'POST', `/api/invites/${revived.memberId}/accept`);
+    expect(accept.status).toBe(200);
+
+    const active = await CampaignMemberRepository.findActiveMember(campaign.id, member.userId);
+    expect(active?.id).toBe(originalMemberId);
+  });
+});

--- a/test/helpers/test-slices.ts
+++ b/test/helpers/test-slices.ts
@@ -8,6 +8,7 @@ export const DB_BACKED_TEST_FILES = [
   'test/auth-google.test.ts',
   'test/auth-provider.test.ts',
   'test/auth-restart.test.ts',
+  'test/campaign-api.test.ts',
   'test/campaign-repositories.test.ts',
   'test/conversation.test.ts',
   'test/cross-game-isolation.test.ts',


### PR DESCRIPTION
## Summary

Campaign lifecycle + membership per ADR 0021, in two layers:

- **`src/campaign/campaign-service.ts`** — the contract enforcement point. Every operation takes a `CallerIdentity` and decides visibility/permission before touching repositories: membership gate on every campaign-scoped call (non-members, invitees, departed members, and malformed/absent ids all yield the same 404), owner-only invite/remove/delete, allowlist at create + invite + join (a lapsed entry blocks the join), owner-cannot-leave (structurally covers last-member-cannot-leave since the owner outlasts everyone), re-invite of a departed member revives their row so rejoin keeps character ownership, CAS shared-state writes.
- **REST routes in `src/server.ts`** — thin handlers + a dual-channel `requireCampaignUser` middleware: user-bound OAuth bearer **or** web session cookie (CSRF header on writes). Client-credentials tokens get a structural 403 `user_identity_required`. Reads/writes consume the new `campaign_read` (120/min) / `campaign_write` (60/min) per-user policies (ADR 0018 inventory, eng E7). Version conflicts return 409 with the current state for re-read-and-retry (E3).

## Notable decisions

- **Hono `/*` matches the bare path** in Hono 4 — middleware is registered once per prefix; the double registration pattern double-consumes rate limits (test-caught).
- **Destructive mutations ship one-shot** here (delete campaign, remove member) with `TODO(SQR-279)` markers — the propose→confirm gate is SQR-279's mechanism and retrofits every channel before agent write tools ship. Documented workaround, satisfies the ADR end-state at initiative completion.
- Malformed UUIDs return the indistinguishable 404, not a 400 (a 400 would distinguish "bad id" from "id you cannot see").

## Tests (20, real Postgres)

Auth channels (401 / CSRF / client-token rejection / user-bound bearer / 429), create+list+detail with roster, allowlist rejection at all three checkpoints, 404-indistinguishability matrix, CAS success + conflict, invite/accept incl. foreign-invite theft → 404, leave/remove/rejoin, owner-only matrix cells.

Fixes SQR-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full campaign management API: create, list, view, update (shared state), and delete campaigns.
  * Member invitations with allowlist validation, idempotent re-invite of departed members, invite visibility to invitee, accept/join flow, leave and owner-only removal.
  * Dual-channel auth (API token or session+CSRF) and per-route read/write rate limits; optimistic concurrency on shared-state updates.

* **Tests**
  * End-to-end integration tests covering auth flows, allowlist, rate limiting, concurrency, and membership lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->