### PR TITLE
feat(observability): correlate Sentry app traces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@opentelemetry/sdk-node": "^0.219.0",
         "@redis/client": "^6.0.0",
         "@sentry/node": "^10.57.0",
+        "@sentry/opentelemetry": "^10.57.0",
         "@tailwindcss/node": "^4.3.0",
         "@tailwindcss/oxide": "^4.3.0",
         "deepagents": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@opentelemetry/sdk-node": "^0.219.0",
     "@redis/client": "^6.0.0",
     "@sentry/node": "^10.57.0",
+    "@sentry/opentelemetry": "^10.57.0",
     "@tailwindcss/node": "^4.3.0",
     "@tailwindcss/oxide": "^4.3.0",
     "deepagents": "^1.10.2",

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -7,25 +7,57 @@ import { NodeSDK } from '@opentelemetry/sdk-node';
 import { LangSmithOTLPSpanProcessor } from 'langsmith/experimental/otel/processor';
 import { LangSmithOTLPTraceExporter } from 'langsmith/experimental/otel/exporter';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
+import { SentryPropagator, SentrySampler, SentrySpanProcessor } from '@sentry/opentelemetry';
+import { SentryContextManager } from '@sentry/node';
 import { applySquireEnv } from './squire-env.ts';
 import { langsmithOtelHeaders } from './langsmith-otel.ts';
+import { getTelemetryClient, initTelemetry, sentryTraceSampleRateFromEnv } from './telemetry.ts';
 
 const squireEnv = applySquireEnv();
 const langsmithProject = process.env.LANGSMITH_PROJECT ?? 'squire-production';
 
+function buildLangSmithSpanProcessor(): LangSmithOTLPSpanProcessor {
+  return new LangSmithOTLPSpanProcessor(
+    new LangSmithOTLPTraceExporter({
+      projectName: langsmithProject,
+      headers: langsmithOtelHeaders(),
+      transformExportedSpan: (span) => {
+        span.attributes['langsmith.metadata.environment'] = squireEnv;
+        return span;
+      },
+    }),
+  );
+}
+
+function buildSentryOpenTelemetryConfig() {
+  initTelemetry(process.env);
+  const client = getTelemetryClient();
+  const tracesSampleRate = sentryTraceSampleRateFromEnv(process.env);
+  if (!client || tracesSampleRate === undefined || tracesSampleRate <= 0) {
+    return {
+      spanProcessors: [],
+    };
+  }
+
+  return {
+    spanProcessors: [new SentrySpanProcessor()],
+    sampler: new SentrySampler(client),
+    textMapPropagator: new SentryPropagator(),
+    contextManager: new SentryContextManager(),
+  };
+}
+
+const sentryOpenTelemetry = buildSentryOpenTelemetryConfig();
+
 const sdk = new NodeSDK({
-  spanProcessors: [
-    new LangSmithOTLPSpanProcessor(
-      new LangSmithOTLPTraceExporter({
-        projectName: langsmithProject,
-        headers: langsmithOtelHeaders(),
-        transformExportedSpan: (span) => {
-          span.attributes['langsmith.metadata.environment'] = squireEnv;
-          return span;
-        },
-      }),
-    ),
-  ],
+  spanProcessors: [buildLangSmithSpanProcessor(), ...sentryOpenTelemetry.spanProcessors],
+  ...(sentryOpenTelemetry.sampler ? { sampler: sentryOpenTelemetry.sampler } : {}),
+  ...(sentryOpenTelemetry.textMapPropagator
+    ? { textMapPropagator: sentryOpenTelemetry.textMapPropagator }
+    : {}),
+  ...(sentryOpenTelemetry.contextManager
+    ? { contextManager: sentryOpenTelemetry.contextManager }
+    : {}),
   // Auto-instrument node-postgres so every Drizzle query gets a span. Drizzle
   // uses `pg` under the hood, so this captures all DB activity from day 1.
   instrumentations: [new PgInstrumentation()],

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,6 +1,8 @@
 import * as Sentry from '@sentry/node';
 import type {
   Breadcrumb,
+  Event,
+  EventHint,
   ErrorEvent,
   Log,
   LogSeverityLevel,
@@ -104,6 +106,23 @@ export interface TelemetryInitResult {
   enabled: boolean;
   reason: 'initialized' | 'already_initialized' | 'missing_dsn' | 'init_failed';
 }
+
+type SentryTransactionEvent = Event & { type: 'transaction' };
+type SentrySpanPayload = {
+  data: Record<string, unknown>;
+  description?: string;
+};
+
+const SENTRY_SAFE_DATA_COLLECTION = {
+  userInfo: false,
+  cookies: false,
+  httpHeaders: { request: false, response: false },
+  httpBodies: [],
+  queryParams: false,
+  genAI: { inputs: false, outputs: false },
+  stackFrameVariables: false,
+  frameContextLines: 0,
+};
 
 const PROTECTED_KEY_PARTS = [
   'authorization',
@@ -232,6 +251,15 @@ function safeSquireEnv(env: Env = process.env): string {
 function safeString(value: string | undefined): string | undefined {
   if (!hasText(value)) return undefined;
   return value.trim();
+}
+
+export function sentryTraceSampleRateFromEnv(env: Env = process.env): number | undefined {
+  const raw = safeString(env.SENTRY_TRACES_SAMPLE_RATE);
+  if (!raw) return undefined;
+
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0 || value > 1) return undefined;
+  return value;
 }
 
 function markerOr(value: string | undefined): string {
@@ -434,6 +462,17 @@ function sanitizeSentryLog(log: Log): Log {
   return sanitizeTelemetryPayload('log', log) as unknown as Log;
 }
 
+function sanitizeSentryTransaction<T extends SentryTransactionEvent>(
+  event: T,
+  _hint: EventHint,
+): T {
+  return sanitizeTelemetryPayload('transaction', event) as unknown as T;
+}
+
+function sanitizeSentrySpan<T extends SentrySpanPayload>(span: T): T {
+  return sanitizeTelemetryPayload('span', span) as unknown as T;
+}
+
 function safeJsonRecord(value: SafeJson): Record<string, SafeJson> {
   if (value && typeof value === 'object' && !Array.isArray(value)) return value;
   return {};
@@ -487,17 +526,22 @@ export function initTelemetry(env: Env = process.env): TelemetryInitResult {
   if (initializedDsn === dsn) return { enabled: true, reason: 'already_initialized' };
 
   try {
+    const tracesSampleRate = sentryTraceSampleRateFromEnv(env);
     Sentry.init({
       dsn,
       environment: safeSquireEnv(env),
       release: safeString(env.SENTRY_RELEASE),
       defaultIntegrations: false,
       sendDefaultPii: false,
-      tracesSampleRate: 0,
+      dataCollection: SENTRY_SAFE_DATA_COLLECTION,
+      tracesSampleRate,
+      skipOpenTelemetrySetup: true,
       enableLogs: true,
       beforeSend: sanitizeSentryEvent,
       beforeBreadcrumb: sanitizeSentryBreadcrumb,
       beforeSendLog: sanitizeSentryLog,
+      beforeSendTransaction: sanitizeSentryTransaction,
+      beforeSendSpan: sanitizeSentrySpan,
     });
     initializedDsn = dsn;
     return { enabled: true, reason: 'initialized' };
@@ -512,6 +556,10 @@ export function initTelemetry(env: Env = process.env): TelemetryInitResult {
  */
 export function isTelemetryEnabled(): boolean {
   return initializedDsn !== null;
+}
+
+export function getTelemetryClient(): ReturnType<typeof Sentry.getClient> | undefined {
+  return isTelemetryEnabled() ? Sentry.getClient() : undefined;
 }
 
 /**

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -11,6 +11,8 @@ const {
   mockCaptureTelemetryMessage,
   mockAddTelemetryBreadcrumb,
   mockFlushTelemetry,
+  mockGetTelemetryClient,
+  mockSentryTraceSampleRateFromEnv,
 } = vi.hoisted(() => ({
   mockAsk: vi.fn(),
   mockInitTelemetry: vi.fn(() => ({ enabled: false, reason: 'missing_dsn' })),
@@ -18,6 +20,8 @@ const {
   mockCaptureTelemetryMessage: vi.fn(),
   mockAddTelemetryBreadcrumb: vi.fn(),
   mockFlushTelemetry: vi.fn().mockResolvedValue(true),
+  mockGetTelemetryClient: vi.fn(() => undefined),
+  mockSentryTraceSampleRateFromEnv: vi.fn(() => undefined),
 }));
 
 vi.mock('../src/service.ts', () => ({
@@ -60,6 +64,8 @@ vi.mock('../src/tools.ts', () => ({
 
 vi.mock('../src/telemetry.ts', () => ({
   initTelemetry: mockInitTelemetry,
+  getTelemetryClient: mockGetTelemetryClient,
+  sentryTraceSampleRateFromEnv: mockSentryTraceSampleRateFromEnv,
   captureTelemetryError: mockCaptureTelemetryError,
   captureTelemetryMessage: mockCaptureTelemetryMessage,
   addTelemetryBreadcrumb: mockAddTelemetryBreadcrumb,

--- a/test/instrumentation.test.ts
+++ b/test/instrumentation.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  class MockNodeSDK {
+    static instances: MockNodeSDK[] = [];
+    config: Record<string, unknown>;
+    start = vi.fn();
+
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+      MockNodeSDK.instances.push(this);
+    }
+  }
+
+  class MockLangSmithOTLPSpanProcessor {
+    exporter: unknown;
+
+    constructor(exporter: unknown) {
+      this.exporter = exporter;
+    }
+  }
+
+  class MockLangSmithOTLPTraceExporter {
+    config: Record<string, unknown>;
+
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+    }
+  }
+
+  class MockPgInstrumentation {}
+  class MockSentrySpanProcessor {}
+  class MockSentrySampler {
+    client: unknown;
+
+    constructor(client: unknown) {
+      this.client = client;
+    }
+  }
+  class MockSentryPropagator {}
+  class MockSentryContextManager {}
+
+  return {
+    MockNodeSDK,
+    MockLangSmithOTLPSpanProcessor,
+    MockLangSmithOTLPTraceExporter,
+    MockPgInstrumentation,
+    MockSentrySpanProcessor,
+    MockSentrySampler,
+    MockSentryPropagator,
+    MockSentryContextManager,
+    initTelemetry: vi.fn(() => ({ enabled: false, reason: 'missing_dsn' })),
+    getTelemetryClient: vi.fn(() => undefined as unknown),
+    sentryTraceSampleRateFromEnv: vi.fn(() => undefined as number | undefined),
+    langsmithOtelHeaders: vi.fn(() => ({ 'x-api-key': 'langsmith-key' })),
+  };
+});
+
+vi.mock('@opentelemetry/sdk-node', () => ({ NodeSDK: mocks.MockNodeSDK }));
+vi.mock('langsmith/experimental/otel/processor', () => ({
+  LangSmithOTLPSpanProcessor: mocks.MockLangSmithOTLPSpanProcessor,
+}));
+vi.mock('langsmith/experimental/otel/exporter', () => ({
+  LangSmithOTLPTraceExporter: mocks.MockLangSmithOTLPTraceExporter,
+}));
+vi.mock('@opentelemetry/instrumentation-pg', () => ({
+  PgInstrumentation: mocks.MockPgInstrumentation,
+}));
+vi.mock('@sentry/opentelemetry', () => ({
+  SentryPropagator: mocks.MockSentryPropagator,
+  SentrySampler: mocks.MockSentrySampler,
+  SentrySpanProcessor: mocks.MockSentrySpanProcessor,
+}));
+vi.mock('@sentry/node', () => ({
+  SentryContextManager: mocks.MockSentryContextManager,
+}));
+vi.mock('../src/telemetry.ts', () => ({
+  getTelemetryClient: mocks.getTelemetryClient,
+  initTelemetry: mocks.initTelemetry,
+  sentryTraceSampleRateFromEnv: mocks.sentryTraceSampleRateFromEnv,
+}));
+vi.mock('../src/langsmith-otel.ts', () => ({
+  langsmithOtelHeaders: mocks.langsmithOtelHeaders,
+}));
+
+const ORIGINAL_ENV = {
+  LANGSMITH_PROJECT: process.env.LANGSMITH_PROJECT,
+  SENTRY_DSN: process.env.SENTRY_DSN,
+  SENTRY_TRACES_SAMPLE_RATE: process.env.SENTRY_TRACES_SAMPLE_RATE,
+  SQUIRE_ENV: process.env.SQUIRE_ENV,
+};
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+async function importInstrumentation() {
+  await import('../src/instrumentation.ts');
+  const instance = mocks.MockNodeSDK.instances[0];
+  if (!instance) throw new Error('NodeSDK was not constructed');
+  return instance;
+}
+
+describe('OpenTelemetry instrumentation setup', () => {
+  beforeEach(() => {
+    restoreEnv();
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.MockNodeSDK.instances = [];
+    mocks.initTelemetry.mockReturnValue({ enabled: false, reason: 'missing_dsn' });
+    mocks.getTelemetryClient.mockReturnValue(undefined);
+    mocks.sentryTraceSampleRateFromEnv.mockReturnValue(undefined);
+    mocks.langsmithOtelHeaders.mockReturnValue({ 'x-api-key': 'langsmith-key' });
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('starts LangSmith tracing and pg instrumentation without Sentry trace config', async () => {
+    process.env.SQUIRE_ENV = 'production';
+    process.env.LANGSMITH_PROJECT = 'squire-production';
+
+    const sdk = await importInstrumentation();
+
+    expect(mocks.initTelemetry).toHaveBeenCalledTimes(1);
+    expect(sdk.start).toHaveBeenCalledTimes(1);
+    expect(mocks.MockNodeSDK.instances).toHaveLength(1);
+    expect(sdk.config).toMatchObject({
+      spanProcessors: [expect.any(mocks.MockLangSmithOTLPSpanProcessor)],
+      instrumentations: [expect.any(mocks.MockPgInstrumentation)],
+    });
+    expect(sdk.config).not.toHaveProperty('sampler');
+    expect(sdk.config).not.toHaveProperty('textMapPropagator');
+    expect(sdk.config).not.toHaveProperty('contextManager');
+
+    const langsmithProcessor = (sdk.config.spanProcessors as unknown[])[0];
+    const exporter = (langsmithProcessor as { exporter: unknown }).exporter as {
+      config: { transformExportedSpan: (span: { attributes: Record<string, unknown> }) => unknown };
+    };
+    const span = { attributes: {} };
+    expect(exporter.config.transformExportedSpan(span)).toBe(span);
+    expect(span.attributes).toEqual({
+      'langsmith.metadata.environment': 'production',
+    });
+  });
+
+  it('configures Sentry and LangSmith span processors together exactly once', async () => {
+    const sentryClient = { name: 'sentry-client' };
+    mocks.initTelemetry.mockReturnValue({ enabled: true, reason: 'initialized' });
+    mocks.getTelemetryClient.mockReturnValue(sentryClient);
+    mocks.sentryTraceSampleRateFromEnv.mockReturnValue(0.25);
+
+    const sdk = await importInstrumentation();
+
+    expect(mocks.initTelemetry).toHaveBeenCalledTimes(1);
+    expect(mocks.sentryTraceSampleRateFromEnv).toHaveBeenCalledTimes(1);
+    expect(mocks.MockNodeSDK.instances).toHaveLength(1);
+    expect(sdk.start).toHaveBeenCalledTimes(1);
+    expect(sdk.config).toMatchObject({
+      spanProcessors: [
+        expect.any(mocks.MockLangSmithOTLPSpanProcessor),
+        expect.any(mocks.MockSentrySpanProcessor),
+      ],
+      sampler: expect.any(mocks.MockSentrySampler),
+      textMapPropagator: expect.any(mocks.MockSentryPropagator),
+      contextManager: expect.any(mocks.MockSentryContextManager),
+      instrumentations: [expect.any(mocks.MockPgInstrumentation)],
+    });
+    expect((sdk.config.sampler as { client: unknown }).client).toBe(sentryClient);
+  });
+
+  it('does not add Sentry trace components when the sample rate disables traces', async () => {
+    mocks.initTelemetry.mockReturnValue({ enabled: true, reason: 'initialized' });
+    mocks.getTelemetryClient.mockReturnValue({ name: 'sentry-client' });
+    mocks.sentryTraceSampleRateFromEnv.mockReturnValue(0);
+
+    const sdk = await importInstrumentation();
+
+    expect(sdk.config).toMatchObject({
+      spanProcessors: [expect.any(mocks.MockLangSmithOTLPSpanProcessor)],
+    });
+    expect(sdk.config).not.toHaveProperty('sampler');
+    expect(sdk.config).not.toHaveProperty('textMapPropagator');
+    expect(sdk.config).not.toHaveProperty('contextManager');
+  });
+});

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -77,6 +77,8 @@ const {
   mockCaptureTelemetryMessage,
   mockAddTelemetryBreadcrumb,
   mockFlushTelemetry,
+  mockGetTelemetryClient,
+  mockSentryTraceSampleRateFromEnv,
 } = vi.hoisted(() => ({
   mockInitialize: vi.fn(),
   mockEnsureBootstrapStatus: vi.fn(),
@@ -97,6 +99,8 @@ const {
   mockCaptureTelemetryMessage: vi.fn(),
   mockAddTelemetryBreadcrumb: vi.fn(),
   mockFlushTelemetry: vi.fn().mockResolvedValue(true),
+  mockGetTelemetryClient: vi.fn(() => undefined),
+  mockSentryTraceSampleRateFromEnv: vi.fn(() => undefined),
 }));
 
 vi.mock('../src/service.ts', () => ({
@@ -127,6 +131,8 @@ vi.mock('../src/health.ts', () => ({
 
 vi.mock('../src/telemetry.ts', () => ({
   initTelemetry: mockInitTelemetry,
+  getTelemetryClient: mockGetTelemetryClient,
+  sentryTraceSampleRateFromEnv: mockSentryTraceSampleRateFromEnv,
   captureTelemetryError: mockCaptureTelemetryError,
   captureTelemetryFeedback: mockCaptureTelemetryFeedback,
   captureTelemetryMessage: mockCaptureTelemetryMessage,

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -50,12 +50,14 @@ import {
   redactTelemetryValue,
   resetTelemetryForTests,
   sanitizeTelemetryPayload,
+  sentryTraceSampleRateFromEnv,
 } from '../src/telemetry.ts';
 
 const ORIGINAL_ENV = {
   NODE_ENV: process.env.NODE_ENV,
   SENTRY_DSN: process.env.SENTRY_DSN,
   SENTRY_RELEASE: process.env.SENTRY_RELEASE,
+  SENTRY_TRACES_SAMPLE_RATE: process.env.SENTRY_TRACES_SAMPLE_RATE,
   SQUIRE_ENV: process.env.SQUIRE_ENV,
 };
 
@@ -109,6 +111,7 @@ describe('telemetry boundary', () => {
     process.env.SENTRY_DSN = 'https://public@example.sentry.io/123';
     process.env.SENTRY_RELEASE = 'abc123';
     process.env.SQUIRE_ENV = 'production';
+    process.env.SENTRY_TRACES_SAMPLE_RATE = '0.25';
 
     expect(initTelemetry(process.env)).toEqual({ enabled: true, reason: 'initialized' });
     expect(initTelemetry(process.env)).toEqual({ enabled: true, reason: 'already_initialized' });
@@ -121,13 +124,38 @@ describe('telemetry boundary', () => {
         release: 'abc123',
         defaultIntegrations: false,
         sendDefaultPii: false,
-        tracesSampleRate: 0,
+        tracesSampleRate: 0.25,
+        skipOpenTelemetrySetup: true,
         enableLogs: true,
+        dataCollection: {
+          userInfo: false,
+          cookies: false,
+          httpHeaders: { request: false, response: false },
+          httpBodies: [],
+          queryParams: false,
+          genAI: { inputs: false, outputs: false },
+          stackFrameVariables: false,
+          frameContextLines: 0,
+        },
         beforeSend: expect.any(Function),
         beforeBreadcrumb: expect.any(Function),
         beforeSendLog: expect.any(Function),
+        beforeSendTransaction: expect.any(Function),
+        beforeSendSpan: expect.any(Function),
       }),
     );
+  });
+
+  it('parses Sentry trace sampling from environment only when valid', () => {
+    expect(sentryTraceSampleRateFromEnv({ SENTRY_TRACES_SAMPLE_RATE: undefined })).toBeUndefined();
+    expect(sentryTraceSampleRateFromEnv({ SENTRY_TRACES_SAMPLE_RATE: '0' })).toBe(0);
+    expect(sentryTraceSampleRateFromEnv({ SENTRY_TRACES_SAMPLE_RATE: '0.5' })).toBe(0.5);
+    expect(sentryTraceSampleRateFromEnv({ SENTRY_TRACES_SAMPLE_RATE: '1' })).toBe(1);
+    expect(sentryTraceSampleRateFromEnv({ SENTRY_TRACES_SAMPLE_RATE: '-0.1' })).toBeUndefined();
+    expect(sentryTraceSampleRateFromEnv({ SENTRY_TRACES_SAMPLE_RATE: '1.1' })).toBeUndefined();
+    expect(
+      sentryTraceSampleRateFromEnv({ SENTRY_TRACES_SAMPLE_RATE: 'not-a-number' }),
+    ).toBeUndefined();
   });
 
   it('keeps the diagnostic field contract stable and explicit about unavailable fields', () => {
@@ -428,6 +456,90 @@ describe('telemetry boundary', () => {
         },
       },
     });
+  });
+
+  it('redacts Sentry app trace payloads before transactions and spans are sent', () => {
+    process.env.SENTRY_DSN = 'https://public@example.sentry.io/123';
+    process.env.SENTRY_TRACES_SAMPLE_RATE = '1';
+    process.env.SQUIRE_ENV = 'production';
+    initTelemetry(process.env);
+
+    const initOptions = sentry.init.mock.calls[0]?.[0];
+    const sanitizedSpan = initOptions.beforeSendSpan({
+      trace_id: '0123456789abcdef0123456789abcdef',
+      span_id: '0123456789abcdef',
+      start_timestamp: 1,
+      data: {
+        'squire.request_id': 'req-1',
+        'squire.conversation_id': 'conv-1',
+        'langsmith.metadata.thread_id': 'conv-1',
+        'gen_ai.prompt': 'raw prompt',
+        'gen_ai.completion': 'full model answer',
+        providerPayload: { body: 'raw provider payload' },
+        retrievedPassages: ['source passage'],
+        transcript: 'raw transcript',
+      },
+      description: 'squire.agent.run',
+    });
+    const sanitizedTransaction = initOptions.beforeSendTransaction(
+      {
+        type: 'transaction',
+        transaction: '/chat/conv-1',
+        contexts: {
+          trace: {
+            trace_id: '0123456789abcdef0123456789abcdef',
+            span_id: '0123456789abcdef',
+          },
+        },
+        request: {
+          data: { prompt: 'hidden prompt' },
+          headers: { authorization: 'Bearer secret-token' },
+        },
+        spans: [
+          {
+            data: {
+              'squire.request_id': 'req-1',
+              'gen_ai.prompt': 'raw prompt',
+              modelOutput: 'raw model output',
+            },
+          },
+        ],
+      },
+      {},
+    );
+
+    expect(sanitizedSpan).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          'squire.request_id': 'req-1',
+          'squire.conversation_id': 'conv-1',
+          'langsmith.metadata.thread_id': 'conv-1',
+          'gen_ai.prompt': TELEMETRY_REDACTED,
+          'gen_ai.completion': TELEMETRY_REDACTED,
+          providerPayload: TELEMETRY_REDACTED,
+          retrievedPassages: TELEMETRY_REDACTED,
+          transcript: TELEMETRY_REDACTED,
+        }),
+      }),
+    );
+    expect(sanitizedTransaction).toEqual(
+      expect.objectContaining({
+        transaction: '/chat/conv-1',
+        request: {
+          data: TELEMETRY_REDACTED,
+          headers: { authorization: TELEMETRY_REDACTED },
+        },
+        spans: [
+          {
+            data: {
+              'squire.request_id': 'req-1',
+              'gen_ai.prompt': TELEMETRY_REDACTED,
+              modelOutput: TELEMETRY_REDACTED,
+            },
+          },
+        ],
+      }),
+    );
   });
 
   it('captures Sentry logs with stable safe attributes and arbitrary sanitized attributes', () => {


### PR DESCRIPTION
## Summary
- initialize Sentry with custom OpenTelemetry mode and safe trace data-collection controls
- add Sentry sampler, span processor, propagator, and context manager to the existing NodeSDK only when SENTRY_DSN and SENTRY_TRACES_SAMPLE_RATE are configured
- keep LangSmith span export first and scrub AI prompt/output/provider/retrieval fields from Sentry transaction/span payloads
- add focused instrumentation and telemetry tests

## Tests
- npm test -- --run test/telemetry.test.ts test/instrumentation.test.ts
- npm test -- --run test/conversation.test.ts test/server-api.test.ts test/instrumentation.test.ts test/telemetry.test.ts
- npm run typecheck
- npm run check

Fixes SQR-329