### PR TITLE
SQR-300: Seed unlock graphs in production

### DIFF
--- a/.github/workflows/production-seed-unlock-graphs.yml
+++ b/.github/workflows/production-seed-unlock-graphs.yml
@@ -1,0 +1,83 @@
+name: Production seed unlock graphs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/extracted/unlock-graphs/**'
+      - 'scripts/seed-unlock-graphs.ts'
+      - 'src/seed/seed-unlock-graphs.ts'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-seed-unlock-graphs
+  cancel-in-progress: false
+
+jobs:
+  seed-unlock-graphs:
+    name: Seed production unlock graphs
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://squire.maz.org
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+      NODE_ENV: production
+      SQUIRE_ENV: production
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
+
+      - run: npm ci
+
+      - name: Verify production database target
+        run: npm run production-data:verify-db-url
+
+      - name: Start Fly Postgres proxy
+        shell: bash
+        run: |
+          remote_host="$(node -e 'console.log(new URL(process.env.PRODUCTION_DATABASE_URL).hostname)')"
+          proxied_url="$(node -e 'const url = new URL(process.env.PRODUCTION_DATABASE_URL); url.hostname = "127.0.0.1"; url.port = "15432"; console.log(url.toString())')"
+          echo "::add-mask::$proxied_url"
+          echo "DATABASE_URL=$proxied_url" >> "$GITHUB_ENV"
+          flyctl wireguard websockets enable
+          flyctl proxy 15432:5432 "$remote_host" --app maz-squire > /tmp/fly-postgres-proxy.log 2>&1 &
+          echo "$!" > /tmp/fly-postgres-proxy.pid
+          for _ in {1..20}; do
+            if (echo > /dev/tcp/127.0.0.1/15432) >/dev/null 2>&1; then
+              exit 0
+            fi
+            if ! kill -0 "$(cat /tmp/fly-postgres-proxy.pid)" 2>/dev/null; then
+              cat /tmp/fly-postgres-proxy.log
+              exit 1
+            fi
+            sleep 1
+          done
+          cat /tmp/fly-postgres-proxy.log
+          exit 1
+
+      - name: Run production migrations
+        run: npm run db:migrate
+
+      - name: Seed unlock graphs
+        run: npm run seed:unlock-graphs
+
+      - name: Sanity check unlock graphs
+        run: npm run production-data:check -- unlock-graphs
+
+      - name: Stop Fly Postgres proxy
+        if: always()
+        run: kill "$(cat /tmp/fly-postgres-proxy.pid)" 2>/dev/null || true

--- a/docs/runbooks/production-operations.md
+++ b/docs/runbooks/production-operations.md
@@ -285,6 +285,31 @@ npm run production-data:check -- scenario-section-books --game "$SQUIRE_DATA_GAM
 non-empty `scenario_book_scenarios`, `section_book_sections`, and
 `book_references` tables.
 
+### Unlock graphs
+
+`Production seed unlock graphs` runs on merges to `main` that change
+`data/extracted/unlock-graphs/` or the unlock-graph seed code. It can also be run
+manually with `workflow_dispatch`. Unlike the card and scenario/section-book
+workflows it has no `game` input — the seed always imports every module.
+
+The workflow runs:
+
+```bash
+npm run production-data:verify-db-url
+npm run db:migrate
+npm run seed:unlock-graphs
+npm run production-data:check -- unlock-graphs
+```
+
+`npm run seed:unlock-graphs` is idempotent: it upserts the curated scenario and
+thread rows for every module in `data/extracted/unlock-graphs/` (frosthaven `fh`,
+gloomhaven-2e `gh2e` + `solo2e`) into `unlock_graph_scenarios` and
+`unlock_graph_threads`. `loadModuleGraphs()` reads those tables to render the
+campaign scenario-progression dashboard. The migration that creates the tables is
+DDL-only, so without this workflow they stay empty and every campaign shows "No
+scenario data for this campaign's modules yet." The sanity check requires a
+non-empty `unlock_graph_scenarios` row count for every supported game.
+
 ### Rule-source embeddings
 
 `Production reindex rule sources` runs on merges to `main` that change

--- a/scripts/check-production-data.ts
+++ b/scripts/check-production-data.ts
@@ -28,7 +28,7 @@ const SCENARIO_SECTION_TABLES = [
   'book_references',
 ] as const;
 
-type CheckCommand = 'cards' | 'scenario-section-books' | 'embeddings' | 'all';
+type CheckCommand = 'cards' | 'scenario-section-books' | 'unlock-graphs' | 'embeddings' | 'all';
 type ProductionDataCommand = CheckCommand | 'smoke' | 'verify-url' | 'truncate-embeddings';
 
 export interface ProductionDataOptions {
@@ -176,6 +176,31 @@ async function checkScenarioSectionBooks(db: Db, games: readonly GameId[]): Prom
   );
 }
 
+async function checkUnlockGraphs(db: Db, games: readonly GameId[]): Promise<void> {
+  // The dashboard's loadModuleGraphs() reads unlock_graph_scenarios; an empty
+  // table for a campaign's game silently renders "No scenario data" rather than
+  // erroring, so the seed gap is invisible without this check. Every supported
+  // game has a curated graph (frosthaven=fh, gloomhaven-2e=gh2e+solo2e), so a
+  // zero count is always a missing seed, never expected-empty coverage.
+  const counts = new Map<GameId, number>();
+  for (const game of games) {
+    counts.set(game, await countTableForGame(db, 'unlock_graph_scenarios', game));
+  }
+
+  const emptyGames = [...counts.entries()].filter(([, count]) => count <= 0).map(([game]) => game);
+  if (emptyGames.length > 0) {
+    throw new Error(
+      `Unlock-graph seed sanity check failed. No unlock_graph_scenarios rows for: ${emptyGames.join(', ')}`,
+    );
+  }
+
+  console.log(
+    `OK unlock-graph data sanity check passed: ${[...counts.entries()]
+      .map(([game, count]) => `${game}=${count}`)
+      .join(', ')}.`,
+  );
+}
+
 async function checkEmbeddingsForGames(db: Db, games: readonly GameId[]): Promise<void> {
   for (const game of games) {
     await checkEmbeddingsForGame(db, game);
@@ -279,6 +304,7 @@ async function runCheck(db: Db, command: CheckCommand, games: readonly GameId[])
   if (command === 'scenario-section-books' || command === 'all') {
     await checkScenarioSectionBooks(db, games);
   }
+  if (command === 'unlock-graphs' || command === 'all') await checkUnlockGraphs(db, games);
   if (command === 'embeddings' || command === 'all') await checkEmbeddingsForGames(db, games);
 }
 
@@ -287,6 +313,7 @@ function parseCommand(rawCommand: string | undefined): ProductionDataCommand {
   if (
     command === 'cards' ||
     command === 'scenario-section-books' ||
+    command === 'unlock-graphs' ||
     command === 'embeddings' ||
     command === 'all' ||
     command === 'smoke' ||
@@ -296,7 +323,7 @@ function parseCommand(rawCommand: string | undefined): ProductionDataCommand {
     return command;
   }
   throw new Error(
-    `Unknown production data command "${command}". Expected cards, scenario-section-books, embeddings, all, verify-url, or truncate-embeddings.`,
+    `Unknown production data command "${command}". Expected cards, scenario-section-books, unlock-graphs, embeddings, all, verify-url, or truncate-embeddings.`,
   );
 }
 

--- a/scripts/check-production-data.ts
+++ b/scripts/check-production-data.ts
@@ -323,7 +323,7 @@ function parseCommand(rawCommand: string | undefined): ProductionDataCommand {
     return command;
   }
   throw new Error(
-    `Unknown production data command "${command}". Expected cards, scenario-section-books, unlock-graphs, embeddings, all, verify-url, or truncate-embeddings.`,
+    `Unknown production data command "${command}". Expected cards, scenario-section-books, unlock-graphs, embeddings, all, smoke, verify-url, or truncate-embeddings.`,
   );
 }
 

--- a/test/production-data-workflows.test.ts
+++ b/test/production-data-workflows.test.ts
@@ -151,6 +151,11 @@ describe('production data lifecycle workflows', () => {
     expect(() => parseProductionDataOptions(['cards', '--game', 'jotl'])).toThrow(
       /Unsupported game id/,
     );
+    // The unknown-command help text must list every accepted command, including
+    // unlock-graphs and smoke (CodeRabbit on #543).
+    expect(() => parseProductionDataOptions(['bogus'])).toThrow(
+      /cards, scenario-section-books, unlock-graphs, embeddings, all, smoke, verify-url, or truncate-embeddings/,
+    );
   });
 
   it('seeds production card data only through the protected production environment', async () => {

--- a/test/production-data-workflows.test.ts
+++ b/test/production-data-workflows.test.ts
@@ -128,6 +128,10 @@ describe('production data lifecycle workflows', () => {
       command: 'cards',
       games: ['frosthaven', 'gloomhaven-2e'],
     });
+    expect(parseProductionDataOptions(['unlock-graphs'])).toEqual({
+      command: 'unlock-graphs',
+      games: ['frosthaven', 'gloomhaven-2e'],
+    });
     expect(parseProductionDataOptions(['embeddings', '--game', 'gh2'])).toEqual({
       command: 'embeddings',
       games: ['gloomhaven-2e'],
@@ -210,6 +214,31 @@ describe('production data lifecycle workflows', () => {
     );
   });
 
+  it('seeds production unlock graphs through the protected production environment', async () => {
+    const workflow = await readProjectFile('.github/workflows/production-seed-unlock-graphs.yml');
+
+    expect(workflow).toContain('name: Production seed unlock graphs');
+    expect(workflow).toContain('branches: [main]');
+    expect(workflow).toContain('data/extracted/unlock-graphs/**');
+    expect(workflow).toContain('scripts/seed-unlock-graphs.ts');
+    expect(workflow).toContain('src/seed/seed-unlock-graphs.ts');
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('name: production');
+    expect(workflow).toContain('FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}');
+    expect(workflow).toContain('PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}');
+    expect(workflow).toContain('NODE_ENV: production');
+    expect(workflow).toContain('SQUIRE_ENV: production');
+    expect(workflow).toContain('superfly/flyctl-actions/setup-flyctl');
+    expect(workflow).toContain('flyctl proxy 15432:5432 "$remote_host" --app maz-squire');
+    expect(workflow).toContain('echo "::add-mask::$proxied_url"');
+    expect(workflow).toContain('run: npm run production-data:verify-db-url');
+    expect(workflow).toContain('run: npm run db:migrate');
+    expect(workflow).toContain('run: npm run seed:unlock-graphs');
+    expect(workflow).toContain('npm run production-data:check -- unlock-graphs');
+    // The seed is all-modules: no game input, unlike the card/scenario workflows.
+    expect(workflow).not.toContain('inputs.game');
+  });
+
   it('indexes production rule sources with normal and protected rebuild modes', async () => {
     const workflow = await readProjectFile('.github/workflows/production-reindex-pdfs.yml');
 
@@ -265,14 +294,18 @@ describe('production data lifecycle workflows', () => {
       '## Production data lifecycle',
       'Production seed card data',
       'Production seed scenario and section books',
+      'Production seed unlock graphs',
       'Production reindex rule sources',
       'PRODUCTION_DATABASE_URL',
       'data/extracted/',
       'data/extracted/scenario-section-books.json',
+      'data/extracted/unlock-graphs/',
       'data/pdfs/',
       'data/rule-sources/',
       'npm run seed:cards',
       'npm run seed:scenario-section-books',
+      'npm run seed:unlock-graphs',
+      'unlock_graph_scenarios',
       'npm run index',
       'npm run production-data:smoke',
       'rules search',


### PR DESCRIPTION
## Why

A new Gloomhaven-2e campaign created in prod shows **"No scenario data for this campaign's modules yet"** — no scenario progression on the dashboard.

**Root cause:** the `unlock_graph_scenarios` / `unlock_graph_threads` tables are empty in prod. `loadModuleGraphs()` (`src/campaign/unlock-graph-loader.ts`) reads those tables; empty → `[]` → no scenarios (silently, no error). They're populated **only** by `npm run seed:unlock-graphs`, the `20260612210000_unlock_graphs` migration is DDL-only, and **no production workflow ran the seed** — prod had card and scenario/section-book seed workflows but never one for unlock graphs.

(`migrate:live-gh2e` is unrelated — it imports a specific Replit prototype campaign and itself depends on the graphs being seeded.)

## What

- **`.github/workflows/production-seed-unlock-graphs.yml`** — mirrors `production-seed-cards.yml`: Fly Postgres proxy → `production-data:verify-db-url` → `db:migrate` → `seed:unlock-graphs` → `production-data:check -- unlock-graphs`. Triggers on `data/extracted/unlock-graphs/**` pushes and `workflow_dispatch`. No `game` input — the seed is all-modules.
- **`check-production-data.ts`** — new `unlock-graphs` sanity-check target asserting `unlock_graph_scenarios` is non-empty for every supported game.
- **runbook** — documents the workflow under "Production data lifecycle" (the missing entry that let this gap ship).
- **tests** — parser, workflow YAML, and runbook assertions.

## Verification

- `npm run check` green (1,691 tests); `actionlint` clean.
- **After merge:** run the `Production seed unlock graphs` workflow via `workflow_dispatch` (production environment). Then the prod gh2e dashboard should show scenario threads, and the workflow's sanity-check step confirms non-empty `unlock_graph_scenarios`.

Closes SQR-300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated production workflow to seed and validate unlock graphs (manual trigger, concurrency control, DB proxy, migrations, seeding, post-seed sanity check, guaranteed cleanup).
  * Added a CLI command to run unlock-graphs production-data checks.

* **Documentation**
  * Added operational runbook section describing the unlock-graphs seeding and verification process and idempotency expectations.

* **Tests**
  * Expanded tests to cover the new CLI command and verify the new workflow’s behavior and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->