### PR TITLE
v0.1.20 feat: capture server errors in Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.20] - 2026-06-14
+
+### Added
+
+- Initialized server-side Sentry through the Squire telemetry boundary after existing LangSmith/OpenTelemetry instrumentation.
+- Captured unhandled Hono server errors and startup failures with safe request, route, status, user-id, and release metadata while preserving generic user-facing failures.
+
 ## [0.1.19] - 2026-06-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.104.1",
         "@aws-sdk/client-s3": "^3.1068.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "engines": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -158,6 +158,15 @@ import {
 } from './chat/conversation-service.ts';
 import * as MessageStreamEventRepository from './db/repositories/message-stream-event-repository.ts';
 import type { BrowserStreamEventName } from './db/repositories/message-stream-event-repository.ts';
+import {
+  captureTelemetryError,
+  flushTelemetry,
+  initTelemetry,
+  type TelemetryCaptureInput,
+  type TelemetryUserIdentity,
+} from './telemetry.ts';
+
+initTelemetry(process.env);
 
 export const app = new Hono();
 
@@ -218,13 +227,58 @@ function auditContext(c: Context): { ipAddress: string | null; userAgent: string
 }
 
 function correlateRequest(c: Context): string {
+  const existingRequestId = c.get('requestId');
+  if (typeof existingRequestId === 'string' && existingRequestId.trim().length > 0) {
+    c.header('X-Request-ID', existingRequestId);
+    return existingRequestId;
+  }
+
   const incomingRequestId = c.req.header('x-request-id');
   const requestId =
     incomingRequestId && /^[A-Za-z0-9._:-]{1,128}$/.test(incomingRequestId)
       ? incomingRequestId
       : randomUUID();
+  c.set('requestId', requestId);
   c.header('X-Request-ID', requestId);
   return requestId;
+}
+
+function safeRequestRoute(c: Context): string {
+  try {
+    return c.req.routePath || c.req.path;
+  } catch {
+    return c.req.path;
+  }
+}
+
+function safeUserFromContext(c: Context): TelemetryUserIdentity | undefined {
+  const callerIdentity = c.get('callerIdentity') as CallerIdentity | undefined;
+  if (callerIdentity?.userId) return { id: callerIdentity.userId };
+
+  const authInfo = c.get('authInfo') as AuthInfo | undefined;
+  const tokenUserId = userIdFromAuthInfo(authInfo);
+  if (tokenUserId) return { id: tokenUserId };
+
+  const session = c.get('session') as { userId?: unknown } | undefined;
+  return typeof session?.userId === 'string' && session.userId.trim().length > 0
+    ? { id: session.userId }
+    : undefined;
+}
+
+function buildServerErrorTelemetry(c: Context, requestId: string): TelemetryCaptureInput {
+  const route = safeRequestRoute(c);
+  return {
+    route,
+    requestId,
+    user: safeUserFromContext(c),
+    context: {
+      surface: 'server',
+      method: c.req.method,
+      path: c.req.path,
+      route,
+      status: 500,
+    },
+  };
 }
 
 async function checkRegisterRateLimit(c: Context): Promise<RateLimitDecision> {
@@ -2716,6 +2770,8 @@ app.notFound((c) => {
 
 app.onError((err, c) => {
   console.error('Unhandled error:', err instanceof Error ? err.message : err);
+  const requestId = correlateRequest(c);
+  captureTelemetryError(err, buildServerErrorTelemetry(c, requestId));
   return c.json(jsonError('Internal server error', 500), 500);
 });
 
@@ -3582,14 +3638,26 @@ app.delete('/api/characters/:id/cards/:cardId', async (c) => {
 
 export async function startServer(): Promise<void> {
   const { createAdaptorServer } = await import('@hono/node-server');
-  await startHttpServer({
-    appFetch: app.fetch,
-    createAdaptorServer,
-    loadServerConfig,
-    getWorktreeRuntime,
-    claimWorktreePort,
-    startBootstrapLifecycle,
-  });
+  try {
+    await startHttpServer({
+      appFetch: app.fetch,
+      createAdaptorServer,
+      loadServerConfig,
+      getWorktreeRuntime,
+      claimWorktreePort,
+      startBootstrapLifecycle,
+    });
+  } catch (error) {
+    captureTelemetryError(error, {
+      route: 'server.startup',
+      context: {
+        surface: 'server',
+        phase: 'startup',
+      },
+    });
+    await flushTelemetry(2_000);
+    throw error;
+  }
 }
 
 // CLI entrypoint

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -71,6 +71,9 @@ const {
   mockListCards,
   mockGetCard,
   mockRunReadinessChecks,
+  mockInitTelemetry,
+  mockCaptureTelemetryError,
+  mockFlushTelemetry,
 } = vi.hoisted(() => ({
   mockInitialize: vi.fn(),
   mockEnsureBootstrapStatus: vi.fn(),
@@ -85,6 +88,9 @@ const {
   mockListCards: vi.fn(),
   mockGetCard: vi.fn(),
   mockRunReadinessChecks: vi.fn(),
+  mockInitTelemetry: vi.fn(() => ({ enabled: false, reason: 'missing_dsn' })),
+  mockCaptureTelemetryError: vi.fn(),
+  mockFlushTelemetry: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('../src/service.ts', () => ({
@@ -111,6 +117,12 @@ vi.mock('../src/tools.ts', () => ({
 
 vi.mock('../src/health.ts', () => ({
   runReadinessChecks: mockRunReadinessChecks,
+}));
+
+vi.mock('../src/telemetry.ts', () => ({
+  initTelemetry: mockInitTelemetry,
+  captureTelemetryError: mockCaptureTelemetryError,
+  flushTelemetry: mockFlushTelemetry,
 }));
 
 // Bypass the Drizzle-backed auth provider — these tests don't exercise OAuth
@@ -376,6 +388,53 @@ describe('GET /api/search/rules', () => {
   it('defaults topK to 6', async () => {
     await app.request('/api/search/rules?q=loot', { headers: await auth() });
     expect(mockSearchRules).toHaveBeenCalledWith('loot', 6);
+  });
+
+  it('captures unhandled server errors once while keeping the generic 500 response', async () => {
+    const error = new Error('database unavailable');
+    mockSearchRules.mockRejectedValueOnce(error);
+    mockVerifyAccessToken.mockResolvedValueOnce({
+      token: 'stub',
+      clientId: 'stub-client',
+      scopes: [],
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      extra: { userId: 'user-123' },
+    });
+
+    const res = await app.request('/api/search/rules?q=loot', {
+      headers: {
+        Authorization: 'Bearer stub-token',
+        Cookie: 'session=secret',
+        'X-Request-ID': 'req-server-error-1',
+      },
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.headers.get('X-Request-ID')).toBe('req-server-error-1');
+    await expect(res.json()).resolves.toEqual({
+      error: 'Internal server error',
+      status: 500,
+    });
+    expect(mockCaptureTelemetryError).toHaveBeenCalledTimes(1);
+    expect(mockCaptureTelemetryError).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        route: '/api/search/rules',
+        requestId: 'req-server-error-1',
+        user: { id: 'user-123' },
+        context: {
+          surface: 'server',
+          method: 'GET',
+          path: '/api/search/rules',
+          route: '/api/search/rules',
+          status: 500,
+        },
+      }),
+    );
+    const telemetryInput = JSON.stringify(mockCaptureTelemetryError.mock.calls[0][1]);
+    expect(telemetryInput).not.toContain('Bearer stub-token');
+    expect(telemetryInput).not.toContain('session=secret');
+    expect(telemetryInput).not.toContain('loot');
   });
 
   it('returns 400 for unsupported game ids before searching rules', async () => {

--- a/test/start-server.test.ts
+++ b/test/start-server.test.ts
@@ -4,11 +4,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 class FakeServer extends EventEmitter {
   listenCalls: number[] = [];
   refCalls = 0;
+  listenError: Error | null = null;
 
   listen(port: number, _host?: string): this {
     this.listenCalls.push(port);
     queueMicrotask(() => {
-      this.emit('listening');
+      if (this.listenError) {
+        this.emit('error', this.listenError);
+      } else {
+        this.emit('listening');
+      }
     });
     return this;
   }
@@ -24,6 +29,7 @@ async function loadStartServer(options: {
   configuredHost?: string;
   claimedPort?: number;
   bootstrapImpl?: () => unknown;
+  listenError?: Error;
 }) {
   vi.resetModules();
 
@@ -42,6 +48,7 @@ async function loadStartServer(options: {
   vi.stubEnv('VITEST', 'true');
 
   const fakeServer = new FakeServer();
+  fakeServer.listenError = options.listenError ?? null;
   const createAdaptorServer = vi.fn(() => fakeServer);
   const claimRelease = vi.fn().mockResolvedValue(undefined);
   const claimWorktreePort = vi.fn().mockResolvedValue({
@@ -49,11 +56,19 @@ async function loadStartServer(options: {
     release: claimRelease,
   });
   const startBootstrapLifecycle = vi.fn(options.bootstrapImpl ?? (() => undefined));
+  const initTelemetry = vi.fn(() => ({ enabled: false, reason: 'missing_dsn' }));
+  const captureTelemetryError = vi.fn();
+  const flushTelemetry = vi.fn().mockResolvedValue(true);
 
   vi.doMock('@hono/node-server', () => ({
     createAdaptorServer,
   }));
   vi.doMock('../src/instrumentation.ts', () => ({}));
+  vi.doMock('../src/telemetry.ts', () => ({
+    initTelemetry,
+    captureTelemetryError,
+    flushTelemetry,
+  }));
   vi.doMock('../src/service.ts', () => ({
     ask: vi.fn(),
     ensureBootstrapStatus: vi.fn().mockResolvedValue({
@@ -177,6 +192,9 @@ async function loadStartServer(options: {
     createAdaptorServer,
     claimWorktreePort,
     startBootstrapLifecycle,
+    initTelemetry,
+    captureTelemetryError,
+    flushTelemetry,
   };
 }
 
@@ -210,5 +228,27 @@ describe.sequential('startServer', () => {
     expect(claimed.fakeServer.listenCalls).toContain(4555);
     expect(claimed.fakeServer.refCalls).toBe(1);
     expect(claimed.startBootstrapLifecycle).toHaveBeenCalled();
+  }, 30_000);
+
+  it('captures and flushes startup failures before rethrowing', async () => {
+    const listenError = Object.assign(new Error('address already in use'), { code: 'EADDRINUSE' });
+    const configured = await loadStartServer({
+      configuredPort: '4123',
+      listenError,
+    });
+
+    await expect(configured.startServer()).rejects.toBe(listenError);
+
+    expect(configured.captureTelemetryError).toHaveBeenCalledWith(
+      listenError,
+      expect.objectContaining({
+        route: 'server.startup',
+        context: {
+          surface: 'server',
+          phase: 'startup',
+        },
+      }),
+    );
+    expect(configured.flushTelemetry).toHaveBeenCalledWith(2_000);
   }, 30_000);
 });


### PR DESCRIPTION
## Summary
- initialize server-side Sentry through the Squire telemetry boundary after existing LangSmith/OpenTelemetry instrumentation
- capture Hono app.onError failures with safe route/request/user/status context while preserving the generic 500 response
- capture and flush startup failures before rethrowing from startServer
- bump release metadata to 0.1.20

## Tests
- npm test -- test/server-api.test.ts test/start-server.test.ts test/telemetry.test.ts
- npm run typecheck
- npm run lint
- npm run lint:css
- npm run lint:md
- npm run lint:actions
- npm run format:check
- npm test
- git diff --check
- npm audit --omit=dev

Closes SQR-303