### PR TITLE
feat(observability): add Sentry alert catalog

### DIFF
--- a/docs/runbooks/production-operations.md
+++ b/docs/runbooks/production-operations.md
@@ -164,6 +164,10 @@ Fly's Sentry extension documentation describes the sponsored Team-plan quota as
 per month. If that sponsored period ends, Sentry keeps accepting events on the
 Developer plan with lower quotas; events over quota are dropped.
 
+Production alert rules and safe test events live in
+[sentry-alerts.md](sentry-alerts.md). Those alerts use Sentry tags and uptime
+monitors, not Fly log retention.
+
 #### Safe browser replay and feedback smoke
 
 Use a non-production Sentry environment first. Open a safe page with no real

--- a/docs/runbooks/sentry-alerts.md
+++ b/docs/runbooks/sentry-alerts.md
@@ -1,0 +1,83 @@
+# Sentry Alert Catalog
+
+Sentry owns Squire app alerting. Fly logs are a fallback for timeline context,
+not the alert source.
+
+The Sentry project is the Fly-provisioned `maz-squire` project
+(`project=4511564194643969`). Open it with:
+
+```bash
+flyctl extensions sentry dashboard -a maz-squire
+```
+
+Use the Sentry alert builder to create the production rules below. Route each
+rule to the default owner notification channel until Sentry has a dedicated
+Slack/PagerDuty integration. Thresholds are intentionally written here, not in
+code, so they can be adjusted in Sentry without an app deploy.
+
+## Alert Rules
+
+| Alert name                                      | Sentry view     | Filter/query                                                                                           | Trigger                                   | First action                                                    | Safe test event                                                                                      |
+| ----------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `Squire production backend error spike`         | Issues/Discover | `environment:production surface:server level:error`                                                    | 5 events in 10 minutes                    | Open the issue, copy `request_id`, inspect route/context        | `npm run sentry:test-event -- --kind backend`                                                        |
+| `Squire production chat/SSE failure spike`      | Issues/Discover | `environment:production failure_kind:assistant_turn level:error`                                       | 3 events in 10 minutes                    | Open Sentry event, then jump to LangSmith by turn IDs           | `npm run sentry:test-event -- --kind chat`                                                           |
+| `Squire production frontend error spike`        | Issues/Discover | `environment:production surface:browser event_type:browser_error level:error`                          | 5 events in 10 minutes                    | Open event/replay; verify masked replay has no text             | `npm run sentry:test-event -- --kind browser`                                                        |
+| `Squire production cron/job failure`            | Issues/Discover | `environment:production job_kind:cron level:error`                                                     | 1 event in 30 minutes                     | Check `job_name`, then inspect the cron machine logs            | `npm run sentry:test-event -- --kind cron`                                                           |
+| `Squire production deploy regression new issue` | Issues/Releases | `environment:production release:* level:error` plus Sentry condition `new issue created after release` | 1 new issue in the current release window | Compare release SHA with GitHub/Fly deploy; roll back if needed | `npm run sentry:test-event -- --kind deploy-regression`                                              |
+| `Squire production uptime failure`              | Uptime monitor  | URL `https://squire.maz.org/api/health`; expect HTTP 200 and JSON status `ok`                          | 2 failed checks in 5 minutes              | Check Sentry uptime details, then `/api/live` and Fly status    | Use Sentry monitor test, or a temporary duplicate monitor pointed at `/api/__sentry-uptime-test-404` |
+
+## Safe Test Events
+
+Run test events from an environment with the production `SENTRY_DSN`,
+`SQUIRE_ENV=production`, and `SENTRY_RELEASE` available. The production Fly
+image includes the script:
+
+```bash
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind backend'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind chat'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind browser'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind cron'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind deploy-regression'
+```
+
+Local dry runs print the safe tags/context without sending to Sentry:
+
+```bash
+npm run sentry:test-event -- --kind chat --dry-run
+```
+
+The safe test events use synthetic IDs only:
+
+- `request_id=sentry-test-<kind>`
+- `conversation_id=sentry-test-conversation` for chat/browser tests
+- `user_message_id=sentry-test-user-message` for chat/browser tests
+- no cookies, auth headers, raw prompts, model output, provider payloads, or
+  retrieved passages
+
+For the uptime rule, prefer Sentry's monitor test control if it is available in
+the project. If it is not, create a temporary duplicate uptime monitor against
+`https://squire.maz.org/api/__sentry-uptime-test-404`, verify the rule matches,
+then delete the duplicate monitor. Do not break the real `/api/health` endpoint
+to test alerting.
+
+## Required Tags
+
+Alert filters depend on these stable tags:
+
+- `environment`
+- `release`
+- `route`
+- `request_id`
+- `conversation_id`
+- `user_message_id`
+- `assistant_message_id`
+- `surface`
+- `failure_kind`
+- `event_type`
+- `job_name`
+- `job_kind`
+- `security_event`
+
+If a new event path cannot populate these tags, it should still capture the
+event, but the follow-up should add the missing low-cardinality tag before that
+path becomes alert-critical.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "e2e:browser:prepare": "npm run db:migrate:test && NODE_ENV=test npm run seed:dev-user",
     "e2e:browser": "npm run e2e:browser:prepare && playwright test --config=playwright.e2e.config.ts",
     "agent:check": "node scripts/check-agent-parity.ts",
+    "sentry:test-event": "node scripts/send-sentry-safe-test-event.ts",
     "security:alerts:dry-run": "SECURITY_ALERT_DRY_RUN=1 node scripts/sync-security-alerts-to-linear.ts",
     "security:alerts:validate-config": "node scripts/sync-security-alerts-to-linear.ts --validate-config",
     "lint": "eslint src/ test/ scripts/",

--- a/scripts/send-sentry-safe-test-event.ts
+++ b/scripts/send-sentry-safe-test-event.ts
@@ -1,0 +1,144 @@
+import {
+  captureTelemetryError,
+  captureTelemetryMessage,
+  flushTelemetry,
+  initTelemetry,
+} from '../src/telemetry.ts';
+
+const SAFE_TEST_KINDS = ['backend', 'chat', 'browser', 'cron', 'deploy-regression'] as const;
+
+type SafeTestKind = (typeof SAFE_TEST_KINDS)[number];
+
+const SAFE_TEST_ERROR_NAMES: Record<Exclude<SafeTestKind, 'browser'>, string> = {
+  backend: 'SquireSafeBackendAlertTest',
+  chat: 'SquireSafeChatAlertTest',
+  cron: 'SquireSafeCronAlertTest',
+  'deploy-regression': 'SquireSafeDeployRegressionAlertTest',
+};
+
+interface ParsedArgs {
+  kind: SafeTestKind;
+  dryRun: boolean;
+}
+
+function usage(): string {
+  return `Usage: node scripts/send-sentry-safe-test-event.ts --kind <${SAFE_TEST_KINDS.join('|')}> [--dry-run]`;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  let kind: SafeTestKind | undefined;
+  let dryRun = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    if (arg === '--kind') {
+      const value = argv[index + 1];
+      if (!SAFE_TEST_KINDS.includes(value as SafeTestKind)) {
+        throw new Error(usage());
+      }
+      kind = value as SafeTestKind;
+      index += 1;
+      continue;
+    }
+    throw new Error(usage());
+  }
+
+  if (!kind) throw new Error(usage());
+  return { kind, dryRun };
+}
+
+function safeTestInput(kind: SafeTestKind) {
+  const requestId = `sentry-test-${kind}`;
+  const conversationId = 'sentry-test-conversation';
+  const userMessageId = 'sentry-test-user-message';
+
+  switch (kind) {
+    case 'backend':
+      return {
+        route: '/__sentry-test/backend',
+        requestId,
+        context: {
+          surface: 'server',
+          eventType: 'safe_test',
+        },
+      };
+    case 'chat':
+      return {
+        route: '/chat/sentry-test-conversation/messages/sentry-test-user-message/stream',
+        requestId,
+        conversationId,
+        userMessageId,
+        context: {
+          surface: 'chat_sse',
+          failureKind: 'assistant_turn',
+          eventType: 'safe_test',
+        },
+      };
+    case 'browser':
+      return {
+        route: '/chat/sentry-test-conversation',
+        requestId,
+        conversationId,
+        userMessageId,
+        context: {
+          surface: 'browser',
+          eventType: 'browser_error',
+          maskedReplay: {
+            textMasked: true,
+            attributesMasked: true,
+            turns: { assistantTurnCount: 1, errorBannerCount: 1 },
+          },
+        },
+      };
+    case 'cron':
+      return {
+        route: '/scripts/sweep-expired-sessions',
+        requestId,
+        context: {
+          scriptName: 'sweep-expired-sessions',
+          scriptKind: 'cron',
+          eventType: 'safe_test',
+        },
+      };
+    case 'deploy-regression':
+      return {
+        route: '/__sentry-test/deploy-regression',
+        requestId,
+        context: {
+          surface: 'server',
+          eventType: 'deploy_regression_test',
+        },
+      };
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const input = safeTestInput(args.kind);
+
+  if (args.dryRun) {
+    console.log(JSON.stringify({ kind: args.kind, input }, null, 2));
+    return;
+  }
+
+  const init = initTelemetry();
+  if (!init.enabled) {
+    throw new Error(`Sentry telemetry is not enabled: ${init.reason}`);
+  }
+
+  const eventId =
+    args.kind === 'browser'
+      ? captureTelemetryMessage('browser.browser_error', 'error', input)
+      : captureTelemetryError(new Error(SAFE_TEST_ERROR_NAMES[args.kind]), input);
+  await flushTelemetry(2_000);
+  console.log(JSON.stringify({ kind: args.kind, eventId }, null, 2));
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -169,6 +169,31 @@ function truncateTag(value: string): string {
   return value.length > 200 ? `${value.slice(0, 197)}...` : value;
 }
 
+const TAG_TOKEN_PATTERN = /^[A-Za-z0-9._:/-]{1,128}$/;
+
+function safeContextTag(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!TAG_TOKEN_PATTERN.test(trimmed)) return undefined;
+  return truncateTag(trimmed);
+}
+
+function contextTagPairs(input: { context?: Record<string, unknown> }): Array<[string, string]> {
+  const context = input.context;
+  if (!context) return [];
+
+  const pairs: Array<[string, string | undefined]> = [
+    ['surface', safeContextTag(context.surface)],
+    ['failure_kind', safeContextTag(context.failureKind)],
+    ['event_type', safeContextTag(context.eventType)],
+    ['job_name', safeContextTag(context.scriptName)],
+    ['job_kind', safeContextTag(context.scriptKind)],
+    ['security_event', safeContextTag(context.event)],
+  ];
+
+  return pairs.filter((pair): pair is [string, string] => pair[1] !== undefined);
+}
+
 function redactSensitiveString(value: string): string {
   if (/\bBearer\s+[A-Za-z0-9._~+/=-]+/i.test(value)) return TELEMETRY_REDACTED;
   if (/\b(?:sk|rk|pk|xox[baprs]|gh[pousr])_[A-Za-z0-9_=-]{12,}\b/.test(value)) {
@@ -246,7 +271,7 @@ export function buildDiagnosticMetadata(
  * extend this function intentionally when a new diagnostic tag is approved.
  */
 export function buildSafeTelemetryTags(
-  input: TelemetryDiagnosticInput = {},
+  input: TelemetryDiagnosticInput & { context?: Record<string, unknown> } = {},
   env: Env = process.env,
 ): Record<string, string> {
   const metadata = buildDiagnosticMetadata(input, env);
@@ -260,6 +285,7 @@ export function buildSafeTelemetryTags(
     ['assistant_message_id', metadata.assistantMessageId],
     ['user_id', metadata.userId],
     ['user_hash', metadata.userHash],
+    ...contextTagPairs(input),
   ];
 
   return Object.fromEntries(

--- a/test/sentry-alerts.test.ts
+++ b/test/sentry-alerts.test.ts
@@ -1,0 +1,76 @@
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+
+async function readProjectFile(path: string): Promise<string> {
+  return readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+describe('Sentry alert catalog', () => {
+  it('documents each production alert rule with stable filters and safe tests', async () => {
+    const runbook = await readProjectFile('docs/runbooks/sentry-alerts.md');
+
+    for (const alertName of [
+      'Squire production backend error spike',
+      'Squire production chat/SSE failure spike',
+      'Squire production frontend error spike',
+      'Squire production cron/job failure',
+      'Squire production deploy regression new issue',
+      'Squire production uptime failure',
+    ]) {
+      expect(runbook).toContain(alertName);
+    }
+
+    for (const filter of [
+      'environment:production surface:server level:error',
+      'environment:production failure_kind:assistant_turn level:error',
+      'environment:production surface:browser event_type:browser_error level:error',
+      'environment:production job_kind:cron level:error',
+      'environment:production release:* level:error',
+      'https://squire.maz.org/api/health',
+    ]) {
+      expect(runbook).toContain(filter);
+    }
+
+    for (const kind of ['backend', 'chat', 'browser', 'cron', 'deploy-regression']) {
+      expect(runbook).toContain(`npm run sentry:test-event -- --kind ${kind}`);
+    }
+    expect(runbook).toContain('api/__sentry-uptime-test-404');
+  });
+
+  it('exposes the safe test-event command without sending events in dry-run mode', async () => {
+    const packageJson = JSON.parse(await readProjectFile('package.json')) as {
+      scripts?: Record<string, string>;
+    };
+    expect(packageJson.scripts?.['sentry:test-event']).toBe(
+      'node scripts/send-sentry-safe-test-event.ts',
+    );
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ['scripts/send-sentry-safe-test-event.ts', '--kind', 'chat', '--dry-run'],
+      { cwd: repoRoot },
+    );
+    const payload = JSON.parse(stdout) as {
+      kind?: string;
+      input?: { context?: Record<string, unknown> };
+    };
+
+    expect(payload.kind).toBe('chat');
+    expect(payload.input?.context).toMatchObject({
+      surface: 'chat_sse',
+      failureKind: 'assistant_turn',
+      eventType: 'safe_test',
+    });
+    expect(stdout).not.toContain('cookie');
+    expect(stdout).not.toContain('Bearer');
+    expect(stdout).not.toContain('prompt');
+    expect(stdout).not.toContain('answer');
+  });
+});

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -187,6 +187,37 @@ describe('telemetry boundary', () => {
     });
   });
 
+  it('adds safe low-cardinality context tags for alert filters only', () => {
+    process.env.SQUIRE_ENV = 'production';
+    process.env.SENTRY_RELEASE = 'abc123';
+
+    expect(
+      buildSafeTelemetryTags({
+        route: '/chat/conv-1/messages/msg-1/stream',
+        context: {
+          surface: 'chat_sse',
+          failureKind: 'assistant_turn',
+          eventType: 'browser_error',
+          scriptName: 'sweep-expired-sessions',
+          scriptKind: 'cron',
+          event: 'rate_limit_rejected',
+          unsafe: 'Bearer secret-token',
+          rawPrompt: 'What is my hidden prompt?',
+        },
+      }),
+    ).toEqual({
+      environment: 'production',
+      release: 'abc123',
+      route: '/chat/conv-1/messages/msg-1/stream',
+      surface: 'chat_sse',
+      failure_kind: 'assistant_turn',
+      event_type: 'browser_error',
+      job_name: 'sweep-expired-sessions',
+      job_kind: 'cron',
+      security_event: 'rate_limit_rejected',
+    });
+  });
+
   it('redacts protected fields recursively while preserving safe diagnostics', () => {
     const redacted = redactTelemetryValue({
       requestId: 'req-1',
@@ -346,6 +377,7 @@ describe('telemetry boundary', () => {
       conversation_id: 'conv-1',
       user_message_id: 'msg-user-1',
       user_id: 'user-1',
+      surface: 'browser',
       feedback_kind: 'stream_failed',
     });
     expect(sentry.scope.setContext).toHaveBeenCalledWith(
@@ -375,6 +407,7 @@ describe('telemetry boundary', () => {
           conversation_id: 'conv-1',
           user_message_id: 'msg-user-1',
           user_id: 'user-1',
+          surface: 'browser',
           feedback_kind: 'stream_failed',
         },
       },


### PR DESCRIPTION
## Summary
- promote safe low-cardinality Sentry context fields into tags for alert filters
- add the production Sentry alert catalog for backend, chat/SSE, frontend, cron, deploy-regression, and uptime failures
- add a safe test-event script plus dry-run coverage so alert filters can be tested without real user data

## Tests
- npm run check
- npm test -- test/telemetry.test.ts test/sentry-alerts.test.ts
- npm audit --omit=dev

## Note
Fly confirms the `maz-squire` Sentry project exists, but this environment has no Sentry API token or authenticated dashboard automation for creating live alert rules. This PR lands the repo-side alert contract and safe test events; the live Sentry rules still need to be created from `docs/runbooks/sentry-alerts.md`.

Refs SQR-311