### PR TITLE
docs(observability): add production debugging runbook

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,6 +71,8 @@ The active baseline is:
 - Sentry is the app observability, browser diagnostics, release-health,
   alerting, and error-tracking path, provisioned through Fly and correlated to
   LangSmith by safe IDs and links.
+  The operator workflow is documented in
+  [docs/runbooks/observability.md](runbooks/observability.md).
 
 Existing regression coverage protects the current path:
 
@@ -749,6 +751,10 @@ instead of duplicating prompt, model-output, or retrieved-context payloads.
 Operators start in Sentry for app/runtime errors and release regressions, then
 jump to LangSmith when the question is whether the agent reasoned correctly,
 retrieved the right sources, or passed eval expectations.
+The production handoff path is
+[docs/runbooks/observability.md](runbooks/observability.md): user report ->
+Sentry event/replay/log context -> LangSmith trace/thread/run -> Linear Evidence
+section, with unavailable fields explicitly marked.
 
 ---
 
@@ -895,6 +901,13 @@ For developer setup, running the server, working on import scripts locally, and 
 ---
 
 ## Changelog
+
+- **2026-06-14:** SQR-312 closed the APM/RUM decision in the architecture:
+  Sentry owns app observability, alerting, replay, and release health, while
+  LangSmith remains the LLM trace/eval surface. Added the production
+  observability runbook for moving from user report to Sentry, LangSmith, and
+  Linear evidence without copying raw prompts, answers, provider payloads,
+  cookies, tokens, or retrieved passages into tickets.
 
 - **2026-05-27:** SQR-216 through SQR-219 refreshed the GH2 production data
   architecture. Production card seeding, scenario/section-book seeding, and

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -79,6 +79,32 @@ payloads, retrieved passages, or full user answers into Sentry. LangSmith stays
 the trace and eval surface for LLM behavior; Sentry is only for app errors,
 browser/runtime diagnostics, release health, and links back to LangSmith.
 
+Production and staging Sentry values are environment-managed, not committed.
+Production stores `SENTRY_DSN` as a Fly secret through the Fly Sentry extension,
+sets `SQUIRE_ENV=production`, and stamps `SENTRY_RELEASE` from the deployed Git
+SHA. A future staging app should use its own Sentry project or environment,
+`SQUIRE_ENV=staging`, and its own DSN secret so test events cannot mix with
+production alerts.
+
+Safe Sentry test events are documented in
+[docs/runbooks/observability.md](runbooks/observability.md) and
+[docs/runbooks/sentry-alerts.md](runbooks/sentry-alerts.md). Local dry runs
+must not send events:
+
+```bash
+npm run sentry:test-event -- --kind chat --dry-run
+```
+
+Production checks should run inside the Fly app so they use the deployed
+`SENTRY_DSN`, `SQUIRE_ENV`, and `SENTRY_RELEASE`:
+
+```bash
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind backend'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind chat'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind browser'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind cron'
+```
+
 `GOOGLE_OAUTH_REDIRECT_URI` is still the configured fallback callback for
 production and non-local hosts. In local development, `/auth/google/start` and
 `/auth/google/callback` reuse the current `localhost` origin so linked

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -1,0 +1,262 @@
+# Squire Observability Runbook
+
+Use this runbook when a user reports a bad production conversation, failed
+stream, browser problem, backend error, cron failure, or uptime alert.
+
+## Ownership
+
+- Sentry owns app observability: backend errors, swallowed chat failures, SSE
+  failures, browser errors, cron/script failures, uptime checks, release health,
+  replay, feedback, and alerting.
+- LangSmith owns LLM traces and eval debugging: model input/output, tool calls,
+  retrieval behavior, answer quality, eval regressions, and trace comparison.
+- Linear owns the bug record. Tickets must use the diagnostic bundle and
+  required Evidence section from `src/linear-bug-report-template.ts`.
+
+Sentry links to LangSmith by safe IDs and URLs. Do not duplicate raw prompt,
+model output, provider payload, retrieved passage, cookie, bearer token, OAuth
+token, secret, full source document, email address, or full transcript content
+in Sentry or Linear.
+
+## Correlation Fields
+
+Use these fields to move between the conversation, Sentry, LangSmith, and
+Linear:
+
+- `environment`: `production`, `staging`, `development`, or `test`
+- `release`: the deployed Git SHA from `SENTRY_RELEASE`
+- `request_id`: the HTTP request ID, also returned as `X-Request-ID`
+- `route`: Hono route or browser surface
+- `conversation_id`: the `/chat/<conversationId>` UUID
+- `user_message_id`: the `/messages/<userMessageId>/stream` UUID for the turn
+- `assistant_message_id`: the persisted assistant row when available
+- `langsmith_thread_id`: equal to `conversation_id` for web chat
+- `langsmith_trace_url`, `langsmith_thread_url`, or `langsmith_run_url`
+- `sentry_issue_url`, `sentry_event_url`, and `sentry_replay_url`
+
+If a field is missing, do not leave the ticket blank. Mark it as unavailable
+with the reason returned by the diagnostic bundle.
+
+## Where To Start
+
+Start in Sentry when the report is about an exception, generic 500, failed
+stream, duplicate/early-ended stream, browser UI break, masked replay, cron/job
+failure, uptime alert, release regression, auth/rate-limit failure, or budget
+failure.
+
+Start in LangSmith when the app behaved normally but the answer was wrong,
+missed a rule, cited the wrong source, chose the wrong tool path, ignored a
+perk/effect, failed an eval, or otherwise looks like agent reasoning/retrieval
+quality.
+
+If the user report is ambiguous, start with the conversation URL and timestamp,
+then gather a diagnostic bundle. The bundle should tell the bug ticket which
+Sentry and LangSmith links are present and which are unavailable.
+
+## User Report To Linear
+
+1. Capture the conversation URL, selected turn URL if available, user-reported
+   timestamp, observed behavior, and expected behavior.
+2. For a web-chat report, parse `/chat/<conversationId>` and, when present,
+   `/messages/<userMessageId>/stream` from the URL. For REST reports, capture
+   `X-Request-ID`.
+3. Gather safe evidence with `collectDiagnosticBundle()` when you have an
+   authenticated user and a conversation URL, conversation ID, or user-message
+   ID. Use `buildDiagnosticBundle()` when you already have safe links and IDs
+   from Sentry, LangSmith, logs, or screenshots.
+4. Render the Linear issue body with `createLinearBugReportBody()`.
+   `kind: "app_runtime"` puts Sentry first. `kind: "answer_quality"` puts
+   LangSmith first.
+5. Keep every required Evidence field in the issue:
+   `Conversation`, `Turn`, `Request`, `Sentry Issue/Event/Replay`, `Release`,
+   `Environment`, `LangSmith Trace/Thread/Run`, `Observed`, `Expected`,
+   `Likely failing area`, `First files to inspect`, `Repro`, and `Acceptance`.
+6. Attach screenshots only if they do not show raw user prompts, model answers,
+   secrets, cookies, or private source passages. Prefer masked Sentry replay for
+   layout and stream-state reports.
+
+## Bad Answer
+
+Use this path when the user says the answer is wrong but the UI and stream
+completed.
+
+1. Start in LangSmith with `env:production`.
+2. Search for `metadata.conversationId=<conversationId>` and
+   `metadata.userMessageId=<userMessageId>`. If the report came from REST
+   `/api/ask`, search by `metadata.requestId=<requestId>` instead.
+3. Confirm the root `squire.agent.run` trace has:
+   `metadata.thread_id`, `metadata.requestId`, `metadata.squireEnv`,
+   `metadata.model`, `metadata.toolSurface`, stop reason, iterations, tool-call
+   count, and token usage.
+4. Inspect tool observations in order. Check searched source labels, canonical
+   refs, tool errors, and whether the agent skipped the source family that
+   should answer the question.
+5. Check Sentry only for the same `request_id`, `conversation_id`, or
+   `user_message_id` if the trace ended in an error, the browser saw a generic
+   assistant failure, or a release regression alert fired.
+6. File the bug as `kind: "answer_quality"` unless Sentry shows an app/runtime
+   failure that directly caused the answer.
+
+Likely first files:
+
+- `src/agent-langgraph.ts`
+- `src/agent.ts`
+- `src/tools.ts`
+- `src/vector-store.ts`
+- `src/retrieval-source.ts`
+- `src/chat/conversation-service.ts`
+- eval suite files under `eval/suites/`
+
+## Stream Or Chat Failure
+
+Use this path for generic assistant failure rows, failed `/api/ask` responses,
+SSE errors, reconnect problems, duplicate text, or streams that end early.
+
+1. Start in Sentry and search:
+   `environment:production failure_kind:assistant_turn level:error`
+2. If the failure is a browser transport problem, also search:
+   `environment:production surface:browser event_type:stream_error`
+3. Open the Sentry event and copy `request_id`, `route`, `conversation_id`,
+   `user_message_id`, `assistant_message_id`, `release`, and any LangSmith link.
+4. Open the LangSmith trace when present. If there is no trace, check whether
+   the failure happened before the agent run started.
+5. Inspect durable SSE rows for the user message:
+
+   ```sql
+   select sequence, event, payload, created_at
+   from message_stream_events
+   where user_message_id = '<userMessageId>'
+   order by sequence;
+   ```
+
+   A stored `done` or `error` means reconnects should replay and close without
+   starting another agent run. Partial non-terminal rows with no active
+   generation lock should end in one persisted assistant failure, not a silent
+   graph restart.
+
+6. File the bug as `kind: "app_runtime"` unless Sentry is clean and the failure
+   is purely answer quality.
+
+Likely first files:
+
+- `src/chat/conversation-service.ts`
+- `src/server.ts`
+- `src/service.ts`
+- `src/telemetry.ts`
+- `src/web-ui/squire.js`
+- `test/conversation.test.ts`
+- `test/server-api.test.ts`
+
+## Browser Or UI Report
+
+Use this path for layout breakage, JavaScript errors, broken buttons, replay
+reports, and feedback events.
+
+1. Start in Sentry and search:
+   `environment:production surface:browser level:error`
+2. For stream transport failures, narrow to `event_type:stream_error`.
+3. Open the masked replay if one exists. It should show layout, viewport,
+   transcript turn counts, input state, and route IDs, not raw transcript text.
+4. Confirm browser context has safe URL path, viewport, user agent, release,
+   conversation ID, and user-message ID when available.
+5. If a user screenshot is needed, ask for the smallest crop that shows layout
+   or state without private text.
+6. File the bug as `kind: "app_runtime"`.
+
+Likely first files:
+
+- `src/web-ui/squire.js`
+- `src/web-ui/layout.ts`
+- `src/web-ui/styles.css`
+- `src/web-ui/assets.ts`
+- `src/server.ts`
+
+## Backend, Cron, And Uptime
+
+Backend errors:
+
+1. Start in Sentry with `environment:production surface:server level:error`.
+2. Use `request_id`, `route`, and `release` to decide whether this is a deploy
+   regression, input-specific bug, or dependency failure.
+3. If user-facing, build a diagnostic bundle and file `kind: "app_runtime"`.
+
+Cron and script failures:
+
+1. Start in Sentry with `environment:production job_kind:cron level:error`.
+2. Check `job_name`, `release`, and error class.
+3. Use Fly logs only for timeline context:
+
+   ```bash
+   fly logs -a maz-squire --no-tail | grep '<job_name>'
+   ```
+
+4. Confirm the failed job preserved a nonzero exit and successful jobs do not
+   create error events.
+
+Uptime failures:
+
+1. Start in the Sentry uptime monitor for
+   `https://squire.maz.org/api/health`.
+2. Compare with:
+
+   ```bash
+   node scripts/check-deploy-health.ts --base-url https://maz-squire.fly.dev
+   flyctl status -a maz-squire
+   fly releases -a maz-squire --image
+   ```
+
+3. If `/api/live` passes but `/api/health` fails, inspect database, vector, and
+   embedder readiness before rolling back.
+4. If the failure follows a new release and Sentry has a deploy-regression
+   issue, compare `SENTRY_RELEASE` with the GitHub deploy run and rollback only
+   after confirming a current-release fault.
+
+## Safe Test Cases
+
+Run safe test events from an environment with production `SENTRY_DSN`,
+`SQUIRE_ENV=production`, and `SENTRY_RELEASE` available:
+
+```bash
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind backend'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind chat'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind browser'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind cron'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind deploy-regression'
+```
+
+Local dry runs must not send to Sentry:
+
+```bash
+npm run sentry:test-event -- --kind chat --dry-run
+```
+
+Browser replay and feedback smoke:
+
+1. Use a non-production Sentry environment first.
+2. Open a safe page with no real conversation text.
+3. Run the browser console smoke in
+   [production-operations.md](production-operations.md#safe-browser-replay-and-feedback-smoke).
+4. Confirm Sentry receives a browser error and feedback event with masked replay
+   metadata only.
+
+Uptime smoke:
+
+1. Prefer Sentry's monitor test control when available.
+2. If unavailable, create a temporary duplicate uptime monitor pointed at
+   `https://squire.maz.org/api/__sentry-uptime-test-404`.
+3. Verify the alert matches, then delete the duplicate monitor.
+4. Do not break the real `/api/health` endpoint to test alerting.
+
+## Release Checklist
+
+After observability changes deploy:
+
+1. Run `node scripts/check-deploy-health.ts --base-url https://maz-squire.fly.dev`.
+2. Verify Sentry events show `environment`, `release`, `request_id`, `route`,
+   and the relevant conversation/message/job/browser tags.
+3. Verify LangSmith traces for one real chat show `metadata.conversationId`,
+   `metadata.thread_id`, `metadata.userMessageId`, and `metadata.requestId`.
+4. Generate or preview safe Sentry test events for backend, chat, browser, cron,
+   deploy-regression, and uptime paths.
+5. Create or update a Linear bug with the required Evidence template, using
+   unavailable reasons for anything not present.

--- a/docs/runbooks/production-operations.md
+++ b/docs/runbooks/production-operations.md
@@ -20,7 +20,8 @@ Actions after CI passes on `main`.
   in `ORIGIN_SHARED_SECRET`
 - Runtime environment label: `SQUIRE_ENV=production`
 - App observability: Sentry via Fly extension, with `SENTRY_DSN` stored as a
-  Fly secret and `SENTRY_RELEASE` stamped from the deployed Git SHA
+  Fly secret and `SENTRY_RELEASE` stamped from the deployed Git SHA. The
+  operator workflow lives in [observability.md](observability.md).
 - Background cleanup: Fly `cron` process group runs Supercronic with
   `/app/crontab` and prunes expired sessions hourly
 
@@ -153,11 +154,10 @@ The GitHub deploy workflow sets `SENTRY_RELEASE` to the exact
 that the app maps into both LangSmith metadata and Sentry event environment.
 
 Missing `SENTRY_DSN` must remain a no-op for local dev and tests. Production
-should have the Fly secret present once the Sentry SDK work lands; until then,
-the secret can exist without changing runtime behavior. LangSmith remains the
-LLM trace/eval owner. Sentry app events should carry correlation IDs and links
-to LangSmith, not raw prompts, model outputs, cookies, bearer tokens, OAuth
-tokens, provider payloads, retrieved passages, or full answers.
+should have the Fly secret present. LangSmith remains the LLM trace/eval owner.
+Sentry app events should carry correlation IDs and links to LangSmith, not raw
+prompts, model outputs, cookies, bearer tokens, OAuth tokens, provider payloads,
+retrieved passages, or full answers.
 
 Fly's Sentry extension documentation describes the sponsored Team-plan quota as
 50k errors, 100k performance units, 500 session replays, and 1GB of attachments
@@ -165,7 +165,8 @@ per month. If that sponsored period ends, Sentry keeps accepting events on the
 Developer plan with lower quotas; events over quota are dropped.
 
 Production alert rules and safe test events live in
-[sentry-alerts.md](sentry-alerts.md). Those alerts use Sentry tags and uptime
+[sentry-alerts.md](sentry-alerts.md). The production debugging path lives in
+[observability.md](observability.md). Those alerts use Sentry tags and uptime
 monitors, not Fly log retention.
 
 #### Safe browser replay and feedback smoke
@@ -480,67 +481,26 @@ Check LangSmith after the question:
   tool names, compact tool inputs, tool summaries, canonical refs, and errors
   without raw email addresses or session cookies.
 
-## Troubleshoot one production chat
+## Troubleshoot a production report
 
-Use this path when a user reports a bad answer, failed stream, or suspicious
-chat behavior.
+Use [observability.md](observability.md) for the full Sentry + LangSmith +
+Linear workflow. Start with the browser URL or `X-Request-ID`, then choose the
+right lane:
 
-1. Start with the browser URL. `/chat/<conversationId>` gives the persisted
-   conversation UUID. The pending answer stream URL
-   `/chat/<conversationId>/messages/<userMessageId>/stream` gives the user
-   message UUID for the exact turn.
-2. Search LangSmith in `env:production` for a `squire.agent.run` trace whose
-   metadata has that `conversationId` and `userMessageId`. If the report came
-   from REST `/api/ask`, search by the `X-Request-ID` response header or caller
-   log value instead.
-3. In the root trace, inspect:
-   - input question and final answer or error output
-   - `metadata.userId`, `metadata.conversationId`, `metadata.thread_id`,
-     `metadata.userMessageId`, `metadata.requestId`, `metadata.squireEnv`
-   - `metadata.model`, `metadata.toolSurface`, iterations, tool-call count, and
-     stop reason
-   - tags: `runtime`, provider (`anthropic`), SDK (`claude-sdk`), model, tool
-     surface, and `env:production`
-4. Open child observations in order. Generation observations show compact model
-   input/output, stop reason, and token usage. Tool observations show tool name,
-   compact input, output summary, source labels, canonical refs, and tool
-   errors.
-5. If the user saw a reconnect, duplicate text, or a stream that ended early,
-   inspect the durable SSE log for that user message. Event `sequence` values
-   are the browser `id` / `Last-Event-ID` values.
+- Bad answer with a successful stream: start in LangSmith
+  (`metadata.conversationId`, `metadata.thread_id`, `metadata.userMessageId`,
+  `metadata.requestId`).
+- Generic assistant failure, failed stream, browser error, backend error, cron
+  failure, uptime alert, or release regression: start in Sentry and use safe
+  tags such as `request_id`, `conversation_id`, `user_message_id`, `route`,
+  `surface`, `failure_kind`, `event_type`, `job_name`, and `release`.
+- Bug ticket: gather a diagnostic bundle and render the required Linear
+  Evidence section. Every unavailable field needs an explicit reason.
 
-   ```sql
-   select sequence, event, payload, created_at
-   from message_stream_events
-   where user_message_id = '<userMessageId>'
-   order by sequence;
-   ```
-
-   A stored `done` or `error` means reconnects should replay and close without
-   another agent run. Partial non-terminal rows with no active generation lock
-   are expected to end in one persisted assistant failure rather than a silent
-   graph restart.
-
-6. If LangSmith has no trace for the turn, check Fly logs around the same time
-   and request ID:
-
-   ```bash
-   fly logs -a maz-squire --no-tail | grep '<requestId>'
-   fly logs -a maz-squire --no-tail | grep '<conversationId>'
-   ```
-
-7. If the failure follows a deploy, check the GitHub deploy run before changing
-   app code:
-
-   ```bash
-   gh run list --workflow "Deploy to Fly" --branch main --limit 5
-   gh run view <run-id> --log
-   gh api 'repos/maz-org/squire/deployments?environment=production'
-   ```
-
-Do not paste raw user questions, email addresses, cookies, bearer tokens, or
-full trace payloads into issues. Use UUIDs, request IDs, model/tool metadata,
-stop reasons, and short redacted excerpts.
+Do not paste raw user questions, email addresses, cookies, bearer tokens, full
+model answers, provider payloads, retrieved passages, or full trace payloads
+into issues. Use UUIDs, request IDs, model/tool metadata, stop reasons, Sentry
+links, LangSmith links, and short redacted excerpts.
 
 Probe the edge:
 

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -266,16 +266,24 @@ describe('deployment configuration', () => {
     const development = await readProjectFile('docs/DEVELOPMENT.md');
     const architecture = await readProjectFile('docs/ARCHITECTURE.md');
     const runbook = await readProjectFile('docs/runbooks/production-operations.md');
+    const observability = await readProjectFile('docs/runbooks/observability.md');
 
     expect(development).toContain('SENTRY_DSN');
     expect(development).toContain('Missing `SENTRY_DSN` is a local no-op');
+    expect(development).toContain('SQUIRE_ENV=staging');
+    expect(development).toContain('npm run sentry:test-event -- --kind chat --dry-run');
     expect(runbook).toContain('fly ext sentry create -a maz-squire');
     expect(runbook).toContain('fly ext sentry dashboard -a maz-squire');
     expect(runbook).toMatch(/sets\s+`SENTRY_DSN` as a Fly secret/);
     expect(runbook).toContain('Do not add `SENTRY_DSN` to `fly.toml`');
     expect(runbook).toContain('SENTRY_RELEASE');
+    expect(runbook).toContain('[observability.md](observability.md)');
     expect(architecture).toContain('Sentry owns app observability');
     expect(architecture).toContain('LangSmith remains the owner for LLM traces and evals');
+    expect(architecture).toContain('[docs/runbooks/observability.md](runbooks/observability.md)');
+    expect(architecture).not.toContain('APM / RUM stack is open');
+    expect(observability).toContain('Sentry owns app observability');
+    expect(observability).toContain('LangSmith owns LLM traces and eval debugging');
   });
 
   it('runs actionlint in CI for GitHub workflow changes', async () => {

--- a/test/deployment-operations-docs.test.ts
+++ b/test/deployment-operations-docs.test.ts
@@ -35,7 +35,7 @@ describe('deployment operations documentation', () => {
       'one real rules question',
       'LangSmith',
       'env:production',
-      'Troubleshoot one production chat',
+      'Troubleshoot a production report',
       'metadata.conversationId',
       'metadata.thread_id',
       'metadata.userMessageId',
@@ -47,6 +47,60 @@ describe('deployment operations documentation', () => {
     }
 
     expect(guide).not.toContain('Cloudflare WAF');
+  });
+
+  it('documents the Sentry and LangSmith production debugging workflow', async () => {
+    const guide = await readProjectFile('docs/runbooks/production-operations.md');
+    const observability = await readProjectFile('docs/runbooks/observability.md');
+    const bugReporting = await readProjectFile('docs/agent/bug-reporting.md');
+
+    expect(guide).toContain('[observability.md](observability.md)');
+
+    for (const expected of [
+      '# Squire Observability Runbook',
+      'Sentry owns app observability',
+      'LangSmith owns LLM traces and eval debugging',
+      'Start in Sentry',
+      'Start in LangSmith',
+      'User Report To Linear',
+      'Bad Answer',
+      'Stream Or Chat Failure',
+      'Browser Or UI Report',
+      'Backend, Cron, And Uptime',
+      'Safe Test Cases',
+      'collectDiagnosticBundle()',
+      'createLinearBugReportBody()',
+      'environment:production failure_kind:assistant_turn level:error',
+      'environment:production surface:browser event_type:stream_error',
+      'environment:production job_kind:cron level:error',
+      'https://squire.maz.org/api/__sentry-uptime-test-404',
+      'fly ssh console -a maz-squire -C',
+      'npm run sentry:test-event -- --kind chat --dry-run',
+      'unavailable',
+    ]) {
+      expect(observability).toContain(expected);
+    }
+
+    for (const requiredEvidenceField of [
+      'Conversation',
+      'Turn',
+      'Request',
+      'Sentry Issue/Event/Replay',
+      'Release',
+      'Environment',
+      'LangSmith Trace/Thread/Run',
+      'Observed',
+      'Expected',
+      'Likely failing area',
+      'First files to inspect',
+      'Repro',
+      'Acceptance',
+    ]) {
+      expect(observability).toContain(requiredEvidenceField);
+    }
+
+    expect(bugReporting).toContain('SQR-298');
+    expect(bugReporting).toContain('SQR-299');
   });
 
   it('keeps current architecture docs on AWS WAF and GitHub-driven Fly deploys', async () => {


### PR DESCRIPTION
## Summary
- add the Squire observability runbook for user report -> Sentry -> LangSmith -> Linear evidence flows
- update architecture, development, and production operations docs to name Sentry as app observability and LangSmith as LLM trace/eval owner
- add doc assertions for the runbook, safe test events, and required Linear Evidence fields

## Tests
- npm test -- test/deployment-config.test.ts test/deployment-operations-docs.test.ts test/sentry-alerts.test.ts
- npm run lint:md
- npm run typecheck
- npm run check
- npm audit --omit=dev
- npm run sentry:test-event -- --kind backend --dry-run
- npm run sentry:test-event -- --kind chat --dry-run
- npm run sentry:test-event -- --kind browser --dry-run
- npm run sentry:test-event -- --kind cron --dry-run
- npm run sentry:test-event -- --kind deploy-regression --dry-run

Fixes SQR-312
Refs SQR-311