### PR TITLE
feat(web-ui): create a character from the campaign dashboard (SQR-318)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -864,6 +864,10 @@ async function renderCampaignDashboardPage(
   const identity = identityFromSessionUser(session.userId);
   const detail = await CampaignService.getCampaignDetail(identity, campaignId);
   const csrfToken = createCsrfToken(session.id);
+  // Per-user, never-cached: set on every path through the shared renderer
+  // (GET and the create-error re-render) so neither leaks across sessions.
+  c.header('Cache-Control', 'no-store');
+  c.header('Vary', 'Cookie');
   const body = await layoutShell({
     session,
     csrfToken,
@@ -901,8 +905,6 @@ async function renderCampaignDashboardPage(
 
 app.get('/campaigns/:id', async (c) => {
   const campaignId = campaignRouteId(c, 'id');
-  c.header('Cache-Control', 'no-store');
-  c.header('Vary', 'Cookie');
   if (!campaignId) return c.notFound();
   try {
     return await renderCampaignDashboardPage(c, campaignId);
@@ -935,6 +937,17 @@ app.post('/campaigns/:id/characters', async (c) => {
         c,
         campaignId,
         { characterError: 'Character name is required.' },
+        422,
+      );
+    }
+    // An explicit non-empty check: in no-materials mode `knownClassNames` is
+    // empty and `checkClassName` accepts anything, so a blank/tampered class
+    // would otherwise slip through.
+    if (!classNameInput) {
+      return await renderCampaignDashboardPage(
+        c,
+        campaignId,
+        { characterError: 'Class is required.' },
         422,
       );
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import {
 } from './campaign/identity.ts';
 import * as CampaignService from './campaign/campaign-service.ts';
 import * as CharacterService from './campaign/character-service.ts';
+import { checkClassName, knownClassNames } from './campaign/class-validation.ts';
 import { VersionConflictError } from './db/repositories/types.ts';
 import { html } from 'hono/html';
 import { streamSSE } from 'hono/streaming';
@@ -847,49 +848,121 @@ app.post('/campaigns/:id/leave-web', async (c) => {
   }
 });
 
-app.get('/campaigns/:id', async (c) => {
+/**
+ * Render the `/campaigns/:id` dashboard page. Shared by the GET route and the
+ * create-character POST error path so a failed create re-renders in place with
+ * an inline banner (SQR-318). Throws `CampaignNotFoundError` for non-members —
+ * callers map it to the indistinguishable 404 (ADR 0021).
+ */
+async function renderCampaignDashboardPage(
+  c: Context,
+  campaignId: string,
+  opts: { characterError?: string } = {},
+  status: 200 | 422 = 200,
+): Promise<Response> {
   const session = c.get('session')!;
+  const identity = identityFromSessionUser(session.userId);
+  const detail = await CampaignService.getCampaignDetail(identity, campaignId);
+  const csrfToken = createCsrfToken(session.id);
+  const body = await layoutShell({
+    session,
+    csrfToken,
+    showChatChrome: false,
+    showRail: false,
+    campaignStrip: {
+      campaignId: detail.campaign.id,
+      campaignName: detail.campaign.name,
+      game: detail.campaign.game,
+    },
+    campaignStripProminent: true,
+    mainContent: renderCampaignDashboardContent(
+      detail,
+      await dashboardThreadsFragment(detail.campaign, csrfToken),
+      renderCampaignJournal(await listJournal(identity, campaignId)),
+      // Sheet links (SQR-277): member-visible projection only.
+      (await CharacterRepository.listMemberVisibleByCampaign(campaignId)).map((character) => ({
+        id: character.id,
+        name: character.name,
+        className: character.className,
+        level: character.level,
+        placeholder: character.placeholderForEmail !== null,
+      })),
+      // Create-character form (SQR-318): a select of the game's real class
+      // names structurally prevents an invalid class.
+      {
+        csrfToken,
+        classOptions: await knownClassNames(detail.campaign.game),
+        errorMessage: opts.characterError,
+      },
+    ),
+  });
+  return c.html(body, status);
+}
+
+app.get('/campaigns/:id', async (c) => {
   const campaignId = campaignRouteId(c, 'id');
   c.header('Cache-Control', 'no-store');
   c.header('Vary', 'Cookie');
   if (!campaignId) return c.notFound();
   try {
-    const detail = await CampaignService.getCampaignDetail(
-      identityFromSessionUser(session.userId),
-      campaignId,
-    );
-    return c.html(
-      await layoutShell({
-        session,
-        csrfToken: createCsrfToken(session.id),
-        showChatChrome: false,
-        showRail: false,
-        campaignStrip: {
-          campaignId: detail.campaign.id,
-          campaignName: detail.campaign.name,
-          game: detail.campaign.game,
-        },
-        campaignStripProminent: true,
-        mainContent: renderCampaignDashboardContent(
-          detail,
-          await dashboardThreadsFragment(detail.campaign, createCsrfToken(session.id)),
-          renderCampaignJournal(
-            await listJournal(identityFromSessionUser(session.userId), campaignId),
-          ),
-          // Sheet links (SQR-277): member-visible projection only.
-          (await CharacterRepository.listMemberVisibleByCampaign(campaignId)).map((character) => ({
-            id: character.id,
-            name: character.name,
-            className: character.className,
-            level: character.level,
-            placeholder: character.placeholderForEmail !== null,
-          })),
-        ),
-      }),
-    );
+    return await renderCampaignDashboardPage(c, campaignId);
   } catch (error) {
     // Non-member and absent are the same 404 page (ADR 0021).
     if (error instanceof CampaignService.CampaignNotFoundError) return c.notFound();
+    throw error;
+  }
+});
+
+/** Create a character from the dashboard form (SQR-318). */
+app.post('/campaigns/:id/characters', async (c) => {
+  const session = c.get('session')!;
+  const campaignId = campaignRouteId(c, 'id');
+  if (!campaignId) return c.notFound();
+  const identity = identityFromSessionUser(session.userId);
+  const form = await c.req.formData();
+  const name = typeof form.get('name') === 'string' ? (form.get('name') as string).trim() : '';
+  const classNameInput =
+    typeof form.get('className') === 'string' ? (form.get('className') as string).trim() : '';
+  const levelRaw = form.get('level');
+  const levelNum = typeof levelRaw === 'string' ? Number.parseInt(levelRaw, 10) : Number.NaN;
+  const level = Number.isFinite(levelNum) ? Math.min(20, Math.max(1, levelNum)) : 1;
+
+  try {
+    // getCampaignDetail gates membership: a non-member gets the 404 below.
+    const detail = await CampaignService.getCampaignDetail(identity, campaignId);
+    if (!name) {
+      return await renderCampaignDashboardPage(
+        c,
+        campaignId,
+        { characterError: 'Character name is required.' },
+        422,
+      );
+    }
+    // Validate against the game's class list (real names only). The select
+    // already constrains this; the check covers no-JS / tampered posts.
+    const check = checkClassName(classNameInput, await knownClassNames(detail.campaign.game));
+    if (!check.ok) {
+      const message = check.suggestion
+        ? `Unknown class "${classNameInput}". Did you mean ${check.suggestion}?`
+        : `"${classNameInput}" is not a class in this game.`;
+      return await renderCampaignDashboardPage(c, campaignId, { characterError: message }, 422);
+    }
+    await CharacterService.createCharacter(identity, campaignId, {
+      name,
+      className: check.canonical,
+      level,
+    });
+    return c.redirect(`/campaigns/${campaignId}`, 303);
+  } catch (error) {
+    if (error instanceof CampaignService.CampaignNotFoundError) return c.notFound();
+    if (error instanceof CampaignService.CampaignForbiddenError) {
+      return await renderCampaignDashboardPage(
+        c,
+        campaignId,
+        { characterError: error.message },
+        422,
+      );
+    }
     throw error;
   }
 });

--- a/src/web-ui/campaign-pages.ts
+++ b/src/web-ui/campaign-pages.ts
@@ -168,12 +168,70 @@ export interface DashboardCharacterRow {
   placeholder: boolean;
 }
 
+/** The "New character" create form on the dashboard (SQR-318). */
+export interface CharacterCreateForm {
+  csrfToken: string;
+  /**
+   * Valid class names for the campaign's game (real names only, never
+   * codenames). A populated list renders a select — structurally preventing
+   * an invalid class. Empty (no imported mats) degrades to a free-text input.
+   */
+  classOptions: string[];
+  /** Inline error rendered above the form after a failed create attempt. */
+  errorMessage?: string;
+}
+
+/** The dashboard Characters section: existing sheet links + the create form. */
+function renderCharacterCreateForm(
+  campaignId: string,
+  data: CharacterCreateForm,
+): HtmlEscapedString {
+  return html`${data.errorMessage
+      ? html`<div class="squire-banner squire-banner--error" role="alert">
+          <span class="squire-banner__label">COULD NOT SAVE</span>
+          <p class="squire-banner__body">${data.errorMessage}</p>
+        </div>`
+      : html``}
+    <form
+      method="post"
+      action="/campaigns/${campaignId}/characters"
+      class="squire-character-create"
+      aria-label="Add a character"
+    >
+      <input type="hidden" name="_csrf" value="${data.csrfToken}" />
+      <label class="squire-character-create__field">
+        <span class="squire-character-create__field-label">NAME</span>
+        <input name="name" type="text" required maxlength="100" autocomplete="off" />
+      </label>
+      <label class="squire-character-create__field">
+        <span class="squire-character-create__field-label">CLASS</span>
+        ${data.classOptions.length > 0
+          ? html`<select name="className" required>
+              ${data.classOptions.map((cls) => html`<option value="${cls}">${cls}</option>`)}
+            </select>`
+          : html`<input
+              name="className"
+              type="text"
+              required
+              maxlength="100"
+              autocomplete="off"
+            />`}
+      </label>
+      <label class="squire-character-create__field">
+        <span class="squire-character-create__field-label">LEVEL</span>
+        <input name="level" type="number" min="1" max="20" value="1" />
+      </label>
+      <button type="submit" class="squire-character-create__submit">ADD CHARACTER</button>
+    </form>` as HtmlEscapedString;
+}
+
 /** `/campaigns/:id` — dashboard: header, threads (SQR-276), roster. */
 export function renderCampaignDashboardContent(
   detail: CampaignDetail,
   threadsFragment?: HtmlEscapedString,
   journalFragment?: HtmlEscapedString,
   characters?: DashboardCharacterRow[],
+  characterCreate?: CharacterCreateForm,
 ): HtmlEscapedString {
   const { campaign } = detail;
   const activeMembers = detail.members.filter((member) => member.status === 'active');
@@ -199,10 +257,10 @@ export function renderCampaignDashboardContent(
         )}
       </ul>
     </section>
-    ${characters && characters.length > 0
-      ? html`<section class="squire-campaign-dashboard__characters" aria-label="Characters">
-          <h2 class="squire-campaign-dashboard__section-title">Characters</h2>
-          <ul class="squire-campaign-dashboard__members">
+    <section class="squire-campaign-dashboard__characters" aria-label="Characters">
+      <h2 class="squire-campaign-dashboard__section-title">Characters</h2>
+      ${characters && characters.length > 0
+        ? html`<ul class="squire-campaign-dashboard__members">
             ${characters.map(
               (character) =>
                 html`<li class="squire-campaign-dashboard__member">
@@ -217,9 +275,12 @@ export function renderCampaignDashboardContent(
                   >
                 </li>`,
             )}
-          </ul>
-        </section>`
-      : html``}
+          </ul>`
+        : html`<p class="squire-campaign-dashboard__empty">
+            No characters yet — add your first below.
+          </p>`}
+      ${characterCreate ? renderCharacterCreateForm(campaign.id, characterCreate) : html``}
+    </section>
     ${threadsFragment ??
     html`<section
       class="squire-campaign-dashboard__threads"

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -2166,7 +2166,10 @@ template#squire-banner-fixtures {
 .squire-campaign-dashboard__empty {
   font-family: 'Geist', system-ui, sans-serif;
   font-size: 13px;
-  color: var(--sepia-dim);
+
+  /* Match the AA-compliant empty-state tone used elsewhere (not sepia-dim,
+     which fails normal-text contrast at this size). */
+  color: var(--sepia);
   padding: var(--space-sm) 0;
 }
 

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -2163,6 +2163,64 @@ template#squire-banner-fixtures {
   letter-spacing: 0.14em;
 }
 
+.squire-campaign-dashboard__empty {
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 13px;
+  color: var(--sepia-dim);
+  padding: var(--space-sm) 0;
+}
+
+/* New-character create form (SQR-318): mirrors the campaign create form —
+   small-caps field labels, wax primary action, 44px controls. */
+.squire-character-create {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  align-items: end;
+  margin-top: var(--space-sm);
+}
+
+.squire-character-create__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.squire-character-create__field-label {
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--sepia);
+}
+
+.squire-character-create__field input,
+.squire-character-create__field select {
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  color: var(--parchment);
+  min-height: 44px;
+  padding: 0 var(--space-sm);
+  font-family: 'Geist', system-ui, sans-serif;
+}
+
+.squire-character-create__submit {
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--parchment);
+  background: var(--wax);
+  border: 1px solid var(--wax);
+  border-radius: 4px;
+  padding: 0 var(--space-md);
+  min-height: 44px;
+  cursor: pointer;
+}
+
+.squire-character-create__submit:hover {
+  background: var(--wax-dim);
+}
+
 .squire-campaigns__row-actions {
   display: flex;
   gap: var(--space-sm);

--- a/test/campaign-character-create.test.ts
+++ b/test/campaign-character-create.test.ts
@@ -208,6 +208,15 @@ describe('create-character UI (SQR-318)', () => {
     expect(await res.text()).toContain('Character name is required.');
   });
 
+  it('requires a class (the guard runs before class-name canonicalization)', async () => {
+    const { owner, campaign } = await setupFixture();
+    // A blank/whitespace class is rejected before checkClassName — which in
+    // no-materials mode would otherwise accept anything.
+    const res = await createCharacter(owner, campaign.id, { name: 'No Class', className: '   ' });
+    expect(res.status).toBe(422);
+    expect(await res.text()).toContain('Class is required.');
+  });
+
   it('404s a non-member who tries to create on a campaign they cannot see', async () => {
     const { campaign } = await setupFixture();
     const outsider = await createTestUser(OUTSIDER_EMAIL);

--- a/test/campaign-character-create.test.ts
+++ b/test/campaign-character-create.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Create-a-character web UI tests (SQR-318).
+ *
+ * The dashboard Characters section always renders a "New character" form
+ * (a class select sourced from the game's real class names). Posting it
+ * creates the character on the active campaign under the caller's identity;
+ * an unknown/codename class is rejected with an inline banner; a non-member
+ * gets the indistinguishable 404.
+ */
+import { generateSignedCookie } from 'hono/cookie';
+import { inArray } from 'drizzle-orm';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+process.env.SESSION_SECRET = 'test-session-secret-must-be-at-least-32-characters-long';
+
+import { app } from '../src/server.ts';
+import { getDb, shutdownServerPool } from '../src/db.ts';
+import { createCsrfToken } from '../src/auth/csrf.ts';
+import { SESSION_COOKIE_NAME, getSessionSecret } from '../src/auth/session-middleware.ts';
+import * as SessionRepository from '../src/db/repositories/session-repository.ts';
+import { SESSION_LIFETIME_MS } from '../src/db/repositories/session-repository.ts';
+import * as CampaignService from '../src/campaign/campaign-service.ts';
+import { identityFromSessionUser } from '../src/campaign/identity.ts';
+import { users } from '../src/db/schema/core.ts';
+import { cardCharacterMats } from '../src/db/schema/cards.ts';
+import { resetTestDb, setupTestDb, teardownTestDb } from './helpers/db.ts';
+
+interface TestUser {
+  cookie: string;
+  sessionId: string;
+  userId: string;
+}
+
+const OWNER_EMAIL = 'owner@example.com';
+const OUTSIDER_EMAIL = 'outsider@example.com';
+
+// Card tables are NOT reset between tests (resetTestDb only truncates campaign/
+// auth state), so seed once and clean up in afterAll.
+const MAT_SOURCE_IDS = ['test-create-drifter', 'test-create-banner-spear'];
+
+async function createTestUser(email: string): Promise<TestUser> {
+  const { db } = getDb('server');
+  const [user] = await db
+    .insert(users)
+    .values({ email, googleSub: `google-sub-${email}`, name: email.split('@')[0] })
+    .returning();
+  const { sessionId } = await SessionRepository.create(db, { userId: user.id });
+  const signedCookie = await generateSignedCookie(
+    SESSION_COOKIE_NAME,
+    sessionId,
+    getSessionSecret(),
+    { path: '/', httpOnly: true, sameSite: 'Lax', maxAge: SESSION_LIFETIME_MS / 1000 },
+  );
+  return { cookie: signedCookie.split(';')[0], sessionId, userId: user.id };
+}
+
+async function seedMats() {
+  const { db } = getDb('server');
+  await db
+    .insert(cardCharacterMats)
+    .values([
+      {
+        game: 'frosthaven',
+        sourceId: MAT_SOURCE_IDS[0],
+        name: 'Drifter',
+        characterClass: 'Inox',
+        handSize: 9,
+        traits: [],
+        hp: {},
+        perks: [],
+        masteries: [],
+      },
+      {
+        game: 'frosthaven',
+        sourceId: MAT_SOURCE_IDS[1],
+        name: 'Banner Spear',
+        characterClass: 'Human',
+        handSize: 10,
+        traits: [],
+        hp: {},
+        perks: [],
+        masteries: [],
+      },
+    ])
+    .onConflictDoNothing();
+}
+
+async function setupFixture() {
+  const owner = await createTestUser(OWNER_EMAIL);
+  const campaign = await CampaignService.createCampaign(identityFromSessionUser(owner.userId), {
+    name: 'Roster Campaign',
+    game: 'frosthaven',
+    modules: [],
+  });
+  return { owner, campaign };
+}
+
+async function createCharacter(
+  user: TestUser,
+  campaignId: string,
+  fields: { name?: string; className?: string; level?: string },
+): Promise<Response> {
+  const form = new FormData();
+  form.set('_csrf', createCsrfToken(user.sessionId));
+  if (fields.name !== undefined) form.set('name', fields.name);
+  if (fields.className !== undefined) form.set('className', fields.className);
+  if (fields.level !== undefined) form.set('level', fields.level);
+  return app.request(`/campaigns/${campaignId}/characters`, {
+    method: 'POST',
+    headers: { Cookie: user.cookie, 'HX-Request': 'true' },
+    body: form,
+  });
+}
+
+beforeAll(async () => {
+  await setupTestDb();
+  await seedMats();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  await seedMats();
+  process.env.SQUIRE_ALLOWED_EMAILS = [OWNER_EMAIL, OUTSIDER_EMAIL].join(',');
+});
+
+afterAll(async () => {
+  delete process.env.SQUIRE_ALLOWED_EMAILS;
+  const { db } = getDb('server');
+  await db.delete(cardCharacterMats).where(inArray(cardCharacterMats.sourceId, MAT_SOURCE_IDS));
+  await teardownTestDb();
+  await shutdownServerPool();
+});
+
+describe('create-character UI (SQR-318)', () => {
+  it('renders a New character form with a class select of real class names', async () => {
+    const { owner, campaign } = await setupFixture();
+    const res = await app.request(`/campaigns/${campaign.id}`, {
+      headers: { Cookie: owner.cookie },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('squire-character-create');
+    expect(body).toContain('action="/campaigns/' + campaign.id + '/characters"');
+    // Class select offers the seeded real class names.
+    expect(body).toContain('<option value="Banner Spear">Banner Spear</option>');
+    expect(body).toContain('<option value="Drifter">Drifter</option>');
+    // Empty roster shows the create call-to-action, never fake values.
+    expect(body).toContain('No characters yet');
+  });
+
+  it('creates a character and shows it in the roster', async () => {
+    const { owner, campaign } = await setupFixture();
+    const created = await createCharacter(owner, campaign.id, {
+      name: 'Vesper',
+      className: 'Drifter',
+      level: '3',
+    });
+    expect(created.status).toBe(303);
+    expect(created.headers.get('location')).toBe(`/campaigns/${campaign.id}`);
+
+    const dash = await app.request(`/campaigns/${campaign.id}`, {
+      headers: { Cookie: owner.cookie },
+    });
+    const body = await dash.text();
+    expect(body).toContain('Vesper');
+    // The role span wraps across lines; normalize whitespace to assert content.
+    expect(body.replace(/\s+/g, ' ')).toContain('DRIFTER · L3');
+    expect(body).toContain('/characters/'); // sheet link
+  });
+
+  it('normalizes case to the canonical class name', async () => {
+    const { owner, campaign } = await setupFixture();
+    const created = await createCharacter(owner, campaign.id, {
+      name: 'Casing Hero',
+      className: 'banner spear',
+      level: '1',
+    });
+    expect(created.status).toBe(303);
+    const dash = await app.request(`/campaigns/${campaign.id}`, {
+      headers: { Cookie: owner.cookie },
+    });
+    expect((await dash.text()).replace(/\s+/g, ' ')).toContain('BANNER SPEAR · L1');
+  });
+
+  it('rejects an unknown/codename class with an inline error and no create', async () => {
+    const { owner, campaign } = await setupFixture();
+    const res = await createCharacter(owner, campaign.id, {
+      name: 'Bad Class',
+      className: 'Eclipse', // a GH2e codename, not a Frosthaven class
+      level: '1',
+    });
+    expect(res.status).toBe(422);
+    const body = await res.text();
+    expect(body).toContain('COULD NOT SAVE');
+    expect(body).toContain('not a class in this game');
+
+    // Nothing was created — the roster is still empty.
+    const dash = await app.request(`/campaigns/${campaign.id}`, {
+      headers: { Cookie: owner.cookie },
+    });
+    expect(await dash.text()).toContain('No characters yet');
+  });
+
+  it('requires a name', async () => {
+    const { owner, campaign } = await setupFixture();
+    const res = await createCharacter(owner, campaign.id, { name: '  ', className: 'Drifter' });
+    expect(res.status).toBe(422);
+    expect(await res.text()).toContain('Character name is required.');
+  });
+
+  it('404s a non-member who tries to create on a campaign they cannot see', async () => {
+    const { campaign } = await setupFixture();
+    const outsider = await createTestUser(OUTSIDER_EMAIL);
+    const res = await createCharacter(outsider, campaign.id, {
+      name: 'Intruder',
+      className: 'Drifter',
+    });
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## What

Adds a **"New character"** form to the `/campaigns/:id` dashboard Characters section, so a member can create a character (name + class + level) from the web UI. Until now the only paths to create were the JSON API and conversational onboarding — Brian hit this directly ("how do i set up characters?" / "why is there no ui for any of this?").

## How

- The Characters section now **always renders** (empty-state note + create form), not just when characters exist.
- The class field is a `<select>` sourced from the game's **real class names** (`knownClassNames`) — structurally preventing an invalid class. A game with no imported mats degrades to a free-text input.
- New web route `POST /campaigns/:id/characters` wraps `CharacterService.createCharacter`. It validates the class with `checkClassName` (covers no-JS / tampered posts), clamps level to `[1,20]`, **PRG-redirects** on success, and re-renders the dashboard with an inline `.squire-banner--error` on failure.
- A non-member gets the indistinguishable **404** (`getCampaignDetail` gates membership, per ADR 0021). The dashboard render is factored into a shared `renderCampaignDashboardPage` helper used by both GET and the create error path.
- Styling (`.squire-character-create*`) mirrors the existing campaign create form — small-caps labels, wax primary action, 44px controls.

## Files

- `src/web-ui/campaign-pages.ts` — `CharacterCreateForm` + `renderCharacterCreateForm`; always-render Characters section.
- `src/server.ts` — `renderCampaignDashboardPage` helper + `POST /campaigns/:id/characters`.
- `src/web-ui/styles.css` — `.squire-character-create*`.
- `test/campaign-character-create.test.ts` — 6 tests.

## Test plan

- `npm run check` green — **1706 tests** pass.
- New vitest: renders form + real-name class options + empty note; create persists & appears; case normalizes to canonical (`banner spear` → Banner Spear); unknown/codename class rejected (422); name required; non-member 404.
- **Browser-verified** on a Frosthaven campaign: the select lists all 17 real class names; creating "Vesper / Drifter / L3" shows `DRIFTER · L3` with a sheet link and clears the empty note; a tampered `Eclipse` (a GH2e codename) returns a 422 with a properly-escaped inline error. No console errors.

Closes SQR-318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “New character” create form to the campaign dashboard, with class options sourced from available materials.
  * Created characters are added to the roster and link to the character sheet immediately.

* **Improvements / Validation**
  * Added inline validation for missing/invalid name and class, with helpful class guidance.
  * Improved class handling by normalizing to canonical naming on submission.

* **UI / Styling**
  * Updated campaign dashboard empty-state and added styling for the character create form.

* **Tests**
  * Added end-to-end UI integration coverage for character creation, validation, and access control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->