### PR TITLE
SQR-316: Expose skippedScenarios on write_campaign_state so the agent can skip

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -289,7 +289,7 @@ export const AGENT_TOOLS = [
   {
     name: 'write_campaign_state',
     description:
-      'Apply a non-destructive shared campaign-state update for the signed-in member: mark scenarios played or drawn, raise prosperity, record unlocks, rename. Arrays replace the whole list, so include existing values plus additions. Destructive changes (un-playing a scenario, lowering prosperity) return proposal_required; stage those with propose_state_change instead.',
+      'Apply a non-destructive shared campaign-state update for the signed-in member: mark scenarios played, drawn, or skipped, raise prosperity, record unlocks, rename. "Skipped" is for a skippable intro the party chose not to play (e.g. GH2e scenario 0): it shows as SKIPPED, is no longer playable, and opens whatever playing it would have. Arrays replace the whole list, so include existing values plus additions. Destructive changes (un-playing a scenario, lowering prosperity) return proposal_required; stage those with propose_state_change instead.',
     input_schema: {
       type: 'object',
       properties: {
@@ -303,6 +303,11 @@ export const AGENT_TOOLS = [
             activeScenario: { type: ['string', 'null'] },
             playedScenarios: { type: 'array', items: { type: 'string' } },
             drawnScenarios: { type: 'array', items: { type: 'string' } },
+            skippedScenarios: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Qualified keys of skippable scenarios the party skipped (e.g. gh2e:0)',
+            },
             unlockedClasses: { type: 'array', items: { type: 'string' } },
             unlockedItems: { type: 'array', items: { type: 'string' } },
             unlockedBuildings: { type: 'array', items: { type: 'string' } },

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -225,13 +225,13 @@ export function createMcpServer(): McpServer {
     'write_campaign_state',
     {
       description:
-        'Apply a non-destructive shared campaign-state update for the signed-in member: mark scenarios played or drawn, raise prosperity, record unlocks, rename. Arrays replace the whole list. Destructive changes return proposal_required; stage those with propose_state_change.',
+        'Apply a non-destructive shared campaign-state update for the signed-in member: mark scenarios played, drawn, or skipped, raise prosperity, record unlocks, rename. "Skipped" is for a skippable intro the party chose not to play (e.g. GH2e scenario 0): it shows as SKIPPED, is no longer playable, and opens whatever playing it would have. Arrays replace the whole list. Destructive changes return proposal_required; stage those with propose_state_change.',
       inputSchema: {
         campaignId: z.string().describe('Campaign UUID'),
         patch: z
           .record(z.string(), z.unknown())
           .describe(
-            'Fields to set: name, prosperity, activeScenario, playedScenarios, drawnScenarios, unlockedClasses, unlockedItems, unlockedBuildings',
+            'Fields to set: name, prosperity, activeScenario, playedScenarios, drawnScenarios, skippedScenarios (qualified keys like gh2e:0), unlockedClasses, unlockedItems, unlockedBuildings',
           ),
       },
     },

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -459,6 +459,23 @@ describe('runAgentLoop', () => {
     expect(AGENT_SYSTEM_PROMPT).not.toContain('follow_links');
   });
 
+  it('exposes skippedScenarios on write_campaign_state (agent schema must not drift from the writer)', () => {
+    const tool = AGENT_TOOLS.find((t) => t.name === 'write_campaign_state');
+    const patch = (
+      tool?.input_schema as {
+        properties?: { patch?: { properties?: Record<string, unknown> } };
+      }
+    )?.properties?.patch?.properties;
+    // The Zod writer accepts skippedScenarios; the hand-written agent schema and
+    // description must advertise it too, or the model can't mark a scenario
+    // skipped (it has no field to set / no awareness it's allowed).
+    expect(patch).toBeDefined();
+    expect(patch).toHaveProperty('skippedScenarios');
+    expect(patch).toHaveProperty('playedScenarios');
+    expect(patch).toHaveProperty('drawnScenarios');
+    expect(tool?.description).toContain('skipped');
+  });
+
   it('keeps the legacy tool list stable', async () => {
     mockMessagesCreate.mockResolvedValue(textResponse('Answer'));
     await runAgentLoop('test', { toolSurface: 'legacy' });

--- a/test/campaign-write-tools.test.ts
+++ b/test/campaign-write-tools.test.ts
@@ -210,6 +210,17 @@ describe('direct non-destructive writes', () => {
     expect(body.error.message).toContain('patch.prosperity');
   });
 
+  it('marks a scenario skipped via write_campaign_state (SQR-313)', async () => {
+    const { owner, campaign } = await setupCampaign();
+    const body = await callWriteTool(
+      'write_campaign_state',
+      { campaignId: campaign.id, patch: { skippedScenarios: ['fh:0'] } },
+      owner.userId,
+    );
+    expect(body.ok).toBe(true);
+    expect(body.campaign.skippedScenarios).toContain('fh:0');
+  });
+
   it('surfaces destructive direct writes as proposal_required', async () => {
     const { owner, campaign } = await setupCampaign();
     const body = await callWriteTool(


### PR DESCRIPTION
## Bug

After SQR-313 shipped, telling the agent to mark a scenario skipped returns *"that's not a supported state I can write…"* — it offers only played/drawn.

## Root cause

SQR-313 taught the **Zod writer** (`WriteCampaignStateInputSchema`) about `skippedScenarios`, but the **hand-written agent and MCP tool schemas are separate** and weren't updated. The model had no `skippedScenarios` field in `write_campaign_state` and no description hint, so it correctly refused.

## Fix

- Add `skippedScenarios` to the agent `input_schema` (`AGENT_TOOLS`) + both tool descriptions (`agent.ts`, `mcp.ts`), explaining "skipped" (a skippable intro → shows SKIPPED, opens what playing it would).
- **Guard test** (`agent.test.ts`): asserts `write_campaign_state`'s schema exposes `skippedScenarios` and the description mentions "skipped", so the hand-written schema can't silently drift from the writer again.
- **End-to-end test** (`campaign-write-tools.test.ts`): a `skippedScenarios` write persists.

App-code only — no data change, no re-seed.

Follow-up noted in SQR-316: derive the agent/MCP tool schemas from the Zod writers so this drift class can't recur.

Closes SQR-316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking scenarios as skipped in campaigns. Skippable scenarios can now be marked as skipped, making them non-playable while automatically unlocking the rewards and content they would have granted.

* **Tests**
  * Added comprehensive test coverage to verify the new scenario-skipping capability functions correctly and properly updates campaign state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->