### PR TITLE
feat(web-ui): rename a campaign from the dashboard header (SQR-320)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -857,7 +857,7 @@ app.post('/campaigns/:id/leave-web', async (c) => {
 async function renderCampaignDashboardPage(
   c: Context,
   campaignId: string,
-  opts: { characterError?: string; inviteError?: string } = {},
+  opts: { characterError?: string; inviteError?: string; renameError?: string } = {},
   status: 200 | 422 = 200,
 ): Promise<Response> {
   const session = c.get('session')!;
@@ -904,6 +904,9 @@ async function renderCampaignDashboardPage(
       // Invite-member affordance (SQR-319): form is owner-only; the error
       // banner still renders for a non-owner who tampers the route.
       { csrfToken, canInvite: isOwner, errorMessage: opts.inviteError },
+      // Rename affordance (SQR-320): any active member; the name is shared
+      // state. expectedVersion drives optimistic concurrency.
+      { csrfToken, version: detail.campaign.version, errorMessage: opts.renameError },
     ),
   });
   return c.html(body, status);
@@ -1027,6 +1030,67 @@ app.post('/campaigns/:id/invites', async (c) => {
       error instanceof CampaignService.AlreadyInvitedError
     ) {
       return await renderCampaignDashboardPage(c, campaignId, { inviteError: error.message }, 422);
+    }
+    throw error;
+  }
+});
+
+/** Rename a campaign from the dashboard header (SQR-320). */
+app.post('/campaigns/:id/rename', async (c) => {
+  const session = c.get('session')!;
+  const campaignId = campaignRouteId(c, 'id');
+  if (!campaignId) return c.notFound();
+  const identity = identityFromSessionUser(session.userId);
+  const form = await c.req.formData();
+  const name = typeof form.get('name') === 'string' ? (form.get('name') as string).trim() : '';
+  const versionRaw = form.get('expectedVersion');
+  const expectedVersion =
+    typeof versionRaw === 'string' ? Number.parseInt(versionRaw, 10) : Number.NaN;
+
+  try {
+    // getCampaignDetail gates membership: a non-member gets the 404 below.
+    // The name is shared state, so any active member may rename (no owner gate),
+    // matching updateSharedState's authorization and the scenario-toggle control.
+    await CampaignService.getCampaignDetail(identity, campaignId);
+    if (!name) {
+      return await renderCampaignDashboardPage(
+        c,
+        campaignId,
+        { renameError: 'Campaign name is required.' },
+        422,
+      );
+    }
+    if (name.length > 200) {
+      return await renderCampaignDashboardPage(
+        c,
+        campaignId,
+        { renameError: 'Campaign name must be 200 characters or fewer.' },
+        422,
+      );
+    }
+    if (!Number.isInteger(expectedVersion) || expectedVersion < 0) {
+      return await renderCampaignDashboardPage(
+        c,
+        campaignId,
+        { renameError: 'Could not save — please refresh and try again.' },
+        422,
+      );
+    }
+    await CampaignService.updateSharedState(identity, campaignId, { name, expectedVersion });
+    return c.redirect(`/campaigns/${campaignId}`, 303);
+  } catch (error) {
+    if (error instanceof CampaignService.CampaignNotFoundError) return c.notFound();
+    if (error instanceof VersionConflictError) {
+      // A concurrent edit won — re-render with the latest state + a notice.
+      return await renderCampaignDashboardPage(
+        c,
+        campaignId,
+        { renameError: 'Updated elsewhere — showing the latest. Try the rename again.' },
+        422,
+      );
+    }
+    if (error instanceof CampaignService.CampaignForbiddenError) {
+      return await renderCampaignDashboardPage(c, campaignId, { renameError: error.message }, 422);
     }
     throw error;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1272,9 +1272,9 @@ app.post('/campaigns/:id/rename', async (c) => {
   const identity = identityFromSessionUser(session.userId);
   const form = await c.req.formData();
   const name = typeof form.get('name') === 'string' ? (form.get('name') as string).trim() : '';
-  const versionRaw = form.get('expectedVersion');
-  const expectedVersion =
-    typeof versionRaw === 'string' ? Number.parseInt(versionRaw, 10) : Number.NaN;
+  // Strict parse via formInt (`/^\d+$/` → null) so a malformed token like
+  // "7abc" can't slip past Number.parseInt's leniency into the version guard.
+  const expectedVersion = formInt(form, 'expectedVersion');
 
   try {
     // getCampaignDetail gates membership: a non-member gets the 404 below.
@@ -1297,7 +1297,7 @@ app.post('/campaigns/:id/rename', async (c) => {
         422,
       );
     }
-    if (!Number.isInteger(expectedVersion) || expectedVersion < 0) {
+    if (expectedVersion === null) {
       return await renderCampaignDashboardPage(
         c,
         campaignId,

--- a/src/web-ui/campaign-pages.ts
+++ b/src/web-ui/campaign-pages.ts
@@ -263,6 +263,54 @@ function renderInviteMemberForm(campaignId: string, data: InviteMemberForm): Htm
     : html``}` as HtmlEscapedString;
 }
 
+/** The dashboard "Rename campaign" affordance (SQR-320). */
+export interface CampaignRenameForm {
+  csrfToken: string;
+  /** Optimistic-concurrency token; submitted as expectedVersion. */
+  version: number;
+  /** Inline error/notice after a failed rename (validation or version race). */
+  errorMessage?: string;
+}
+
+/**
+ * A quiet rename disclosure under the campaign title. Any active member may
+ * rename (campaign name is shared state, like the scenario toggles), so the
+ * affordance is not owner-gated. The disclosure opens automatically when a
+ * prior attempt failed so the error and form are visible.
+ */
+function renderCampaignRenameForm(campaign: Campaign, data: CampaignRenameForm): HtmlEscapedString {
+  return html`<details class="squire-campaign-rename" ${data.errorMessage ? 'open' : ''}>
+    <summary class="squire-campaign-rename__toggle">Rename</summary>
+    ${data.errorMessage
+      ? html`<div class="squire-banner squire-banner--error" role="alert">
+          <span class="squire-banner__label">COULD NOT SAVE</span>
+          <p class="squire-banner__body">${data.errorMessage}</p>
+        </div>`
+      : html``}
+    <form
+      method="post"
+      action="/campaigns/${campaign.id}/rename"
+      class="squire-campaign-rename__form"
+      aria-label="Rename campaign"
+    >
+      <input type="hidden" name="_csrf" value="${data.csrfToken}" />
+      <input type="hidden" name="expectedVersion" value="${data.version}" />
+      <label class="squire-campaign-rename__field">
+        <span class="squire-campaign-rename__field-label">CAMPAIGN NAME</span>
+        <input
+          name="name"
+          type="text"
+          required
+          maxlength="200"
+          autocomplete="off"
+          value="${campaign.name}"
+        />
+      </label>
+      <button type="submit" class="squire-campaign-rename__submit">SAVE</button>
+    </form>
+  </details>` as HtmlEscapedString;
+}
+
 /** `/campaigns/:id` — dashboard: header, threads (SQR-276), roster. */
 export function renderCampaignDashboardContent(
   detail: CampaignDetail,
@@ -271,6 +319,7 @@ export function renderCampaignDashboardContent(
   characters?: DashboardCharacterRow[],
   characterCreate?: CharacterCreateForm,
   inviteForm?: InviteMemberForm,
+  renameForm?: CampaignRenameForm,
 ): HtmlEscapedString {
   const { campaign } = detail;
   const activeMembers = detail.members.filter((member) => member.status === 'active');
@@ -283,6 +332,7 @@ export function renderCampaignDashboardContent(
         ${gameLabel(campaign.game)} · PROSPERITY ${campaign.prosperity} · PLAYED
         ${campaign.playedScenarios.length} · DRAWN ${campaign.drawnScenarios.length}
       </p>
+      ${renameForm ? renderCampaignRenameForm(campaign, renameForm) : html``}
     </header>
     <section class="squire-campaign-dashboard__roster" aria-label="Party roster">
       <h2 class="squire-campaign-dashboard__section-title">Party</h2>

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -2279,6 +2279,76 @@ template#squire-banner-fixtures {
   background: var(--wax-dim);
 }
 
+/* Rename campaign (SQR-320): a quiet disclosure under the title. */
+.squire-campaign-rename {
+  margin-top: var(--space-sm);
+}
+
+.squire-campaign-rename__toggle {
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--sepia-dim);
+  cursor: pointer;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+}
+
+.squire-campaign-rename__toggle:hover {
+  color: var(--sepia);
+}
+
+.squire-campaign-rename__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  align-items: end;
+  margin-top: var(--space-sm);
+}
+
+.squire-campaign-rename__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.squire-campaign-rename__field-label {
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--sepia);
+}
+
+.squire-campaign-rename__field input {
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  color: var(--parchment);
+  min-height: 44px;
+  padding: 0 var(--space-sm);
+  font-family: 'Geist', system-ui, sans-serif;
+  min-width: 16rem;
+}
+
+.squire-campaign-rename__submit {
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--parchment);
+  background: var(--wax);
+  border: 1px solid var(--wax);
+  border-radius: 4px;
+  padding: 0 var(--space-md);
+  min-height: 44px;
+  cursor: pointer;
+}
+
+.squire-campaign-rename__submit:hover {
+  background: var(--wax-dim);
+}
+
 .squire-campaigns__row-actions {
   display: flex;
   gap: var(--space-sm);

--- a/test/campaign-rename.test.ts
+++ b/test/campaign-rename.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Rename-a-campaign web UI tests (SQR-320).
+ *
+ * A quiet rename disclosure under the dashboard title. The campaign name is
+ * shared state, so any active member may rename (matching updateSharedState's
+ * authorization and the scenario-toggle control) — not owner-gated. Renaming
+ * updates the title AND the header context strip; empty/over-long names and
+ * stale version tokens surface inline; a non-member gets the 404.
+ */
+import { generateSignedCookie } from 'hono/cookie';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+process.env.SESSION_SECRET = 'test-session-secret-must-be-at-least-32-characters-long';
+
+import { app } from '../src/server.ts';
+import { getDb, shutdownServerPool } from '../src/db.ts';
+import { createCsrfToken } from '../src/auth/csrf.ts';
+import { SESSION_COOKIE_NAME, getSessionSecret } from '../src/auth/session-middleware.ts';
+import * as SessionRepository from '../src/db/repositories/session-repository.ts';
+import { SESSION_LIFETIME_MS } from '../src/db/repositories/session-repository.ts';
+import * as CampaignService from '../src/campaign/campaign-service.ts';
+import { identityFromSessionUser } from '../src/campaign/identity.ts';
+import { users } from '../src/db/schema/core.ts';
+import { resetTestDb, setupTestDb, teardownTestDb } from './helpers/db.ts';
+
+interface TestUser {
+  cookie: string;
+  sessionId: string;
+  userId: string;
+}
+
+const OWNER_EMAIL = 'owner@example.com';
+const MEMBER_EMAIL = 'member@example.com';
+const OUTSIDER_EMAIL = 'outsider@example.com';
+
+async function createTestUser(email: string): Promise<TestUser> {
+  const { db } = getDb('server');
+  const [user] = await db
+    .insert(users)
+    .values({ email, googleSub: `google-sub-${email}`, name: email.split('@')[0] })
+    .returning();
+  const { sessionId } = await SessionRepository.create(db, { userId: user.id });
+  const signedCookie = await generateSignedCookie(
+    SESSION_COOKIE_NAME,
+    sessionId,
+    getSessionSecret(),
+    { path: '/', httpOnly: true, sameSite: 'Lax', maxAge: SESSION_LIFETIME_MS / 1000 },
+  );
+  return { cookie: signedCookie.split(';')[0], sessionId, userId: user.id };
+}
+
+async function setupFixture() {
+  const owner = await createTestUser(OWNER_EMAIL);
+  const campaign = await CampaignService.createCampaign(identityFromSessionUser(owner.userId), {
+    name: 'Original Name',
+    game: 'frosthaven',
+    modules: [],
+  });
+  return { owner, campaign };
+}
+
+async function addActiveMember(
+  owner: TestUser,
+  campaignId: string,
+  email: string,
+): Promise<TestUser> {
+  const invite = await CampaignService.inviteMember(
+    identityFromSessionUser(owner.userId),
+    campaignId,
+    email,
+  );
+  const user = await createTestUser(email);
+  await CampaignService.acceptInvite(identityFromSessionUser(user.userId), invite.memberId);
+  return user;
+}
+
+async function rename(
+  user: TestUser,
+  campaignId: string,
+  name: string,
+  expectedVersion: number | string,
+): Promise<Response> {
+  const form = new FormData();
+  form.set('_csrf', createCsrfToken(user.sessionId));
+  form.set('name', name);
+  form.set('expectedVersion', String(expectedVersion));
+  return app.request(`/campaigns/${campaignId}/rename`, {
+    method: 'POST',
+    headers: { Cookie: user.cookie, 'HX-Request': 'true' },
+    body: form,
+  });
+}
+
+beforeAll(async () => {
+  await setupTestDb();
+});
+
+beforeEach(async () => {
+  await resetTestDb();
+  process.env.SQUIRE_ALLOWED_EMAILS = [OWNER_EMAIL, MEMBER_EMAIL].join(',');
+});
+
+afterAll(async () => {
+  delete process.env.SQUIRE_ALLOWED_EMAILS;
+  await teardownTestDb();
+  await shutdownServerPool();
+});
+
+describe('rename-campaign UI (SQR-320)', () => {
+  it('renders the rename disclosure on the dashboard', async () => {
+    const { owner, campaign } = await setupFixture();
+    const body = await (
+      await app.request(`/campaigns/${campaign.id}`, { headers: { Cookie: owner.cookie } })
+    ).text();
+    expect(body).toContain('squire-campaign-rename');
+    expect(body).toContain('action="/campaigns/' + campaign.id + '/rename"');
+    expect(body).toContain('CAMPAIGN NAME');
+    // The current name pre-fills the input.
+    expect(body).toContain('value="Original Name"');
+  });
+
+  it('renames the campaign and updates the title + context strip', async () => {
+    const { owner, campaign } = await setupFixture();
+    const res = await rename(owner, campaign.id, 'Renamed Quest', campaign.version);
+    expect(res.status).toBe(303);
+    expect(res.headers.get('location')).toBe(`/campaigns/${campaign.id}`);
+
+    const body = await (
+      await app.request(`/campaigns/${campaign.id}`, { headers: { Cookie: owner.cookie } })
+    ).text();
+    // Title (h1).
+    expect(body).toContain('>Renamed Quest</h1>');
+    // Header context strip rebuilt from the new name.
+    expect(body.replace(/\s+/g, ' ')).toContain('RENAMED QUEST');
+    expect(body).not.toContain('>Original Name</h1>');
+  });
+
+  it('lets any active member rename (name is shared state, not owner-gated)', async () => {
+    const { owner, campaign } = await setupFixture();
+    const member = await addActiveMember(owner, campaign.id, MEMBER_EMAIL);
+    const res = await rename(member, campaign.id, 'Member Renamed', campaign.version);
+    expect(res.status).toBe(303);
+    const body = await (
+      await app.request(`/campaigns/${campaign.id}`, { headers: { Cookie: member.cookie } })
+    ).text();
+    expect(body).toContain('>Member Renamed</h1>');
+  });
+
+  it('rejects an empty name with an inline error', async () => {
+    const { owner, campaign } = await setupFixture();
+    const res = await rename(owner, campaign.id, '   ', campaign.version);
+    expect(res.status).toBe(422);
+    const body = await res.text();
+    expect(body).toContain('COULD NOT SAVE');
+    expect(body).toContain('Campaign name is required.');
+  });
+
+  it('rejects an over-long name', async () => {
+    const { owner, campaign } = await setupFixture();
+    const res = await rename(owner, campaign.id, 'x'.repeat(201), campaign.version);
+    expect(res.status).toBe(422);
+    expect(await res.text()).toContain('200 characters or fewer');
+  });
+
+  it('surfaces a version conflict (stale expectedVersion)', async () => {
+    const { owner, campaign } = await setupFixture();
+    // First rename succeeds and bumps the version.
+    await rename(owner, campaign.id, 'First', campaign.version);
+    // Second rename reuses the now-stale original version.
+    const conflict = await rename(owner, campaign.id, 'Second', campaign.version);
+    expect(conflict.status).toBe(422);
+    expect(await conflict.text()).toContain('Updated elsewhere');
+  });
+
+  it('404s a non-member who posts the rename route', async () => {
+    const { campaign } = await setupFixture();
+    const outsider = await createTestUser(OUTSIDER_EMAIL);
+    const res = await rename(outsider, campaign.id, 'Hijack', campaign.version);
+    expect(res.status).toBe(404);
+  });
+});

--- a/test/campaign-rename.test.ts
+++ b/test/campaign-rename.test.ts
@@ -172,6 +172,14 @@ describe('rename-campaign UI (SQR-320)', () => {
     expect(await conflict.text()).toContain('Updated elsewhere');
   });
 
+  it('rejects a malformed version token instead of parsing it leniently', async () => {
+    const { owner, campaign } = await setupFixture();
+    // "7abc" must not parse to 7 (Number.parseInt would); strict /^\d+$/ rejects.
+    const res = await rename(owner, campaign.id, 'New Name', '7abc');
+    expect(res.status).toBe(422);
+    expect(await res.text()).toContain('Could not save');
+  });
+
   it('404s a non-member who posts the rename route', async () => {
     const { campaign } = await setupFixture();
     const outsider = await createTestUser(OUTSIDER_EMAIL);

--- a/test/helpers/test-slices.ts
+++ b/test/helpers/test-slices.ts
@@ -22,6 +22,7 @@ export const DB_BACKED_TEST_FILES = [
   'test/campaign-live-migration.test.ts',
   'test/campaign-pages.test.ts',
   'test/campaign-proposals.test.ts',
+  'test/campaign-rename.test.ts',
   'test/campaign-write-tools.test.ts',
   'test/character-sheet.test.ts',
   'test/profile-page.test.ts',


### PR DESCRIPTION
## What

Adds a quiet **Rename** disclosure under the campaign title on `/campaigns/:id`, so a campaign can be renamed from the web UI (previously only conversational or via the JSON API).

## How

- A `<details>` "Rename" disclosure under the title with a name input pre-filled from the current name + a hidden `expectedVersion`. The disclosure auto-opens when a prior attempt errored, so the message and form are visible.
- New web route `POST /campaigns/:id/rename` wraps `CampaignService.updateSharedState({ name, expectedVersion })`. Validates non-empty + max 200; **optimistic-concurrency aware** (`VersionConflictError` → inline "Updated elsewhere — showing the latest"); a non-member gets the indistinguishable **404**.
- On success the shared dashboard renderer rebuilds **both the title and the header context strip** from the new name.
- `.squire-campaign-rename*` styling, 4px input radius per DESIGN.md's small-element vocabulary.

## Permission decision (deviates from the ticket's "owner-only")

Rename is allowed to **any active member**, not owner-only. The campaign name is **shared state** — the JSON `PATCH /api/campaigns/:id` routes through `updateSharedState`, which authorizes any active member (same gate as the scenario-toggle control). Owner-gating only the web path would invent a new restriction and create an API/UI asymmetry. See the [SQR-320 Linear comment](https://linear.app/maz-org/issue/SQR-320) — trivially flippable to owner-only if preferred.

## Files

- `src/web-ui/campaign-pages.ts` — `CampaignRenameForm` + `renderCampaignRenameForm`; disclosure in the header.
- `src/server.ts` — `POST /campaigns/:id/rename`; pass the rename form through the shared renderer.
- `src/web-ui/styles.css` — `.squire-campaign-rename*`.
- `test/campaign-rename.test.ts` — 7 tests; registered in `DB_BACKED_TEST_FILES` (serial slice).

## Test plan

- 7 vitest pass in isolation: renders disclosure; rename updates title + context strip + bumps version; **any active member** can rename; empty name; over-long name; version conflict; non-member 404.
- **Browser-verified** on a Frosthaven campaign: renamed to "Frosthaven North Party" → title + strip (`FH · FROSTHAVEN NORTH PARTY`) both update, version bumps to 2; a stale version returns "Updated elsewhere"; an empty name returns the required error.
- _Note: the full local `npm run check` is currently blocked by an unrelated agent worktree under `.claude/worktrees/` whose `node_modules` markdown trips `lint:md` (14708 errors, 0 in this tree); CI on a clean checkout is the authoritative gate._

Closes SQR-320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaign rename functionality is now available, enabling any active member to update the campaign name directly from the dashboard with built-in validation and error feedback.
  * Names are validated for length (maximum 200 characters) and must be non-empty.

* **Style**
  * Added styling for the campaign rename interface and form controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->