### PR TITLE
v0.1.24 feat: capture browser telemetry safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.24] - 2026-06-14
+
+### Added
+
+- Added same-origin browser telemetry for frontend exceptions, unhandled rejections, HTMX transport failures, and EventSource stream failures without adding a bundler or exposing a browser Sentry DSN.
+- Added browser telemetry tests covering CSP-compatible config, strict server-side payload allowlisting, safe route/source stripping, viewport/user-agent context, and transcript/prompt exclusion.
+
 ## [0.1.23] - 2026-06-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.104.1",
         "@aws-sdk/client-s3": "^3.1068.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "engines": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -161,6 +161,7 @@ import * as MessageStreamEventRepository from './db/repositories/message-stream-
 import type { BrowserStreamEventName } from './db/repositories/message-stream-event-repository.ts';
 import {
   captureTelemetryError,
+  captureTelemetryMessage,
   flushTelemetry,
   initTelemetry,
   type TelemetryCaptureInput,
@@ -278,6 +279,91 @@ function buildServerErrorTelemetry(c: Context, requestId: string): TelemetryCapt
       path: c.req.path,
       route,
       status: 500,
+    },
+  };
+}
+
+const BrowserTelemetryTokenSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9._:-]+$/);
+
+const BrowserTelemetrySchema = z
+  .object({
+    type: z.enum([
+      'browser_error',
+      'browser_unhandledrejection',
+      'browser_stream_error',
+      'browser_htmx_error',
+    ]),
+    route: z.string().min(1).max(2048).optional(),
+    conversationId: BrowserTelemetryTokenSchema.optional(),
+    userMessageId: BrowserTelemetryTokenSchema.optional(),
+    errorName: BrowserTelemetryTokenSchema.optional(),
+    reasonType: BrowserTelemetryTokenSchema.optional(),
+    source: z.string().min(1).max(2048).optional(),
+    line: z.number().int().nonnegative().max(1_000_000).optional(),
+    column: z.number().int().nonnegative().max(1_000_000).optional(),
+    viewport: z
+      .object({
+        width: z.number().int().positive().max(20_000),
+        height: z.number().int().positive().max(20_000),
+      })
+      .strict()
+      .optional(),
+    userAgent: z.string().min(1).max(512).optional(),
+    streamErrorKind: z.enum(['transport', 'session']).optional(),
+    streamReadyState: z.number().int().min(0).max(2).optional(),
+    htmxEvent: BrowserTelemetryTokenSchema.optional(),
+    htmxStatus: z.number().int().min(0).max(999).optional(),
+  })
+  .strict();
+
+type BrowserTelemetryEvent = z.infer<typeof BrowserTelemetrySchema>;
+
+function browserPathOnly(raw: string | undefined): string | undefined {
+  const value = raw?.trim();
+  if (!value) return undefined;
+
+  try {
+    if (/^https?:\/\//i.test(value)) return new URL(value).pathname || '/';
+  } catch {
+    return undefined;
+  }
+
+  if (!value.startsWith('/')) return undefined;
+  return value.split('?')[0]?.split('#')[0] || '/';
+}
+
+function buildBrowserTelemetryInput(
+  c: Context,
+  requestId: string,
+  event: BrowserTelemetryEvent,
+): TelemetryCaptureInput {
+  const route = browserPathOnly(event.route) ?? '/browser';
+  const source = browserPathOnly(event.source);
+  return {
+    route,
+    requestId,
+    conversationId: event.conversationId,
+    userMessageId: event.userMessageId,
+    user: safeUserFromContext(c),
+    context: {
+      surface: 'browser',
+      eventType: event.type,
+      telemetryEndpoint: '/api/browser-telemetry',
+      errorName: event.errorName ?? null,
+      reasonType: event.reasonType ?? null,
+      source: source ?? null,
+      line: event.line ?? null,
+      column: event.column ?? null,
+      viewport: event.viewport ?? null,
+      userAgent: event.userAgent ?? null,
+      streamErrorKind: event.streamErrorKind ?? null,
+      streamReadyState: event.streamReadyState ?? null,
+      htmxEvent: event.htmxEvent ?? null,
+      htmxStatus: event.htmxStatus ?? null,
     },
   };
 }
@@ -2788,6 +2874,29 @@ app.get('/api/health', async (c) => {
 
 app.get('/api/live', (c) => {
   return c.json({ status: 'ok' });
+});
+
+// Browser observability endpoint. It deliberately accepts only a strict,
+// operational allowlist; invalid telemetry is ignored because diagnostics must
+// never change the page behavior or mirror unknown browser data into Sentry.
+app.post('/api/browser-telemetry', optionalSession(), async (c) => {
+  const requestId = correlateRequest(c);
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.body(null, 204);
+  }
+
+  const result = BrowserTelemetrySchema.safeParse(body);
+  if (!result.success) return c.body(null, 204);
+
+  captureTelemetryMessage(
+    `browser.${result.data.type}`,
+    'error',
+    buildBrowserTelemetryInput(c, requestId, result.data),
+  );
+  return c.body(null, 204);
 });
 
 // ─── Search endpoints ────────────────────────────────────────────────────────

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -126,6 +126,18 @@ interface DocumentOptions {
   csrfToken?: string;
 }
 
+const BROWSER_TELEMETRY_ENDPOINT = '/api/browser-telemetry';
+
+function renderBrowserTelemetryConfig(): HtmlEscapedString {
+  const enabled = Boolean(process.env.SENTRY_DSN?.trim());
+  const config = JSON.stringify({
+    enabled,
+    endpoint: BROWSER_TELEMETRY_ENDPOINT,
+  });
+
+  return html`<meta name="squire-browser-telemetry" content="${config}" />` as HtmlEscapedString;
+}
+
 function getDisplayName(session: Session): string {
   return session.user.name?.trim() || session.user.email;
 }
@@ -384,6 +396,7 @@ async function renderDocument(options: DocumentOptions): Promise<HtmlEscapedStri
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <meta name="htmx-config" content='{"includeIndicatorStyles":false}' />
+        ${renderBrowserTelemetryConfig()}
         <title>Squire</title>
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         ${options.csrfToken

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -18,6 +18,218 @@ var defaultActiveGame = FALLBACK_DEFAULT_ACTIVE_GAME;
 var supportedActiveGames = fallbackSupportedActiveGames;
 var activeGame = defaultActiveGame;
 var activeGameInitialized = false;
+var browserTelemetryConfig = null;
+
+function safePathOnly(raw) {
+  if (typeof raw !== 'string') return null;
+  var value = raw.trim();
+  if (!value) return null;
+  var withoutHash = value.split('#')[0];
+  var withoutQuery = withoutHash.split('?')[0];
+  if (withoutQuery.charAt(0) === '/') return withoutQuery || '/';
+
+  var absoluteMatch = withoutQuery.match(/^https?:\/\/[^/]+(\/.*)?$/i);
+  if (absoluteMatch) return absoluteMatch[1] || '/';
+  return null;
+}
+
+function readBrowserTelemetryConfig() {
+  if (browserTelemetryConfig) return browserTelemetryConfig;
+
+  browserTelemetryConfig = { enabled: false, endpoint: null };
+  if (!document.querySelector) return browserTelemetryConfig;
+
+  var meta = document.querySelector('meta[name="squire-browser-telemetry"]');
+  var content = meta && meta.getAttribute ? meta.getAttribute('content') : null;
+  if (!content) return browserTelemetryConfig;
+
+  try {
+    var parsed = JSON.parse(content);
+    if (
+      parsed &&
+      parsed.enabled === true &&
+      typeof parsed.endpoint === 'string' &&
+      parsed.endpoint.charAt(0) === '/'
+    ) {
+      browserTelemetryConfig = { enabled: true, endpoint: parsed.endpoint };
+    }
+  } catch {
+    browserTelemetryConfig = { enabled: false, endpoint: null };
+  }
+
+  return browserTelemetryConfig;
+}
+
+function currentRoutePath() {
+  var pathname =
+    window.location && typeof window.location.pathname === 'string'
+      ? window.location.pathname
+      : '/';
+  return safePathOnly(pathname) || '/';
+}
+
+function conversationIdFromPath(path) {
+  var match = path && path.match(/^\/chat\/([^/]+)$/);
+  return match ? match[1] : null;
+}
+
+function streamIdsFromUrl(streamUrl) {
+  var path = safePathOnly(streamUrl);
+  var match = path && path.match(/^\/chat\/([^/]+)\/messages\/([^/]+)\/stream$/);
+  return match ? { conversationId: match[1], userMessageId: match[2] } : {};
+}
+
+function telemetryToken(value, fallback) {
+  if (typeof value !== 'string') return fallback;
+  var trimmed = value.trim();
+  if (!trimmed) return fallback;
+  return trimmed.replace(/[^A-Za-z0-9_.:-]/g, '_').slice(0, 128) || fallback;
+}
+
+function errorNameFromValue(value, fallback) {
+  if (value && typeof value === 'object' && typeof value.name === 'string') {
+    return telemetryToken(value.name, fallback);
+  }
+  return fallback;
+}
+
+function reasonTypeFromValue(value) {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'Array';
+  if (value && typeof value === 'object' && typeof value.name === 'string') {
+    return telemetryToken(value.name, 'object');
+  }
+  return typeof value;
+}
+
+function positiveTelemetryNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : null;
+}
+
+function viewportTelemetry() {
+  var width = positiveTelemetryNumber(window.innerWidth);
+  var height = positiveTelemetryNumber(window.innerHeight);
+  return width && height ? { width: width, height: height } : null;
+}
+
+function userAgentTelemetry() {
+  var navigatorLike = window.navigator;
+  if (!navigatorLike || typeof navigatorLike.userAgent !== 'string') return null;
+  return navigatorLike.userAgent.slice(0, 512);
+}
+
+function assignTelemetryValue(target, key, value) {
+  if (typeof value === 'string') {
+    var trimmed = value.trim();
+    if (trimmed) target[key] = trimmed;
+    return;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    target[key] = value;
+    return;
+  }
+  if (value && typeof value === 'object') {
+    target[key] = value;
+  }
+}
+
+function sendBrowserTelemetry(type, details) {
+  var config = readBrowserTelemetryConfig();
+  if (!config.enabled || !config.endpoint) return;
+
+  var route = currentRoutePath();
+  var payload = {
+    type: type,
+    route: route,
+  };
+  var routeConversationId = conversationIdFromPath(route);
+  if (routeConversationId) payload.conversationId = routeConversationId;
+
+  if (details && details.streamUrl) {
+    var streamIds = streamIdsFromUrl(details.streamUrl);
+    if (streamIds.conversationId) payload.conversationId = streamIds.conversationId;
+    if (streamIds.userMessageId) payload.userMessageId = streamIds.userMessageId;
+  }
+
+  var viewport = viewportTelemetry();
+  if (viewport) payload.viewport = viewport;
+  var userAgent = userAgentTelemetry();
+  if (userAgent) payload.userAgent = userAgent;
+
+  if (details) {
+    assignTelemetryValue(payload, 'errorName', details.errorName);
+    assignTelemetryValue(payload, 'reasonType', details.reasonType);
+    assignTelemetryValue(payload, 'source', details.source);
+    assignTelemetryValue(payload, 'line', details.line);
+    assignTelemetryValue(payload, 'column', details.column);
+    assignTelemetryValue(payload, 'streamErrorKind', details.streamErrorKind);
+    assignTelemetryValue(payload, 'streamReadyState', details.streamReadyState);
+    assignTelemetryValue(payload, 'htmxEvent', details.htmxEvent);
+    assignTelemetryValue(payload, 'htmxStatus', details.htmxStatus);
+  }
+
+  var fetchFn = window.fetch;
+  if (typeof fetchFn !== 'function') return;
+
+  try {
+    var result = fetchFn.call(window, config.endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+    if (result && typeof result.catch === 'function') result.catch(function () {});
+  } catch {
+    // Browser telemetry must never affect the app UI.
+  }
+}
+
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('error', function (event) {
+    var line = positiveTelemetryNumber(event && event.lineno);
+    var column = positiveTelemetryNumber(event && event.colno);
+    sendBrowserTelemetry('browser_error', {
+      errorName: errorNameFromValue(event && event.error, 'ErrorEvent'),
+      source: safePathOnly(event && event.filename),
+      line: line,
+      column: column,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', function (event) {
+    var reason = event && event.reason;
+    sendBrowserTelemetry('browser_unhandledrejection', {
+      errorName: errorNameFromValue(reason, 'UnhandledRejection'),
+      reasonType: reasonTypeFromValue(reason),
+    });
+  });
+}
+
+function reportHtmxTransportError(eventName, event) {
+  var detail = (event && event.detail) || {};
+  var xhr = detail.xhr || {};
+  var pathInfo = detail.pathInfo || {};
+  var status = positiveTelemetryNumber(xhr.status);
+  sendBrowserTelemetry('browser_htmx_error', {
+    htmxEvent: eventName,
+    htmxStatus: status,
+    source: safePathOnly(xhr.responseURL || pathInfo.requestPath),
+  });
+}
+
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+  document.addEventListener('htmx:sendError', function (event) {
+    reportHtmxTransportError('htmx:sendError', event);
+  });
+  document.addEventListener('htmx:responseError', function (event) {
+    reportHtmxTransportError('htmx:responseError', event);
+  });
+  document.addEventListener('htmx:timeout', function (event) {
+    reportHtmxTransportError('htmx:timeout', event);
+  });
+}
 
 function isSupportedActiveGame(value) {
   return (
@@ -2225,6 +2437,11 @@ function attachPendingAnswerStream(answerEl) {
     if (event.data) {
       payload = JSON.parse(event.data);
     }
+    sendBrowserTelemetry('browser_stream_error', {
+      streamUrl: streamUrl,
+      streamErrorKind: payload.kind === 'session' ? 'session' : 'transport',
+      streamReadyState: positiveTelemetryNumber(source.readyState),
+    });
     renderPendingError(
       answerEl,
       payload.kind === 'session' ? 'SESSION ENDED' : 'TROUBLE CONNECTING',

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -233,6 +233,98 @@ afterEach(() => {
   resetRateLimiterForTesting();
 });
 
+describe('POST /api/browser-telemetry', () => {
+  beforeEach(() => {
+    resetRouteMocks();
+  });
+
+  it('captures browser diagnostics through Sentry with same-origin-safe metadata', async () => {
+    const res = await app.request('/api/browser-telemetry', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-request-id': 'req-browser-1',
+      },
+      body: JSON.stringify({
+        type: 'browser_error',
+        route: '/chat/conv-1?token=secret',
+        conversationId: 'conv-1',
+        userMessageId: 'msg-user-1',
+        errorName: 'TypeError',
+        source: 'https://squire.maz.org/squire.abc123.js?token=secret',
+        line: 12,
+        column: 4,
+        viewport: { width: 390, height: 844 },
+        userAgent: 'SquireTest/1.0',
+      }),
+    });
+
+    expect(res.status).toBe(204);
+    expect(mockCaptureTelemetryMessage).toHaveBeenCalledTimes(1);
+    expect(mockCaptureTelemetryMessage).toHaveBeenCalledWith(
+      'browser.browser_error',
+      'error',
+      expect.objectContaining({
+        route: '/chat/conv-1',
+        requestId: 'req-browser-1',
+        conversationId: 'conv-1',
+        userMessageId: 'msg-user-1',
+        context: expect.objectContaining({
+          surface: 'browser',
+          eventType: 'browser_error',
+          telemetryEndpoint: '/api/browser-telemetry',
+          errorName: 'TypeError',
+          source: '/squire.abc123.js',
+          line: 12,
+          column: 4,
+          viewport: { width: 390, height: 844 },
+          userAgent: 'SquireTest/1.0',
+        }),
+      }),
+    );
+    const telemetryInput = JSON.stringify(mockCaptureTelemetryMessage.mock.calls[0][2]);
+    expect(telemetryInput).not.toContain('token=secret');
+    expect(telemetryInput).not.toContain('public@example.sentry.io');
+  });
+
+  it('drops malformed browser telemetry instead of capturing protected fields', async () => {
+    const res = await app.request('/api/browser-telemetry', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-request-id': 'req-browser-bad-1',
+      },
+      body: JSON.stringify({
+        type: 'browser_error',
+        route: '/chat/conv-1',
+        rawPrompt: 'What is the secret rule?',
+      }),
+    });
+
+    expect(res.status).toBe(204);
+    expect(mockCaptureTelemetryMessage).not.toHaveBeenCalled();
+  });
+
+  it('drops browser telemetry with prompt-like diagnostic identifiers', async () => {
+    const res = await app.request('/api/browser-telemetry', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-request-id': 'req-browser-bad-id-1',
+      },
+      body: JSON.stringify({
+        type: 'browser_error',
+        route: '/chat/conv-1',
+        conversationId: 'What is the secret rule?',
+        userMessageId: 'msg-user-1',
+      }),
+    });
+
+    expect(res.status).toBe(204);
+    expect(mockCaptureTelemetryMessage).not.toHaveBeenCalled();
+  });
+});
+
 describe('GET /api/health', () => {
   beforeEach(() => {
     resetRouteMocks();

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -158,6 +158,26 @@ describe('GET / — companion-first layout shell (SQR-65)', () => {
     expect(body).toContain('<link rel="icon" href="/favicon.svg" type="image/svg+xml" />');
   });
 
+  it('renders same-origin browser telemetry config without leaking a Sentry DSN', async () => {
+    const originalDsn = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = 'https://public@example.sentry.io/123';
+    try {
+      const body = String(await actualLayout.renderLoginPage());
+
+      expect(body).toContain('name="squire-browser-telemetry"');
+      expect(body).toContain('/api/browser-telemetry');
+      expect(body).toContain('&quot;enabled&quot;:true');
+      expect(body).not.toContain('public@example.sentry.io');
+      expect(body).not.toContain('sentry.io/123');
+    } finally {
+      if (originalDsn === undefined) {
+        delete process.env.SENTRY_DSN;
+      } else {
+        process.env.SENTRY_DSN = originalDsn;
+      }
+    }
+  });
+
   it('serves the favicon svg asset', async () => {
     const res = await app.request('/favicon.svg');
     expect(res.status).toBe(200);

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -275,10 +275,23 @@ function createFakeClock(startMs = 0) {
   };
 }
 
-function bootPendingTranscript(options: { clock?: ReturnType<typeof createFakeClock> } = {}) {
+function bootPendingTranscript(
+  options: {
+    browserTelemetry?: boolean;
+    clock?: ReturnType<typeof createFakeClock>;
+    streamUrl?: string;
+  } = {},
+) {
   const listeners = new Map<string, Array<(event?: unknown) => void>>();
   const storedValues = new Map<string, string>();
+  const telemetryPayloads: Array<{ url: string; body: unknown }> = [];
   const clock = options.clock ?? createFakeClock();
+  const telemetryMeta = {
+    getAttribute(name: string) {
+      if (name !== 'content') return null;
+      return JSON.stringify({ enabled: true, endpoint: '/api/browser-telemetry' });
+    },
+  };
 
   // SQR-108: setFormPendingState writes to form.dataset and reads back
   // form.querySelector('input[name="question"]'/'button[type="submit"]'),
@@ -325,7 +338,7 @@ function bootPendingTranscript(options: { clock?: ReturnType<typeof createFakeCl
   answerEl.classList.add('squire-answer--pending');
   // SQR-108 / ADR 0012: stream URL lives on the pending answer article,
   // not on the (now-deleted) `.squire-transcript--pending` wrapper.
-  answerEl.setAttribute('data-stream-url', '/chat/stream');
+  answerEl.setAttribute('data-stream-url', options.streamUrl ?? '/chat/stream');
   answerEl.appendChild(workEl);
   answerEl.appendChild(artifactsEl);
   answerEl.appendChild(contentEl);
@@ -353,6 +366,9 @@ function bootPendingTranscript(options: { clock?: ReturnType<typeof createFakeCl
       return new FakeElement(tagName);
     },
     querySelector(selector: string) {
+      if (selector === 'meta[name="squire-browser-telemetry"]' && options.browserTelemetry) {
+        return telemetryMeta;
+      }
       if (selector === '.squire-input-dock') return form;
       return null;
     },
@@ -406,6 +422,13 @@ function bootPendingTranscript(options: { clock?: ReturnType<typeof createFakeCl
         },
       },
       setInterval: clock.setInterval,
+      fetch(url: string, init?: { body?: unknown }) {
+        telemetryPayloads.push({
+          url,
+          body: typeof init?.body === 'string' ? JSON.parse(init.body) : init?.body,
+        });
+        return Promise.resolve({ ok: true });
+      },
     },
   });
 
@@ -428,9 +451,64 @@ function bootPendingTranscript(options: { clock?: ReturnType<typeof createFakeCl
     skeletonEl,
     source,
     storedValues,
+    telemetryPayloads,
     workEl,
     workRowsEl,
     workStatusEl,
+  };
+}
+
+function bootBrowserTelemetryHarness(pathname = '/chat/conv-1') {
+  const docListeners = new Map<string, Array<(event?: unknown) => void>>();
+  const windowListeners = new Map<string, Array<(event?: unknown) => void>>();
+  const telemetryPayloads: Array<{ url: string; body: unknown }> = [];
+  const telemetryMeta = {
+    getAttribute(name: string) {
+      if (name !== 'content') return null;
+      return JSON.stringify({ enabled: true, endpoint: '/api/browser-telemetry' });
+    },
+  };
+  const document = {
+    addEventListener(event: string, callback: (event?: unknown) => void) {
+      docListeners.set(event, [...(docListeners.get(event) ?? []), callback]);
+    },
+    querySelector(selector: string) {
+      return selector === 'meta[name="squire-browser-telemetry"]' ? telemetryMeta : null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    documentElement: { scrollHeight: 0 },
+  };
+  const window = {
+    location: { pathname },
+    crypto: {},
+    EventSource: function () {},
+    addEventListener(event: string, callback: (event?: unknown) => void) {
+      windowListeners.set(event, [...(windowListeners.get(event) ?? []), callback]);
+    },
+    scrollY: 0,
+    innerHeight: 844,
+    innerWidth: 390,
+    navigator: { userAgent: 'SquireTest/1.0' },
+    scrollTo: () => {},
+    fetch(url: string, init?: { body?: unknown }) {
+      telemetryPayloads.push({
+        url,
+        body: typeof init?.body === 'string' ? JSON.parse(init.body) : init?.body,
+      });
+      return Promise.resolve({ ok: true });
+    },
+  };
+  const context = vm.createContext({ document, window });
+
+  vm.runInContext(scriptSource, context);
+
+  return {
+    emitWindow(event: string, payload: unknown) {
+      for (const callback of windowListeners.get(event) ?? []) callback(payload);
+    },
+    telemetryPayloads,
   };
 }
 
@@ -441,6 +519,83 @@ function workRowMessage(row: FakeElement): string | undefined {
 function workRowMessages(rowsEl: FakeElement): Array<string | undefined> {
   return rowsEl.children.map((row) => workRowMessage(row));
 }
+
+describe('squire.js browser telemetry', () => {
+  it('reports window errors without sending the thrown message body', () => {
+    const { emitWindow, telemetryPayloads } = bootBrowserTelemetryHarness('/chat/conv-1');
+
+    emitWindow('error', {
+      error: { name: 'TypeError', message: 'raw prompt should stay out' },
+      filename: 'https://squire.maz.org/squire.abc123.js?token=secret',
+      lineno: 12,
+      colno: 4,
+      message: 'raw prompt should stay out',
+    });
+
+    expect(telemetryPayloads).toHaveLength(1);
+    expect(telemetryPayloads[0]).toEqual({
+      url: '/api/browser-telemetry',
+      body: expect.objectContaining({
+        type: 'browser_error',
+        route: '/chat/conv-1',
+        conversationId: 'conv-1',
+        errorName: 'TypeError',
+        source: '/squire.abc123.js',
+        line: 12,
+        column: 4,
+        viewport: { width: 390, height: 844 },
+        userAgent: 'SquireTest/1.0',
+      }),
+    });
+    expect(JSON.stringify(telemetryPayloads[0].body)).not.toContain('raw prompt');
+    expect(JSON.stringify(telemetryPayloads[0].body)).not.toContain('token=secret');
+  });
+
+  it('reports unhandled rejections without sending the rejected text', () => {
+    const { emitWindow, telemetryPayloads } = bootBrowserTelemetryHarness('/chat/conv-1');
+
+    emitWindow('unhandledrejection', {
+      reason: new Error('model answer should stay out'),
+    });
+
+    expect(telemetryPayloads).toHaveLength(1);
+    expect(telemetryPayloads[0].body).toEqual(
+      expect.objectContaining({
+        type: 'browser_unhandledrejection',
+        route: '/chat/conv-1',
+        conversationId: 'conv-1',
+        errorName: 'Error',
+        reasonType: 'Error',
+      }),
+    );
+    expect(JSON.stringify(telemetryPayloads[0].body)).not.toContain('model answer');
+  });
+
+  it('reports stream transport errors with conversation and message ids only', () => {
+    const { source, telemetryPayloads } = bootPendingTranscript({
+      browserTelemetry: true,
+      streamUrl: '/chat/conv-1/messages/msg-user-1/stream',
+    });
+
+    source.emit('error', {
+      kind: 'transport',
+      message: 'raw transcript should stay out',
+    });
+
+    expect(telemetryPayloads).toHaveLength(1);
+    expect(telemetryPayloads[0]).toEqual({
+      url: '/api/browser-telemetry',
+      body: expect.objectContaining({
+        type: 'browser_stream_error',
+        route: '/chat/test',
+        conversationId: 'conv-1',
+        userMessageId: 'msg-user-1',
+        streamErrorKind: 'transport',
+      }),
+    });
+    expect(JSON.stringify(telemetryPayloads[0].body)).not.toContain('raw transcript');
+  });
+});
 
 describe('squire.js chat form retargeting', () => {
   it('SQR-203: initializes the active game from localStorage, falls back safely, and syncs hidden chat fields', () => {


### PR DESCRIPTION
## Summary
- Adds same-origin browser telemetry config without exposing a browser Sentry DSN or adding a bundler.
- Captures frontend exceptions, unhandled rejections, HTMX transport failures, and EventSource stream failures through `/api/browser-telemetry`, then uses the existing server Sentry boundary for final capture/redaction.
- Enforces a strict browser payload allowlist, strips route/source query strings, requires token-shaped diagnostic IDs, and keeps prompt/transcript/error-message bodies out of telemetry.
- Bumps Squire to `0.1.24` and records the browser telemetry release notes.

## Test Coverage
All new code paths have test coverage.

Covered paths:
- Layout emits endpoint-only browser telemetry config and does not leak the DSN.
- `/api/browser-telemetry` captures valid diagnostics with safe metadata.
- `/api/browser-telemetry` drops malformed payloads and prompt-like diagnostic identifiers.
- `squire.js` reports `window.error`, `unhandledrejection`, and stream transport failures without sending thrown/rejected/transcript text.

## Pre-Landing Review
No issues found after the gstack checklist pass. One hardening gap was found during review and fixed before commit: diagnostic identifiers now must be token-shaped so arbitrary prompt-like text cannot ride through `conversationId`, `userMessageId`, `errorName`, `reasonType`, or HTMX event fields.

## Design Review
Design Review (lite): No issues found. The PR touches frontend JS/layout plumbing, but does not change styling, spacing, copy, or visual composition.

## Eval Results
No prompt-related files changed; evals skipped.

## Plan Completion
SQR-307 scope delivered: no bundler, CSP-compatible same-origin browser telemetry, browser error/rejection/stream diagnostics, safe Sentry server capture, and tests. No separate plan file detected.

## Verification Results
No dev server/browser manual verification run. The change is covered by server/layout tests and VM tests for the unbundled browser script.

## Test plan
- [x] `npm test -- test/server-api.test.ts test/web-ui-squire.regression-1.test.ts test/web-ui-layout.test.ts` (235 tests)
- [x] `npm run check` (142 test files, 1740 tests)
- [x] `git diff --check`
- [x] `npm run lint:actions`
- [x] `npm audit --omit=dev`

Fixes SQR-307
