### PR TITLE
feat(observability): define Sentry telemetry privacy contract

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -23,6 +23,7 @@ export const TELEMETRY_DIAGNOSTIC_FIELDS = [
   'conversationId',
   'userMessageId',
   'assistantMessageId',
+  'sentryTraceId',
   'langsmithThreadUrl',
   'langsmithRunUrl',
   'userId',
@@ -49,6 +50,7 @@ export interface TelemetryDiagnosticInput {
   conversationId?: string;
   userMessageId?: string;
   assistantMessageId?: string;
+  sentryTraceId?: string;
   langsmithThreadUrl?: string;
   langsmithRunUrl?: string;
   user?: TelemetryUserIdentity;
@@ -98,6 +100,16 @@ const PROTECTED_KEY_PARTS = [
   'secret',
   'password',
   'dsn',
+  'email',
+  'phone',
+  'address',
+  'ipaddress',
+  'creditcard',
+  'cardnumber',
+  'ssn',
+  'socialsecurity',
+  'privatekey',
+  'pem',
   'prompt',
   'fullanswer',
   'answer',
@@ -122,12 +134,69 @@ const PROTECTED_KEY_PARTS = [
 
 let initializedDsn: string | null = null;
 
+const PROTECTED_EXACT_KEYS = new Set([
+  'name',
+  'username',
+  'firstname',
+  'lastname',
+  'fullname',
+  'displayname',
+  'customername',
+  'clientname',
+  'card',
+  'mailingaddress',
+  'streetaddress',
+  'postaladdress',
+  'phonenumber',
+  'mobilenumber',
+  'emailaddress',
+  'useremail',
+]);
+
+const REQUEST_OR_RESPONSE_PATH_PARTS = new Set([
+  'request',
+  'response',
+  'http',
+  'httpcontext',
+  'requestcontext',
+  'responsecontext',
+]);
+
+const SENSITIVE_VALUE_PATTERNS = [
+  /\bBearer\s+[A-Za-z0-9._~+/=-]+/i,
+  /\b(?:sk|rk|pk|xox[baprs]|gh[pousr])_[A-Za-z0-9_=-]{12,}\b/,
+  /\bAKIA[0-9A-Z]{16}\b/,
+  /\bAIza[0-9A-Za-z_-]{35}\b/,
+  /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i,
+  /\b\d{3}-\d{2}-\d{4}\b/,
+  /(?:^|[^A-Fa-f0-9-])(?:\d{13,19}|\d{4}[ -]\d{4}[ -]\d{4}(?:[ -]\d{1,7})?)(?![A-Fa-f0-9-])/,
+  /\b(?:\d{1,3}\.){3}\d{1,3}\b/,
+  /\b[a-z][a-z0-9+.-]*:\/\/[^/\s:@]+:[^/\s@]+@/i,
+  /[?&](?:access_token|auth|authorization|code|cookie|email|key|password|secret|session|state|token)=/i,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  /(?:\+\d{1,3}[\s.-]?)?(?:\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{4})/,
+];
+
 function normalizeKey(key: string): string {
   return key.toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
-function isProtectedKey(key: string): boolean {
+function normalizedPathHasRequestOrResponse(path: string[]): boolean {
+  return path
+    .slice(0, -1)
+    .map(normalizeKey)
+    .some((part) => REQUEST_OR_RESPONSE_PATH_PARTS.has(part));
+}
+
+function isProtectedKey(key: string, path: string[]): boolean {
   const normalized = normalizeKey(key);
+  if (PROTECTED_EXACT_KEYS.has(normalized)) return true;
+  if (
+    (normalized === 'data' || normalized === 'body') &&
+    normalizedPathHasRequestOrResponse(path)
+  ) {
+    return true;
+  }
   return PROTECTED_KEY_PARTS.some((part) => normalized.includes(part));
 }
 
@@ -195,14 +264,12 @@ function contextTagPairs(input: { context?: Record<string, unknown> }): Array<[s
 }
 
 function redactSensitiveString(value: string): string {
-  if (/\bBearer\s+[A-Za-z0-9._~+/=-]+/i.test(value)) return TELEMETRY_REDACTED;
-  if (/\b(?:sk|rk|pk|xox[baprs]|gh[pousr])_[A-Za-z0-9_=-]{12,}\b/.test(value)) {
-    return TELEMETRY_REDACTED;
-  }
-  return value;
+  return SENSITIVE_VALUE_PATTERNS.some((pattern) => pattern.test(value))
+    ? TELEMETRY_REDACTED
+    : value;
 }
 
-function redactInternal(value: unknown, seen: WeakSet<object>): SafeJson {
+function redactInternal(value: unknown, seen: WeakSet<object>, path: string[]): SafeJson {
   if (value === null) return null;
   if (value === undefined) return TELEMETRY_UNAVAILABLE;
   if (typeof value === 'string') return redactSensitiveString(value);
@@ -218,7 +285,9 @@ function redactInternal(value: unknown, seen: WeakSet<object>): SafeJson {
       message: redactSensitiveString(value.message),
     };
   }
-  if (Array.isArray(value)) return value.map((item) => redactInternal(item, seen));
+  if (Array.isArray(value)) {
+    return value.map((item, index) => redactInternal(item, seen, [...path, String(index)]));
+  }
 
   if (typeof value === 'object') {
     if (seen.has(value)) return TELEMETRY_UNAVAILABLE;
@@ -226,7 +295,10 @@ function redactInternal(value: unknown, seen: WeakSet<object>): SafeJson {
 
     const output: { [key: string]: SafeJson } = {};
     for (const [key, child] of Object.entries(value)) {
-      output[key] = isProtectedKey(key) ? TELEMETRY_REDACTED : redactInternal(child, seen);
+      const childPath = [...path, key];
+      output[key] = isProtectedKey(key, childPath)
+        ? TELEMETRY_REDACTED
+        : redactInternal(child, seen, childPath);
     }
     return output;
   }
@@ -239,7 +311,18 @@ function redactInternal(value: unknown, seen: WeakSet<object>): SafeJson {
  * Safe inputs are low-cardinality ids, route patterns, and operational flags.
  */
 export function redactTelemetryValue(value: unknown): SafeJson {
-  return redactInternal(value, new WeakSet());
+  return redactInternal(value, new WeakSet(), []);
+}
+
+export type TelemetryPayloadKind = 'event' | 'breadcrumb' | 'log' | 'transaction' | 'span';
+
+/**
+ * Single Sentry privacy boundary for every payload family. New Sentry logs,
+ * transactions, and spans should route through this function before leaving
+ * the process.
+ */
+export function sanitizeTelemetryPayload(_kind: TelemetryPayloadKind, value: unknown): SafeJson {
+  return redactTelemetryValue(value);
 }
 
 /**
@@ -259,6 +342,7 @@ export function buildDiagnosticMetadata(
     conversationId: markerOr(input.conversationId),
     userMessageId: markerOr(input.userMessageId),
     assistantMessageId: markerOr(input.assistantMessageId),
+    sentryTraceId: markerOr(input.sentryTraceId),
     langsmithThreadUrl: markerOr(input.langsmithThreadUrl),
     langsmithRunUrl: markerOr(input.langsmithRunUrl),
     userId: markerOr(input.user?.id),
@@ -283,6 +367,7 @@ export function buildSafeTelemetryTags(
     ['conversation_id', metadata.conversationId],
     ['user_message_id', metadata.userMessageId],
     ['assistant_message_id', metadata.assistantMessageId],
+    ['sentry_trace_id', metadata.sentryTraceId],
     ['user_id', metadata.userId],
     ['user_hash', metadata.userHash],
     ...contextTagPairs(input),
@@ -321,11 +406,11 @@ function buildSentryContext(input: TelemetryCaptureInput, env: Env): Record<stri
 }
 
 function sanitizeSentryEvent(event: ErrorEvent): ErrorEvent {
-  return redactTelemetryValue(event) as unknown as ErrorEvent;
+  return sanitizeTelemetryPayload('event', event) as unknown as ErrorEvent;
 }
 
 function sanitizeSentryBreadcrumb(breadcrumb: Breadcrumb): Breadcrumb {
-  return redactTelemetryValue(breadcrumb) as unknown as Breadcrumb;
+  return sanitizeTelemetryPayload('breadcrumb', breadcrumb) as unknown as Breadcrumb;
 }
 
 /**

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -40,6 +40,7 @@ import {
   initTelemetry,
   redactTelemetryValue,
   resetTelemetryForTests,
+  sanitizeTelemetryPayload,
 } from '../src/telemetry.ts';
 
 const ORIGINAL_ENV = {
@@ -128,6 +129,7 @@ describe('telemetry boundary', () => {
       'conversationId',
       'userMessageId',
       'assistantMessageId',
+      'sentryTraceId',
       'langsmithThreadUrl',
       'langsmithRunUrl',
       'userId',
@@ -150,6 +152,7 @@ describe('telemetry boundary', () => {
       conversationId: 'conv-1',
       userMessageId: TELEMETRY_UNAVAILABLE,
       assistantMessageId: TELEMETRY_UNAVAILABLE,
+      sentryTraceId: TELEMETRY_UNAVAILABLE,
       langsmithThreadUrl: TELEMETRY_UNAVAILABLE,
       langsmithRunUrl: TELEMETRY_UNAVAILABLE,
       userId: 'user-1',
@@ -168,6 +171,7 @@ describe('telemetry boundary', () => {
         conversationId: 'conv-1',
         userMessageId: 'msg-user-1',
         assistantMessageId: 'msg-assistant-1',
+        sentryTraceId: '0123456789abcdef0123456789abcdef',
         langsmithThreadUrl: 'https://smith.langchain.com/o/org/projects/p/threads/t',
         langsmithRunUrl: 'https://smith.langchain.com/o/org/projects/p/r/r1',
         user: {
@@ -183,6 +187,7 @@ describe('telemetry boundary', () => {
       conversation_id: 'conv-1',
       user_message_id: 'msg-user-1',
       assistant_message_id: 'msg-assistant-1',
+      sentry_trace_id: '0123456789abcdef0123456789abcdef',
       user_id: 'user-1',
     });
   });
@@ -258,6 +263,110 @@ describe('telemetry boundary', () => {
       nested: {
         safeFlag: true,
         embedding: TELEMETRY_REDACTED,
+      },
+    });
+  });
+
+  it('redacts structured PII keys and sensitive value patterns without dropping safe ids', () => {
+    const redacted = redactTelemetryValue({
+      request_id: 'req-1',
+      sentry_trace_id: '0123456789abcdef0123456789abcdef',
+      conversation_id: 'conv-1',
+      conversationUuid: '11111111-1111-4111-8111-111111111111',
+      customerName: 'Alice Example',
+      first_name: 'Alice',
+      lastName: 'Example',
+      display_name: 'Alice E.',
+      user_email: 'alice@example.com',
+      phoneNumber: '+1 415 555 1212',
+      mailingAddress: '1 Market St, San Francisco, CA',
+      ipAddress: '203.0.113.10',
+      card: '4111 1111 1111 1111',
+      ssn: '123-45-6789',
+      callbackUrl: 'https://alice:secret@example.com/callback',
+      pem: '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----',
+      safeCount: 3,
+    });
+
+    expect(redacted).toEqual({
+      request_id: 'req-1',
+      sentry_trace_id: '0123456789abcdef0123456789abcdef',
+      conversation_id: 'conv-1',
+      conversationUuid: '11111111-1111-4111-8111-111111111111',
+      customerName: TELEMETRY_REDACTED,
+      first_name: TELEMETRY_REDACTED,
+      lastName: TELEMETRY_REDACTED,
+      display_name: TELEMETRY_REDACTED,
+      user_email: TELEMETRY_REDACTED,
+      phoneNumber: TELEMETRY_REDACTED,
+      mailingAddress: TELEMETRY_REDACTED,
+      ipAddress: TELEMETRY_REDACTED,
+      card: TELEMETRY_REDACTED,
+      ssn: TELEMETRY_REDACTED,
+      callbackUrl: TELEMETRY_REDACTED,
+      pem: TELEMETRY_REDACTED,
+      safeCount: 3,
+    });
+  });
+
+  it('handles circular telemetry structures without throwing', () => {
+    const payload: Record<string, unknown> = { requestId: 'req-1' };
+    payload.self = payload;
+
+    expect(redactTelemetryValue(payload)).toEqual({
+      requestId: 'req-1',
+      self: TELEMETRY_UNAVAILABLE,
+    });
+  });
+
+  it('sanitizes future log, transaction, and span payloads with the same boundary', () => {
+    expect(
+      sanitizeTelemetryPayload('log', {
+        message: 'user alice@example.com submitted feedback',
+        attributes: {
+          request_id: 'req-1',
+          userMessageId: 'msg-user-1',
+          rawFeedback: 'my transcript should stay out',
+        },
+      }),
+    ).toEqual({
+      message: TELEMETRY_REDACTED,
+      attributes: {
+        request_id: 'req-1',
+        userMessageId: 'msg-user-1',
+        rawFeedback: TELEMETRY_REDACTED,
+      },
+    });
+
+    expect(
+      sanitizeTelemetryPayload('transaction', {
+        transaction: '/chat/conv-1?token=secret',
+        request: {
+          headers: { cookie: 'session=value' },
+          data: { prompt: 'raw prompt' },
+        },
+      }),
+    ).toEqual({
+      transaction: TELEMETRY_REDACTED,
+      request: {
+        headers: { cookie: TELEMETRY_REDACTED },
+        data: TELEMETRY_REDACTED,
+      },
+    });
+
+    expect(
+      sanitizeTelemetryPayload('span', {
+        description: "select * from users where email = 'alice@example.com'",
+        data: {
+          request_id: 'req-1',
+          retrieved_passages: ['rule text'],
+        },
+      }),
+    ).toEqual({
+      description: TELEMETRY_REDACTED,
+      data: {
+        request_id: 'req-1',
+        retrieved_passages: TELEMETRY_REDACTED,
       },
     });
   });


### PR DESCRIPTION
## Summary

- Extends the Squire telemetry diagnostic contract with a safe `sentryTraceId` field and matching Sentry tag.
- Expands the shared telemetry sanitizer for future Sentry events, breadcrumbs, logs, transactions, and spans.
- Redacts structured PII and sensitive value patterns including names, emails, phone numbers, addresses, IPs, card-shaped numbers, SSNs, private keys, auth URLs, tokens, prompts, provider payloads, transcripts, embeddings, and retrieved passages.
- Preserves safe operational IDs such as request IDs, conversation IDs, UUIDs, and Sentry trace IDs.

## Test Coverage

All new sanitizer paths have focused unit coverage in `test/telemetry.test.ts`, including PII key redaction, sensitive string redaction, circular structures, and log/transaction/span payload sanitization.

## Pre-Landing Review

Manual `/review` pass completed against the installed skill's embedded categories. No remaining findings.

Note: the installed gstack review skill references `review/checklist.md`, but that adjunct file is missing from this local install. The review used the checklist categories embedded directly in the skill text.

## Scope Drift

Scope Check: CLEAN

Intent: define the Sentry log/trace privacy contract and sanitizer for SQR-327.

Delivered: telemetry boundary and tests only.

## Plan Completion

SQR-327 acceptance covered:

- no-DSN no-op behavior remains covered by existing tests
- safe tags include stable diagnostic fields and `sentry_trace_id`
- sanitizer covers event, breadcrumb, log, transaction, and span payload families
- redaction blocks PII/secrets/raw prompts/model output/provider payloads/retrieved passages
- safe app IDs remain available for diagnostics and later Linear evidence

## Documentation

No docs changed. Later project issues cover agent/runbook telemetry guidance.

## Test plan

- [x] `npm test -- --run test/telemetry.test.ts test/diagnostic-bundle.test.ts test/security-log.test.ts`
- [x] `npm run typecheck`
- [x] `npm run check` after merging current `origin/main` and after commit: 146 test files, 1768 tests

Fixes SQR-327


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sentry trace identifier to telemetry diagnostics for improved error tracking.

* **Bug Fixes**
  * Enhanced sensitive data protection across all telemetry payloads.
  * Improved handling of circular references in diagnostic data.
  * Strengthened sanitization consistency for all telemetry payload types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->