### PR TITLE
feat(observability): capture cron script failures (SQR-305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.23] - 2026-06-14
+
+### Added
+
+- Added telemetry capture and flush handling for Supercronic cleanup jobs, Fly release migrations, and the live GH2e migration script.
+- Added cron script tests proving successful runs stay quiet while failed expired-session sweeps capture, flush, preserve stderr, set exit code 1, and close the DB pool.
+
 ## [0.1.22] - 2026-06-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.104.1",
         "@aws-sdk/client-s3": "^3.1068.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "engines": {

--- a/scripts/db-migrate.ts
+++ b/scripts/db-migrate.ts
@@ -16,6 +16,7 @@ import {
   isManagedLocalDatabaseUrl,
   resolveDatabaseUrl,
 } from '../src/db.ts';
+import { runScriptWithTelemetry } from '../src/script-telemetry.ts';
 
 const { Pool } = pg;
 
@@ -100,7 +101,10 @@ function redact(url: string): string {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main().catch((err) => {
+  runScriptWithTelemetry(main, {
+    scriptName: 'db-migrate',
+    scriptKind: 'release_command',
+  }).catch((err) => {
     console.error(err);
     process.exit(1);
   });

--- a/scripts/migrate-live-gh2e.ts
+++ b/scripts/migrate-live-gh2e.ts
@@ -8,9 +8,11 @@
 import 'dotenv/config';
 
 import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
 import { getDb } from '../src/db.ts';
 import { LiveCaptureSchema, migrateLiveCampaign } from '../src/campaign/live-migration.ts';
+import { runScriptWithTelemetry } from '../src/script-telemetry.ts';
 
 const DEFAULT_OWNER_EMAIL = 'bcm@maz.org';
 
@@ -40,7 +42,16 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+export async function runLiveGh2eMigrationCli(): Promise<void> {
+  await runScriptWithTelemetry(main, {
+    scriptName: 'migrate-live-gh2e',
+    scriptKind: 'manual_migration',
+  });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runLiveGh2eMigrationCli().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/sweep-expired-proposals.ts
+++ b/scripts/sweep-expired-proposals.ts
@@ -10,6 +10,7 @@ import { pathToFileURL } from 'node:url';
 
 import { shutdownServerPool } from '../src/db.ts';
 import { sweepExpiredProposals } from '../src/campaign/pending-mutations.ts';
+import { runScriptWithTelemetry } from '../src/script-telemetry.ts';
 
 export async function main(): Promise<number> {
   const swept = await sweepExpiredProposals();
@@ -17,13 +18,20 @@ export async function main(): Promise<number> {
   return swept;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main()
-    .catch((err) => {
-      console.error('[proposal-gc] failed to sweep proposals:', err);
-      process.exitCode = 1;
-    })
-    .finally(async () => {
-      await shutdownServerPool();
+export async function runExpiredProposalSweepCli(): Promise<void> {
+  try {
+    await runScriptWithTelemetry(main, {
+      scriptName: 'sweep-expired-proposals',
+      scriptKind: 'cron',
     });
+  } catch (err) {
+    console.error('[proposal-gc] failed to sweep proposals:', err);
+    process.exitCode = 1;
+  } finally {
+    await shutdownServerPool();
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void runExpiredProposalSweepCli();
 }

--- a/scripts/sweep-expired-sessions.ts
+++ b/scripts/sweep-expired-sessions.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from 'node:url';
 
 import { shutdownServerPool } from '../src/db.ts';
 import * as SessionRepository from '../src/db/repositories/session-repository.ts';
+import { runScriptWithTelemetry } from '../src/script-telemetry.ts';
 
 export async function main(): Promise<number> {
   const deleted = await SessionRepository.deleteExpired();
@@ -14,13 +15,20 @@ export async function main(): Promise<number> {
   return deleted;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main()
-    .catch((err) => {
-      console.error('[session-gc] failed to delete expired sessions:', err);
-      process.exitCode = 1;
-    })
-    .finally(async () => {
-      await shutdownServerPool();
+export async function runExpiredSessionSweepCli(): Promise<void> {
+  try {
+    await runScriptWithTelemetry(main, {
+      scriptName: 'sweep-expired-sessions',
+      scriptKind: 'cron',
     });
+  } catch (err) {
+    console.error('[session-gc] failed to delete expired sessions:', err);
+    process.exitCode = 1;
+  } finally {
+    await shutdownServerPool();
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void runExpiredSessionSweepCli();
 }

--- a/src/script-telemetry.ts
+++ b/src/script-telemetry.ts
@@ -1,0 +1,35 @@
+import { captureTelemetryError, flushTelemetry, initTelemetry } from './telemetry.ts';
+
+export type ScriptTelemetryKind = 'cron' | 'release_command' | 'manual_migration' | 'script';
+
+interface ScriptTelemetryOptions {
+  scriptName: string;
+  scriptKind: ScriptTelemetryKind;
+  route?: string;
+  flushTimeoutMs?: number;
+}
+
+/**
+ * Initialize Sentry for non-Hono entrypoints, capture failures, flush before
+ * exit, and leave success paths silent.
+ */
+export async function runScriptWithTelemetry<T>(
+  operation: () => Promise<T>,
+  options: ScriptTelemetryOptions,
+): Promise<T> {
+  initTelemetry();
+
+  try {
+    return await operation();
+  } catch (error) {
+    captureTelemetryError(error, {
+      route: options.route ?? `/scripts/${options.scriptName}`,
+      context: {
+        scriptName: options.scriptName,
+        scriptKind: options.scriptKind,
+      },
+    });
+    await flushTelemetry(options.flushTimeoutMs ?? 2_000);
+    throw error;
+  }
+}

--- a/test/sweep-expired-sessions-script.test.ts
+++ b/test/sweep-expired-sessions-script.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockDeleteExpired,
+  mockShutdownServerPool,
+  mockInitTelemetry,
+  mockCaptureTelemetryError,
+  mockFlushTelemetry,
+} = vi.hoisted(() => ({
+  mockDeleteExpired: vi.fn(),
+  mockShutdownServerPool: vi.fn(),
+  mockInitTelemetry: vi.fn(() => ({ enabled: false, reason: 'missing_dsn' })),
+  mockCaptureTelemetryError: vi.fn(),
+  mockFlushTelemetry: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../src/db.ts', () => ({
+  shutdownServerPool: mockShutdownServerPool,
+}));
+
+vi.mock('../src/db/repositories/session-repository.ts', () => ({
+  deleteExpired: mockDeleteExpired,
+}));
+
+vi.mock('../src/telemetry.ts', () => ({
+  initTelemetry: mockInitTelemetry,
+  captureTelemetryError: mockCaptureTelemetryError,
+  flushTelemetry: mockFlushTelemetry,
+}));
+
+import { runExpiredSessionSweepCli } from '../scripts/sweep-expired-sessions.ts';
+
+const ORIGINAL_EXIT_CODE = process.exitCode;
+
+beforeEach(() => {
+  process.exitCode = undefined;
+  mockDeleteExpired.mockReset();
+  mockShutdownServerPool.mockReset();
+  mockInitTelemetry.mockClear();
+  mockCaptureTelemetryError.mockReset();
+  mockFlushTelemetry.mockReset();
+  mockFlushTelemetry.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  process.exitCode = ORIGINAL_EXIT_CODE;
+  vi.restoreAllMocks();
+});
+
+describe('expired session sweep script telemetry', () => {
+  it('does not capture or flush telemetry for successful cron runs', async () => {
+    mockDeleteExpired.mockResolvedValue(2);
+    mockShutdownServerPool.mockResolvedValue(undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runExpiredSessionSweepCli();
+
+    expect(log).toHaveBeenCalledWith('[session-gc] deleted 2 expired session(s)');
+    expect(mockInitTelemetry).toHaveBeenCalledTimes(1);
+    expect(mockCaptureTelemetryError).not.toHaveBeenCalled();
+    expect(mockFlushTelemetry).not.toHaveBeenCalled();
+    expect(mockShutdownServerPool).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('captures, flushes, and preserves nonzero exit behavior for failing cron runs', async () => {
+    const failure = new Error('database unavailable');
+    mockDeleteExpired.mockRejectedValue(failure);
+    mockShutdownServerPool.mockResolvedValue(undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await runExpiredSessionSweepCli();
+
+    expect(error).toHaveBeenCalledWith('[session-gc] failed to delete expired sessions:', failure);
+    expect(mockCaptureTelemetryError).toHaveBeenCalledTimes(1);
+    expect(mockCaptureTelemetryError).toHaveBeenCalledWith(failure, {
+      route: '/scripts/sweep-expired-sessions',
+      context: {
+        scriptName: 'sweep-expired-sessions',
+        scriptKind: 'cron',
+      },
+    });
+    expect(mockFlushTelemetry).toHaveBeenCalledWith(2_000);
+    expect(mockShutdownServerPool).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared non-Hono script telemetry runner that initializes Sentry, captures failures, flushes before exit, and leaves success paths quiet
- wire Supercronic expired-session/proposal sweepers through the runner while preserving existing console output, exit code behavior, and DB pool shutdown
- wire Fly release migrations and the live GH2e migration script through the same capture/flush boundary
- bump version to 0.1.23 and update changelog

## Verification
- npm test -- test/sweep-expired-sessions-script.test.ts
- npm test -- test/sweep-expired-sessions-script.test.ts test/db-migrate.test.ts test/deployment-config.test.ts
- npm run typecheck
- npm run check
- git diff --check
- npm run lint:actions
- npm audit --omit=dev

Linear: SQR-305