### PR TITLE
feat(observability): send security logs to Sentry logs

### DIFF
--- a/src/security-log.ts
+++ b/src/security-log.ts
@@ -1,12 +1,9 @@
-import type { SeverityLevel } from '@sentry/node';
-
 import { resolveSquireEnv } from './squire-env.ts';
-import { addTelemetryBreadcrumb, captureTelemetryMessage } from './telemetry.ts';
+import { captureTelemetryLog } from './telemetry.ts';
 
 type SecurityLogLevel = 'info' | 'warn' | 'error';
 type SecurityLogFieldValue = string | number | boolean | null;
 type SecurityLogFields = Record<string, SecurityLogFieldValue>;
-type SecurityTelemetryMode = 'breadcrumb' | 'message';
 
 interface SecurityLogBase {
   event: string;
@@ -14,38 +11,9 @@ interface SecurityLogBase {
   fields?: SecurityLogFields;
 }
 
-const SECURITY_TELEMETRY_EVENTS = {
-  campaign_client_token_rejected: 'breadcrumb',
-  llm_budget_warning: 'breadcrumb',
-  rate_limit_rejected: 'breadcrumb',
-  llm_budget_accounting_failed: 'message',
-  rate_limit_redis_error: 'message',
-  rate_limit_unavailable: 'message',
-} as const satisfies Record<string, SecurityTelemetryMode>;
-
-const SECURITY_TELEMETRY_FIELD_KEYS = new Set<string>([
-  'budget_day',
-  'budget_usd_micros',
-  'client_id',
-  'error_code',
-  'error_type',
-  'has_user_id',
-  'identity_hash',
-  'identity_kind',
-  'limit',
-  'method',
-  'model',
-  'policy',
-  'reset_after_seconds',
-  'retry_after_seconds',
-  'route',
-  'spent_usd_micros',
-  'threshold_percent',
-  'window_ms',
-]);
-
 const SAFE_ERROR_TYPE_PATTERN = /^[A-Za-z][A-Za-z0-9_.:-]{0,63}$/;
 const SAFE_ERROR_CODE_PATTERN = /^[A-Za-z0-9_.:-]{1,64}$/;
+const SAFE_DIAGNOSTIC_TOKEN_PATTERN = /^[A-Za-z0-9._:/-]{1,128}$/;
 
 function safeSquireEnv(): string {
   try {
@@ -70,6 +38,26 @@ function safeRouteField(value: SecurityLogFieldValue): string | null {
   return route.split('?')[0]?.split('#')[0] || '/';
 }
 
+function safeDiagnosticToken(value: SecurityLogFieldValue): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return SAFE_DIAGNOSTIC_TOKEN_PATTERN.test(trimmed) ? trimmed : undefined;
+}
+
+function safeLangSmithUrl(value: SecurityLogFieldValue): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'https:' || url.hostname !== 'smith.langchain.com') return undefined;
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return undefined;
+  }
+}
+
 function safeErrorType(value: unknown): string {
   if (typeof value !== 'string') return 'unknown';
   const trimmed = value.trim();
@@ -82,75 +70,73 @@ function safeErrorCode(value: unknown): string | null {
   return SAFE_ERROR_CODE_PATTERN.test(trimmed) ? trimmed : null;
 }
 
-function toTelemetryLevel(level: SecurityLogLevel): SeverityLevel {
-  return level === 'warn' ? 'warning' : level;
-}
+function buildSecurityLogAttributes(input: {
+  event: string;
+  level: SecurityLogLevel;
+  squireEnv: string;
+  fields: SecurityLogFields;
+}): SecurityLogFields {
+  const attributes: SecurityLogFields = {};
 
-function safeSecurityTelemetryFields(fields: SecurityLogFields): SecurityLogFields {
-  const safeFields: SecurityLogFields = {};
-
-  for (const [key, value] of Object.entries(fields)) {
-    if (!SECURITY_TELEMETRY_FIELD_KEYS.has(key)) continue;
-
+  for (const [key, value] of Object.entries(input.fields)) {
     if (key === 'route') {
       const route = safeRouteField(value);
-      if (route !== null) safeFields.route = route;
+      if (route !== null) attributes.route = route;
       continue;
     }
 
     if (key === 'error_type') {
-      safeFields.error_type = safeErrorType(value);
+      attributes.error_type = safeErrorType(value);
       continue;
     }
 
     if (key === 'error_code') {
-      safeFields.error_code = safeErrorCode(value);
+      attributes.error_code = safeErrorCode(value);
       continue;
     }
 
-    safeFields[key] = value;
+    attributes[key] = value;
   }
 
-  return safeFields;
+  return {
+    ...attributes,
+    event: input.event,
+    level: input.level,
+    squire_env: input.squireEnv,
+    log_kind: 'security',
+  };
 }
 
-function emitSecurityTelemetry(input: {
+function emitSecurityTelemetryLog(input: {
   event: string;
   level: SecurityLogLevel;
   squireEnv: string;
   fields: SecurityLogFields;
 }): void {
-  const mode = SECURITY_TELEMETRY_EVENTS[input.event as keyof typeof SECURITY_TELEMETRY_EVENTS];
-  if (!mode) return;
-
-  const fields = safeSecurityTelemetryFields(input.fields);
-  const route = typeof fields.route === 'string' ? fields.route : undefined;
-  const telemetryInput = {
-    route,
-    context: {
-      event: input.event,
-      level: input.level,
-      squire_env: input.squireEnv,
-      fields,
-    },
-  };
+  const route = safeRouteField(input.fields.route);
+  const requestId = safeDiagnosticToken(input.fields.request_id);
+  const userId = safeDiagnosticToken(input.fields.user_id);
+  const userHash = safeDiagnosticToken(input.fields.user_hash);
 
   try {
-    if (mode === 'breadcrumb') {
-      addTelemetryBreadcrumb({
-        category: 'security_log',
-        message: input.event,
-        level: toTelemetryLevel(input.level),
-        ...telemetryInput,
-      });
-      return;
-    }
-
-    captureTelemetryMessage(
-      `security_log.${input.event}`,
-      toTelemetryLevel(input.level),
-      telemetryInput,
-    );
+    captureTelemetryLog(input.level, `security_log.${input.event}`, {
+      route: route ?? undefined,
+      requestId,
+      conversationId: safeDiagnosticToken(input.fields.conversation_id),
+      userMessageId: safeDiagnosticToken(input.fields.user_message_id),
+      assistantMessageId: safeDiagnosticToken(input.fields.assistant_message_id),
+      sentryTraceId: safeDiagnosticToken(input.fields.sentry_trace_id),
+      langsmithThreadUrl: safeLangSmithUrl(input.fields.langsmith_thread_url),
+      langsmithRunUrl: safeLangSmithUrl(input.fields.langsmith_run_url),
+      user: userId || userHash ? { id: userId, hash: userHash } : undefined,
+      context: {
+        event: input.event,
+        level: input.level,
+        squire_env: input.squireEnv,
+        surface: 'security_log',
+      },
+      attributes: buildSecurityLogAttributes(input),
+    });
   } catch {
     // Logging must never fail because telemetry did.
   }
@@ -168,7 +154,7 @@ export function writeSecurityLog({ event, level = 'warn', fields = {} }: Securit
     }),
   );
 
-  emitSecurityTelemetry({ event, level, squireEnv, fields });
+  emitSecurityTelemetryLog({ event, level, squireEnv, fields });
 }
 
 export function errorLogFields(error: unknown): Record<string, string | null> {

--- a/test/security-log-sentry.test.ts
+++ b/test/security-log-sentry.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sentry = vi.hoisted(() => {
+  const scope = {
+    setTags: vi.fn(),
+    setContext: vi.fn(),
+    setUser: vi.fn(),
+  };
+  type Scope = {
+    setTags: typeof scope.setTags;
+    setContext: typeof scope.setContext;
+    setUser: typeof scope.setUser;
+  };
+
+  return {
+    scope,
+    init: vi.fn(),
+    withScope: vi.fn((callback: (scopeArg: Scope) => void) => callback(scope)),
+    captureException: vi.fn(),
+    captureFeedback: vi.fn(),
+    captureMessage: vi.fn(),
+    logger: {
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    },
+    addBreadcrumb: vi.fn(),
+    flush: vi.fn(),
+  };
+});
+
+vi.mock('@sentry/node', () => sentry);
+
+import { writeSecurityLog } from '../src/security-log.ts';
+import { TELEMETRY_REDACTED, initTelemetry, resetTelemetryForTests } from '../src/telemetry.ts';
+
+const ORIGINAL_ENV = {
+  SENTRY_DSN: process.env.SENTRY_DSN,
+  SENTRY_RELEASE: process.env.SENTRY_RELEASE,
+  SQUIRE_ENV: process.env.SQUIRE_ENV,
+};
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+describe('writeSecurityLog Sentry log integration', () => {
+  beforeEach(() => {
+    restoreEnv();
+    resetTelemetryForTests();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    resetTelemetryForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('sends broad security logs through the Sentry sanitizer without changing stdout JSON', () => {
+    process.env.SENTRY_DSN = 'https://public@example.sentry.io/123';
+    process.env.SENTRY_RELEASE = 'abc123';
+    process.env.SQUIRE_ENV = 'production';
+    initTelemetry(process.env);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    writeSecurityLog({
+      event: 'custom_security_event',
+      fields: {
+        route: '/api/ask?token=secret',
+        request_id: 'req-1',
+        policy: 'api_ask',
+        safe_count: 2,
+        authorization: 'Bearer secret-token',
+        cookie: 'session=value',
+        token: 'secret-token',
+        email: 'alice@example.com',
+        name: 'Alice Example',
+        first_name: 'Alice',
+        raw_prompt: 'hidden prompt',
+        answer: 'raw model output',
+        transcript: 'raw chat transcript',
+      },
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const stdoutPayload = JSON.parse(warn.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(stdoutPayload).toMatchObject({
+      event: 'custom_security_event',
+      level: 'warn',
+      squire_env: 'production',
+      route: '/api/ask?token=secret',
+      request_id: 'req-1',
+      policy: 'api_ask',
+      authorization: 'Bearer secret-token',
+      cookie: 'session=value',
+      token: 'secret-token',
+      email: 'alice@example.com',
+      name: 'Alice Example',
+      first_name: 'Alice',
+      raw_prompt: 'hidden prompt',
+      answer: 'raw model output',
+      transcript: 'raw chat transcript',
+    });
+
+    expect(sentry.scope.setTags).toHaveBeenCalledWith({
+      environment: 'production',
+      release: 'abc123',
+      route: '/api/ask',
+      request_id: 'req-1',
+      surface: 'security_log',
+      security_event: 'custom_security_event',
+    });
+    expect(sentry.logger.warn).toHaveBeenCalledWith('security_log.custom_security_event', {
+      event: 'custom_security_event',
+      level: 'warn',
+      squire_env: 'production',
+      log_kind: 'security',
+      route: '/api/ask',
+      request_id: 'req-1',
+      policy: 'api_ask',
+      safe_count: 2,
+      authorization: TELEMETRY_REDACTED,
+      cookie: TELEMETRY_REDACTED,
+      token: TELEMETRY_REDACTED,
+      email: TELEMETRY_REDACTED,
+      name: TELEMETRY_REDACTED,
+      first_name: TELEMETRY_REDACTED,
+      raw_prompt: TELEMETRY_REDACTED,
+      answer: TELEMETRY_REDACTED,
+      transcript: TELEMETRY_REDACTED,
+      context: {
+        event: 'custom_security_event',
+        level: 'warn',
+        squire_env: 'production',
+        surface: 'security_log',
+      },
+      surface: 'security_log',
+      security_event: 'custom_security_event',
+      environment: 'production',
+      release: 'abc123',
+    });
+  });
+});

--- a/test/security-log.test.ts
+++ b/test/security-log.test.ts
@@ -1,13 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockAddTelemetryBreadcrumb, mockCaptureTelemetryMessage } = vi.hoisted(() => ({
-  mockAddTelemetryBreadcrumb: vi.fn(),
-  mockCaptureTelemetryMessage: vi.fn(),
+const { mockCaptureTelemetryLog } = vi.hoisted(() => ({
+  mockCaptureTelemetryLog: vi.fn(),
 }));
 
 vi.mock('../src/telemetry.ts', () => ({
-  addTelemetryBreadcrumb: mockAddTelemetryBreadcrumb,
-  captureTelemetryMessage: mockCaptureTelemetryMessage,
+  captureTelemetryLog: mockCaptureTelemetryLog,
 }));
 
 import { errorLogFields, writeSecurityLog } from '../src/security-log.ts';
@@ -15,8 +13,7 @@ import { errorLogFields, writeSecurityLog } from '../src/security-log.ts';
 const ORIGINAL_SQUIRE_ENV = process.env.SQUIRE_ENV;
 
 beforeEach(() => {
-  mockAddTelemetryBreadcrumb.mockReset();
-  mockCaptureTelemetryMessage.mockReset();
+  mockCaptureTelemetryLog.mockReset();
 });
 
 afterEach(() => {
@@ -56,7 +53,7 @@ describe('writeSecurityLog', () => {
     expect(payload.ts).not.toBe('spoofed_timestamp');
   });
 
-  it('mirrors rate-limit rejections as safe Sentry breadcrumbs', () => {
+  it('emits rate-limit rejections as broad structured Sentry logs', () => {
     process.env.SQUIRE_ENV = 'production';
     vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -69,6 +66,7 @@ describe('writeSecurityLog', () => {
         limit: 20,
         window_ms: 60_000,
         identity_hash: 'identity-hash',
+        request_id: 'req-1',
         retry_after_seconds: 3,
         reset_after_seconds: 12,
         authorization: 'Bearer secret-token',
@@ -78,32 +76,43 @@ describe('writeSecurityLog', () => {
       },
     });
 
-    expect(mockAddTelemetryBreadcrumb).toHaveBeenCalledTimes(1);
-    expect(mockAddTelemetryBreadcrumb).toHaveBeenCalledWith({
-      category: 'security_log',
-      message: 'rate_limit_rejected',
-      level: 'warning',
-      route: '/api/ask',
-      context: {
-        event: 'rate_limit_rejected',
-        level: 'warn',
-        squire_env: 'production',
-        fields: {
+    expect(mockCaptureTelemetryLog).toHaveBeenCalledTimes(1);
+    expect(mockCaptureTelemetryLog).toHaveBeenCalledWith(
+      'warn',
+      'security_log.rate_limit_rejected',
+      {
+        route: '/api/ask',
+        requestId: 'req-1',
+        context: {
+          event: 'rate_limit_rejected',
+          level: 'warn',
+          squire_env: 'production',
+          surface: 'security_log',
+        },
+        attributes: {
+          event: 'rate_limit_rejected',
+          level: 'warn',
+          squire_env: 'production',
+          log_kind: 'security',
           route: '/api/ask',
           method: 'POST',
           policy: 'api_ask',
           limit: 20,
           window_ms: 60_000,
           identity_hash: 'identity-hash',
+          request_id: 'req-1',
           retry_after_seconds: 3,
           reset_after_seconds: 12,
+          authorization: 'Bearer secret-token',
+          cookie: 'session=value',
+          raw_prompt: 'What is in the hidden prompt?',
+          email: 'alice@example.com',
         },
       },
-    });
-    expect(mockCaptureTelemetryMessage).not.toHaveBeenCalled();
+    );
   });
 
-  it('captures important app failures as safe Sentry messages', () => {
+  it('emits important app failures as error Sentry logs', () => {
     process.env.SQUIRE_ENV = 'production';
     vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -121,43 +130,193 @@ describe('writeSecurityLog', () => {
       },
     });
 
-    expect(mockCaptureTelemetryMessage).toHaveBeenCalledTimes(1);
-    expect(mockCaptureTelemetryMessage).toHaveBeenCalledWith(
-      'security_log.rate_limit_unavailable',
+    expect(mockCaptureTelemetryLog).toHaveBeenCalledTimes(1);
+    expect(mockCaptureTelemetryLog).toHaveBeenCalledWith(
       'error',
+      'security_log.rate_limit_unavailable',
       {
         route: '/register',
         context: {
           event: 'rate_limit_unavailable',
           level: 'error',
           squire_env: 'production',
-          fields: {
-            route: '/register',
-            method: 'POST',
-            policy: 'register_client',
-            error_type: 'RedisConnectionError',
-            error_code: 'ECONNREFUSED',
-          },
+          surface: 'security_log',
+        },
+        attributes: {
+          event: 'rate_limit_unavailable',
+          level: 'error',
+          squire_env: 'production',
+          log_kind: 'security',
+          route: '/register',
+          method: 'POST',
+          policy: 'register_client',
+          error_type: 'RedisConnectionError',
+          error_code: 'ECONNREFUSED',
+          token: 'secret-token',
+          answer: 'raw model output',
         },
       },
     );
-    expect(mockAddTelemetryBreadcrumb).not.toHaveBeenCalled();
   });
 
-  it('does not mirror unrecognized security log events to Sentry', () => {
+  it('emits unrecognized security log events to Sentry logs', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     writeSecurityLog({
       event: 'unclassified_debug_event',
       fields: {
         route: '/debug',
+        request_id: 'req-debug-1',
         detail: 'still written to stdout',
       },
     });
 
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(mockAddTelemetryBreadcrumb).not.toHaveBeenCalled();
-    expect(mockCaptureTelemetryMessage).not.toHaveBeenCalled();
+    expect(mockCaptureTelemetryLog).toHaveBeenCalledTimes(1);
+    expect(mockCaptureTelemetryLog).toHaveBeenCalledWith(
+      'warn',
+      'security_log.unclassified_debug_event',
+      {
+        route: '/debug',
+        requestId: 'req-debug-1',
+        context: {
+          event: 'unclassified_debug_event',
+          level: 'warn',
+          squire_env: 'test',
+          surface: 'security_log',
+        },
+        attributes: {
+          event: 'unclassified_debug_event',
+          level: 'warn',
+          squire_env: 'test',
+          log_kind: 'security',
+          route: '/debug',
+          request_id: 'req-debug-1',
+          detail: 'still written to stdout',
+        },
+      },
+    );
+  });
+
+  it('maps available snake_case diagnostic fields into telemetry metadata', () => {
+    process.env.SQUIRE_ENV = 'production';
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    writeSecurityLog({
+      event: 'diagnostic_security_event',
+      level: 'info',
+      fields: {
+        route: '/chat/conv-1/messages/msg-1/stream?token=secret',
+        request_id: 'req-1',
+        conversation_id: 'conv-1',
+        user_message_id: 'msg-user-1',
+        assistant_message_id: 'msg-assistant-1',
+        sentry_trace_id: '0123456789abcdef0123456789abcdef',
+        langsmith_thread_url:
+          'https://smith.langchain.com/o/org/projects/p/threads/thread-1?token=secret',
+        langsmith_run_url: 'https://smith.langchain.com/o/org/projects/p/r/run-1#fragment',
+        user_id: 'user-1',
+        user_hash: 'user-hash-1',
+      },
+    });
+
+    expect(mockCaptureTelemetryLog).toHaveBeenCalledWith(
+      'info',
+      'security_log.diagnostic_security_event',
+      expect.objectContaining({
+        route: '/chat/conv-1/messages/msg-1/stream',
+        requestId: 'req-1',
+        conversationId: 'conv-1',
+        userMessageId: 'msg-user-1',
+        assistantMessageId: 'msg-assistant-1',
+        sentryTraceId: '0123456789abcdef0123456789abcdef',
+        langsmithThreadUrl: 'https://smith.langchain.com/o/org/projects/p/threads/thread-1',
+        langsmithRunUrl: 'https://smith.langchain.com/o/org/projects/p/r/run-1',
+        user: { id: 'user-1', hash: 'user-hash-1' },
+      }),
+    );
+  });
+
+  it('does not promote unsafe diagnostic fields into telemetry metadata', () => {
+    process.env.SQUIRE_ENV = 'production';
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    writeSecurityLog({
+      event: 'unsafe_diagnostic_security_event',
+      fields: {
+        route: '/debug',
+        request_id: 'alice@example.com',
+        user_id: 'alice@example.com',
+        user_hash: 'Bearer secret-token',
+        langsmith_thread_url: 'https://evil.test/o/org/projects/p/threads/thread-1',
+        langsmith_run_url: 'not a url',
+      },
+    });
+
+    expect(mockCaptureTelemetryLog).toHaveBeenCalledWith(
+      'warn',
+      'security_log.unsafe_diagnostic_security_event',
+      expect.objectContaining({
+        route: '/debug',
+        requestId: undefined,
+        langsmithThreadUrl: undefined,
+        langsmithRunUrl: undefined,
+        user: undefined,
+      }),
+    );
+  });
+
+  it('preserves stdout JSON while the telemetry boundary sanitizes unsafe fields', () => {
+    process.env.SQUIRE_ENV = 'production';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    writeSecurityLog({
+      event: 'custom_security_event',
+      fields: {
+        route: '/debug?token=secret',
+        request_id: 'req-debug-2',
+        email: 'alice@example.com',
+        raw_prompt: 'hidden prompt',
+        name: 'Alice Example',
+      },
+    });
+
+    const payload = JSON.parse(warn.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      event: 'custom_security_event',
+      level: 'warn',
+      squire_env: 'production',
+      route: '/debug?token=secret',
+      request_id: 'req-debug-2',
+      email: 'alice@example.com',
+      raw_prompt: 'hidden prompt',
+      name: 'Alice Example',
+    });
+    expect(mockCaptureTelemetryLog).toHaveBeenCalledWith(
+      'warn',
+      'security_log.custom_security_event',
+      {
+        route: '/debug',
+        requestId: 'req-debug-2',
+        context: {
+          event: 'custom_security_event',
+          level: 'warn',
+          squire_env: 'production',
+          surface: 'security_log',
+        },
+        attributes: {
+          event: 'custom_security_event',
+          level: 'warn',
+          squire_env: 'production',
+          log_kind: 'security',
+          route: '/debug',
+          request_id: 'req-debug-2',
+          email: 'alice@example.com',
+          raw_prompt: 'hidden prompt',
+          name: 'Alice Example',
+        },
+      },
+    );
   });
 
   it('sanitizes error type and code fields', () => {


### PR DESCRIPTION
## Summary
- Send every `writeSecurityLog()` event to Sentry Logs through `captureTelemetryLog()` instead of the old selected breadcrumb/message mirror.
- Preserve stdout JSON shape and canonical fields while normalizing route/request_id and other diagnostic IDs for Sentry correlation.
- Keep sensitive field redaction at the telemetry boundary and add integration coverage that proves raw prompts, answers, transcripts, cookies, auth headers, tokens, emails, and name fields do not reach Sentry Logs.

Fixes SQR-330

## Test plan
- [x] `npm test -- --run test/security-log.test.ts test/security-log-sentry.test.ts test/telemetry.test.ts`
- [x] `npm run typecheck`
- [x] `npm run check` (148 files / 1780 tests)
