### PR TITLE
feat(observability): mirror security logs to Sentry (SQR-304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.22] - 2026-06-14
+
+### Added
+
+- Mirrored important structured security and app logs into Sentry as safe breadcrumbs or messages while preserving existing JSON stdout output.
+- Added security-log telemetry tests covering event allowlisting, field allowlisting, route stripping, and sanitized error type/code diagnostics.
+
 ## [0.1.21] - 2026-06-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.104.1",
         "@aws-sdk/client-s3": "^3.1068.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "engines": {

--- a/src/security-log.ts
+++ b/src/security-log.ts
@@ -1,10 +1,51 @@
+import type { SeverityLevel } from '@sentry/node';
+
 import { resolveSquireEnv } from './squire-env.ts';
+import { addTelemetryBreadcrumb, captureTelemetryMessage } from './telemetry.ts';
+
+type SecurityLogLevel = 'info' | 'warn' | 'error';
+type SecurityLogFieldValue = string | number | boolean | null;
+type SecurityLogFields = Record<string, SecurityLogFieldValue>;
+type SecurityTelemetryMode = 'breadcrumb' | 'message';
 
 interface SecurityLogBase {
   event: string;
-  level?: 'info' | 'warn' | 'error';
-  fields?: Record<string, string | number | boolean | null>;
+  level?: SecurityLogLevel;
+  fields?: SecurityLogFields;
 }
+
+const SECURITY_TELEMETRY_EVENTS = {
+  campaign_client_token_rejected: 'breadcrumb',
+  llm_budget_warning: 'breadcrumb',
+  rate_limit_rejected: 'breadcrumb',
+  llm_budget_accounting_failed: 'message',
+  rate_limit_redis_error: 'message',
+  rate_limit_unavailable: 'message',
+} as const satisfies Record<string, SecurityTelemetryMode>;
+
+const SECURITY_TELEMETRY_FIELD_KEYS = new Set<string>([
+  'budget_day',
+  'budget_usd_micros',
+  'client_id',
+  'error_code',
+  'error_type',
+  'has_user_id',
+  'identity_hash',
+  'identity_kind',
+  'limit',
+  'method',
+  'model',
+  'policy',
+  'reset_after_seconds',
+  'retry_after_seconds',
+  'route',
+  'spent_usd_micros',
+  'threshold_percent',
+  'window_ms',
+]);
+
+const SAFE_ERROR_TYPE_PATTERN = /^[A-Za-z][A-Za-z0-9_.:-]{0,63}$/;
+const SAFE_ERROR_CODE_PATTERN = /^[A-Za-z0-9_.:-]{1,64}$/;
 
 function safeSquireEnv(): string {
   try {
@@ -14,22 +55,126 @@ function safeSquireEnv(): string {
   }
 }
 
+function safeRouteField(value: SecurityLogFieldValue): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+
+  let route = trimmed;
+  try {
+    if (/^https?:\/\//i.test(trimmed)) route = new URL(trimmed).pathname || '/';
+  } catch {
+    return null;
+  }
+
+  return route.split('?')[0]?.split('#')[0] || '/';
+}
+
+function safeErrorType(value: unknown): string {
+  if (typeof value !== 'string') return 'unknown';
+  const trimmed = value.trim();
+  return SAFE_ERROR_TYPE_PATTERN.test(trimmed) ? trimmed : 'unknown';
+}
+
+function safeErrorCode(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return SAFE_ERROR_CODE_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+function toTelemetryLevel(level: SecurityLogLevel): SeverityLevel {
+  return level === 'warn' ? 'warning' : level;
+}
+
+function safeSecurityTelemetryFields(fields: SecurityLogFields): SecurityLogFields {
+  const safeFields: SecurityLogFields = {};
+
+  for (const [key, value] of Object.entries(fields)) {
+    if (!SECURITY_TELEMETRY_FIELD_KEYS.has(key)) continue;
+
+    if (key === 'route') {
+      const route = safeRouteField(value);
+      if (route !== null) safeFields.route = route;
+      continue;
+    }
+
+    if (key === 'error_type') {
+      safeFields.error_type = safeErrorType(value);
+      continue;
+    }
+
+    if (key === 'error_code') {
+      safeFields.error_code = safeErrorCode(value);
+      continue;
+    }
+
+    safeFields[key] = value;
+  }
+
+  return safeFields;
+}
+
+function emitSecurityTelemetry(input: {
+  event: string;
+  level: SecurityLogLevel;
+  squireEnv: string;
+  fields: SecurityLogFields;
+}): void {
+  const mode = SECURITY_TELEMETRY_EVENTS[input.event as keyof typeof SECURITY_TELEMETRY_EVENTS];
+  if (!mode) return;
+
+  const fields = safeSecurityTelemetryFields(input.fields);
+  const route = typeof fields.route === 'string' ? fields.route : undefined;
+  const telemetryInput = {
+    route,
+    context: {
+      event: input.event,
+      level: input.level,
+      squire_env: input.squireEnv,
+      fields,
+    },
+  };
+
+  try {
+    if (mode === 'breadcrumb') {
+      addTelemetryBreadcrumb({
+        category: 'security_log',
+        message: input.event,
+        level: toTelemetryLevel(input.level),
+        ...telemetryInput,
+      });
+      return;
+    }
+
+    captureTelemetryMessage(
+      `security_log.${input.event}`,
+      toTelemetryLevel(input.level),
+      telemetryInput,
+    );
+  } catch {
+    // Logging must never fail because telemetry did.
+  }
+}
+
 export function writeSecurityLog({ event, level = 'warn', fields = {} }: SecurityLogBase): void {
+  const squireEnv = safeSquireEnv();
   console.warn(
     JSON.stringify({
       ...fields,
       ts: new Date().toISOString(),
       level,
       event,
-      squire_env: safeSquireEnv(),
+      squire_env: squireEnv,
     }),
   );
+
+  emitSecurityTelemetry({ event, level, squireEnv, fields });
 }
 
 export function errorLogFields(error: unknown): Record<string, string | null> {
   const withCode = error as { code?: unknown };
   return {
-    error_type: error instanceof Error && error.name ? error.name : 'unknown',
-    error_code: typeof withCode.code === 'string' ? withCode.code : null,
+    error_type: error instanceof Error && error.name ? safeErrorType(error.name) : 'unknown',
+    error_code: safeErrorCode(withCode.code),
   };
 }

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -4,14 +4,21 @@ import { generateSignedCookie } from 'hono/cookie';
 
 import { resetTestDb, setupTestDb, teardownTestDb } from './helpers/db.ts';
 
-const { mockAsk, mockInitTelemetry, mockCaptureTelemetryError, mockFlushTelemetry } = vi.hoisted(
-  () => ({
-    mockAsk: vi.fn(),
-    mockInitTelemetry: vi.fn(() => ({ enabled: false, reason: 'missing_dsn' })),
-    mockCaptureTelemetryError: vi.fn(),
-    mockFlushTelemetry: vi.fn().mockResolvedValue(true),
-  }),
-);
+const {
+  mockAsk,
+  mockInitTelemetry,
+  mockCaptureTelemetryError,
+  mockCaptureTelemetryMessage,
+  mockAddTelemetryBreadcrumb,
+  mockFlushTelemetry,
+} = vi.hoisted(() => ({
+  mockAsk: vi.fn(),
+  mockInitTelemetry: vi.fn(() => ({ enabled: false, reason: 'missing_dsn' })),
+  mockCaptureTelemetryError: vi.fn(),
+  mockCaptureTelemetryMessage: vi.fn(),
+  mockAddTelemetryBreadcrumb: vi.fn(),
+  mockFlushTelemetry: vi.fn().mockResolvedValue(true),
+}));
 
 vi.mock('../src/service.ts', () => ({
   initialize: vi.fn(),
@@ -54,6 +61,8 @@ vi.mock('../src/tools.ts', () => ({
 vi.mock('../src/telemetry.ts', () => ({
   initTelemetry: mockInitTelemetry,
   captureTelemetryError: mockCaptureTelemetryError,
+  captureTelemetryMessage: mockCaptureTelemetryMessage,
+  addTelemetryBreadcrumb: mockAddTelemetryBreadcrumb,
   flushTelemetry: mockFlushTelemetry,
 }));
 

--- a/test/security-log.test.ts
+++ b/test/security-log.test.ts
@@ -1,8 +1,23 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { writeSecurityLog } from '../src/security-log.ts';
+const { mockAddTelemetryBreadcrumb, mockCaptureTelemetryMessage } = vi.hoisted(() => ({
+  mockAddTelemetryBreadcrumb: vi.fn(),
+  mockCaptureTelemetryMessage: vi.fn(),
+}));
+
+vi.mock('../src/telemetry.ts', () => ({
+  addTelemetryBreadcrumb: mockAddTelemetryBreadcrumb,
+  captureTelemetryMessage: mockCaptureTelemetryMessage,
+}));
+
+import { errorLogFields, writeSecurityLog } from '../src/security-log.ts';
 
 const ORIGINAL_SQUIRE_ENV = process.env.SQUIRE_ENV;
+
+beforeEach(() => {
+  mockAddTelemetryBreadcrumb.mockReset();
+  mockCaptureTelemetryMessage.mockReset();
+});
 
 afterEach(() => {
   if (ORIGINAL_SQUIRE_ENV === undefined) {
@@ -39,5 +54,131 @@ describe('writeSecurityLog', () => {
       detail: 'preserved_field',
     });
     expect(payload.ts).not.toBe('spoofed_timestamp');
+  });
+
+  it('mirrors rate-limit rejections as safe Sentry breadcrumbs', () => {
+    process.env.SQUIRE_ENV = 'production';
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    writeSecurityLog({
+      event: 'rate_limit_rejected',
+      fields: {
+        route: '/api/ask?token=secret',
+        method: 'POST',
+        policy: 'api_ask',
+        limit: 20,
+        window_ms: 60_000,
+        identity_hash: 'identity-hash',
+        retry_after_seconds: 3,
+        reset_after_seconds: 12,
+        authorization: 'Bearer secret-token',
+        cookie: 'session=value',
+        raw_prompt: 'What is in the hidden prompt?',
+        email: 'alice@example.com',
+      },
+    });
+
+    expect(mockAddTelemetryBreadcrumb).toHaveBeenCalledTimes(1);
+    expect(mockAddTelemetryBreadcrumb).toHaveBeenCalledWith({
+      category: 'security_log',
+      message: 'rate_limit_rejected',
+      level: 'warning',
+      route: '/api/ask',
+      context: {
+        event: 'rate_limit_rejected',
+        level: 'warn',
+        squire_env: 'production',
+        fields: {
+          route: '/api/ask',
+          method: 'POST',
+          policy: 'api_ask',
+          limit: 20,
+          window_ms: 60_000,
+          identity_hash: 'identity-hash',
+          retry_after_seconds: 3,
+          reset_after_seconds: 12,
+        },
+      },
+    });
+    expect(mockCaptureTelemetryMessage).not.toHaveBeenCalled();
+  });
+
+  it('captures important app failures as safe Sentry messages', () => {
+    process.env.SQUIRE_ENV = 'production';
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    writeSecurityLog({
+      event: 'rate_limit_unavailable',
+      level: 'error',
+      fields: {
+        route: 'https://squire.maz.org/register?cookie=session',
+        method: 'POST',
+        policy: 'register_client',
+        error_type: 'RedisConnectionError',
+        error_code: 'ECONNREFUSED',
+        token: 'secret-token',
+        answer: 'raw model output',
+      },
+    });
+
+    expect(mockCaptureTelemetryMessage).toHaveBeenCalledTimes(1);
+    expect(mockCaptureTelemetryMessage).toHaveBeenCalledWith(
+      'security_log.rate_limit_unavailable',
+      'error',
+      {
+        route: '/register',
+        context: {
+          event: 'rate_limit_unavailable',
+          level: 'error',
+          squire_env: 'production',
+          fields: {
+            route: '/register',
+            method: 'POST',
+            policy: 'register_client',
+            error_type: 'RedisConnectionError',
+            error_code: 'ECONNREFUSED',
+          },
+        },
+      },
+    );
+    expect(mockAddTelemetryBreadcrumb).not.toHaveBeenCalled();
+  });
+
+  it('does not mirror unrecognized security log events to Sentry', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    writeSecurityLog({
+      event: 'unclassified_debug_event',
+      fields: {
+        route: '/debug',
+        detail: 'still written to stdout',
+      },
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(mockAddTelemetryBreadcrumb).not.toHaveBeenCalled();
+    expect(mockCaptureTelemetryMessage).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes error type and code fields', () => {
+    const redisError = new Error('connect failed') as Error & { code?: string };
+    redisError.name = 'RedisConnectionError';
+    redisError.code = 'ECONNREFUSED';
+
+    expect(errorLogFields(redisError)).toEqual({
+      error_type: 'RedisConnectionError',
+      error_code: 'ECONNREFUSED',
+    });
+
+    const unsafeError = new Error('token sk_secret should not leave logs') as Error & {
+      code?: string;
+    };
+    unsafeError.name = 'Error With Spaces';
+    unsafeError.code = 'ECONNRESET;DROP';
+
+    expect(errorLogFields(unsafeError)).toEqual({
+      error_type: 'unknown',
+      error_code: null,
+    });
   });
 });

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -73,6 +73,8 @@ const {
   mockRunReadinessChecks,
   mockInitTelemetry,
   mockCaptureTelemetryError,
+  mockCaptureTelemetryMessage,
+  mockAddTelemetryBreadcrumb,
   mockFlushTelemetry,
 } = vi.hoisted(() => ({
   mockInitialize: vi.fn(),
@@ -90,6 +92,8 @@ const {
   mockRunReadinessChecks: vi.fn(),
   mockInitTelemetry: vi.fn(() => ({ enabled: false, reason: 'missing_dsn' })),
   mockCaptureTelemetryError: vi.fn(),
+  mockCaptureTelemetryMessage: vi.fn(),
+  mockAddTelemetryBreadcrumb: vi.fn(),
   mockFlushTelemetry: vi.fn().mockResolvedValue(true),
 }));
 
@@ -122,6 +126,8 @@ vi.mock('../src/health.ts', () => ({
 vi.mock('../src/telemetry.ts', () => ({
   initTelemetry: mockInitTelemetry,
   captureTelemetryError: mockCaptureTelemetryError,
+  captureTelemetryMessage: mockCaptureTelemetryMessage,
+  addTelemetryBreadcrumb: mockAddTelemetryBreadcrumb,
   flushTelemetry: mockFlushTelemetry,
 }));
 


### PR DESCRIPTION
## Summary
- mirror allowlisted structured security/app logs into Sentry as breadcrumbs or messages
- keep existing JSON stdout payloads unchanged
- strip route queries and allowlist telemetry fields before handing log data to Sentry helpers
- sanitize error type/code diagnostics and update test telemetry mocks
- bump version to 0.1.22 and update changelog

## Verification
- npm test -- test/security-log.test.ts
- npm test -- test/security-log.test.ts test/telemetry.test.ts
- npm test -- test/security-log.test.ts test/telemetry.test.ts test/server-api.test.ts
- npm test -- test/conversation.test.ts
- npm run typecheck
- npm run check
- git diff --check
- npm run lint:actions
- npm audit --omit=dev

Linear: SQR-304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.1.22

* **New Features**
  * Security logs are now mirrored to Sentry for enhanced observability while preserving existing JSON output
  * Improved data sanitization for security-related monitoring events

* **Tests**
  * Added security log telemetry tests covering field sanitization and error handling scenarios

* **Chores**
  * Version bumped to 0.1.22

<!-- end of auto-generated comment: release notes by coderabbit.ai -->