### PR TITLE
v0.1.21 feat: capture chat failures in Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.21] - 2026-06-14
+
+### Added
+
+- Captured web-chat, SSE, and `/api/ask` failures in Sentry with safe request, route, user, conversation, message, game, and LangSmith thread-id metadata.
+- Added chat telemetry tests proving generic assistant failure rows and SSE error events are unchanged while raw prompts, partial answers, and provider error text stay out of Sentry inputs.
+
 ## [0.1.20] - 2026-06-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.104.1",
         "@aws-sdk/client-s3": "^3.1068.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "engines": {

--- a/src/chat/chat-telemetry.ts
+++ b/src/chat/chat-telemetry.ts
@@ -1,0 +1,69 @@
+import {
+  captureTelemetryError,
+  type TelemetryCaptureInput,
+  type TelemetryUserIdentity,
+} from '../telemetry.ts';
+
+export type ChatTelemetrySurface = 'web_chat' | 'chat_sse' | 'api_ask';
+
+export interface ChatFailureTelemetryInput {
+  surface: ChatTelemetrySurface;
+  failureKind: 'assistant_turn' | 'api_ask';
+  route?: string;
+  requestId?: string;
+  conversationId?: string;
+  userMessageId?: string;
+  assistantMessageId?: string;
+  user?: TelemetryUserIdentity;
+  game?: string | null;
+  context?: Record<string, unknown>;
+}
+
+function originalErrorName(error: unknown): string {
+  if (!(error instanceof Error)) return 'Error';
+  const name = error.name.trim();
+  return /^[A-Za-z][A-Za-z0-9_.:-]{0,63}$/.test(name) ? name : 'Error';
+}
+
+function safeErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const candidate =
+    (error as { code?: unknown }).code ?? (error as { cause?: { code?: unknown } }).cause?.code;
+  if (typeof candidate !== 'string') return undefined;
+
+  const code = candidate.trim();
+  return /^[A-Z0-9_:-]{1,64}$/.test(code) ? code : undefined;
+}
+
+function safeChatFailureError(error: unknown): Error {
+  const safe = new Error('Squire chat failure');
+  safe.name = `ChatFailure:${originalErrorName(error)}`;
+  return safe;
+}
+
+export function captureChatFailureTelemetry(
+  error: unknown,
+  input: ChatFailureTelemetryInput,
+): void {
+  const context = {
+    ...(input.context ?? {}),
+    surface: input.surface,
+    failureKind: input.failureKind,
+    game: input.game ?? null,
+    originalErrorName: originalErrorName(error),
+    langsmithThreadId: input.conversationId ?? input.userMessageId ?? null,
+    ...(safeErrorCode(error) ? { originalErrorCode: safeErrorCode(error) } : {}),
+  };
+
+  const telemetryInput: TelemetryCaptureInput = {
+    route: input.route,
+    requestId: input.requestId,
+    conversationId: input.conversationId,
+    userMessageId: input.userMessageId,
+    assistantMessageId: input.assistantMessageId,
+    user: input.user,
+    context,
+  };
+
+  captureTelemetryError(safeChatFailureError(error), telemetryInput);
+}

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -12,6 +12,7 @@ import type {
 } from '../db/repositories/types.ts';
 import { SUPPORTED_GAMES } from '../game.ts';
 import { retrievalSourceLabelToFooterLabel } from '../web-ui/consulted-footer.ts';
+import { captureChatFailureTelemetry, type ChatTelemetrySurface } from './chat-telemetry.ts';
 
 const HISTORY_LIMIT = 20;
 const RETRY_DELAY_MS = 200;
@@ -41,6 +42,11 @@ export interface ConversationHistoryViewModel {
   rows: ConversationHistoryViewRow[];
   nextCursor: string | null;
   query?: string;
+}
+
+interface ConversationTelemetryOptions {
+  route?: string;
+  surface?: ChatTelemetrySurface;
 }
 
 const DEFAULT_HISTORY_LIMIT = 30;
@@ -290,6 +296,7 @@ async function persistAssistantOutcome(input: {
   requestId?: string;
   onEvent?: EmitFn;
   failureMessage?: string;
+  telemetry?: ConversationTelemetryOptions;
 }): Promise<ConversationMessage> {
   const priorMessages = await MessageRepository.listByConversationId(input.conversationId, {
     includeErrors: false,
@@ -408,6 +415,20 @@ async function persistAssistantOutcome(input: {
         input.conversationId,
         failureMessage.createdAt,
       );
+      captureChatFailureTelemetry(err, {
+        route: input.telemetry?.route,
+        surface: input.telemetry?.surface ?? (input.onEvent ? 'chat_sse' : 'web_chat'),
+        failureKind: 'assistant_turn',
+        requestId: input.requestId,
+        conversationId: input.conversationId,
+        userMessageId: input.currentUserMessageId,
+        assistantMessageId: failureMessage.id,
+        user: { id: input.userId },
+        game: input.game ?? currentMessage?.game ?? null,
+        context: {
+          persistedAssistantFailure: true,
+        },
+      });
       return failureMessage;
     }
   });
@@ -528,6 +549,7 @@ export async function streamAssistantTurn(input: {
   requestId?: string;
   onEvent: EmitFn;
   failureMessage?: string;
+  telemetry?: ConversationTelemetryOptions;
 }): Promise<ConversationMessage> {
   return persistAssistantOutcome({
     conversationId: input.conversationId,
@@ -539,6 +561,7 @@ export async function streamAssistantTurn(input: {
     requestId: input.requestId,
     onEvent: input.onEvent,
     failureMessage: input.failureMessage,
+    telemetry: input.telemetry,
   });
 }
 
@@ -586,6 +609,7 @@ export async function startConversation(input: {
   game?: string;
   campaignId?: string | null;
   requestId?: string;
+  telemetry?: ConversationTelemetryOptions;
 }): Promise<Conversation> {
   const result = await createConversationTurn(input);
   if (result.currentUserMessage) {
@@ -596,6 +620,7 @@ export async function startConversation(input: {
       currentUserMessageId: result.currentUserMessage.id,
       game: result.currentUserMessage.game ?? input.game,
       requestId: input.requestId,
+      telemetry: input.telemetry,
     });
   }
 
@@ -612,6 +637,7 @@ export async function appendMessage(input: {
   game?: string;
   campaignId?: string | null;
   requestId?: string;
+  telemetry?: ConversationTelemetryOptions;
 }): Promise<Conversation | null> {
   const result = await createPendingFollowUp(input);
   if (!result?.currentUserMessage) return null;
@@ -623,6 +649,7 @@ export async function appendMessage(input: {
     currentUserMessageId: result.currentUserMessage.id,
     game: result.currentUserMessage.game ?? input.game,
     requestId: input.requestId,
+    telemetry: input.telemetry,
   });
 
   return ConversationRepository.findOwnedById(input.userId, input.conversationId);

--- a/src/server.ts
+++ b/src/server.ts
@@ -156,6 +156,7 @@ import {
   startConversation,
   streamAssistantTurn,
 } from './chat/conversation-service.ts';
+import { captureChatFailureTelemetry } from './chat/chat-telemetry.ts';
 import * as MessageStreamEventRepository from './db/repositories/message-stream-event-repository.ts';
 import type { BrowserStreamEventName } from './db/repositories/message-stream-event-repository.ts';
 import {
@@ -2176,6 +2177,7 @@ app.post('/chat', async (c) => {
     game,
     campaignId: await chatCampaignBinding(session.userId, rawCampaignId),
     requestId,
+    telemetry: { route: '/chat', surface: 'web_chat' },
   });
 
   c.header('Cache-Control', 'no-store');
@@ -2241,6 +2243,7 @@ app.post('/chat/:conversationId/messages', async (c) => {
     game,
     campaignId: await chatCampaignBinding(session.userId, rawCampaignId),
     requestId,
+    telemetry: { route: '/chat/:conversationId/messages', surface: 'web_chat' },
   });
   if (!conversation) return c.notFound();
 
@@ -2430,6 +2433,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
       currentUserMessageId: loaded.message.id,
       game: loaded.message.game ?? undefined,
       requestId,
+      telemetry: { route: '/chat/:conversationId/messages/:messageId/stream', surface: 'chat_sse' },
       onEvent: async (event, data) => {
         if (event === 'text') {
           await persistAndWrite('text-delta', data);
@@ -3017,7 +3021,18 @@ app.post('/api/ask', async (c) => {
           await stream.writeSSE({ event, data: JSON.stringify(data) });
         },
       });
-    } catch {
+    } catch (error) {
+      captureChatFailureTelemetry(error, {
+        route: '/api/ask',
+        surface: 'api_ask',
+        failureKind: 'api_ask',
+        requestId,
+        user: safeUserFromContext(c),
+        game: options.game ?? null,
+        context: {
+          method: 'POST',
+        },
+      });
       await stream.writeSSE({
         event: 'error',
         data: JSON.stringify({ message: 'Internal server error' }),

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -4,9 +4,14 @@ import { generateSignedCookie } from 'hono/cookie';
 
 import { resetTestDb, setupTestDb, teardownTestDb } from './helpers/db.ts';
 
-const { mockAsk } = vi.hoisted(() => ({
-  mockAsk: vi.fn(),
-}));
+const { mockAsk, mockInitTelemetry, mockCaptureTelemetryError, mockFlushTelemetry } = vi.hoisted(
+  () => ({
+    mockAsk: vi.fn(),
+    mockInitTelemetry: vi.fn(() => ({ enabled: false, reason: 'missing_dsn' })),
+    mockCaptureTelemetryError: vi.fn(),
+    mockFlushTelemetry: vi.fn().mockResolvedValue(true),
+  }),
+);
 
 vi.mock('../src/service.ts', () => ({
   initialize: vi.fn(),
@@ -44,6 +49,12 @@ vi.mock('../src/tools.ts', () => ({
   listCardTypes: vi.fn(),
   listCards: vi.fn(),
   getCard: vi.fn(),
+}));
+
+vi.mock('../src/telemetry.ts', () => ({
+  initTelemetry: mockInitTelemetry,
+  captureTelemetryError: mockCaptureTelemetryError,
+  flushTelemetry: mockFlushTelemetry,
 }));
 
 process.env.SESSION_SECRET = 'test-session-secret-must-be-at-least-32-characters-long';
@@ -1344,7 +1355,10 @@ describe('conversation web backend', () => {
     const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
       method: 'POST',
       csrf: true,
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-request-id': 'req-chat-failure-1',
+      },
       body: formBody({
         question: 'Will this fail?',
         idempotencyKey: 'idem-failure',
@@ -1362,17 +1376,47 @@ describe('conversation web backend', () => {
 
     const { db } = getDb('server');
     const messages = await db.execute(sql`
-      select role, content
+      select id, role, content, response_to_message_id as "responseToMessageId"
       from messages
       order by created_at asc, id asc
     `);
-    expect(messages.rows).toEqual([
+    expect(messages.rows.map(({ role, content }) => ({ role, content }))).toEqual([
       { role: 'user', content: 'Will this fail?' },
       {
         role: 'assistant',
         content: "I hit an error and couldn't answer that. Please try again.",
       },
     ]);
+
+    const userMessage = messages.rows.find((row) => row.role === 'user')!;
+    const assistantMessage = messages.rows.find((row) => row.role === 'assistant')!;
+    expect(mockCaptureTelemetryError).toHaveBeenCalledTimes(1);
+    const [capturedError, telemetryInput] = mockCaptureTelemetryError.mock.calls[0]!;
+    expect(capturedError).toEqual(
+      expect.objectContaining({
+        name: 'ChatFailure:Error',
+        message: 'Squire chat failure',
+      }),
+    );
+    expect(JSON.stringify(capturedError)).not.toContain('upstream exploded');
+    expect(telemetryInput).toEqual(
+      expect.objectContaining({
+        route: '/chat',
+        requestId: 'req-chat-failure-1',
+        conversationId: location.split('/').at(-1),
+        userMessageId: userMessage.id,
+        assistantMessageId: assistantMessage.id,
+        user: { id: auth.userId },
+        context: expect.objectContaining({
+          surface: 'web_chat',
+          failureKind: 'assistant_turn',
+          game: null,
+          originalErrorName: 'Error',
+          persistedAssistantFailure: true,
+        }),
+      }),
+    );
+    expect(JSON.stringify(telemetryInput)).not.toContain('Will this fail?');
   });
 
   it('forwards prior stored history unchanged on follow-up messages', async () => {
@@ -2862,7 +2906,9 @@ describe('conversation web backend', () => {
     const streamUrl = body.match(/data-stream-url="([^"]+)"/)?.[1];
     expect(streamUrl).toBeTruthy();
 
-    const streamRes = await requestWithAuth(auth, `http://localhost:3000${streamUrl}`);
+    const streamRes = await requestWithAuth(auth, `http://localhost:3000${streamUrl}`, {
+      headers: { 'x-request-id': 'req-chat-sse-1' },
+    });
     const events = parseSse(await streamRes.text());
     expect(events).toEqual([
       {
@@ -2879,6 +2925,46 @@ describe('conversation web backend', () => {
       },
     ]);
     expect(mockAsk).toHaveBeenCalledTimes(1);
+
+    const streamMatch = streamUrl!.match(/^\/chat\/([^/]+)\/messages\/([^/]+)\/stream$/);
+    expect(streamMatch).toBeTruthy();
+    const [, conversationId, userMessageId] = streamMatch!;
+    const { db } = getDb('server');
+    const assistantMessages = await db.execute(sql`
+      select id, response_to_message_id as "responseToMessageId"
+      from messages
+      where role = 'assistant'
+      order by created_at asc, id asc
+    `);
+    expect(assistantMessages.rows).toHaveLength(1);
+
+    expect(mockCaptureTelemetryError).toHaveBeenCalledTimes(1);
+    const [capturedError, telemetryInput] = mockCaptureTelemetryError.mock.calls[0]!;
+    expect(capturedError).toEqual(
+      expect.objectContaining({
+        name: 'ChatFailure:Error',
+        message: 'Squire chat failure',
+      }),
+    );
+    expect(telemetryInput).toEqual(
+      expect.objectContaining({
+        route: '/chat/:conversationId/messages/:messageId/stream',
+        requestId: 'req-chat-sse-1',
+        conversationId,
+        userMessageId,
+        assistantMessageId: assistantMessages.rows[0].id,
+        user: { id: auth.userId },
+        context: expect.objectContaining({
+          surface: 'chat_sse',
+          failureKind: 'assistant_turn',
+          game: null,
+          originalErrorName: 'Error',
+          originalErrorCode: 'ETIMEDOUT',
+          persistedAssistantFailure: true,
+        }),
+      }),
+    );
+    expect(JSON.stringify(telemetryInput)).not.toContain('Partial answer.');
   });
 });
 

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -1215,10 +1215,21 @@ describe('POST /api/ask', () => {
   });
 
   it('emits error event when ask() throws', async () => {
+    mockVerifyAccessToken.mockResolvedValueOnce({
+      token: 'stub',
+      clientId: 'stub-client',
+      scopes: [],
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      extra: { userId: 'api-user-1' },
+    });
     mockAsk.mockRejectedValue(new Error('Claude API error'));
     const res = await app.request('/api/ask', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...(await auth()) },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-request-id': 'req-api-ask-failure-1',
+        ...(await auth()),
+      },
       body: JSON.stringify({ question: 'test' }),
     });
     expect(res.status).toBe(200); // SSE streams always return 200
@@ -1227,6 +1238,28 @@ describe('POST /api/ask', () => {
     const errorEvent = events.find((e) => e.event === 'error');
     expect(errorEvent).toBeDefined();
     expect(JSON.parse(errorEvent!.data)).toHaveProperty('message', 'Internal server error');
+    expect(mockCaptureTelemetryError).toHaveBeenCalledTimes(1);
+    const [capturedError, telemetryInput] = mockCaptureTelemetryError.mock.calls[0]!;
+    expect(capturedError).toEqual(
+      expect.objectContaining({
+        name: 'ChatFailure:Error',
+        message: 'Squire chat failure',
+      }),
+    );
+    expect(telemetryInput).toEqual(
+      expect.objectContaining({
+        route: '/api/ask',
+        requestId: 'req-api-ask-failure-1',
+        user: { id: 'api-user-1' },
+        context: expect.objectContaining({
+          surface: 'api_ask',
+          failureKind: 'api_ask',
+          game: null,
+          originalErrorName: 'Error',
+        }),
+      }),
+    );
+    expect(JSON.stringify(telemetryInput)).not.toContain('test');
   });
 });
 


### PR DESCRIPTION
## Summary

- Add a chat telemetry helper that captures a generic Sentry exception plus safe chat diagnostics only.
- Capture persisted web-chat and SSE assistant failures from the shared conversation-service catch path.
- Capture `/api/ask` stream failures before emitting the existing generic SSE error.
- Keep prompts, partial streamed answers, provider error text, cookies, auth headers, and retrieved passages out of Sentry inputs.

## Validation

- `npm test -- test/conversation.test.ts test/server-api.test.ts`
- `npm run typecheck`
- `npm run check`
- `npm run lint:actions`
- `git diff --check`
- `npm audit --omit=dev`

## Review

- Ran the gstack pre-landing review checklist manually after the packaged `/review` skill pointed at a missing bundled checklist path. One privacy hardening issue was found and fixed: chat telemetry now allowlists `Error.name` before it is used in Sentry error names/context.

Fixes SQR-306
