### PR TITLE
feat(observability): add masked browser feedback capture

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -739,6 +739,11 @@ message ID, and LangSmith thread/run links when available. Sentry must not store
 raw prompts, full model answers, provider payloads, cookies, bearer tokens,
 OAuth tokens, secrets, or retrieved source passages.
 
+Browser feedback is categorical and tied to Sentry event ids when available.
+Browser replay data is masked structural context only: approved selectors,
+turn/input/history counts, viewport, and route ids. Raw transcript text and
+free-form feedback prose stay out of Sentry.
+
 LangSmith remains the owner for LLM traces and evals. Sentry links to LangSmith
 instead of duplicating prompt, model-output, or retrieved-context payloads.
 Operators start in Sentry for app/runtime errors and release regressions, then

--- a/docs/runbooks/production-operations.md
+++ b/docs/runbooks/production-operations.md
@@ -164,6 +164,39 @@ Fly's Sentry extension documentation describes the sponsored Team-plan quota as
 per month. If that sponsored period ends, Sentry keeps accepting events on the
 Developer plan with lower quotas; events over quota are dropped.
 
+#### Safe browser replay and feedback smoke
+
+Use a non-production Sentry environment first. Open a safe page with no real
+conversation text, then run this browser-console smoke:
+
+```js
+window.dispatchEvent(
+  new ErrorEvent('error', {
+    error: new Error('SquireSafeBrowserSmoke'),
+    filename: '/squire.js',
+    lineno: 1,
+    colno: 1,
+  }),
+);
+
+document.dispatchEvent(
+  new CustomEvent('squire:browser-feedback', {
+    detail: { feedbackKind: 'ui_broken' },
+  }),
+);
+```
+
+Expected result in Sentry: one `browser.browser_error` event and one feedback
+event. The browser event should include the Squire context fields
+`maskedReplay.textMasked=true`, `maskedReplay.attributesMasked=true`, masked
+selectors including `.squire-transcript` and `.squire-input-dock`, and structural
+turn/input/history counts only. The feedback event should have
+`associatedEventId` when the browser received the previous event id. Neither
+event may contain transcript text, input text, prompt text, model output, source
+passages, cookies, auth headers, or URL query strings. If `SENTRY_DSN` is
+missing, the page should still work and no browser telemetry request should be
+sent.
+
 GitHub repository secrets:
 
 - `FLY_API_TOKEN`

--- a/src/server.ts
+++ b/src/server.ts
@@ -161,10 +161,12 @@ import * as MessageStreamEventRepository from './db/repositories/message-stream-
 import type { BrowserStreamEventName } from './db/repositories/message-stream-event-repository.ts';
 import {
   captureTelemetryError,
+  captureTelemetryFeedback,
   captureTelemetryMessage,
   flushTelemetry,
   initTelemetry,
   type TelemetryCaptureInput,
+  type TelemetryFeedbackInput,
   type TelemetryUserIdentity,
 } from './telemetry.ts';
 
@@ -289,6 +291,73 @@ const BrowserTelemetryTokenSchema = z
   .max(128)
   .regex(/^[A-Za-z0-9._:-]+$/);
 
+const BrowserTelemetryEventIdSchema = z
+  .string()
+  .length(32)
+  .regex(/^[a-f0-9]+$/i);
+
+const BrowserFeedbackKindSchema = z.enum([
+  'wrong_answer',
+  'stream_failed',
+  'ui_broken',
+  'source_problem',
+  'other',
+]);
+
+const BrowserMaskedReplayMaskSelectorSchema = z.enum([
+  '.squire-transcript',
+  '.squire-question',
+  '.squire-answer',
+  '.squire-answer__content',
+  '.squire-answer__artifacts',
+  '.squire-answer-work',
+  '.squire-input-dock',
+  '.squire-input-dock textarea',
+  '.squire-history-row',
+  '.squire-campaign-strip',
+  '.squire-campaign-dashboard',
+  '.squire-character-sheet',
+]);
+
+const BrowserMaskedReplayBlockSelectorSchema = z.enum([
+  '.squire-account-menu',
+  '.squire-account-menu__panel',
+  '.squire-account-menu__avatar',
+]);
+
+const BrowserMaskedReplaySchema = z
+  .object({
+    version: z.literal(1),
+    textMasked: z.literal(true),
+    attributesMasked: z.literal(true),
+    snapshotId: BrowserTelemetryTokenSchema.optional(),
+    maskSelectors: z.array(BrowserMaskedReplayMaskSelectorSchema).min(1).max(24),
+    blockSelectors: z.array(BrowserMaskedReplayBlockSelectorSchema).min(1).max(12),
+    turns: z
+      .object({
+        userTurnCount: z.number().int().nonnegative().max(1_000),
+        assistantTurnCount: z.number().int().nonnegative().max(1_000),
+        pendingTurnCount: z.number().int().nonnegative().max(1_000),
+        workLogCount: z.number().int().nonnegative().max(1_000),
+        errorBannerCount: z.number().int().nonnegative().max(1_000),
+      })
+      .strict(),
+    input: z
+      .object({
+        present: z.boolean(),
+        valueLengthBucket: z.enum(['0', '1-80', '81-240', '241+']),
+      })
+      .strict(),
+    history: z
+      .object({
+        rowCount: z.number().int().nonnegative().max(1_000),
+        activeStatus: z.enum(['idle', 'running', 'error', 'unknown']),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
 const BrowserTelemetrySchema = z
   .object({
     type: z.enum([
@@ -296,6 +365,7 @@ const BrowserTelemetrySchema = z
       'browser_unhandledrejection',
       'browser_stream_error',
       'browser_htmx_error',
+      'browser_feedback',
     ]),
     route: z.string().min(1).max(2048).optional(),
     conversationId: BrowserTelemetryTokenSchema.optional(),
@@ -317,6 +387,9 @@ const BrowserTelemetrySchema = z
     streamReadyState: z.number().int().min(0).max(2).optional(),
     htmxEvent: BrowserTelemetryTokenSchema.optional(),
     htmxStatus: z.number().int().min(0).max(999).optional(),
+    feedbackKind: BrowserFeedbackKindSchema.optional(),
+    associatedEventId: BrowserTelemetryEventIdSchema.optional(),
+    maskedReplay: BrowserMaskedReplaySchema.optional(),
   })
   .strict();
 
@@ -364,7 +437,22 @@ function buildBrowserTelemetryInput(
       streamReadyState: event.streamReadyState ?? null,
       htmxEvent: event.htmxEvent ?? null,
       htmxStatus: event.htmxStatus ?? null,
+      maskedReplay: event.maskedReplay ?? null,
     },
+  };
+}
+
+function buildBrowserFeedbackInput(
+  c: Context,
+  requestId: string,
+  event: BrowserTelemetryEvent,
+): TelemetryFeedbackInput | null {
+  if (event.type !== 'browser_feedback' || !event.feedbackKind) return null;
+  const input = buildBrowserTelemetryInput(c, requestId, event);
+  return {
+    ...input,
+    feedbackKind: event.feedbackKind,
+    associatedEventId: event.associatedEventId,
   };
 }
 
@@ -2891,12 +2979,19 @@ app.post('/api/browser-telemetry', optionalSession(), async (c) => {
   const result = BrowserTelemetrySchema.safeParse(body);
   if (!result.success) return c.body(null, 204);
 
-  captureTelemetryMessage(
+  if (result.data.type === 'browser_feedback') {
+    const feedbackInput = buildBrowserFeedbackInput(c, requestId, result.data);
+    if (!feedbackInput) return c.body(null, 204);
+    const eventId = captureTelemetryFeedback(feedbackInput);
+    return c.json({ eventId }, 202);
+  }
+
+  const eventId = captureTelemetryMessage(
     `browser.${result.data.type}`,
     'error',
     buildBrowserTelemetryInput(c, requestId, result.data),
   );
-  return c.body(null, 204);
+  return c.json({ eventId }, 202);
 });
 
 // ─── Search endpoints ────────────────────────────────────────────────────────

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -69,6 +69,18 @@ export interface TelemetryBreadcrumbInput extends TelemetryCaptureInput {
   level?: SeverityLevel;
 }
 
+export type TelemetryFeedbackKind =
+  | 'wrong_answer'
+  | 'stream_failed'
+  | 'ui_broken'
+  | 'source_problem'
+  | 'other';
+
+export interface TelemetryFeedbackInput extends TelemetryCaptureInput {
+  feedbackKind: TelemetryFeedbackKind;
+  associatedEventId?: string;
+}
+
 export interface TelemetryInitResult {
   enabled: boolean;
   reason: 'initialized' | 'already_initialized' | 'missing_dsn' | 'init_failed';
@@ -96,6 +108,8 @@ const PROTECTED_KEY_PARTS = [
   'providerresponse',
   'requestbody',
   'responsebody',
+  'rawfeedback',
+  'comment',
   'retrievedpassage',
   'retrievedsource',
   'sourcepassage',
@@ -263,6 +277,16 @@ function buildSafeUser(input: TelemetryDiagnosticInput): User | undefined {
   return hash ? { id: hash } : undefined;
 }
 
+function buildSafeFeedbackTags(
+  input: TelemetryFeedbackInput,
+  env: Env = process.env,
+): Record<string, string> {
+  return {
+    ...buildSafeTelemetryTags(input, env),
+    feedback_kind: input.feedbackKind,
+  };
+}
+
 function buildSentryContext(input: TelemetryCaptureInput, env: Env): Record<string, SafeJson> {
   return {
     diagnostic: buildDiagnosticMetadata(input, env),
@@ -318,19 +342,25 @@ export function isTelemetryEnabled(): boolean {
  * context. Raw prompts, model output, provider payloads, and retrieved text must
  * stay in LangSmith or source systems, never in this input.
  */
-export function captureTelemetryError(error: unknown, input: TelemetryCaptureInput = {}): void {
-  if (!isTelemetryEnabled()) return;
+export function captureTelemetryError(
+  error: unknown,
+  input: TelemetryCaptureInput = {},
+): string | null {
+  if (!isTelemetryEnabled()) return null;
 
   try {
+    let eventId: string | null = null;
     Sentry.withScope((scope) => {
       scope.setTags(buildSafeTelemetryTags(input));
       scope.setContext('squire', buildSentryContext(input, process.env));
       const user = buildSafeUser(input);
       if (user) scope.setUser(user);
-      Sentry.captureException(error);
+      eventId = Sentry.captureException(error);
     });
+    return eventId;
   } catch {
     // Telemetry must never change app behavior.
+    return null;
   }
 }
 
@@ -342,19 +372,56 @@ export function captureTelemetryMessage(
   message: string,
   level: SeverityLevel = 'error',
   input: TelemetryCaptureInput = {},
-): void {
-  if (!isTelemetryEnabled()) return;
+): string | null {
+  if (!isTelemetryEnabled()) return null;
 
   try {
+    let eventId: string | null = null;
     Sentry.withScope((scope) => {
       scope.setTags(buildSafeTelemetryTags(input));
       scope.setContext('squire', buildSentryContext(input, process.env));
       const user = buildSafeUser(input);
       if (user) scope.setUser(user);
-      Sentry.captureMessage(redactSensitiveString(message), level);
+      eventId = Sentry.captureMessage(redactSensitiveString(message), level);
     });
+    return eventId;
   } catch {
     // Telemetry must never change app behavior.
+    return null;
+  }
+}
+
+/**
+ * Capture categorical browser feedback without accepting free-form prose.
+ * If an associated event id exists, Sentry links the feedback to that event.
+ */
+export function captureTelemetryFeedback(input: TelemetryFeedbackInput): string | null {
+  if (!isTelemetryEnabled()) return null;
+
+  try {
+    let eventId: string | null = null;
+    const route = buildDiagnosticMetadata(input).route;
+    const tags = buildSafeFeedbackTags(input);
+    Sentry.withScope((scope) => {
+      scope.setTags(tags);
+      scope.setContext('squire', buildSentryContext(input, process.env));
+      const user = buildSafeUser(input);
+      if (user) scope.setUser(user);
+      eventId = Sentry.captureFeedback(
+        {
+          message: `Squire browser feedback: ${input.feedbackKind}`,
+          source: 'squire-browser',
+          associatedEventId: safeString(input.associatedEventId),
+          url: route === TELEMETRY_UNAVAILABLE ? undefined : route,
+          tags,
+        },
+        { includeReplay: true },
+      );
+    });
+    return eventId;
+  } catch {
+    // Telemetry must never change app behavior.
+    return null;
   }
 }
 

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -19,6 +19,34 @@ var supportedActiveGames = fallbackSupportedActiveGames;
 var activeGame = defaultActiveGame;
 var activeGameInitialized = false;
 var browserTelemetryConfig = null;
+var lastBrowserTelemetryEventId = null;
+
+var MASKED_REPLAY_MASK_SELECTORS = [
+  '.squire-transcript',
+  '.squire-question',
+  '.squire-answer',
+  '.squire-answer__content',
+  '.squire-answer__artifacts',
+  '.squire-answer-work',
+  '.squire-input-dock',
+  '.squire-input-dock textarea',
+  '.squire-history-row',
+  '.squire-campaign-strip',
+  '.squire-campaign-dashboard',
+  '.squire-character-sheet',
+];
+var MASKED_REPLAY_BLOCK_SELECTORS = [
+  '.squire-account-menu',
+  '.squire-account-menu__panel',
+  '.squire-account-menu__avatar',
+];
+var ALLOWED_BROWSER_FEEDBACK_KINDS = {
+  wrong_answer: true,
+  stream_failed: true,
+  ui_broken: true,
+  source_problem: true,
+  other: true,
+};
 
 function safePathOnly(raw) {
   if (typeof raw !== 'string') return null;
@@ -120,6 +148,106 @@ function userAgentTelemetry() {
   return navigatorLike.userAgent.slice(0, 512);
 }
 
+function boundedSelectorCount(selector) {
+  if (!document.querySelectorAll) return 0;
+  try {
+    var nodes = document.querySelectorAll(selector);
+    return Math.min(1000, positiveTelemetryNumber(nodes.length) || 0);
+  } catch {
+    return 0;
+  }
+}
+
+function inputValueLengthBucket() {
+  var input = document.querySelector ? document.querySelector('.squire-input-dock textarea') : null;
+  var value = input && typeof input.value === 'string' ? input.value : '';
+  var length = value.length;
+  if (length === 0) return '0';
+  if (length <= 80) return '1-80';
+  if (length <= 240) return '81-240';
+  return '241+';
+}
+
+function activeHistoryStatus() {
+  var row = document.querySelector ? document.querySelector('.squire-history-row.is-active') : null;
+  var value = row && row.getAttribute ? row.getAttribute('data-history-status') : null;
+  if (value === 'idle' || value === 'running' || value === 'error') return value;
+  return 'unknown';
+}
+
+function maskedReplaySnapshotId() {
+  var cryptoLike = window.crypto;
+  if (cryptoLike && typeof cryptoLike.randomUUID === 'function') {
+    return telemetryToken(cryptoLike.randomUUID(), 'masked-replay-snapshot');
+  }
+  return 'masked-replay-snapshot';
+}
+
+function buildMaskedReplaySnapshot() {
+  // This is intentionally structural, not DOM/text capture. Sentry gets enough
+  // shape to debug layout and stream state without transcript, prompt, or input text.
+  return {
+    version: 1,
+    textMasked: true,
+    attributesMasked: true,
+    snapshotId: maskedReplaySnapshotId(),
+    maskSelectors: MASKED_REPLAY_MASK_SELECTORS.slice(),
+    blockSelectors: MASKED_REPLAY_BLOCK_SELECTORS.slice(),
+    turns: {
+      userTurnCount: boundedSelectorCount('.squire-question'),
+      assistantTurnCount: boundedSelectorCount('.squire-answer'),
+      pendingTurnCount: boundedSelectorCount('.squire-answer--pending'),
+      workLogCount: boundedSelectorCount('.squire-answer-work'),
+      errorBannerCount: boundedSelectorCount('.squire-banner--error'),
+    },
+    input: {
+      present: Boolean(
+        document.querySelector && document.querySelector('.squire-input-dock textarea'),
+      ),
+      valueLengthBucket: inputValueLengthBucket(),
+    },
+    history: {
+      rowCount: boundedSelectorCount('.squire-history-row'),
+      activeStatus: activeHistoryStatus(),
+    },
+  };
+}
+
+function sentryEventId(value) {
+  if (typeof value !== 'string') return null;
+  var trimmed = value.trim();
+  return /^[a-f0-9]{32}$/i.test(trimmed) ? trimmed : null;
+}
+
+function browserFeedbackKind(value) {
+  if (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(ALLOWED_BROWSER_FEEDBACK_KINDS, value)
+  ) {
+    return value;
+  }
+  return 'other';
+}
+
+function rememberBrowserTelemetryEventId(response, rememberEventId) {
+  if (!response || typeof response.json !== 'function') return null;
+  try {
+    var parsed = response.json();
+    if (!parsed || typeof parsed.then !== 'function') return null;
+    return parsed
+      .then(function (body) {
+        var eventId = sentryEventId(body && body.eventId);
+        if (eventId && rememberEventId) lastBrowserTelemetryEventId = eventId;
+        return eventId;
+      })
+      .catch(function () {
+        return null;
+      });
+  } catch {
+    return null;
+  }
+}
+
 function assignTelemetryValue(target, key, value) {
   if (typeof value === 'string') {
     var trimmed = value.trim();
@@ -168,22 +296,50 @@ function sendBrowserTelemetry(type, details) {
     assignTelemetryValue(payload, 'streamReadyState', details.streamReadyState);
     assignTelemetryValue(payload, 'htmxEvent', details.htmxEvent);
     assignTelemetryValue(payload, 'htmxStatus', details.htmxStatus);
+    assignTelemetryValue(payload, 'feedbackKind', details.feedbackKind);
+    assignTelemetryValue(payload, 'associatedEventId', details.associatedEventId);
+  }
+  if (!details || details.includeMaskedReplay !== false) {
+    payload.maskedReplay = buildMaskedReplaySnapshot();
   }
 
   var fetchFn = window.fetch;
   if (typeof fetchFn !== 'function') return;
 
   try {
+    var rememberEventId = !details || details.rememberEventId !== false;
     var result = fetchFn.call(window, config.endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
       keepalive: true,
     });
+    if (result && typeof result.then === 'function') {
+      var handled = result.then(function (response) {
+        return rememberBrowserTelemetryEventId(response, rememberEventId);
+      });
+      if (handled && typeof handled.catch === 'function') handled.catch(function () {});
+      return handled;
+    }
     if (result && typeof result.catch === 'function') result.catch(function () {});
+    return result;
   } catch {
     // Browser telemetry must never affect the app UI.
   }
+}
+
+function reportBrowserFeedback(details) {
+  var eventId =
+    sentryEventId(details && details.eventId) ||
+    sentryEventId(details && details.associatedEventId) ||
+    lastBrowserTelemetryEventId;
+  var payload = {
+    feedbackKind: browserFeedbackKind(details && details.feedbackKind),
+    rememberEventId: false,
+  };
+  if (eventId) payload.associatedEventId = eventId;
+  if (details && details.streamUrl) payload.streamUrl = details.streamUrl;
+  sendBrowserTelemetry('browser_feedback', payload);
 }
 
 if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
@@ -228,6 +384,9 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
   });
   document.addEventListener('htmx:timeout', function (event) {
     reportHtmxTransportError('htmx:timeout', event);
+  });
+  document.addEventListener('squire:browser-feedback', function (event) {
+    reportBrowserFeedback(event && event.detail);
   });
 }
 

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -73,6 +73,7 @@ const {
   mockRunReadinessChecks,
   mockInitTelemetry,
   mockCaptureTelemetryError,
+  mockCaptureTelemetryFeedback,
   mockCaptureTelemetryMessage,
   mockAddTelemetryBreadcrumb,
   mockFlushTelemetry,
@@ -92,6 +93,7 @@ const {
   mockRunReadinessChecks: vi.fn(),
   mockInitTelemetry: vi.fn(() => ({ enabled: false, reason: 'missing_dsn' })),
   mockCaptureTelemetryError: vi.fn(),
+  mockCaptureTelemetryFeedback: vi.fn(),
   mockCaptureTelemetryMessage: vi.fn(),
   mockAddTelemetryBreadcrumb: vi.fn(),
   mockFlushTelemetry: vi.fn().mockResolvedValue(true),
@@ -126,6 +128,7 @@ vi.mock('../src/health.ts', () => ({
 vi.mock('../src/telemetry.ts', () => ({
   initTelemetry: mockInitTelemetry,
   captureTelemetryError: mockCaptureTelemetryError,
+  captureTelemetryFeedback: mockCaptureTelemetryFeedback,
   captureTelemetryMessage: mockCaptureTelemetryMessage,
   addTelemetryBreadcrumb: mockAddTelemetryBreadcrumb,
   flushTelemetry: mockFlushTelemetry,
@@ -227,6 +230,7 @@ function resetRouteMocks() {
   mockListCards.mockReset();
   mockGetCard.mockReset();
   mockRunReadinessChecks.mockReset();
+  mockCaptureTelemetryFeedback.mockReset();
 }
 
 afterEach(() => {
@@ -239,6 +243,8 @@ describe('POST /api/browser-telemetry', () => {
   });
 
   it('captures browser diagnostics through Sentry with same-origin-safe metadata', async () => {
+    mockCaptureTelemetryMessage.mockReturnValueOnce('0123456789abcdef0123456789abcdef');
+
     const res = await app.request('/api/browser-telemetry', {
       method: 'POST',
       headers: {
@@ -259,7 +265,10 @@ describe('POST /api/browser-telemetry', () => {
       }),
     });
 
-    expect(res.status).toBe(204);
+    expect(res.status).toBe(202);
+    await expect(res.json()).resolves.toEqual({
+      eventId: '0123456789abcdef0123456789abcdef',
+    });
     expect(mockCaptureTelemetryMessage).toHaveBeenCalledTimes(1);
     expect(mockCaptureTelemetryMessage).toHaveBeenCalledWith(
       'browser.browser_error',
@@ -279,6 +288,7 @@ describe('POST /api/browser-telemetry', () => {
           column: 4,
           viewport: { width: 390, height: 844 },
           userAgent: 'SquireTest/1.0',
+          maskedReplay: null,
         }),
       }),
     );
@@ -303,6 +313,7 @@ describe('POST /api/browser-telemetry', () => {
 
     expect(res.status).toBe(204);
     expect(mockCaptureTelemetryMessage).not.toHaveBeenCalled();
+    expect(mockCaptureTelemetryFeedback).not.toHaveBeenCalled();
   });
 
   it('drops browser telemetry with prompt-like diagnostic identifiers', async () => {
@@ -322,6 +333,115 @@ describe('POST /api/browser-telemetry', () => {
 
     expect(res.status).toBe(204);
     expect(mockCaptureTelemetryMessage).not.toHaveBeenCalled();
+    expect(mockCaptureTelemetryFeedback).not.toHaveBeenCalled();
+  });
+
+  it('captures masked replay feedback without accepting raw user prose', async () => {
+    mockCaptureTelemetryFeedback.mockReturnValueOnce('fedcba9876543210fedcba9876543210');
+
+    const res = await app.request('/api/browser-telemetry', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-request-id': 'req-browser-feedback-1',
+      },
+      body: JSON.stringify({
+        type: 'browser_feedback',
+        route: '/chat/conv-1?token=secret',
+        conversationId: 'conv-1',
+        userMessageId: 'msg-user-1',
+        feedbackKind: 'stream_failed',
+        associatedEventId: '0123456789abcdef0123456789abcdef',
+        maskedReplay: {
+          version: 1,
+          textMasked: true,
+          attributesMasked: true,
+          maskSelectors: ['.squire-transcript', '.squire-input-dock'],
+          blockSelectors: ['.squire-account-menu'],
+          turns: {
+            userTurnCount: 1,
+            assistantTurnCount: 1,
+            pendingTurnCount: 0,
+            workLogCount: 1,
+            errorBannerCount: 1,
+          },
+          input: {
+            present: true,
+            valueLengthBucket: '81-240',
+          },
+          history: {
+            rowCount: 3,
+            activeStatus: 'error',
+          },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(202);
+    await expect(res.json()).resolves.toEqual({
+      eventId: 'fedcba9876543210fedcba9876543210',
+    });
+    expect(mockCaptureTelemetryMessage).not.toHaveBeenCalled();
+    expect(mockCaptureTelemetryFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        feedbackKind: 'stream_failed',
+        associatedEventId: '0123456789abcdef0123456789abcdef',
+        route: '/chat/conv-1',
+        requestId: 'req-browser-feedback-1',
+        conversationId: 'conv-1',
+        userMessageId: 'msg-user-1',
+        context: expect.objectContaining({
+          surface: 'browser',
+          eventType: 'browser_feedback',
+          telemetryEndpoint: '/api/browser-telemetry',
+          maskedReplay: expect.objectContaining({
+            textMasked: true,
+            maskSelectors: ['.squire-transcript', '.squire-input-dock'],
+          }),
+        }),
+      }),
+    );
+    const telemetryInput = JSON.stringify(mockCaptureTelemetryFeedback.mock.calls[0][0]);
+    expect(telemetryInput).not.toContain('token=secret');
+  });
+
+  it('drops browser feedback that tries to include prose or unapproved replay selectors', async () => {
+    const res = await app.request('/api/browser-telemetry', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-request-id': 'req-browser-feedback-bad-1',
+      },
+      body: JSON.stringify({
+        type: 'browser_feedback',
+        route: '/chat/conv-1',
+        feedbackKind: 'stream_failed',
+        associatedEventId: '0123456789abcdef0123456789abcdef',
+        comment: 'the raw prompt and answer',
+        maskedReplay: {
+          version: 1,
+          textMasked: true,
+          attributesMasked: true,
+          maskSelectors: ['body'],
+          blockSelectors: ['.squire-account-menu'],
+          turns: {
+            userTurnCount: 1,
+            assistantTurnCount: 1,
+            pendingTurnCount: 0,
+            workLogCount: 1,
+            errorBannerCount: 1,
+          },
+          input: {
+            present: true,
+            valueLengthBucket: '81-240',
+          },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(204);
+    expect(mockCaptureTelemetryMessage).not.toHaveBeenCalled();
+    expect(mockCaptureTelemetryFeedback).not.toHaveBeenCalled();
   });
 });
 

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -17,6 +17,7 @@ const sentry = vi.hoisted(() => {
     init: vi.fn(),
     withScope: vi.fn((callback: (scopeArg: Scope) => void) => callback(scope)),
     captureException: vi.fn(),
+    captureFeedback: vi.fn(),
     captureMessage: vi.fn(),
     addBreadcrumb: vi.fn(),
     flush: vi.fn(),
@@ -33,6 +34,7 @@ import {
   buildDiagnosticMetadata,
   buildSafeTelemetryTags,
   captureTelemetryError,
+  captureTelemetryFeedback,
   captureTelemetryMessage,
   flushTelemetry,
   initTelemetry,
@@ -84,6 +86,7 @@ describe('telemetry boundary', () => {
     expect(sentry.init).not.toHaveBeenCalled();
     expect(sentry.withScope).not.toHaveBeenCalled();
     expect(sentry.captureException).not.toHaveBeenCalled();
+    expect(sentry.captureFeedback).not.toHaveBeenCalled();
     expect(sentry.captureMessage).not.toHaveBeenCalled();
     expect(sentry.addBreadcrumb).not.toHaveBeenCalled();
     expect(sentry.flush).not.toHaveBeenCalled();
@@ -306,5 +309,77 @@ describe('telemetry boundary', () => {
     });
     await expect(flushTelemetry(100)).resolves.toBe(true);
     expect(sentry.flush).toHaveBeenCalledWith(100);
+  });
+
+  it('captures categorical user feedback linked to the browser event without free text', () => {
+    process.env.SENTRY_DSN = 'https://public@example.sentry.io/123';
+    process.env.SENTRY_RELEASE = 'abc123';
+    process.env.SQUIRE_ENV = 'production';
+    sentry.captureFeedback.mockReturnValue('feedback-event-1');
+    initTelemetry(process.env);
+
+    const eventId = captureTelemetryFeedback({
+      feedbackKind: 'stream_failed',
+      associatedEventId: '0123456789abcdef0123456789abcdef',
+      route: '/chat/conv-1?token=secret',
+      requestId: 'req-1',
+      conversationId: 'conv-1',
+      userMessageId: 'msg-user-1',
+      user: { id: 'user-1', email: 'person@example.com' },
+      context: {
+        surface: 'browser',
+        rawFeedback: 'my prompt and answer should stay out',
+        maskedReplay: {
+          textMasked: true,
+          turns: { assistantTurnCount: 1 },
+        },
+      },
+    });
+
+    expect(eventId).toBe('feedback-event-1');
+    expect(sentry.scope.setTags).toHaveBeenCalledWith({
+      environment: 'production',
+      release: 'abc123',
+      route: '/chat/conv-1',
+      request_id: 'req-1',
+      conversation_id: 'conv-1',
+      user_message_id: 'msg-user-1',
+      user_id: 'user-1',
+      feedback_kind: 'stream_failed',
+    });
+    expect(sentry.scope.setContext).toHaveBeenCalledWith(
+      'squire',
+      expect.objectContaining({
+        context: {
+          surface: 'browser',
+          rawFeedback: TELEMETRY_REDACTED,
+          maskedReplay: {
+            textMasked: true,
+            turns: { assistantTurnCount: 1 },
+          },
+        },
+      }),
+    );
+    expect(sentry.captureFeedback).toHaveBeenCalledWith(
+      {
+        message: 'Squire browser feedback: stream_failed',
+        source: 'squire-browser',
+        associatedEventId: '0123456789abcdef0123456789abcdef',
+        url: '/chat/conv-1',
+        tags: {
+          environment: 'production',
+          release: 'abc123',
+          route: '/chat/conv-1',
+          request_id: 'req-1',
+          conversation_id: 'conv-1',
+          user_message_id: 'msg-user-1',
+          user_id: 'user-1',
+          feedback_kind: 'stream_failed',
+        },
+      },
+      { includeReplay: true },
+    );
+    expect(JSON.stringify(sentry.captureFeedback.mock.calls[0])).not.toContain('my prompt');
+    expect(JSON.stringify(sentry.captureFeedback.mock.calls[0])).not.toContain('token=secret');
   });
 });

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -80,6 +80,7 @@ describe('telemetry boundary', () => {
     captureTelemetryError(new Error('boom'), { requestId: 'req-1' });
     captureTelemetryMessage('job failed');
     addTelemetryBreadcrumb({ category: 'auth', message: 'rate limit rejected' });
+    captureTelemetryFeedback({ feedbackKind: 'ui_broken' });
 
     await expect(flushTelemetry()).resolves.toBe(false);
 

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -458,14 +458,35 @@ function bootPendingTranscript(
   };
 }
 
-function bootBrowserTelemetryHarness(pathname = '/chat/conv-1') {
+function fakeNodeList(count: number) {
+  return Array.from({ length: count }, () => ({}));
+}
+
+function bootBrowserTelemetryHarness(
+  pathname = '/chat/conv-1',
+  options: {
+    responseEventIds?: string[];
+    selectorCounts?: Record<string, number>;
+    inputValue?: string;
+    activeHistoryStatus?: string;
+  } = {},
+) {
   const docListeners = new Map<string, Array<(event?: unknown) => void>>();
   const windowListeners = new Map<string, Array<(event?: unknown) => void>>();
   const telemetryPayloads: Array<{ url: string; body: unknown }> = [];
+  const responseEventIds = [...(options.responseEventIds ?? [])];
   const telemetryMeta = {
     getAttribute(name: string) {
       if (name !== 'content') return null;
       return JSON.stringify({ enabled: true, endpoint: '/api/browser-telemetry' });
+    },
+  };
+  const input = {
+    value: options.inputValue ?? '',
+  };
+  const activeHistory = {
+    getAttribute(name: string) {
+      return name === 'data-history-status' ? (options.activeHistoryStatus ?? 'idle') : null;
     },
   };
   const document = {
@@ -473,16 +494,21 @@ function bootBrowserTelemetryHarness(pathname = '/chat/conv-1') {
       docListeners.set(event, [...(docListeners.get(event) ?? []), callback]);
     },
     querySelector(selector: string) {
-      return selector === 'meta[name="squire-browser-telemetry"]' ? telemetryMeta : null;
+      if (selector === 'meta[name="squire-browser-telemetry"]') return telemetryMeta;
+      if (selector === '.squire-input-dock textarea') return input;
+      if (selector === '.squire-history-row.is-active') return activeHistory;
+      return null;
     },
-    querySelectorAll() {
-      return [];
+    querySelectorAll(selector: string) {
+      return fakeNodeList(options.selectorCounts?.[selector] ?? 0);
     },
     documentElement: { scrollHeight: 0 },
   };
   const window = {
     location: { pathname },
-    crypto: {},
+    crypto: {
+      randomUUID: () => 'masked-replay-snapshot-1',
+    },
     EventSource: function () {},
     addEventListener(event: string, callback: (event?: unknown) => void) {
       windowListeners.set(event, [...(windowListeners.get(event) ?? []), callback]);
@@ -497,7 +523,11 @@ function bootBrowserTelemetryHarness(pathname = '/chat/conv-1') {
         url,
         body: typeof init?.body === 'string' ? JSON.parse(init.body) : init?.body,
       });
-      return Promise.resolve({ ok: true });
+      const eventId = responseEventIds.shift() ?? null;
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ eventId }),
+      });
     },
   };
   const context = vm.createContext({ document, window });
@@ -507,6 +537,9 @@ function bootBrowserTelemetryHarness(pathname = '/chat/conv-1') {
   return {
     emitWindow(event: string, payload: unknown) {
       for (const callback of windowListeners.get(event) ?? []) callback(payload);
+    },
+    emitDocument(event: string, payload: unknown) {
+      for (const callback of docListeners.get(event) ?? []) callback(payload);
     },
     telemetryPayloads,
   };
@@ -522,7 +555,17 @@ function workRowMessages(rowsEl: FakeElement): Array<string | undefined> {
 
 describe('squire.js browser telemetry', () => {
   it('reports window errors without sending the thrown message body', () => {
-    const { emitWindow, telemetryPayloads } = bootBrowserTelemetryHarness('/chat/conv-1');
+    const { emitWindow, telemetryPayloads } = bootBrowserTelemetryHarness('/chat/conv-1', {
+      inputValue: 'raw prompt should stay masked',
+      selectorCounts: {
+        '.squire-question': 1,
+        '.squire-answer': 1,
+        '.squire-answer--pending': 0,
+        '.squire-answer-work': 1,
+        '.squire-banner--error': 0,
+        '.squire-history-row': 3,
+      },
+    });
 
     emitWindow('error', {
       error: { name: 'TypeError', message: 'raw prompt should stay out' },
@@ -545,6 +588,29 @@ describe('squire.js browser telemetry', () => {
         column: 4,
         viewport: { width: 390, height: 844 },
         userAgent: 'SquireTest/1.0',
+        maskedReplay: expect.objectContaining({
+          version: 1,
+          textMasked: true,
+          attributesMasked: true,
+          snapshotId: 'masked-replay-snapshot-1',
+          maskSelectors: expect.arrayContaining(['.squire-transcript', '.squire-input-dock']),
+          blockSelectors: expect.arrayContaining(['.squire-account-menu']),
+          turns: {
+            userTurnCount: 1,
+            assistantTurnCount: 1,
+            pendingTurnCount: 0,
+            workLogCount: 1,
+            errorBannerCount: 0,
+          },
+          input: {
+            present: true,
+            valueLengthBucket: '1-80',
+          },
+          history: {
+            rowCount: 3,
+            activeStatus: 'idle',
+          },
+        }),
       }),
     });
     expect(JSON.stringify(telemetryPayloads[0].body)).not.toContain('raw prompt');
@@ -569,6 +635,92 @@ describe('squire.js browser telemetry', () => {
       }),
     );
     expect(JSON.stringify(telemetryPayloads[0].body)).not.toContain('model answer');
+  });
+
+  it('submits categorical feedback linked to the last captured browser event', async () => {
+    const eventId = '0123456789abcdef0123456789abcdef';
+    const { emitWindow, emitDocument, telemetryPayloads } = bootBrowserTelemetryHarness(
+      '/chat/conv-1',
+      {
+        responseEventIds: [eventId, 'fedcba9876543210fedcba9876543210'],
+        inputValue: 'this prompt text must not be sent',
+        selectorCounts: {
+          '.squire-question': 1,
+          '.squire-answer': 1,
+          '.squire-answer--pending': 0,
+          '.squire-answer-work': 1,
+          '.squire-banner--error': 1,
+          '.squire-history-row': 2,
+        },
+        activeHistoryStatus: 'error',
+      },
+    );
+
+    emitWindow('error', {
+      error: { name: 'TypeError', message: 'raw answer should stay out' },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    emitDocument('squire:browser-feedback', {
+      detail: {
+        feedbackKind: 'stream_failed',
+        comment: 'the raw user feedback should stay out',
+      },
+    });
+
+    expect(telemetryPayloads).toHaveLength(2);
+    expect(telemetryPayloads[1]).toEqual({
+      url: '/api/browser-telemetry',
+      body: expect.objectContaining({
+        type: 'browser_feedback',
+        route: '/chat/conv-1',
+        conversationId: 'conv-1',
+        feedbackKind: 'stream_failed',
+        associatedEventId: eventId,
+        maskedReplay: expect.objectContaining({
+          textMasked: true,
+          turns: {
+            userTurnCount: 1,
+            assistantTurnCount: 1,
+            pendingTurnCount: 0,
+            workLogCount: 1,
+            errorBannerCount: 1,
+          },
+          input: {
+            present: true,
+            valueLengthBucket: '1-80',
+          },
+          history: {
+            rowCount: 2,
+            activeStatus: 'error',
+          },
+        }),
+      }),
+    });
+    expect(JSON.stringify(telemetryPayloads[1].body)).not.toContain('raw user feedback');
+    expect(JSON.stringify(telemetryPayloads[1].body)).not.toContain('this prompt text');
+  });
+
+  it('submits categorical feedback without an event link when no event id is available', () => {
+    const { emitDocument, telemetryPayloads } = bootBrowserTelemetryHarness('/chat/conv-1');
+
+    emitDocument('squire:browser-feedback', {
+      detail: {
+        feedbackKind: 'wrong_answer',
+      },
+    });
+
+    expect(telemetryPayloads).toHaveLength(1);
+    expect(telemetryPayloads[0].body).toEqual(
+      expect.objectContaining({
+        type: 'browser_feedback',
+        route: '/chat/conv-1',
+        conversationId: 'conv-1',
+        feedbackKind: 'wrong_answer',
+      }),
+    );
+    expect(telemetryPayloads[0].body).not.toHaveProperty('associatedEventId');
   });
 
   it('reports stream transport errors with conversation and message ids only', () => {


### PR DESCRIPTION
## Summary
- add categorical `squire:browser-feedback` capture through the existing browser telemetry endpoint
- attach a masked structural replay snapshot with allowlisted selectors, turn/input/history counts, viewport, route, conversation id, and event id linkage
- route feedback through the server-side Sentry boundary with safe tags, redaction, and docs for a safe smoke test

## Privacy
- no raw transcript, prompt, model output, source passages, free-form feedback text, cookies, auth headers, or query strings are accepted
- this uses a same-origin masked structural snapshot rather than adding a browser Session Replay SDK or a bundler

## Tests
- npm run check
- git diff --check
- npm audit --omit=dev

Fixes SQR-308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added browser feedback system allowing users to report UI issues and errors directly to telemetry.
  * Implemented masked replay data collection that captures diagnostic context while excluding sensitive information like transcripts and authentication data.
  * Feedback events can now be linked to specific telemetry incidents for better correlation.

* **Documentation**
  * Added observability guide detailing browser feedback and replay data handling.
  * Added production operations runbook for testing feedback systems safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->