### PR TITLE
feat(observability): add Linear bug evidence template

### DIFF
--- a/docs/agent/agent-baseline.md
+++ b/docs/agent/agent-baseline.md
@@ -33,6 +33,7 @@ Read these on demand:
 | Write a tech spec or plan-review checkpoint                                | [planning-artifacts.md](./planning-artifacts.md) |
 | Record a design/eng decision, or implement a feature that might touch one  | [adrs.md](./adrs.md)                             |
 | Search prior agent learnings, plans, transcripts, and gbrain memory        | [learnings.md](./learnings.md)                   |
+| File a production/user-reported bug in Linear                              | [bug-reporting.md](./bug-reporting.md)           |
 
 ## Always-on rules
 

--- a/docs/agent/bug-reporting.md
+++ b/docs/agent/bug-reporting.md
@@ -1,0 +1,63 @@
+# Bug Reporting
+
+Use this workflow when filing a Squire bug from a user report, production
+investigation, QA run, or agent conversation.
+
+## Destination
+
+Default Linear target:
+
+- Team: `SQR`
+- Project: `Squire · Bugs`
+- Assignee: `me`
+- State: `Todo`
+
+Use the current feature project only when the bug is a narrow follow-up from an
+active implementation PR. Production/user-reported defects belong in
+`Squire · Bugs`.
+
+## Evidence Template
+
+Bug tickets must use `createLinearBugReportBody()` from
+`src/linear-bug-report-template.ts`. The helper renders the fixed Evidence
+section from `DiagnosticBundle` and fills every required field with either a
+safe value or `Unavailable: <reason>`.
+
+Required sections:
+
+- `Evidence`
+- `Observed Behavior`
+- `Expected Behavior`
+- `Why This Is Likely Failing`
+- `First Files To Inspect`
+- `Repro Steps`
+- `Acceptance Criteria`
+
+For app/runtime bugs, call the helper with `kind: "app_runtime"` so Sentry is
+listed before LangSmith. For answer-quality bugs, use `kind: "answer_quality"`
+so LangSmith is listed first and Sentry remains context only when there was an
+app/runtime error.
+
+## Inputs
+
+Build the evidence bundle with:
+
+- `collectDiagnosticBundle()` when the caller has an authenticated user and a
+  conversation URL, conversation ID, or user-message ID.
+- `buildDiagnosticBundle()` when the agent already gathered safe links and IDs,
+  such as Sentry event/replay URLs or LangSmith trace/run URLs.
+
+Do not paste raw prompts, full model output, provider payloads, retrieved
+passages, cookies, auth headers, OAuth tokens, or secrets into Linear. If a
+piece of evidence cannot be safely gathered, leave it unavailable with the
+reason from the bundle.
+
+## SQR-298 And SQR-299
+
+SQR-298's in-chat bug report flow should create the same `DiagnosticBundle` and
+pass the user's short observed/expected text into
+`createLinearBugReportBody()` before creating the Linear issue.
+
+SQR-299's shared Codex/Claude bug-reporting skill should use the same helper
+for dry runs and issue creation. The skill can own dedupe, priority, labels, and
+Linear calls, but it should not own a separate issue-body template.

--- a/docs/agent/diagnostic-bundle.md
+++ b/docs/agent/diagnostic-bundle.md
@@ -42,5 +42,7 @@ Use `buildDiagnosticBundle()` when the caller already has safe evidence, such as
 a Sentry URL or LangSmith URL supplied by an agent workflow. Missing fields are
 not omitted; they are marked unavailable.
 
-SQR-310's Linear Evidence template should render from this bundle rather than
+SQR-310's Linear Evidence template renders this bundle with
+`createLinearBugReportBody()` in `src/linear-bug-report-template.ts`. New
+in-chat or agent-created bug report paths should call that helper rather than
 inventing ad hoc field names.

--- a/src/linear-bug-report-template.ts
+++ b/src/linear-bug-report-template.ts
@@ -1,0 +1,115 @@
+import type { DiagnosticBundle, DiagnosticField } from './diagnostic-bundle.ts';
+import { redactTelemetryValue } from './telemetry.ts';
+
+export type LinearBugReportKind = 'app_runtime' | 'answer_quality';
+
+export interface LinearBugReportTemplateInput {
+  bundle: DiagnosticBundle;
+  kind: LinearBugReportKind;
+  observed?: string;
+  expected?: string;
+  likelyFailingArea?: string;
+  firstFilesToInspect?: string[];
+  reproSteps?: string[];
+  acceptanceCriteria?: string[];
+}
+
+const KIND_COPY: Record<LinearBugReportKind, string> = {
+  app_runtime: 'App/runtime bug. Start in Sentry, then use LangSmith only for LLM trace context.',
+  answer_quality:
+    'Answer-quality bug. Start in LangSmith, then use Sentry only if there was an app/runtime error.',
+};
+
+function toSafeText(value: unknown): string {
+  const redacted = redactTelemetryValue(value);
+  if (typeof redacted === 'string') return redacted.trim();
+  if (typeof redacted === 'number' || typeof redacted === 'boolean') return String(redacted);
+  if (redacted === null) return 'null';
+  return JSON.stringify(redacted);
+}
+
+function fieldText(field: DiagnosticField<unknown>): string {
+  if (field.status === 'unavailable') return `Unavailable: ${field.reason}`;
+  const text = toSafeText(field.value);
+  return text.length > 0 ? text : 'Unavailable: value was empty after redaction';
+}
+
+function optionalText(value: string | undefined, reason: string): string {
+  const text = toSafeText(value ?? '').trim();
+  return text.length > 0 ? text : `Unavailable: ${reason}`;
+}
+
+function bulletList(values: string[] | undefined, reason: string): string {
+  const safeValues = (values ?? [])
+    .map((value) => toSafeText(value))
+    .filter((value) => value.length > 0);
+  if (safeValues.length === 0) return `- Unavailable: ${reason}`;
+  return safeValues.map((value) => `- ${value}`).join('\n');
+}
+
+function renderSentryEvidence(bundle: DiagnosticBundle): string {
+  return [
+    'Sentry:',
+    `- Issue: ${fieldText(bundle.sentry.issueUrl)}`,
+    `- Event: ${fieldText(bundle.sentry.eventUrl)}`,
+    `- Replay: ${fieldText(bundle.sentry.replayUrl)}`,
+    `- Release: ${fieldText(bundle.report.release)}`,
+    `- Environment: ${fieldText(bundle.report.environment)}`,
+  ].join('\n');
+}
+
+function renderLangSmithEvidence(bundle: DiagnosticBundle): string {
+  return [
+    'LangSmith:',
+    `- Trace: ${fieldText(bundle.langsmith.traceUrl)}`,
+    `- Thread: ${fieldText(bundle.langsmith.threadId)}`,
+    `- Thread URL: ${fieldText(bundle.langsmith.threadUrl)}`,
+    `- Run ID: ${fieldText(bundle.langsmith.runId)}`,
+  ].join('\n');
+}
+
+function renderEvidence(input: LinearBugReportTemplateInput): string {
+  const coreEvidence = [
+    `Debug lane: ${KIND_COPY[input.kind]}`,
+    `Conversation: ${fieldText(input.bundle.conversation.url)}`,
+    `Turn: userMessageId=${fieldText(input.bundle.conversation.userMessageId)}, assistantMessageId=${fieldText(
+      input.bundle.conversation.assistantMessageId,
+    )}`,
+    `Request: ${fieldText(input.bundle.request.requestId)}`,
+  ].join('\n');
+  const orderedToolEvidence =
+    input.kind === 'answer_quality'
+      ? [renderLangSmithEvidence(input.bundle), renderSentryEvidence(input.bundle)]
+      : [renderSentryEvidence(input.bundle), renderLangSmithEvidence(input.bundle)];
+
+  return ['## Evidence', '', coreEvidence, '', ...orderedToolEvidence].join('\n\n');
+}
+
+export function createLinearBugReportBody(input: LinearBugReportTemplateInput): string {
+  return [
+    renderEvidence(input),
+    '## Observed Behavior',
+    '',
+    optionalText(input.observed, 'observed behavior was not provided'),
+    '',
+    '## Expected Behavior',
+    '',
+    optionalText(input.expected, 'expected behavior was not provided'),
+    '',
+    '## Why This Is Likely Failing',
+    '',
+    optionalText(input.likelyFailingArea, 'likely failing area was not provided'),
+    '',
+    '## First Files To Inspect',
+    '',
+    bulletList(input.firstFilesToInspect, 'first files to inspect were not provided'),
+    '',
+    '## Repro Steps',
+    '',
+    bulletList(input.reproSteps, 'repro steps were not provided'),
+    '',
+    '## Acceptance Criteria',
+    '',
+    bulletList(input.acceptanceCriteria, 'acceptance criteria were not provided'),
+  ].join('\n');
+}

--- a/test/linear-bug-report-template.test.ts
+++ b/test/linear-bug-report-template.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDiagnosticBundle } from '../src/diagnostic-bundle.ts';
+import { createLinearBugReportBody } from '../src/linear-bug-report-template.ts';
+import type { Conversation, ConversationMessage } from '../src/db/repositories/types.ts';
+import type { MessageStreamEvent } from '../src/db/repositories/message-stream-event-repository.ts';
+
+const now = new Date('2026-06-14T12:00:00.000Z');
+const conversation: Conversation = {
+  id: '11111111-1111-4111-8111-111111111111',
+  userId: '22222222-2222-4222-8222-222222222222',
+  creationIdempotencyKey: null,
+  createdAt: new Date('2026-06-14T11:55:00.000Z'),
+  lastMessageAt: new Date('2026-06-14T11:59:00.000Z'),
+};
+const userMessage: ConversationMessage = {
+  id: '33333333-3333-4333-8333-333333333333',
+  conversationId: conversation.id,
+  role: 'user',
+  content: 'raw prompt that must stay out of Linear',
+  game: 'frosthaven',
+  campaignId: '44444444-4444-4444-8444-444444444444',
+  isError: false,
+  responseToMessageId: null,
+  consultedSources: null,
+  createdAt: new Date('2026-06-14T11:56:00.000Z'),
+};
+const assistantMessage: ConversationMessage = {
+  id: '55555555-5555-4555-8555-555555555555',
+  conversationId: conversation.id,
+  role: 'assistant',
+  content: 'full model answer that must stay out of Linear',
+  game: null,
+  campaignId: null,
+  isError: true,
+  responseToMessageId: userMessage.id,
+  consultedSources: ['RULEBOOK'],
+  createdAt: new Date('2026-06-14T11:57:00.000Z'),
+};
+const streamEvents: MessageStreamEvent[] = [
+  {
+    sequence: 1,
+    event: 'tool-result',
+    payload: {
+      labels: ['RULEBOOK'],
+      ok: false,
+      providerPayload: { prompt: 'secret prompt', answer: 'secret answer' },
+    },
+    createdAt: new Date('2026-06-14T11:56:30.000Z'),
+  },
+  {
+    sequence: 2,
+    event: 'error',
+    payload: {
+      message: 'raw stream failure text',
+    },
+    createdAt: new Date('2026-06-14T11:56:31.000Z'),
+  },
+];
+
+function fullBundle() {
+  return buildDiagnosticBundle({
+    now,
+    env: {
+      SQUIRE_ENV: 'production',
+      SENTRY_RELEASE: 'dde5caa6dac615cf6523778944e9a6ba34690f8b',
+    },
+    conversationUrl: `https://squire.maz.org/chat/${conversation.id}?secret=1`,
+    requestId: 'req-safe-1',
+    user: { id: conversation.userId, email: 'person@example.com' },
+    sentryIssueUrl: 'https://sentry.io/organizations/maz/issues/123/?query=secret',
+    sentryEventUrl: 'https://sentry.io/organizations/maz/issues/123/events/abc/?project=1',
+    sentryReplayUrl: 'https://sentry.io/replays/xyz/?query=secret',
+    langsmithTraceUrl: 'https://smith.langchain.com/o/org/projects/p/project/r/run-1?secret=1',
+    langsmithThreadUrl: 'https://smith.langchain.com/o/org/projects/p/project/threads/thread-1',
+    langsmithRunId: 'run-1',
+    conversation,
+    messages: [userMessage, assistantMessage],
+    streamEvents,
+  });
+}
+
+describe('linear bug report template', () => {
+  it('renders every required evidence field for an app/runtime bug', () => {
+    const body = createLinearBugReportBody({
+      bundle: fullBundle(),
+      kind: 'app_runtime',
+      observed: 'The stream failed after the first tool result.',
+      expected: 'The assistant should finish or show the normal SSE error state.',
+      likelyFailingArea: 'SSE transport or conversation-service error handling.',
+      firstFilesToInspect: ['src/chat/conversation-service.ts', 'src/server.ts'],
+      reproSteps: ['Open the conversation URL.', 'Reload the failing assistant turn.'],
+      acceptanceCriteria: [
+        'The same failure creates one Sentry event and a stable Linear bug body.',
+      ],
+    });
+
+    expect(body).toContain('## Evidence');
+    expect(body).toContain(`Conversation: https://squire.maz.org/chat/${conversation.id}`);
+    expect(body).toContain(
+      `Turn: userMessageId=${userMessage.id}, assistantMessageId=${assistantMessage.id}`,
+    );
+    expect(body).toContain('Request: req-safe-1');
+    expect(body).toContain('Sentry:');
+    expect(body).toContain('- Issue: https://sentry.io/organizations/maz/issues/123/');
+    expect(body).toContain('- Event: https://sentry.io/organizations/maz/issues/123/events/abc/');
+    expect(body).toContain('- Replay: https://sentry.io/replays/xyz/');
+    expect(body).toContain('- Release: dde5caa6dac615cf6523778944e9a6ba34690f8b');
+    expect(body).toContain('- Environment: production');
+    expect(body).toContain('LangSmith:');
+    expect(body).toContain('- Trace: https://smith.langchain.com/o/org/projects/p/project/r/run-1');
+    expect(body).toContain('- Thread: 11111111-1111-4111-8111-111111111111');
+    expect(body).toContain(
+      '- Thread URL: https://smith.langchain.com/o/org/projects/p/project/threads/thread-1',
+    );
+    expect(body).toContain('- Run ID: run-1');
+    expect(body).toContain('## Observed Behavior');
+    expect(body).toContain('## Expected Behavior');
+    expect(body).toContain('## Why This Is Likely Failing');
+    expect(body).toContain('## First Files To Inspect');
+    expect(body).toContain('## Repro Steps');
+    expect(body).toContain('## Acceptance Criteria');
+    expect(body.indexOf('Sentry:')).toBeLessThan(body.indexOf('LangSmith:'));
+  });
+
+  it('leads with LangSmith for answer-quality bugs', () => {
+    const body = createLinearBugReportBody({
+      bundle: fullBundle(),
+      kind: 'answer_quality',
+      observed: 'The assistant cited the wrong rule interaction.',
+      expected: 'The assistant should cite the relevant perk rule.',
+      likelyFailingArea: 'Retrieval or final-answer synthesis.',
+      firstFilesToInspect: ['src/agent-langgraph.ts', 'src/vector-store.ts'],
+      reproSteps: ['Open the conversation URL.', 'Review the cited answer turn.'],
+      acceptanceCriteria: ['The corrected answer is backed by the cited rule source.'],
+    });
+
+    expect(body).toContain(
+      'Debug lane: Answer-quality bug. Start in LangSmith, then use Sentry only if there was an app/runtime error.',
+    );
+    expect(body.indexOf('LangSmith:')).toBeLessThan(body.indexOf('Sentry:'));
+  });
+
+  it('emits unavailable reasons instead of omitting missing data', () => {
+    const body = createLinearBugReportBody({
+      bundle: buildDiagnosticBundle({
+        now,
+        env: { SQUIRE_ENV: 'test' },
+        conversationUrl: `https://squire.maz.org/chat/${conversation.id}`,
+      }),
+      kind: 'app_runtime',
+    });
+
+    expect(body).toContain('Request: Unavailable: request id was not provided');
+    expect(body).toContain('- Issue: Unavailable: Sentry issue URL was not provided');
+    expect(body).toContain('- Event: Unavailable: Sentry event URL was not provided');
+    expect(body).toContain('- Replay: Unavailable: Sentry replay URL was not provided');
+    expect(body).toContain('- Release: Unavailable: SENTRY_RELEASE is not configured');
+    expect(body).toContain('- Trace: Unavailable: LangSmith trace URL was not provided');
+    expect(body).toContain('Unavailable: observed behavior was not provided');
+    expect(body).toContain('- Unavailable: first files to inspect were not provided');
+    expect(body).toContain('- Unavailable: repro steps were not provided');
+    expect(body).toContain('- Unavailable: acceptance criteria were not provided');
+  });
+
+  it('does not include protected diagnostic or caller-provided fields', () => {
+    const body = createLinearBugReportBody({
+      bundle: fullBundle(),
+      kind: 'app_runtime',
+      observed: 'Bearer sk_test_secret_secret_secret',
+      expected: 'No raw token should be visible.',
+      likelyFailingArea: 'providerPayload prompt should not leak.',
+      firstFilesToInspect: ['src/server.ts'],
+      reproSteps: ['Open the sanitized conversation URL.'],
+      acceptanceCriteria: ['The ticket contains only safe IDs and links.'],
+    });
+
+    expect(body).not.toContain('secret=1');
+    expect(body).not.toContain('person@example.com');
+    expect(body).not.toContain('raw prompt');
+    expect(body).not.toContain('full model answer');
+    expect(body).not.toContain('secret prompt');
+    expect(body).not.toContain('secret answer');
+    expect(body).not.toContain('raw stream failure text');
+    expect(body).not.toContain('sk_test');
+  });
+});


### PR DESCRIPTION
## Summary
- add `createLinearBugReportBody()` to render the fixed Linear Evidence section from a diagnostic bundle
- order Sentry/LangSmith evidence by bug kind so runtime bugs start in Sentry and answer-quality bugs start in LangSmith
- document the shared path for SQR-298 in-chat reports and SQR-299 agent bug-reporting skill output

## Tests
- npm run check
- npm test -- test/linear-bug-report-template.test.ts test/diagnostic-bundle.test.ts
- npm audit --omit=dev

Fixes SQR-310