### PR TITLE
feat(observability): add diagnostic bundle schema

### DIFF
--- a/docs/agent/diagnostic-bundle.md
+++ b/docs/agent/diagnostic-bundle.md
@@ -1,0 +1,46 @@
+# Diagnostic Bundle Contract
+
+Bug reports that originate from a Squire conversation should use
+`src/diagnostic-bundle.ts` as the evidence contract. The bundle is safe to copy
+into Linear because every evidence field is either:
+
+- `available`, with a redacted low-cardinality value
+- `unavailable`, with a concrete reason
+
+The bundle deliberately excludes raw cookies, auth headers, OAuth tokens, raw
+prompts, full model output, provider payloads, retrieved passages, and full
+source documents. Sentry owns app/runtime evidence, and LangSmith remains the
+trace/eval system for answer-quality debugging.
+
+## Shape
+
+Top-level fields:
+
+- `report`: generated time, environment, release SHA
+- `request`: request ID and route
+- `conversation`: conversation URL, conversation ID, turn IDs, safe user ID/hash,
+  game/campaign IDs, message timestamps, assistant error flag
+- `sentry`: issue, event, and replay URLs
+- `langsmith`: trace/thread/run URLs and IDs
+- `browser`: safe browser URL, user agent, viewport, replay snapshot ID
+- `stream`: terminal status, event count, and safe work-log rows
+- `sourceIndex`: embedding version plus consulted/work-log source labels
+- `unavailable`: flattened list of missing field paths and reasons
+
+Work-log rows are reduced to public event names, sequence numbers, timestamps,
+source labels, boolean success, and canonical refs. They do not include tool
+messages, artifact bodies, state summaries, proposal lines, or stream text.
+
+## Collection
+
+Use `collectDiagnosticBundle()` when the caller has an authenticated safe user
+ID and wants repository-backed evidence from a conversation URL, conversation
+ID, or user-message ID. The collector verifies conversation ownership before it
+loads messages or stream events.
+
+Use `buildDiagnosticBundle()` when the caller already has safe evidence, such as
+a Sentry URL or LangSmith URL supplied by an agent workflow. Missing fields are
+not omitted; they are marked unavailable.
+
+SQR-310's Linear Evidence template should render from this bundle rather than
+inventing ad hoc field names.

--- a/src/diagnostic-bundle.ts
+++ b/src/diagnostic-bundle.ts
@@ -1,0 +1,646 @@
+import { z } from 'zod';
+
+import * as ConversationRepository from './db/repositories/conversation-repository.ts';
+import * as MessageRepository from './db/repositories/message-repository.ts';
+import * as MessageStreamEventRepository from './db/repositories/message-stream-event-repository.ts';
+import type {
+  Conversation,
+  ConversationMessage,
+  ConversationMessagePublicWorkEventName,
+} from './db/repositories/types.ts';
+import {
+  buildDiagnosticMetadata,
+  redactTelemetryValue,
+  TELEMETRY_UNAVAILABLE,
+  type TelemetryUserIdentity,
+} from './telemetry.ts';
+import { EMBEDDING_VERSION } from './vector-store.ts';
+
+type DiagnosticPrimitive = string | number | boolean | null;
+type DiagnosticJson = DiagnosticPrimitive | DiagnosticJson[] | { [key: string]: DiagnosticJson };
+
+export type DiagnosticField<T> =
+  | { status: 'available'; value: T }
+  | { status: 'unavailable'; reason: string };
+
+export interface DiagnosticBrowserMetadata {
+  url?: string;
+  userAgent?: string;
+  viewport?: { width: number; height: number };
+  replaySnapshotId?: string;
+}
+
+export interface DiagnosticBundleLinkInput {
+  sentryIssueUrl?: string;
+  sentryEventUrl?: string;
+  sentryReplayUrl?: string;
+  langsmithTraceUrl?: string;
+  langsmithThreadUrl?: string;
+  langsmithThreadId?: string;
+  langsmithRunUrl?: string;
+  langsmithRunId?: string;
+}
+
+export interface DiagnosticBundleInput extends DiagnosticBundleLinkInput {
+  now?: Date;
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  route?: string;
+  browserUrl?: string;
+  conversationUrl?: string;
+  requestId?: string;
+  conversationId?: string;
+  userMessageId?: string;
+  assistantMessageId?: string;
+  user?: TelemetryUserIdentity;
+  browser?: DiagnosticBrowserMetadata;
+  conversation?: Conversation | null;
+  messages?: ConversationMessage[] | null;
+  streamEvents?: MessageStreamEventRepository.MessageStreamEvent[] | null;
+}
+
+export interface CollectDiagnosticBundleInput extends DiagnosticBundleInput {
+  dataSource?: DiagnosticBundleDataSource;
+}
+
+export interface DiagnosticBundleDataSource {
+  findOwnedConversation(userId: string, conversationId: string): Promise<Conversation | null>;
+  findMessageById(messageId: string): Promise<ConversationMessage | null>;
+  listMessagesByConversationId(conversationId: string): Promise<ConversationMessage[]>;
+  listStreamEventsByUserMessageId(
+    userMessageId: string,
+  ): Promise<MessageStreamEventRepository.MessageStreamEvent[]>;
+}
+
+export interface DiagnosticWorkLogRow {
+  sequence: number;
+  event: ConversationMessagePublicWorkEventName;
+  createdAt: string;
+  sourceLabels: string[];
+  ok?: boolean;
+  ref?: string;
+}
+
+export interface DiagnosticUnavailableField {
+  path: string;
+  reason: string;
+}
+
+const DiagnosticJsonSchema: z.ZodType<DiagnosticJson> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(DiagnosticJsonSchema),
+    z.record(z.string(), DiagnosticJsonSchema),
+  ]),
+);
+
+export const DiagnosticFieldSchema = z.discriminatedUnion('status', [
+  z.object({ status: z.literal('available'), value: DiagnosticJsonSchema }).strict(),
+  z.object({ status: z.literal('unavailable'), reason: z.string().min(1) }).strict(),
+]);
+
+export const DiagnosticWorkLogRowSchema = z
+  .object({
+    sequence: z.number().int().nonnegative(),
+    event: z.enum(['tool-plan', 'tool-progress', 'tool-result', 'answer-artifact']),
+    createdAt: z.string().datetime(),
+    sourceLabels: z.array(z.string().min(1)).max(12),
+    ok: z.boolean().optional(),
+    ref: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const DiagnosticBundleSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    report: z
+      .object({
+        generatedAt: DiagnosticFieldSchema,
+        environment: DiagnosticFieldSchema,
+        release: DiagnosticFieldSchema,
+      })
+      .strict(),
+    request: z
+      .object({
+        requestId: DiagnosticFieldSchema,
+        route: DiagnosticFieldSchema,
+      })
+      .strict(),
+    conversation: z
+      .object({
+        url: DiagnosticFieldSchema,
+        id: DiagnosticFieldSchema,
+        userId: DiagnosticFieldSchema,
+        userHash: DiagnosticFieldSchema,
+        userMessageId: DiagnosticFieldSchema,
+        assistantMessageId: DiagnosticFieldSchema,
+        game: DiagnosticFieldSchema,
+        campaignId: DiagnosticFieldSchema,
+        userMessageCreatedAt: DiagnosticFieldSchema,
+        assistantMessageCreatedAt: DiagnosticFieldSchema,
+        assistantIsError: DiagnosticFieldSchema,
+      })
+      .strict(),
+    sentry: z
+      .object({
+        issueUrl: DiagnosticFieldSchema,
+        eventUrl: DiagnosticFieldSchema,
+        replayUrl: DiagnosticFieldSchema,
+      })
+      .strict(),
+    langsmith: z
+      .object({
+        traceUrl: DiagnosticFieldSchema,
+        threadUrl: DiagnosticFieldSchema,
+        threadId: DiagnosticFieldSchema,
+        runUrl: DiagnosticFieldSchema,
+        runId: DiagnosticFieldSchema,
+      })
+      .strict(),
+    browser: z
+      .object({
+        url: DiagnosticFieldSchema,
+        userAgent: DiagnosticFieldSchema,
+        viewport: DiagnosticFieldSchema,
+        replaySnapshotId: DiagnosticFieldSchema,
+      })
+      .strict(),
+    stream: z
+      .object({
+        status: DiagnosticFieldSchema,
+        terminalEvent: DiagnosticFieldSchema,
+        eventCount: DiagnosticFieldSchema,
+        workLogRows: z.union([
+          z
+            .object({ status: z.literal('available'), value: z.array(DiagnosticWorkLogRowSchema) })
+            .strict(),
+          z.object({ status: z.literal('unavailable'), reason: z.string().min(1) }).strict(),
+        ]),
+      })
+      .strict(),
+    sourceIndex: z
+      .object({
+        embeddingVersion: DiagnosticFieldSchema,
+        consultedSourceLabels: DiagnosticFieldSchema,
+        workLogSourceLabels: DiagnosticFieldSchema,
+      })
+      .strict(),
+    unavailable: z.array(z.object({ path: z.string().min(1), reason: z.string().min(1) }).strict()),
+  })
+  .strict();
+
+export type DiagnosticBundle = z.infer<typeof DiagnosticBundleSchema>;
+
+const DEFAULT_DATA_SOURCE: DiagnosticBundleDataSource = {
+  findOwnedConversation: ConversationRepository.findOwnedById,
+  findMessageById: MessageRepository.findById,
+  listMessagesByConversationId: (conversationId) =>
+    MessageRepository.listByConversationId(conversationId, { includeErrors: true }),
+  listStreamEventsByUserMessageId: (userMessageId) =>
+    MessageStreamEventRepository.listAfter({ userMessageId }),
+};
+
+const TOKEN_PATTERN = /^[A-Za-z0-9._:-]{1,256}$/;
+const SAFE_REF_PATTERN =
+  /^(?:rules|scenario|section|card|source):[A-Za-z0-9._:-]+(?:\/[A-Za-z0-9._:-]+)+(?:#chunk=\d+)?$/;
+const PUBLIC_WORK_EVENTS = new Set<string>([
+  'tool-plan',
+  'tool-progress',
+  'tool-result',
+  'answer-artifact',
+]);
+
+function available<T>(value: T): DiagnosticField<T> {
+  return { status: 'available', value: redactTelemetryValue(value) as T };
+}
+
+function unavailable<T>(reason: string): DiagnosticField<T> {
+  return { status: 'unavailable', reason };
+}
+
+function hasText(value: string | undefined): value is string {
+  return value !== undefined && value.trim().length > 0;
+}
+
+function safeToken(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !TOKEN_PATTERN.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+function safeSourceLabel(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 64) return null;
+  return /^[A-Z][A-Z0-9 _-]*$/.test(trimmed) ? trimmed : null;
+}
+
+function safeRef(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return SAFE_REF_PATTERN.test(trimmed) ? trimmed : undefined;
+}
+
+function safePathOrUrl(value: string | undefined): string | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+
+  try {
+    if (/^https?:\/\//i.test(raw)) {
+      const url = new URL(raw);
+      return `${url.origin}${url.pathname || '/'}`;
+    }
+  } catch {
+    return undefined;
+  }
+
+  if (!raw.startsWith('/')) return undefined;
+  return raw.split('?')[0]?.split('#')[0] || '/';
+}
+
+function safeExternalUrl(value: string | undefined): string | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined;
+    return `${url.origin}${url.pathname || '/'}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function isoDate(value: Date | undefined): string | undefined {
+  if (!value || Number.isNaN(value.getTime())) return undefined;
+  return value.toISOString();
+}
+
+function field<T>(value: T | undefined | null, unavailableReason: string): DiagnosticField<T> {
+  if (value === undefined || value === null) return unavailable(unavailableReason);
+  if (typeof value === 'string' && value.trim().length === 0) return unavailable(unavailableReason);
+  return available(value);
+}
+
+function parseLocator(input: DiagnosticBundleInput): {
+  conversationId?: string;
+  userMessageId?: string;
+  conversationUrl?: string;
+  route?: string;
+  browserUrl?: string;
+} {
+  const conversationUrl = safePathOrUrl(input.conversationUrl);
+  const browserUrl = safePathOrUrl(input.browserUrl ?? input.browser?.url);
+  const route = safePathOrUrl(input.route ?? conversationUrl ?? browserUrl);
+  const path = route ? safePathOrUrl(route) : undefined;
+  const chatMatch = path?.match(/^\/chat\/([^/]+)$/);
+  const streamMatch = path?.match(/^\/chat\/([^/]+)\/messages\/([^/]+)\/stream$/);
+
+  return {
+    conversationId:
+      safeToken(input.conversationId) ?? safeToken(streamMatch?.[1]) ?? safeToken(chatMatch?.[1]),
+    userMessageId: safeToken(input.userMessageId) ?? safeToken(streamMatch?.[2]),
+    conversationUrl,
+    route,
+    browserUrl,
+  };
+}
+
+function findUserMessage(
+  messages: ConversationMessage[],
+  userMessageId: string | undefined,
+  assistantMessage: ConversationMessage | undefined,
+): ConversationMessage | undefined {
+  if (userMessageId) return messages.find((message) => message.id === userMessageId);
+  if (assistantMessage?.responseToMessageId) {
+    return messages.find((message) => message.id === assistantMessage.responseToMessageId);
+  }
+  return [...messages].reverse().find((message) => message.role === 'user');
+}
+
+function findAssistantMessage(
+  messages: ConversationMessage[],
+  assistantMessageId: string | undefined,
+  userMessage: ConversationMessage | undefined,
+): ConversationMessage | undefined {
+  if (assistantMessageId) return messages.find((message) => message.id === assistantMessageId);
+  if (userMessage) {
+    const response = messages.find(
+      (message) => message.role === 'assistant' && message.responseToMessageId === userMessage.id,
+    );
+    if (response) return response;
+  }
+  return [...messages].reverse().find((message) => message.role === 'assistant');
+}
+
+function sourceLabelsFromPayload(payload: Record<string, unknown>): string[] {
+  const labels = new Set<string>();
+  const add = (value: unknown) => {
+    const label = safeSourceLabel(value);
+    if (label) labels.add(label);
+  };
+
+  add(payload.label);
+  add(payload.sourceLabel);
+  if (Array.isArray(payload.labels)) {
+    for (const label of payload.labels) add(label);
+  }
+  return [...labels].slice(0, 12);
+}
+
+function buildWorkLogRows(
+  streamEvents: MessageStreamEventRepository.MessageStreamEvent[] | undefined,
+): DiagnosticField<DiagnosticWorkLogRow[]> {
+  if (!streamEvents) return unavailable('stream events were not loaded');
+
+  const rows: DiagnosticWorkLogRow[] = [];
+  for (const event of streamEvents) {
+    if (!PUBLIC_WORK_EVENTS.has(event.event)) continue;
+    const publicEvent = event.event as ConversationMessagePublicWorkEventName;
+    const payload = event.payload ?? {};
+    const row: DiagnosticWorkLogRow = {
+      sequence: event.sequence,
+      event: publicEvent,
+      createdAt: event.createdAt.toISOString(),
+      sourceLabels: sourceLabelsFromPayload(payload),
+    };
+    if (typeof payload.ok === 'boolean') row.ok = payload.ok;
+    const ref = safeRef(payload.ref);
+    if (ref) row.ref = ref;
+    rows.push(row);
+  }
+  return available(rows);
+}
+
+function streamStatus(
+  streamEvents: MessageStreamEventRepository.MessageStreamEvent[] | undefined,
+): {
+  status: DiagnosticField<string>;
+  terminalEvent: DiagnosticField<string>;
+  eventCount: DiagnosticField<number>;
+} {
+  if (!streamEvents) {
+    return {
+      status: unavailable('stream events were not loaded'),
+      terminalEvent: unavailable('stream events were not loaded'),
+      eventCount: unavailable('stream events were not loaded'),
+    };
+  }
+
+  const terminal = streamEvents.findLast(
+    (event) => event.event === 'done' || event.event === 'error',
+  );
+  return {
+    status: available(
+      terminal?.event === 'done'
+        ? 'complete'
+        : terminal?.event === 'error'
+          ? 'error'
+          : 'incomplete',
+    ),
+    terminalEvent: terminal
+      ? available(terminal.event)
+      : unavailable('no terminal stream event recorded'),
+    eventCount: available(streamEvents.length),
+  };
+}
+
+function collectSourceLabels(
+  assistantMessage: ConversationMessage | undefined,
+  workLogRows: DiagnosticField<DiagnosticWorkLogRow[]>,
+): {
+  consultedSourceLabels: DiagnosticField<string[]>;
+  workLogSourceLabels: DiagnosticField<string[]>;
+} {
+  const consulted = (assistantMessage?.consultedSources ?? [])
+    .map((label) => safeSourceLabel(label) ?? safeToken(label))
+    .filter((label): label is string => Boolean(label));
+
+  const workLogLabels =
+    workLogRows.status === 'available'
+      ? [...new Set(workLogRows.value.flatMap((row) => row.sourceLabels))]
+      : undefined;
+
+  return {
+    consultedSourceLabels:
+      consulted.length > 0
+        ? available([...new Set(consulted)].slice(0, 24))
+        : unavailable('assistant message has no consulted source labels'),
+    workLogSourceLabels:
+      workLogLabels && workLogLabels.length > 0
+        ? available(workLogLabels.slice(0, 24))
+        : unavailable('work log has no source labels'),
+  };
+}
+
+function unavailableFields(value: unknown, path: string[] = []): DiagnosticUnavailableField[] {
+  if (typeof value !== 'object' || value === null) return [];
+  if ('status' in value && (value as { status?: unknown }).status === 'unavailable') {
+    return [
+      {
+        path: path.join('.'),
+        reason: String((value as { reason?: unknown }).reason ?? 'unavailable'),
+      },
+    ];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => unavailableFields(item, [...path, String(index)]));
+  }
+  return Object.entries(value)
+    .filter(([key]) => key !== 'unavailable')
+    .flatMap(([key, child]) => unavailableFields(child, [...path, key]));
+}
+
+export function buildDiagnosticBundle(input: DiagnosticBundleInput = {}): DiagnosticBundle {
+  const locator = parseLocator(input);
+  const metadata = buildDiagnosticMetadata(
+    {
+      route: locator.route ?? input.route,
+      requestId: input.requestId,
+      conversationId: locator.conversationId,
+      userMessageId: locator.userMessageId,
+      assistantMessageId: input.assistantMessageId,
+      user: input.user,
+      langsmithThreadUrl: input.langsmithThreadUrl,
+      langsmithRunUrl: input.langsmithRunUrl,
+    },
+    input.env,
+  );
+  const messages = input.messages ?? [];
+  const explicitAssistantId = safeToken(input.assistantMessageId);
+  const preliminaryAssistant = explicitAssistantId
+    ? messages.find((message) => message.id === explicitAssistantId)
+    : undefined;
+  const userMessage = findUserMessage(messages, locator.userMessageId, preliminaryAssistant);
+  const assistantMessage = findAssistantMessage(messages, explicitAssistantId, userMessage);
+  const workLogRows = buildWorkLogRows(input.streamEvents ?? undefined);
+  const status = streamStatus(input.streamEvents ?? undefined);
+  const sourceLabels = collectSourceLabels(assistantMessage, workLogRows);
+  const conversationId =
+    locator.conversationId ??
+    input.conversation?.id ??
+    userMessage?.conversationId ??
+    assistantMessage?.conversationId;
+
+  const bundleWithoutUnavailable = {
+    schemaVersion: 1 as const,
+    report: {
+      generatedAt: available((input.now ?? new Date()).toISOString()),
+      environment:
+        metadata.environment === TELEMETRY_UNAVAILABLE
+          ? unavailable('environment is not configured')
+          : available(metadata.environment),
+      release:
+        metadata.release === TELEMETRY_UNAVAILABLE
+          ? unavailable('SENTRY_RELEASE is not configured')
+          : available(metadata.release),
+    },
+    request: {
+      requestId:
+        metadata.requestId === TELEMETRY_UNAVAILABLE
+          ? unavailable('request id was not provided')
+          : available(metadata.requestId),
+      route:
+        metadata.route === TELEMETRY_UNAVAILABLE
+          ? unavailable('route could not be derived')
+          : available(metadata.route),
+    },
+    conversation: {
+      url: field(locator.conversationUrl, 'conversation URL was not provided'),
+      id: field(safeToken(conversationId), 'conversation id was not provided or loaded'),
+      userId:
+        metadata.userId === TELEMETRY_UNAVAILABLE
+          ? unavailable('safe user id was not provided')
+          : available(metadata.userId),
+      userHash:
+        metadata.userHash === TELEMETRY_UNAVAILABLE
+          ? unavailable('safe user hash was not provided')
+          : available(metadata.userHash),
+      userMessageId: field(
+        userMessage?.id ?? locator.userMessageId,
+        'user message id was not provided or loaded',
+      ),
+      assistantMessageId: field(
+        assistantMessage?.id ?? explicitAssistantId,
+        'assistant message id was not provided or loaded',
+      ),
+      game: field(userMessage?.game ?? undefined, 'user message game was not loaded'),
+      campaignId: field(userMessage?.campaignId ?? undefined, 'message has no campaign binding'),
+      userMessageCreatedAt: field(isoDate(userMessage?.createdAt), 'user message was not loaded'),
+      assistantMessageCreatedAt: field(
+        isoDate(assistantMessage?.createdAt),
+        'assistant message was not loaded',
+      ),
+      assistantIsError:
+        assistantMessage === undefined
+          ? unavailable('assistant message was not loaded')
+          : available(assistantMessage.isError),
+    },
+    sentry: {
+      issueUrl: field(safeExternalUrl(input.sentryIssueUrl), 'Sentry issue URL was not provided'),
+      eventUrl: field(safeExternalUrl(input.sentryEventUrl), 'Sentry event URL was not provided'),
+      replayUrl: field(
+        safeExternalUrl(input.sentryReplayUrl),
+        'Sentry replay URL was not provided',
+      ),
+    },
+    langsmith: {
+      traceUrl: field(
+        safeExternalUrl(input.langsmithTraceUrl),
+        'LangSmith trace URL was not provided',
+      ),
+      threadUrl: field(
+        safeExternalUrl(input.langsmithThreadUrl),
+        'LangSmith thread URL was not provided',
+      ),
+      threadId: field(
+        safeToken(input.langsmithThreadId) ?? safeToken(conversationId),
+        'LangSmith thread id was not provided or derivable',
+      ),
+      runUrl: field(safeExternalUrl(input.langsmithRunUrl), 'LangSmith run URL was not provided'),
+      runId: field(safeToken(input.langsmithRunId), 'LangSmith run id was not provided'),
+    },
+    browser: {
+      url: field(locator.browserUrl, 'browser URL was not provided'),
+      userAgent: field(
+        hasText(input.browser?.userAgent) ? input.browser.userAgent.slice(0, 512) : undefined,
+        'browser user agent was not provided',
+      ),
+      viewport: field(
+        input.browser?.viewport
+          ? {
+              width: input.browser.viewport.width,
+              height: input.browser.viewport.height,
+            }
+          : undefined,
+        'browser viewport was not provided',
+      ),
+      replaySnapshotId: field(
+        safeToken(input.browser?.replaySnapshotId),
+        'browser replay snapshot id was not provided',
+      ),
+    },
+    stream: {
+      status: status.status,
+      terminalEvent: status.terminalEvent,
+      eventCount: status.eventCount,
+      workLogRows,
+    },
+    sourceIndex: {
+      embeddingVersion: available(EMBEDDING_VERSION),
+      consultedSourceLabels: sourceLabels.consultedSourceLabels,
+      workLogSourceLabels: sourceLabels.workLogSourceLabels,
+    },
+  };
+
+  const bundle = {
+    ...bundleWithoutUnavailable,
+    unavailable: unavailableFields(bundleWithoutUnavailable),
+  };
+  return DiagnosticBundleSchema.parse(bundle);
+}
+
+export async function collectDiagnosticBundle(
+  input: CollectDiagnosticBundleInput = {},
+): Promise<DiagnosticBundle> {
+  const dataSource = input.dataSource ?? DEFAULT_DATA_SOURCE;
+  const locator = parseLocator(input);
+  const userId = safeToken(input.user?.id);
+  let conversation = input.conversation ?? null;
+  let messages = input.messages ?? null;
+  let streamEvents = input.streamEvents ?? null;
+  let conversationId = locator.conversationId;
+  let userMessageId = locator.userMessageId;
+
+  if (!conversationId && userMessageId && userId) {
+    const message = await dataSource.findMessageById(userMessageId);
+    if (message) conversationId = message.conversationId;
+  }
+
+  if (!conversation && conversationId && userId) {
+    conversation = await dataSource.findOwnedConversation(userId, conversationId);
+  }
+
+  if (!messages && conversation) {
+    messages = await dataSource.listMessagesByConversationId(conversation.id);
+  }
+
+  if (!userMessageId && messages) {
+    userMessageId = findUserMessage(messages, undefined, undefined)?.id;
+  }
+
+  if (!streamEvents && userMessageId && conversation) {
+    streamEvents = await dataSource.listStreamEventsByUserMessageId(userMessageId);
+  }
+
+  return buildDiagnosticBundle({
+    ...input,
+    conversationId: conversationId ?? input.conversationId,
+    userMessageId: userMessageId ?? input.userMessageId,
+    conversation,
+    messages,
+    streamEvents,
+  });
+}

--- a/test/diagnostic-bundle.test.ts
+++ b/test/diagnostic-bundle.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildDiagnosticBundle,
+  collectDiagnosticBundle,
+  DiagnosticBundleSchema,
+  type DiagnosticBundleDataSource,
+} from '../src/diagnostic-bundle.ts';
+import type { Conversation, ConversationMessage } from '../src/db/repositories/types.ts';
+import type { MessageStreamEvent } from '../src/db/repositories/message-stream-event-repository.ts';
+import { EMBEDDING_VERSION } from '../src/vector-store.ts';
+
+const now = new Date('2026-06-14T12:00:00.000Z');
+const conversation: Conversation = {
+  id: '11111111-1111-4111-8111-111111111111',
+  userId: '22222222-2222-4222-8222-222222222222',
+  creationIdempotencyKey: null,
+  createdAt: new Date('2026-06-14T11:55:00.000Z'),
+  lastMessageAt: new Date('2026-06-14T11:59:00.000Z'),
+};
+const userMessage: ConversationMessage = {
+  id: '33333333-3333-4333-8333-333333333333',
+  conversationId: conversation.id,
+  role: 'user',
+  content: 'raw prompt with Bearer secret-token',
+  game: 'frosthaven',
+  campaignId: '44444444-4444-4444-8444-444444444444',
+  isError: false,
+  responseToMessageId: null,
+  consultedSources: null,
+  createdAt: new Date('2026-06-14T11:56:00.000Z'),
+};
+const assistantMessage: ConversationMessage = {
+  id: '55555555-5555-4555-8555-555555555555',
+  conversationId: conversation.id,
+  role: 'assistant',
+  content: 'full model answer that must not enter the diagnostic bundle',
+  game: null,
+  campaignId: null,
+  isError: true,
+  responseToMessageId: userMessage.id,
+  consultedSources: ['RULEBOOK', 'search_rules'],
+  createdAt: new Date('2026-06-14T11:57:00.000Z'),
+};
+const streamEvents: MessageStreamEvent[] = [
+  {
+    sequence: 1,
+    event: 'tool-progress',
+    payload: {
+      label: 'RULEBOOK',
+      message: 'Searching raw user prompt text',
+    },
+    createdAt: new Date('2026-06-14T11:56:10.000Z'),
+  },
+  {
+    sequence: 2,
+    event: 'answer-artifact',
+    payload: {
+      sourceLabel: 'SECTION BOOK',
+      ref: 'section:frosthaven/123.1',
+      title: 'Secret section title',
+      body: 'raw retrieved source passage',
+    },
+    createdAt: new Date('2026-06-14T11:56:20.000Z'),
+  },
+  {
+    sequence: 3,
+    event: 'error',
+    payload: {
+      kind: 'transport',
+      message: 'raw error text',
+    },
+    createdAt: new Date('2026-06-14T11:56:30.000Z'),
+  },
+];
+
+describe('diagnostic bundle', () => {
+  it('builds a full safe bundle from conversation evidence', () => {
+    const bundle = buildDiagnosticBundle({
+      now,
+      env: {
+        SQUIRE_ENV: 'production',
+        SENTRY_RELEASE: '5f2b5f152df6c3b277d2234a82717ef8cd060a52',
+      },
+      conversationUrl: `https://squire.maz.org/chat/${conversation.id}?token=secret`,
+      browserUrl: `https://squire.maz.org/chat/${conversation.id}?historyQuery=secret`,
+      requestId: 'req-safe-1',
+      user: { id: conversation.userId, hash: 'user-hash-1', email: 'person@example.com' },
+      sentryIssueUrl: 'https://sentry.io/organizations/maz/issues/123/?query=secret',
+      sentryEventUrl: 'https://sentry.io/organizations/maz/issues/123/events/abc/?project=1',
+      sentryReplayUrl: 'https://sentry.io/replays/xyz/?query=secret',
+      langsmithTraceUrl: 'https://smith.langchain.com/o/org/projects/p/project/r/run-1?secret=1',
+      langsmithThreadUrl: 'https://smith.langchain.com/o/org/projects/p/project/threads/thread-1',
+      langsmithRunId: 'run-1',
+      browser: {
+        userAgent: 'SquireTest/1.0',
+        viewport: { width: 390, height: 844 },
+        replaySnapshotId: 'masked-replay-snapshot-1',
+      },
+      conversation,
+      messages: [userMessage, assistantMessage],
+      streamEvents,
+    });
+
+    expect(DiagnosticBundleSchema.parse(bundle)).toEqual(bundle);
+    expect(bundle.report.generatedAt).toEqual({
+      status: 'available',
+      value: '2026-06-14T12:00:00.000Z',
+    });
+    expect(bundle.conversation.id).toEqual({ status: 'available', value: conversation.id });
+    expect(bundle.conversation.userMessageId).toEqual({
+      status: 'available',
+      value: userMessage.id,
+    });
+    expect(bundle.conversation.assistantMessageId).toEqual({
+      status: 'available',
+      value: assistantMessage.id,
+    });
+    expect(bundle.conversation.url).toEqual({
+      status: 'available',
+      value: `https://squire.maz.org/chat/${conversation.id}`,
+    });
+    expect(bundle.sentry.eventUrl).toEqual({
+      status: 'available',
+      value: 'https://sentry.io/organizations/maz/issues/123/events/abc/',
+    });
+    expect(bundle.langsmith.traceUrl).toEqual({
+      status: 'available',
+      value: 'https://smith.langchain.com/o/org/projects/p/project/r/run-1',
+    });
+    expect(bundle.stream.status).toEqual({ status: 'available', value: 'error' });
+    expect(bundle.stream.workLogRows).toEqual({
+      status: 'available',
+      value: [
+        {
+          sequence: 1,
+          event: 'tool-progress',
+          createdAt: '2026-06-14T11:56:10.000Z',
+          sourceLabels: ['RULEBOOK'],
+        },
+        {
+          sequence: 2,
+          event: 'answer-artifact',
+          createdAt: '2026-06-14T11:56:20.000Z',
+          sourceLabels: ['SECTION BOOK'],
+          ref: 'section:frosthaven/123.1',
+        },
+      ],
+    });
+    expect(bundle.sourceIndex.embeddingVersion).toEqual({
+      status: 'available',
+      value: EMBEDDING_VERSION,
+    });
+    expect(JSON.stringify(bundle)).not.toContain('token=secret');
+    expect(JSON.stringify(bundle)).not.toContain('historyQuery=secret');
+    expect(JSON.stringify(bundle)).not.toContain('raw prompt');
+    expect(JSON.stringify(bundle)).not.toContain('full model answer');
+    expect(JSON.stringify(bundle)).not.toContain('raw retrieved source passage');
+    expect(JSON.stringify(bundle)).not.toContain('person@example.com');
+  });
+
+  it('marks missing Sentry, LangSmith, replay, and message data with unavailable reasons', () => {
+    const bundle = buildDiagnosticBundle({
+      now,
+      env: { SQUIRE_ENV: 'test' },
+      conversationUrl: `https://squire.maz.org/chat/${conversation.id}`,
+    });
+
+    expect(bundle.sentry.issueUrl.status).toBe('unavailable');
+    expect(bundle.sentry.eventUrl.status).toBe('unavailable');
+    expect(bundle.sentry.replayUrl.status).toBe('unavailable');
+    expect(bundle.langsmith.traceUrl.status).toBe('unavailable');
+    expect(bundle.browser.replaySnapshotId.status).toBe('unavailable');
+    expect(bundle.stream.workLogRows.status).toBe('unavailable');
+    expect(bundle.unavailable).toEqual(
+      expect.arrayContaining([
+        { path: 'sentry.issueUrl', reason: 'Sentry issue URL was not provided' },
+        { path: 'langsmith.traceUrl', reason: 'LangSmith trace URL was not provided' },
+        { path: 'stream.workLogRows', reason: 'stream events were not loaded' },
+      ]),
+    );
+  });
+
+  it('does not leak protected fields from browser or work-log evidence', () => {
+    const bundle = buildDiagnosticBundle({
+      now,
+      browserUrl: 'https://squire.maz.org/chat/abc?cookie=session',
+      browser: {
+        userAgent: 'Bearer sk_test_secret_secret_secret',
+        viewport: { width: 1024, height: 768 },
+      },
+      messages: [
+        {
+          ...userMessage,
+          content: 'prompt: do not include this',
+        },
+        {
+          ...assistantMessage,
+          content: 'answer: do not include this',
+          consultedSources: ['RULEBOOK'],
+        },
+      ],
+      streamEvents: [
+        {
+          sequence: 1,
+          event: 'tool-result',
+          payload: {
+            labels: ['RULEBOOK'],
+            ok: false,
+            providerPayload: { prompt: 'secret prompt', answer: 'secret answer' },
+            message: 'raw provider failure',
+          },
+          createdAt: now,
+        },
+      ],
+    });
+
+    const serialized = JSON.stringify(bundle);
+    expect(serialized).not.toContain('cookie=session');
+    expect(serialized).not.toContain('sk_test');
+    expect(serialized).not.toContain('do not include this');
+    expect(serialized).not.toContain('secret prompt');
+    expect(serialized).not.toContain('secret answer');
+    expect(serialized).not.toContain('raw provider failure');
+    expect(bundle.stream.workLogRows).toEqual({
+      status: 'available',
+      value: [
+        {
+          sequence: 1,
+          event: 'tool-result',
+          createdAt: '2026-06-14T12:00:00.000Z',
+          sourceLabels: ['RULEBOOK'],
+          ok: false,
+        },
+      ],
+    });
+  });
+
+  it('collects conversation evidence by message id through an ownership-aware data source', async () => {
+    const dataSource: DiagnosticBundleDataSource = {
+      findOwnedConversation: vi.fn(async () => conversation),
+      findMessageById: vi.fn(async () => userMessage),
+      listMessagesByConversationId: vi.fn(async () => [userMessage, assistantMessage]),
+      listStreamEventsByUserMessageId: vi.fn(async () => streamEvents),
+    };
+
+    const bundle = await collectDiagnosticBundle({
+      now,
+      userMessageId: userMessage.id,
+      user: { id: conversation.userId },
+      dataSource,
+    });
+
+    expect(dataSource.findMessageById).toHaveBeenCalledWith(userMessage.id);
+    expect(dataSource.findOwnedConversation).toHaveBeenCalledWith(
+      conversation.userId,
+      conversation.id,
+    );
+    expect(dataSource.listMessagesByConversationId).toHaveBeenCalledWith(conversation.id);
+    expect(dataSource.listStreamEventsByUserMessageId).toHaveBeenCalledWith(userMessage.id);
+    expect(bundle.conversation.id).toEqual({ status: 'available', value: conversation.id });
+    expect(bundle.conversation.assistantMessageId).toEqual({
+      status: 'available',
+      value: assistantMessage.id,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a safe diagnostic bundle schema for conversation-originated bug reports
- add repository-backed collection by conversation URL, conversation ID, or user-message ID with ownership checks
- document the contract for SQR-310 and cover full, missing, redaction, and collection fixtures

## Tests
- npm run check
- npm test -- test/diagnostic-bundle.test.ts test/telemetry.test.ts
- npm audit --omit=dev

Fixes SQR-309