### PR TITLE
feat(campaign): character CRUD service and REST API (SQR-22)

### DIFF
--- a/src/campaign/campaign-service.ts
+++ b/src/campaign/campaign-service.ts
@@ -131,14 +131,20 @@ function assertAllowlisted(email: string): void {
   }
 }
 
-/** The membership gate on every campaign-scoped operation. */
-async function requireActiveMember(campaignId: string, userId: string): Promise<CampaignMember> {
+/**
+ * The membership gate on every campaign-scoped operation. Shared with the
+ * character service (SQR-22) so both enforce the same contract.
+ */
+export async function requireActiveMember(
+  campaignId: string,
+  userId: string,
+): Promise<CampaignMember> {
   const member = await CampaignMemberRepository.findActiveMember(campaignId, userId);
   if (!member) throw new CampaignNotFoundError();
   return member;
 }
 
-async function requireUser(userId: string) {
+export async function requireUser(userId: string) {
   const user = await UserRepository.findById(userId);
   // Identities come from verified sessions/tokens, so a missing user row
   // means a deleted account still holding credentials — treat as not found.

--- a/src/campaign/character-service.ts
+++ b/src/campaign/character-service.ts
@@ -1,0 +1,291 @@
+/**
+ * Character service (Phase 4, SQR-22).
+ *
+ * Per-member character management under the ADR 0021 contract: any active
+ * campaign member may SEE every character (member-visible projection — the
+ * private tier is absent at the type level, never nulled), but only the
+ * owning member mutates one. Placeholders (characters created for an
+ * invitee) are owned by their creator until the named member joins and
+ * claims them; they can never carry private-tier fields.
+ *
+ * Reuses the campaign service's typed errors: a character id the caller
+ * cannot see (wrong campaign, no membership, absent) is the same
+ * indistinguishable `CampaignNotFoundError`; a visible character the caller
+ * cannot mutate is `CampaignForbiddenError`.
+ */
+import { getDb } from '../db.ts';
+import * as CampaignRepository from '../db/repositories/campaign-repository.ts';
+import * as CampaignMemberRepository from '../db/repositories/campaign-member-repository.ts';
+import * as CharacterRepository from '../db/repositories/character-repository.ts';
+import type {
+  Character,
+  CharacterCard,
+  CharacterCardRole,
+  CharacterItem,
+  MemberVisibleCharacter,
+  UpdateCharacterInput,
+} from '../db/repositories/types.ts';
+import {
+  CampaignForbiddenError,
+  CampaignNotFoundError,
+  requireActiveMember,
+  requireUser,
+} from './campaign-service.ts';
+import type { CallerIdentity } from './identity.ts';
+
+/** Private-tier fields cannot be recorded on a placeholder (ADR 0021). */
+export class PlaceholderPrivateFieldsError extends Error {
+  readonly code = 'placeholder_private_fields';
+
+  constructor() {
+    super('Placeholder characters cannot carry private fields until claimed');
+    this.name = 'PlaceholderPrivateFieldsError';
+  }
+}
+
+export interface CreateCharacterRequest {
+  name: string;
+  className: string;
+  level?: number;
+  xp?: number;
+  gold?: number;
+  perks?: number[];
+  personalQuest?: string | null;
+  battleGoals?: string | null;
+  privateNotes?: string | null;
+  /** Owner-only: create a claimable placeholder for a pending invitee. */
+  placeholderForEmail?: string;
+}
+
+export interface CharacterDetail {
+  /** Full `Character` for the owner; the projection for everyone else. */
+  character: Character | MemberVisibleCharacter;
+  items: CharacterItem[];
+  cards: CharacterCard[];
+  own: boolean;
+}
+
+function hasPrivateFields(input: {
+  personalQuest?: string | null;
+  battleGoals?: string | null;
+  privateNotes?: string | null;
+}): boolean {
+  return input.personalQuest != null || input.battleGoals != null || input.privateNotes != null;
+}
+
+/**
+ * Visibility gate: the character must exist AND the caller must be an
+ * active member of its campaign — otherwise the indistinguishable 404.
+ * Returns the member-visible projection; owner-facing paths re-read with
+ * the private tier afterwards.
+ */
+async function requireVisibleCharacter(
+  identity: CallerIdentity,
+  characterId: string,
+): Promise<MemberVisibleCharacter> {
+  const character = await CharacterRepository.findMemberVisibleById(characterId);
+  if (!character) throw new CampaignNotFoundError();
+  await requireActiveMember(character.campaignId, identity.userId);
+  return character;
+}
+
+async function requireOwnedCharacter(
+  identity: CallerIdentity,
+  characterId: string,
+): Promise<MemberVisibleCharacter> {
+  const character = await requireVisibleCharacter(identity, characterId);
+  if (character.ownerUserId !== identity.userId) {
+    throw new CampaignForbiddenError('Only the owning member can modify a character');
+  }
+  return character;
+}
+
+export async function createCharacter(
+  identity: CallerIdentity,
+  campaignId: string,
+  input: CreateCharacterRequest,
+): Promise<Character> {
+  const member = await requireActiveMember(campaignId, identity.userId);
+  const { db } = getDb('server');
+
+  if (input.placeholderForEmail !== undefined) {
+    if (member.role !== 'owner') {
+      throw new CampaignForbiddenError('Only the owner can create placeholder characters');
+    }
+    if (hasPrivateFields(input)) throw new PlaceholderPrivateFieldsError();
+    const email = input.placeholderForEmail.trim().toLowerCase();
+    const members = await CampaignMemberRepository.listMembers(campaignId);
+    const invitee = members.find(
+      (m) => m.inviteEmail.toLowerCase() === email && m.status === 'invited',
+    );
+    if (!invitee) {
+      throw new CampaignForbiddenError('Placeholders need a pending invite for that email');
+    }
+    return CharacterRepository.create(db, {
+      ...input,
+      campaignId,
+      ownerUserId: identity.userId,
+      placeholderForEmail: email,
+    });
+  }
+
+  return CharacterRepository.create(db, {
+    ...input,
+    campaignId,
+    ownerUserId: identity.userId,
+    placeholderForEmail: null,
+  });
+}
+
+/** Uniform roster surface: member-visible projections for everyone. */
+export async function listCampaignCharacters(
+  identity: CallerIdentity,
+  campaignId: string,
+): Promise<MemberVisibleCharacter[]> {
+  await requireActiveMember(campaignId, identity.userId);
+  return CharacterRepository.listMemberVisibleByCampaign(campaignId);
+}
+
+export async function getCharacterDetail(
+  identity: CallerIdentity,
+  characterId: string,
+): Promise<CharacterDetail> {
+  const visible = await requireVisibleCharacter(identity, characterId);
+  const own = visible.ownerUserId === identity.userId;
+  const character = own
+    ? await CharacterRepository.findOwnedById(characterId, identity.userId)
+    : visible;
+  if (!character) throw new CampaignNotFoundError();
+  return {
+    character,
+    items: await CharacterRepository.listItems(characterId),
+    cards: await CharacterRepository.listCards(characterId),
+    own,
+  };
+}
+
+/**
+ * Owner-scoped CAS update (E3). Retirement (`status`/`successorId`) is
+ * modeled here per the matrix; the guided retirement flow is deferred
+ * (SQR-289) and the destructive gating arrives with the proposal mechanism.
+ * TODO(SQR-279): route retirement through propose→confirm.
+ */
+export async function updateCharacter(
+  identity: CallerIdentity,
+  characterId: string,
+  input: UpdateCharacterInput,
+): Promise<Character> {
+  const character = await requireOwnedCharacter(identity, characterId);
+  if (character.placeholderForEmail !== null && hasPrivateFields(input)) {
+    throw new PlaceholderPrivateFieldsError();
+  }
+  const { db } = getDb('server');
+  return CharacterRepository.update(db, characterId, input);
+}
+
+/**
+ * Owner-scoped delete. Unclaimed placeholders are scratch data; deleting a
+ * real character is destructive per the matrix.
+ * TODO(SQR-279): route non-placeholder deletes through propose→confirm.
+ */
+export async function deleteCharacter(
+  identity: CallerIdentity,
+  characterId: string,
+): Promise<void> {
+  await requireOwnedCharacter(identity, characterId);
+  const { db } = getDb('server');
+  await CharacterRepository.remove(db, characterId);
+}
+
+/**
+ * Claim a placeholder after joining: ownership transfers and the private
+ * tier unlocks for the new owner. The repository guards the write on the
+ * placeholder's named email, so a wrong claimant sees the same 404 as an
+ * absent character.
+ */
+export async function claimCharacter(
+  identity: CallerIdentity,
+  characterId: string,
+): Promise<Character> {
+  await requireVisibleCharacter(identity, characterId);
+  const user = await requireUser(identity.userId);
+  const { db } = getDb('server');
+  const claimed = await CharacterRepository.claimPlaceholder(db, characterId, {
+    claimantUserId: user.id,
+    claimantEmail: user.email.toLowerCase(),
+  });
+  if (!claimed) throw new CampaignNotFoundError();
+  return claimed;
+}
+
+// ─── Items / cards (owner-scoped writes; reads ride the detail view) ────────
+
+/** Items/cards are tagged with the campaign's game for GHS joins (E4). */
+async function campaignGameFor(campaignId: string): Promise<string> {
+  const campaign = await CampaignRepository.findById(campaignId);
+  if (!campaign) throw new CampaignNotFoundError();
+  return campaign.game;
+}
+
+export async function addItem(
+  identity: CallerIdentity,
+  characterId: string,
+  sourceId: string,
+): Promise<CharacterItem> {
+  const character = await requireOwnedCharacter(identity, characterId);
+  const { db } = getDb('server');
+  return CharacterRepository.addItem(db, {
+    characterId,
+    game: await campaignGameFor(character.campaignId),
+    sourceId,
+  });
+}
+
+export async function removeItem(
+  identity: CallerIdentity,
+  characterId: string,
+  itemId: string,
+): Promise<void> {
+  await requireOwnedCharacter(identity, characterId);
+  const { db } = getDb('server');
+  const removed = await CharacterRepository.removeItem(db, characterId, itemId);
+  if (!removed) throw new CampaignNotFoundError();
+}
+
+export async function addCard(
+  identity: CallerIdentity,
+  characterId: string,
+  input: { sourceId: string; role?: CharacterCardRole },
+): Promise<CharacterCard> {
+  const character = await requireOwnedCharacter(identity, characterId);
+  const { db } = getDb('server');
+  return CharacterRepository.addCard(db, {
+    characterId,
+    game: await campaignGameFor(character.campaignId),
+    sourceId: input.sourceId,
+    role: input.role,
+  });
+}
+
+export async function setCardRole(
+  identity: CallerIdentity,
+  characterId: string,
+  cardId: string,
+  role: CharacterCardRole,
+): Promise<void> {
+  await requireOwnedCharacter(identity, characterId);
+  const { db } = getDb('server');
+  const updated = await CharacterRepository.setCardRole(db, characterId, cardId, role);
+  if (!updated) throw new CampaignNotFoundError();
+}
+
+export async function removeCard(
+  identity: CallerIdentity,
+  characterId: string,
+  cardId: string,
+): Promise<void> {
+  await requireOwnedCharacter(identity, characterId);
+  const { db } = getDb('server');
+  const removed = await CharacterRepository.removeCard(db, characterId, cardId);
+  if (!removed) throw new CampaignNotFoundError();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import {
   type CallerIdentity,
 } from './campaign/identity.ts';
 import * as CampaignService from './campaign/campaign-service.ts';
+import * as CharacterService from './campaign/character-service.ts';
 import { VersionConflictError } from './db/repositories/types.ts';
 import { html } from 'hono/html';
 import { streamSSE } from 'hono/streaming';
@@ -2280,6 +2281,227 @@ app.post('/api/invites/:memberId/accept', async (c) => {
     return c.json({ campaign });
   } catch (error) {
     return campaignErrorResponse(c, error);
+  }
+});
+
+// ─── Character API (SQR-22, ADR 0021) ────────────────────────────────────────
+
+app.use('/api/characters/*', requireCampaignUser('/api/characters'));
+
+const PrivateFieldSchema = z.string().trim().min(1).max(5000).nullable();
+
+const CreateCharacterRequestSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+  className: z.string().trim().min(1).max(100),
+  level: z.number().int().min(1).max(20).optional(),
+  xp: z.number().int().min(0).optional(),
+  gold: z.number().int().min(0).optional(),
+  perks: z.array(z.number().int().min(0)).max(100).optional(),
+  personalQuest: PrivateFieldSchema.optional(),
+  battleGoals: PrivateFieldSchema.optional(),
+  privateNotes: PrivateFieldSchema.optional(),
+  placeholderForEmail: z.string().trim().email().max(320).optional(),
+});
+
+const UpdateCharacterRequestSchema = z
+  .object({
+    expectedVersion: z.number().int().min(0),
+    name: z.string().trim().min(1).max(100).optional(),
+    className: z.string().trim().min(1).max(100).optional(),
+    level: z.number().int().min(1).max(20).optional(),
+    xp: z.number().int().min(0).optional(),
+    gold: z.number().int().min(0).optional(),
+    perks: z.array(z.number().int().min(0)).max(100).optional(),
+    personalQuest: PrivateFieldSchema.optional(),
+    battleGoals: PrivateFieldSchema.optional(),
+    privateNotes: PrivateFieldSchema.optional(),
+    status: z.enum(['active', 'retired']).optional(),
+    successorId: z.string().uuid().nullable().optional(),
+  })
+  .refine((body) => Object.keys(body).length > 1, {
+    message: 'At least one field to update is required',
+  });
+
+const AddItemRequestSchema = z.object({
+  sourceId: z.string().trim().min(1).max(200),
+});
+
+const AddCardRequestSchema = z.object({
+  sourceId: z.string().trim().min(1).max(200),
+  role: z.enum(['owned', 'active']).optional(),
+});
+
+const SetCardRoleRequestSchema = z.object({
+  role: z.enum(['owned', 'active']),
+});
+
+/** Character routes share the campaign error mapping plus one more shape. */
+function characterErrorResponse(c: Context, error: unknown): Response {
+  if (error instanceof CharacterService.PlaceholderPrivateFieldsError) {
+    return c.json({ error: error.code, message: error.message, status: 422 }, 422);
+  }
+  return campaignErrorResponse(c, error);
+}
+
+app.post('/api/campaigns/:id/characters', async (c) => {
+  const campaignId = campaignRouteId(c, 'id');
+  if (!campaignId) return c.json(jsonError('Not found', 404), 404);
+  const body = CreateCharacterRequestSchema.safeParse(await c.req.json().catch(() => null));
+  if (!body.success) return c.json(jsonError('Invalid request body', 400), 400);
+  try {
+    const character = await CharacterService.createCharacter(
+      c.get('callerIdentity')!,
+      campaignId,
+      body.data,
+    );
+    return c.json({ character }, 201);
+  } catch (error) {
+    return characterErrorResponse(c, error);
+  }
+});
+
+app.get('/api/campaigns/:id/characters', async (c) => {
+  const campaignId = campaignRouteId(c, 'id');
+  if (!campaignId) return c.json(jsonError('Not found', 404), 404);
+  try {
+    const characters = await CharacterService.listCampaignCharacters(
+      c.get('callerIdentity')!,
+      campaignId,
+    );
+    return c.json({ characters });
+  } catch (error) {
+    return characterErrorResponse(c, error);
+  }
+});
+
+app.get('/api/characters/:id', async (c) => {
+  const characterId = campaignRouteId(c, 'id');
+  if (!characterId) return c.json(jsonError('Not found', 404), 404);
+  try {
+    return c.json(await CharacterService.getCharacterDetail(c.get('callerIdentity')!, characterId));
+  } catch (error) {
+    return characterErrorResponse(c, error);
+  }
+});
+
+app.patch('/api/characters/:id', async (c) => {
+  const characterId = campaignRouteId(c, 'id');
+  if (!characterId) return c.json(jsonError('Not found', 404), 404);
+  const body = UpdateCharacterRequestSchema.safeParse(await c.req.json().catch(() => null));
+  if (!body.success) return c.json(jsonError('Invalid request body', 400), 400);
+  const identity = c.get('callerIdentity')!;
+  try {
+    const character = await CharacterService.updateCharacter(identity, characterId, body.data);
+    return c.json({ character });
+  } catch (error) {
+    if (error instanceof VersionConflictError) {
+      const detail = await CharacterService.getCharacterDetail(identity, characterId);
+      return c.json(
+        {
+          error: 'version_conflict',
+          currentVersion: detail.character.version,
+          character: detail.character,
+          status: 409,
+        },
+        409,
+      );
+    }
+    return characterErrorResponse(c, error);
+  }
+});
+
+app.delete('/api/characters/:id', async (c) => {
+  const characterId = campaignRouteId(c, 'id');
+  if (!characterId) return c.json(jsonError('Not found', 404), 404);
+  try {
+    await CharacterService.deleteCharacter(c.get('callerIdentity')!, characterId);
+    return c.body(null, 204);
+  } catch (error) {
+    return characterErrorResponse(c, error);
+  }
+});
+
+app.post('/api/characters/:id/claim', async (c) => {
+  const characterId = campaignRouteId(c, 'id');
+  if (!characterId) return c.json(jsonError('Not found', 404), 404);
+  try {
+    const character = await CharacterService.claimCharacter(c.get('callerIdentity')!, characterId);
+    return c.json({ character });
+  } catch (error) {
+    return characterErrorResponse(c, error);
+  }
+});
+
+app.post('/api/characters/:id/items', async (c) => {
+  const characterId = campaignRouteId(c, 'id');
+  if (!characterId) return c.json(jsonError('Not found', 404), 404);
+  const body = AddItemRequestSchema.safeParse(await c.req.json().catch(() => null));
+  if (!body.success) return c.json(jsonError('Invalid request body', 400), 400);
+  try {
+    const item = await CharacterService.addItem(
+      c.get('callerIdentity')!,
+      characterId,
+      body.data.sourceId,
+    );
+    return c.json({ item }, 201);
+  } catch (error) {
+    return characterErrorResponse(c, error);
+  }
+});
+
+app.delete('/api/characters/:id/items/:itemId', async (c) => {
+  const characterId = campaignRouteId(c, 'id');
+  const itemId = campaignRouteId(c, 'itemId');
+  if (!characterId || !itemId) return c.json(jsonError('Not found', 404), 404);
+  try {
+    await CharacterService.removeItem(c.get('callerIdentity')!, characterId, itemId);
+    return c.body(null, 204);
+  } catch (error) {
+    return characterErrorResponse(c, error);
+  }
+});
+
+app.post('/api/characters/:id/cards', async (c) => {
+  const characterId = campaignRouteId(c, 'id');
+  if (!characterId) return c.json(jsonError('Not found', 404), 404);
+  const body = AddCardRequestSchema.safeParse(await c.req.json().catch(() => null));
+  if (!body.success) return c.json(jsonError('Invalid request body', 400), 400);
+  try {
+    const card = await CharacterService.addCard(c.get('callerIdentity')!, characterId, body.data);
+    return c.json({ card }, 201);
+  } catch (error) {
+    return characterErrorResponse(c, error);
+  }
+});
+
+app.patch('/api/characters/:id/cards/:cardId', async (c) => {
+  const characterId = campaignRouteId(c, 'id');
+  const cardId = campaignRouteId(c, 'cardId');
+  if (!characterId || !cardId) return c.json(jsonError('Not found', 404), 404);
+  const body = SetCardRoleRequestSchema.safeParse(await c.req.json().catch(() => null));
+  if (!body.success) return c.json(jsonError('Invalid request body', 400), 400);
+  try {
+    await CharacterService.setCardRole(
+      c.get('callerIdentity')!,
+      characterId,
+      cardId,
+      body.data.role,
+    );
+    return c.body(null, 204);
+  } catch (error) {
+    return characterErrorResponse(c, error);
+  }
+});
+
+app.delete('/api/characters/:id/cards/:cardId', async (c) => {
+  const characterId = campaignRouteId(c, 'id');
+  const cardId = campaignRouteId(c, 'cardId');
+  if (!characterId || !cardId) return c.json(jsonError('Not found', 404), 404);
+  try {
+    await CharacterService.removeCard(c.get('callerIdentity')!, characterId, cardId);
+    return c.body(null, 204);
+  } catch (error) {
+    return characterErrorResponse(c, error);
   }
 });
 

--- a/test/campaign-character-api.test.ts
+++ b/test/campaign-character-api.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Character CRUD API integration tests (SQR-22, ADR 0021).
+ *
+ * Covers the SQR-22 acceptance criteria against real Postgres: owner CRUD
+ * paths, non-owner reads showing public fields only (private tier absent at
+ * the API boundary, never nulled), non-owner mutations denied, the
+ * placeholder claim flow, and multi-character members.
+ */
+import { generateSignedCookie } from 'hono/cookie';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+process.env.SESSION_SECRET = 'test-session-secret-must-be-at-least-32-characters-long';
+
+import { app } from '../src/server.ts';
+import { getDb, shutdownServerPool } from '../src/db.ts';
+import { createCsrfToken } from '../src/auth/csrf.ts';
+import { SESSION_COOKIE_NAME, getSessionSecret } from '../src/auth/session-middleware.ts';
+import * as SessionRepository from '../src/db/repositories/session-repository.ts';
+import { SESSION_LIFETIME_MS } from '../src/db/repositories/session-repository.ts';
+import { users } from '../src/db/schema/core.ts';
+import { resetTestDb, setupTestDb, teardownTestDb } from './helpers/db.ts';
+
+interface TestUser {
+  cookie: string;
+  sessionId: string;
+  userId: string;
+  email: string;
+}
+
+const OWNER_EMAIL = 'owner@example.com';
+const MEMBER_EMAIL = 'member@example.com';
+const INVITEE_EMAIL = 'invitee@example.com';
+const ALL_EMAILS = [OWNER_EMAIL, MEMBER_EMAIL, INVITEE_EMAIL].join(',');
+
+const PRIVATE_FIELDS = ['personalQuest', 'battleGoals', 'privateNotes'] as const;
+
+async function createTestUser(email: string): Promise<TestUser> {
+  const { db } = getDb('server');
+  const [user] = await db
+    .insert(users)
+    .values({ email, googleSub: `google-sub-${email}`, name: email.split('@')[0] })
+    .returning();
+  const { sessionId } = await SessionRepository.create(db, { userId: user.id });
+  const signedCookie = await generateSignedCookie(
+    SESSION_COOKIE_NAME,
+    sessionId,
+    getSessionSecret(),
+    { path: '/', httpOnly: true, sameSite: 'Lax', maxAge: SESSION_LIFETIME_MS / 1000 },
+  );
+  return { cookie: signedCookie.split(';')[0], sessionId, userId: user.id, email };
+}
+
+async function request(
+  user: TestUser,
+  method: string,
+  url: string,
+  body?: unknown,
+): Promise<Response> {
+  const headers = new Headers({ Cookie: user.cookie });
+  if (!['GET', 'HEAD'].includes(method)) {
+    headers.set('x-csrf-token', createCsrfToken(user.sessionId));
+  }
+  if (body !== undefined) headers.set('Content-Type', 'application/json');
+  return app.request(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+/** Owner + member in one campaign; the third user stays an outsider. */
+async function setupCampaign(): Promise<{
+  owner: TestUser;
+  member: TestUser;
+  campaignId: string;
+}> {
+  const owner = await createTestUser(OWNER_EMAIL);
+  const member = await createTestUser(MEMBER_EMAIL);
+  const createRes = await request(owner, 'POST', '/api/campaigns', {
+    name: 'Character Test Campaign',
+    game: 'frosthaven',
+    modules: ['fh'],
+  });
+  expect(createRes.status).toBe(201);
+  const { campaign } = (await createRes.json()) as { campaign: { id: string } };
+  const inviteRes = await request(owner, 'POST', `/api/campaigns/${campaign.id}/invites`, {
+    email: MEMBER_EMAIL,
+  });
+  const { member: invite } = (await inviteRes.json()) as { member: { memberId: string } };
+  const acceptRes = await request(member, 'POST', `/api/invites/${invite.memberId}/accept`);
+  expect(acceptRes.status).toBe(200);
+  return { owner, member, campaignId: campaign.id };
+}
+
+async function createCharacter(
+  user: TestUser,
+  campaignId: string,
+  overrides: Record<string, unknown> = {},
+): Promise<{ id: string; version: number }> {
+  const res = await request(user, 'POST', `/api/campaigns/${campaignId}/characters`, {
+    name: 'Snowdancer',
+    className: 'Drifter',
+    level: 3,
+    personalQuest: 'Retire honorably',
+    privateNotes: 'Hoarding gold for item 42',
+    ...overrides,
+  });
+  expect(res.status).toBe(201);
+  const { character } = (await res.json()) as { character: { id: string; version: number } };
+  return character;
+}
+
+beforeAll(async () => {
+  await setupTestDb();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  process.env.SQUIRE_ALLOWED_EMAILS = ALL_EMAILS;
+});
+
+afterAll(async () => {
+  delete process.env.SQUIRE_ALLOWED_EMAILS;
+  await teardownTestDb();
+  await shutdownServerPool();
+});
+
+describe('owner character CRUD', () => {
+  it('creates, reads (with private tier), updates, and deletes own characters', async () => {
+    const { owner, campaignId } = await setupCampaign();
+    const character = await createCharacter(owner, campaignId);
+
+    const detailRes = await request(owner, 'GET', `/api/characters/${character.id}`);
+    expect(detailRes.status).toBe(200);
+    const detail = (await detailRes.json()) as {
+      character: Record<string, unknown>;
+      own: boolean;
+    };
+    expect(detail.own).toBe(true);
+    expect(detail.character.personalQuest).toBe('Retire honorably');
+    expect(detail.character.privateNotes).toBe('Hoarding gold for item 42');
+
+    const patchRes = await request(owner, 'PATCH', `/api/characters/${character.id}`, {
+      expectedVersion: character.version,
+      level: 4,
+      xp: 150,
+      perks: [1, 3],
+    });
+    expect(patchRes.status).toBe(200);
+    const { character: updated } = (await patchRes.json()) as {
+      character: { level: number; version: number; perks: number[] };
+    };
+    expect(updated.level).toBe(4);
+    expect(updated.perks).toEqual([1, 3]);
+    expect(updated.version).toBe(character.version + 1);
+
+    const staleRes = await request(owner, 'PATCH', `/api/characters/${character.id}`, {
+      expectedVersion: character.version,
+      gold: 99,
+    });
+    expect(staleRes.status).toBe(409);
+    const conflict = (await staleRes.json()) as { error: string; currentVersion: number };
+    expect(conflict.error).toBe('version_conflict');
+    expect(conflict.currentVersion).toBe(updated.version);
+
+    const deleteRes = await request(owner, 'DELETE', `/api/characters/${character.id}`);
+    expect(deleteRes.status).toBe(204);
+    const goneRes = await request(owner, 'GET', `/api/characters/${character.id}`);
+    expect(goneRes.status).toBe(404);
+  });
+
+  it('supports multiple characters per member', async () => {
+    const { owner, member, campaignId } = await setupCampaign();
+    await createCharacter(member, campaignId, { name: 'First' });
+    await createCharacter(member, campaignId, { name: 'Second', className: 'Banner Spear' });
+    await createCharacter(owner, campaignId, { name: 'Owners' });
+
+    const listRes = await request(member, 'GET', `/api/campaigns/${campaignId}/characters`);
+    expect(listRes.status).toBe(200);
+    const { characters } = (await listRes.json()) as {
+      characters: Array<Record<string, unknown>>;
+    };
+    expect(characters.map((ch) => ch.name).sort()).toEqual(['First', 'Owners', 'Second']);
+  });
+});
+
+describe('visibility enforcement (private tier, ADR 0021)', () => {
+  it('non-owner reads omit private keys entirely — list and detail', async () => {
+    const { owner, member, campaignId } = await setupCampaign();
+    const character = await createCharacter(owner, campaignId);
+
+    const detailRes = await request(member, 'GET', `/api/characters/${character.id}`);
+    expect(detailRes.status).toBe(200);
+    const detail = (await detailRes.json()) as {
+      character: Record<string, unknown>;
+      own: boolean;
+    };
+    expect(detail.own).toBe(false);
+    expect(detail.character.name).toBe('Snowdancer');
+    expect(detail.character.level).toBe(3);
+    for (const field of PRIVATE_FIELDS) {
+      expect(detail.character, `${field} must not serialize to non-owners`).not.toHaveProperty(
+        field,
+      );
+    }
+
+    const listRes = await request(member, 'GET', `/api/campaigns/${campaignId}/characters`);
+    const { characters } = (await listRes.json()) as {
+      characters: Array<Record<string, unknown>>;
+    };
+    for (const ch of characters) {
+      for (const field of PRIVATE_FIELDS) {
+        expect(ch, `${field} must not serialize in roster lists`).not.toHaveProperty(field);
+      }
+    }
+  });
+
+  it('denies non-owner mutations and hides characters from non-members', async () => {
+    const { owner, member, campaignId } = await setupCampaign();
+    const outsider = await createTestUser(INVITEE_EMAIL);
+    const character = await createCharacter(owner, campaignId);
+
+    const memberPatch = await request(member, 'PATCH', `/api/characters/${character.id}`, {
+      expectedVersion: 1,
+      gold: 1000,
+    });
+    expect(memberPatch.status).toBe(403);
+
+    const memberDelete = await request(member, 'DELETE', `/api/characters/${character.id}`);
+    expect(memberDelete.status).toBe(403);
+
+    const memberItem = await request(member, 'POST', `/api/characters/${character.id}/items`, {
+      sourceId: 'fh-item-001',
+    });
+    expect(memberItem.status).toBe(403);
+
+    // Non-members get the indistinguishable 404 on reads AND writes.
+    const outsiderRead = await request(outsider, 'GET', `/api/characters/${character.id}`);
+    expect(outsiderRead.status).toBe(404);
+    const outsiderPatch = await request(outsider, 'PATCH', `/api/characters/${character.id}`, {
+      expectedVersion: 1,
+      gold: 1000,
+    });
+    expect(outsiderPatch.status).toBe(404);
+  });
+});
+
+describe('placeholder characters', () => {
+  it('owner creates a placeholder for an invitee who later claims it', async () => {
+    const { owner, campaignId } = await setupCampaign();
+    const invitee = await createTestUser(INVITEE_EMAIL);
+
+    const inviteRes = await request(owner, 'POST', `/api/campaigns/${campaignId}/invites`, {
+      email: INVITEE_EMAIL,
+    });
+    const { member: invite } = (await inviteRes.json()) as { member: { memberId: string } };
+
+    const placeholder = await createCharacter(owner, campaignId, {
+      name: 'Reserved Seat',
+      placeholderForEmail: INVITEE_EMAIL,
+      personalQuest: undefined,
+      privateNotes: undefined,
+    });
+
+    // The invitee cannot claim before joining (not yet a member → 404).
+    const earlyClaim = await request(invitee, 'POST', `/api/characters/${placeholder.id}/claim`);
+    expect(earlyClaim.status).toBe(404);
+
+    const acceptRes = await request(invitee, 'POST', `/api/invites/${invite.memberId}/accept`);
+    expect(acceptRes.status).toBe(200);
+
+    const claimRes = await request(invitee, 'POST', `/api/characters/${placeholder.id}/claim`);
+    expect(claimRes.status).toBe(200);
+    const { character: claimed } = (await claimRes.json()) as {
+      character: { ownerUserId: string; placeholderForEmail: string | null };
+    };
+    expect(claimed.ownerUserId).toBe(invitee.userId);
+    expect(claimed.placeholderForEmail).toBeNull();
+
+    // Ownership transferred: the creator can no longer edit it…
+    const creatorPatch = await request(owner, 'PATCH', `/api/characters/${placeholder.id}`, {
+      expectedVersion: 2,
+      level: 9,
+    });
+    expect(creatorPatch.status).toBe(403);
+
+    // …and the private tier unlocked for the new owner.
+    const ownerPatch = await request(invitee, 'PATCH', `/api/characters/${placeholder.id}`, {
+      expectedVersion: 2,
+      personalQuest: 'My own quest now',
+    });
+    expect(ownerPatch.status).toBe(200);
+  });
+
+  it('rejects private fields on placeholders, non-owner creators, and wrong claimants', async () => {
+    const { owner, member, campaignId } = await setupCampaign();
+
+    const inviteRes = await request(owner, 'POST', `/api/campaigns/${campaignId}/invites`, {
+      email: INVITEE_EMAIL,
+    });
+    expect(inviteRes.status).toBe(201);
+
+    const withPrivate = await request(owner, 'POST', `/api/campaigns/${campaignId}/characters`, {
+      name: 'Leaky',
+      className: 'Drifter',
+      placeholderForEmail: INVITEE_EMAIL,
+      personalQuest: 'Should be rejected',
+    });
+    expect(withPrivate.status).toBe(422);
+
+    const byMember = await request(member, 'POST', `/api/campaigns/${campaignId}/characters`, {
+      name: 'Not Allowed',
+      className: 'Drifter',
+      placeholderForEmail: INVITEE_EMAIL,
+    });
+    expect(byMember.status).toBe(403);
+
+    const noInvite = await request(owner, 'POST', `/api/campaigns/${campaignId}/characters`, {
+      name: 'No Invite',
+      className: 'Drifter',
+      placeholderForEmail: 'owner@example.com',
+    });
+    expect(noInvite.status).toBe(403);
+
+    // A member who is NOT the placeholder's named invitee cannot claim it.
+    const placeholder = await createCharacter(owner, campaignId, {
+      name: 'For Invitee',
+      placeholderForEmail: INVITEE_EMAIL,
+      personalQuest: undefined,
+      privateNotes: undefined,
+    });
+    const wrongClaim = await request(member, 'POST', `/api/characters/${placeholder.id}/claim`);
+    expect(wrongClaim.status).toBe(404);
+
+    // Placeholder updates cannot smuggle private fields in before the claim.
+    const privatePatch = await request(owner, 'PATCH', `/api/characters/${placeholder.id}`, {
+      expectedVersion: 1,
+      privateNotes: 'Smuggled',
+    });
+    expect(privatePatch.status).toBe(422);
+  });
+});
+
+describe('items and cards', () => {
+  it('owner manages items/cards tagged with the campaign game', async () => {
+    const { owner, member, campaignId } = await setupCampaign();
+    const character = await createCharacter(owner, campaignId);
+
+    const itemRes = await request(owner, 'POST', `/api/characters/${character.id}/items`, {
+      sourceId: 'fh-item-010',
+    });
+    expect(itemRes.status).toBe(201);
+    const { item } = (await itemRes.json()) as { item: { id: string; game: string } };
+    expect(item.game).toBe('frosthaven');
+
+    const cardRes = await request(owner, 'POST', `/api/characters/${character.id}/cards`, {
+      sourceId: 'fh-drifter-card-01',
+      role: 'owned',
+    });
+    expect(cardRes.status).toBe(201);
+    const { card } = (await cardRes.json()) as { card: { id: string; role: string } };
+    expect(card.role).toBe('owned');
+
+    const roleRes = await request(
+      owner,
+      'PATCH',
+      `/api/characters/${character.id}/cards/${card.id}`,
+      { role: 'active' },
+    );
+    expect(roleRes.status).toBe(204);
+
+    const detailRes = await request(member, 'GET', `/api/characters/${character.id}`);
+    const detail = (await detailRes.json()) as {
+      items: Array<{ id: string }>;
+      cards: Array<{ role: string }>;
+    };
+    expect(detail.items).toHaveLength(1);
+    expect(detail.cards).toEqual([expect.objectContaining({ role: 'active' })]);
+
+    const removeItem = await request(
+      owner,
+      'DELETE',
+      `/api/characters/${character.id}/items/${item.id}`,
+    );
+    expect(removeItem.status).toBe(204);
+
+    // A child id from another character is indistinguishable from absent.
+    const bogusRemove = await request(
+      owner,
+      'DELETE',
+      `/api/characters/${character.id}/items/${card.id}`,
+    );
+    expect(bogusRemove.status).toBe(404);
+  });
+});

--- a/test/helpers/test-slices.ts
+++ b/test/helpers/test-slices.ts
@@ -9,6 +9,7 @@ export const DB_BACKED_TEST_FILES = [
   'test/auth-provider.test.ts',
   'test/auth-restart.test.ts',
   'test/campaign-api.test.ts',
+  'test/campaign-character-api.test.ts',
   'test/campaign-repositories.test.ts',
   'test/conversation.test.ts',
   'test/cross-game-isolation.test.ts',


### PR DESCRIPTION
## Summary

Stacked on #518 (SQR-21) — diff shows only the character layer.

- **`src/campaign/character-service.ts`** — ADR 0021 character semantics: every active member sees every character through the member-visible projection (the private tier — personal quest, battle goals, private notes — is absent at the type level, never nulled, so no serializer path can leak it); only the owning member mutates. Placeholders are owner-created for a **pending invitee**, can never carry private-tier fields (422 on create and on pre-claim update), and claiming transfers ownership + unlocks the private tier for the new owner. Multi-character members supported throughout. CAS updates return 409 + current state (E3). Items/cards are tagged with the campaign's game server-side for GHS `(game, source_id)` joins (E4).
- **REST** — `POST/GET /api/campaigns/:id/characters`, `GET/PATCH/DELETE /api/characters/:id`, `POST /api/characters/:id/claim`, items/cards subroutes; rides SQR-21's dual-channel auth middleware and campaign rate-limit policies.
- Retirement (`status`/`successorId`) is modeled per the matrix; the guided flow stays deferred (SQR-289), and destructive gating arrives with TODO(SQR-279) like the campaign mutations.

## Tests (7, real Postgres)

Owner CRUD round-trip incl. CAS conflict, multi-character roster, private-key absence asserted at the API boundary (detail + list, per-key `not.toHaveProperty`), non-owner mutation denials + non-member 404s, full placeholder lifecycle (early claim 404 → join → claim → creator locked out → private tier unlocked), private-field rejection on placeholder create/update, wrong-claimant 404, items/cards management with game tagging.

Fixes SQR-22

🤖 Generated with [Claude Code](https://claude.com/claude-code)