### PR TITLE
feat(dashboard): mark a skippable scenario SKIPPED from the web UI (SQR-317)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -133,7 +133,7 @@ import { listJournal } from './campaign/journal.ts';
 import * as PendingMutations from './campaign/pending-mutations.ts';
 import * as WriteTools from './campaign/write-tools.ts';
 import { ProposalStateError } from './campaign/pending-mutations.ts';
-import { deriveAvailability } from './campaign/availability.ts';
+import { deriveAvailability, qualifiedKey } from './campaign/availability.ts';
 import { loadModuleGraphs } from './campaign/unlock-graph-loader.ts';
 import type { Campaign } from './db/repositories/types.ts';
 import type { HtmlEscapedString } from 'hono/utils/html';
@@ -925,6 +925,9 @@ app.post('/campaigns/:id/scenarios/toggle', async (c) => {
   const form = await c.req.formData();
   const key = typeof form.get('key') === 'string' ? (form.get('key') as string).trim() : '';
   if (!key || key.length > 200) return c.notFound();
+  // `mode=skip` is the skippable-intro path (GH2e scenario 0); default is the
+  // play/draw advance cycle.
+  const mode = form.get('mode') === 'skip' ? 'skip' : 'advance';
 
   const identity = identityFromSessionUser(session.userId);
   let announcement: string;
@@ -942,8 +945,25 @@ app.post('/campaigns/:id/scenarios/toggle', async (c) => {
     );
     const status = availability.statuses.get(key);
     const shortKey = key.split(':')[1] ?? key;
+    const isSkippable = graphs.some((graph) =>
+      graph.scenarios.some(
+        (scenario) => qualifiedKey(graph.module, scenario.key) === key && scenario.skippable,
+      ),
+    );
 
-    if (status === 'open' || status === 'drew-it') {
+    if (mode === 'skip') {
+      // Skip is only valid for a skippable intro that is currently open. Adding
+      // it to skippedScenarios is non-destructive — it opens what playing would.
+      if (isSkippable && status === 'open') {
+        await CampaignService.updateSharedState(identity, campaignId, {
+          expectedVersion: detail.campaign.version,
+          skippedScenarios: [...detail.campaign.skippedScenarios, key],
+        });
+        announcement = `Scenario ${shortKey} marked skipped.`;
+      } else {
+        announcement = `Scenario ${shortKey} cannot be skipped.`;
+      }
+    } else if (status === 'open' || status === 'drew-it') {
       await CampaignService.updateSharedState(identity, campaignId, {
         expectedVersion: detail.campaign.version,
         playedScenarios: [...detail.campaign.playedScenarios, key],

--- a/src/web-ui/campaign-dashboard.ts
+++ b/src/web-ui/campaign-dashboard.ts
@@ -116,7 +116,13 @@ function scenarioRow(input: {
         <input type="hidden" name="_csrf" value="${input.csrfToken}" />
         <input type="hidden" name="key" value="${input.qualified}" />
         <input type="hidden" name="mode" value="skip" />
-        <button type="submit" class="squire-scenario-row__skip">Skip</button>
+        <button
+          type="submit"
+          class="squire-scenario-row__skip"
+          aria-label="Skip scenario ${input.scenarioKey} ${input.name}"
+        >
+          Skip
+        </button>
       </form>`
     : html``;
 

--- a/src/web-ui/campaign-dashboard.ts
+++ b/src/web-ui/campaign-dashboard.ts
@@ -76,9 +76,14 @@ function scenarioRow(input: {
   cond: string | null;
   /** Character-gate requirement ("NEEDS BRUISER L5") for a locked solo. */
   requirement?: string;
+  /** True for a skippable intro (GH2e scenario 0): offers a Skip action. */
+  skippable?: boolean;
   confirmText?: string;
 }): HtmlEscapedString {
   const label = STATUS_LABEL[input.status];
+  // Skip is offered only for a skippable intro that is currently open — the
+  // single moment the party can decline to play it. Never on other rows.
+  const showSkip = Boolean(input.skippable) && input.status === 'open';
   // A manual scenario explains itself via its event cond; a character-gated
   // solo via its class requirement. Never event language for the latter.
   const subLabel = input.status === 'via-event' && input.cond ? input.cond : input.requirement;
@@ -98,8 +103,29 @@ function scenarioRow(input: {
     </li>` as HtmlEscapedString;
   }
 
+  // Skippable intros carry a quiet secondary Skip control beside the play tap.
+  const skipForm = showSkip
+    ? html`<form
+        method="post"
+        action="/campaigns/${input.campaignId}/scenarios/toggle"
+        hx-post="/campaigns/${input.campaignId}/scenarios/toggle"
+        hx-target="#squire-dashboard-threads"
+        hx-swap="outerHTML"
+        class="squire-scenario-row__skip-form"
+      >
+        <input type="hidden" name="_csrf" value="${input.csrfToken}" />
+        <input type="hidden" name="key" value="${input.qualified}" />
+        <input type="hidden" name="mode" value="skip" />
+        <button type="submit" class="squire-scenario-row__skip">Skip</button>
+      </form>`
+    : html``;
+
   // Actionable rows are real forms: plain-POST safe, HTMX-enhanced swap.
-  return html`<li class="squire-scenario-row squire-scenario-row--${input.status}">
+  return html`<li
+    class="squire-scenario-row squire-scenario-row--${input.status}${showSkip
+      ? ' squire-scenario-row--skippable'
+      : ''}"
+  >
     <form
       method="post"
       action="/campaigns/${input.campaignId}/scenarios/toggle"
@@ -112,6 +138,7 @@ function scenarioRow(input: {
       <input type="hidden" name="key" value="${input.qualified}" />
       <button type="submit" class="squire-scenario-row__tap">${rowBody}</button>
     </form>
+    ${skipForm}
   </li>` as HtmlEscapedString;
 }
 
@@ -183,6 +210,7 @@ export function renderDashboardThreads(input: DashboardThreadsInput): HtmlEscape
                 name: scenario.name,
                 status,
                 cond: scenario.cond,
+                skippable: scenario.skippable,
                 requirement:
                   status === 'locked' && scenario.unlockClass
                     ? `NEEDS ${scenario.unlockClass.toUpperCase()} L${scenario.unlockMinLevel ?? 1}`

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -2427,6 +2427,44 @@ template#squire-banner-fixtures {
   color: var(--sepia-dim);
 }
 
+/* Skippable intro: the play tap keeps the row width; a quiet Skip control
+   sits beside it, visually subordinate to the primary tap. */
+.squire-scenario-row--skippable {
+  display: flex;
+  align-items: center;
+}
+
+.squire-scenario-row--skippable > form:first-of-type {
+  flex: 1;
+}
+
+.squire-scenario-row__skip-form {
+  margin: 0;
+}
+
+.squire-scenario-row__skip {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 var(--space-md);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--sepia-dim);
+}
+
+.squire-scenario-row__skip:hover {
+  color: var(--sepia);
+}
+
+.squire-scenario-row__skip:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+}
+
 .squire-banner--amber {
   border-color: var(--amber);
 }

--- a/test/campaign-dashboard.test.ts
+++ b/test/campaign-dashboard.test.ts
@@ -98,15 +98,45 @@ async function setupFixture() {
   return { owner, campaign };
 }
 
-async function toggle(user: TestUser, campaignId: string, key: string): Promise<Response> {
+async function toggle(
+  user: TestUser,
+  campaignId: string,
+  key: string,
+  mode?: 'skip',
+): Promise<Response> {
   const form = new FormData();
   form.set('_csrf', createCsrfToken(user.sessionId));
   form.set('key', key);
+  if (mode) form.set('mode', mode);
   return app.request(`/campaigns/${campaignId}/scenarios/toggle`, {
     method: 'POST',
     headers: { Cookie: user.cookie, 'HX-Request': 'true' },
     body: form,
   });
+}
+
+/** A module with a skippable intro (scenario 0) gating scenario 1 (SQR-317). */
+async function setupSkipFixture() {
+  const { db } = getDb('server');
+  await seedUnlockGraphModule(db, {
+    provenance: 'test',
+    game: 'frosthaven',
+    module: 'fh',
+    scenarios: [
+      scenario('0', { name: 'Training Course', skippable: true }),
+      scenario('1', { prereqsAll: ['0'] }),
+    ],
+    threads: [
+      { id: 'fh_intro', label: 'Prologue', note: 'The opening', position: 0, keys: ['0', '1'] },
+    ],
+  });
+  const owner = await createTestUser(OWNER_EMAIL);
+  const campaign = await CampaignService.createCampaign(identityFromSessionUser(owner.userId), {
+    name: 'Skip Campaign',
+    game: 'frosthaven',
+    modules: ['fh'],
+  });
+  return { owner, campaign };
 }
 
 beforeAll(async () => {
@@ -189,5 +219,42 @@ describe('toggle route', () => {
     const outsider = await createTestUser(OUTSIDER_EMAIL);
     const denied = await toggle(outsider, campaign.id, 'fh:2');
     expect(denied.status).toBe(404);
+  });
+});
+
+describe('skippable intro (SQR-317)', () => {
+  it('offers a Skip control only on a skippable open scenario', async () => {
+    const { owner, campaign } = await setupSkipFixture();
+    const res = await app.request(`/campaigns/${campaign.id}`, {
+      headers: { Cookie: owner.cookie },
+    });
+    const body = await res.text();
+    // Scenario 0 is skippable + open → carries the quiet Skip control.
+    expect(body).toContain('squire-scenario-row__skip');
+    expect(body).toContain('squire-scenario-row--skippable');
+    expect(body).toContain('name="mode" value="skip"');
+    // Scenario 1 is locked (gated on 0) → only scenario 0 offers skip.
+    expect(body.match(/name="mode" value="skip"/g)?.length).toBe(1);
+  });
+
+  it('marks a skippable scenario skipped and opens what it gated', async () => {
+    const { owner, campaign } = await setupSkipFixture();
+    const skipped = await toggle(owner, campaign.id, 'fh:0', 'skip');
+    expect(skipped.status).toBe(200);
+    const body = await skipped.text();
+    expect(body).toContain('Scenario 0 marked skipped.');
+    expect(body).toContain('SKIPPED');
+    // Scenario 1 (gated on 0) opens now that 0 is done.
+    expect(body).toContain('--open');
+    // Skip is terminal — scenario 0 no longer offers a skip control.
+    expect(body).not.toContain('name="mode" value="skip"');
+  });
+
+  it('refuses to skip a non-skippable scenario', async () => {
+    const { owner, campaign } = await setupSkipFixture();
+    await toggle(owner, campaign.id, 'fh:0', 'skip'); // 1 becomes open
+    const denied = await toggle(owner, campaign.id, 'fh:1', 'skip');
+    expect(denied.status).toBe(200);
+    expect(await denied.text()).toContain('Scenario 1 cannot be skipped.');
   });
 });

--- a/test/campaign-dashboard.test.ts
+++ b/test/campaign-dashboard.test.ts
@@ -233,6 +233,9 @@ describe('skippable intro (SQR-317)', () => {
     expect(body).toContain('squire-scenario-row__skip');
     expect(body).toContain('squire-scenario-row--skippable');
     expect(body).toContain('name="mode" value="skip"');
+    // The Skip button has a scenario-specific accessible name so assistive
+    // control lists never expose indistinguishable "Skip" actions.
+    expect(body).toContain('aria-label="Skip scenario 0 Training Course"');
     // Scenario 1 is locked (gated on 0) → only scenario 0 offers skip.
     expect(body.match(/name="mode" value="skip"/g)?.length).toBe(1);
   });


### PR DESCRIPTION
## What

Adds a **Skip** control to the campaign progression dashboard so a party can mark a skippable intro (GH2e scenario 0 "Training Course") as SKIPPED without dropping to chat.

SQR-313 added the `skippable` flag + the `skipped` status; SQR-316 taught the agent to write it. This closes the loop on the web surface.

## How

- A quiet secondary **Skip** action renders beside the play tap **only** when a scenario is `skippable` AND currently `open` — the single moment the party can decline to play the intro.
- It posts to the existing `/campaigns/:id/scenarios/toggle` route behind a new `mode=skip` form field, which validates skippable+open and adds the key to `skippedScenarios` via `updateSharedState`. Skip is non-destructive (it opens whatever playing would have) and terminal — no hazard confirm.
- Styling follows the DESIGN.md status vocabulary: `--sepia-dim` small-caps, 44px touch target, subordinate to the primary tap.

## Files

- `src/web-ui/campaign-dashboard.ts` — Skip control + `--skippable` row modifier; pass `scenario.skippable` through.
- `src/server.ts` — toggle route `mode=skip` branch (validate, write, announce; reject otherwise).
- `src/web-ui/styles.css` — `.squire-scenario-row__skip`.
- `test/campaign-dashboard.test.ts` — 3 new tests.

## Test plan

- `npm run check` green — 1700 tests pass.
- New vitest coverage: Skip control appears only for skippable+open; skip persists + opens what it gated + is terminal; non-skippable scenarios refuse skip.
- **Browser-verified** on a fresh GH2e campaign: scenario 0 shows OPEN + Skip; clicking marks SKIPPED, stats show `SKIPPED 1`, thread progress `1/3`, control disappears (terminal). Plain-POST (no-JS) path persists too. No console errors. Skip control computed style confirmed sepia-dim 11px uppercase, 44px min-height.

Closes SQR-317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “Skip” option for skippable introductory scenarios when they’re currently available, allowing direct progress to the next gated scenario.

* **Style**
  * Improved styling and layout for skippable scenario rows and the new skip control, including clearer keyboard focus behavior.

* **Tests**
  * Added automated coverage for skipping skippable scenarios, advancing gated scenarios after a skip, and showing an appropriate message when skipping isn’t allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->