### PR TITLE
Add Sentry usage and spend guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ LANGSMITH_PROJECT=squire-evals
 # Missing SENTRY_DSN is a local/test no-op. Production DSNs are Fly secrets.
 # SENTRY_DSN=
 # SENTRY_RELEASE=local-dev
+# Optional Sentry app-span sampling. Unset or 0 disables Sentry span export.
+# Keep LangSmith as the source of truth for AI traces/evals.
+# SENTRY_TRACES_SAMPLE_RATE=0.10
 
 # Optional eval runner defaults. CLI flags override these values.
 # SQUIRE_EVAL_PROVIDER=anthropic

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -86,6 +86,19 @@ SHA. A future staging app should use its own Sentry project or environment,
 `SQUIRE_ENV=staging`, and its own DSN secret so test events cannot mix with
 production alerts.
 
+`SENTRY_TRACES_SAMPLE_RATE` controls Sentry app-span export only. Leave it unset
+or set it to `0` to disable Sentry app spans; set a decimal from `0` to `1` to
+sample app spans. In production, set it as a Fly secret so it can be tuned
+without a code deploy:
+
+```bash
+fly secrets set SENTRY_TRACES_SAMPLE_RATE=0.10 -a maz-squire
+```
+
+Keep broad logs and traces governed by sanitization, not cost-based log
+allowlists. Usage checks and spend controls live in
+[docs/runbooks/sentry-usage-guardrails.md](runbooks/sentry-usage-guardrails.md).
+
 Safe Sentry test events are documented in
 [docs/runbooks/observability.md](runbooks/observability.md) and
 [docs/runbooks/sentry-alerts.md](runbooks/sentry-alerts.md). Local dry runs

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -7,7 +7,7 @@ stream, browser problem, backend error, cron failure, or uptime alert.
 
 - Sentry owns app observability: backend errors, swallowed chat failures, SSE
   failures, browser errors, cron/script failures, uptime checks, release health,
-  replay, feedback, and alerting.
+  replay, feedback, alerting, app logs, app traces, and usage guardrails.
 - LangSmith owns LLM traces and eval debugging: model input/output, tool calls,
   retrieval behavior, answer quality, eval regressions, and trace comparison.
 - Linear owns the bug record. Tickets must use the diagnostic bundle and
@@ -17,6 +17,12 @@ Sentry links to LangSmith by safe IDs and URLs. Do not duplicate raw prompt,
 model output, provider payload, retrieved passage, cookie, bearer token, OAuth
 token, secret, full source document, email address, or full transcript content
 in Sentry or Linear.
+
+Usage and spend checks for Sentry Logs and app traces live in
+[sentry-usage-guardrails.md](sentry-usage-guardrails.md). Cost controls must not
+replace privacy sanitization: keep safe operational logs broad, tune
+`SENTRY_TRACES_SAMPLE_RATE` for span volume, and use explicit emergency
+throttles only with an owner and rollback condition.
 
 ## Correlation Fields
 
@@ -260,3 +266,6 @@ After observability changes deploy:
    deploy-regression, and uptime paths.
 5. Create or update a Linear bug with the required Evidence template, using
    unavailable reasons for anything not present.
+6. Check Sentry `Stats & Usage` for log accepted GB, accepted spans, dropped
+   data, and the PAYG budget path in
+   [sentry-usage-guardrails.md](sentry-usage-guardrails.md).

--- a/docs/runbooks/sentry-alerts.md
+++ b/docs/runbooks/sentry-alerts.md
@@ -10,6 +10,11 @@ The Sentry project is the Fly-provisioned `maz-squire` project
 flyctl extensions sentry dashboard -a maz-squire
 ```
 
+Usage and spend checks for broad Sentry Logs and app traces live in
+[sentry-usage-guardrails.md](sentry-usage-guardrails.md). This alert catalog
+tracks app health and alert routing; the usage runbook tracks quotas, PAYG
+budget, billed log GB, accepted spans, and trace sampling.
+
 Use the Sentry alert builder to create the production rules below. Route each
 rule to the default owner notification channel until Sentry has a dedicated
 Slack/PagerDuty integration. Thresholds are intentionally written here, not in

--- a/docs/runbooks/sentry-usage-guardrails.md
+++ b/docs/runbooks/sentry-usage-guardrails.md
@@ -1,0 +1,178 @@
+# Sentry Usage And Spend Guardrails
+
+Use this runbook after enabling Sentry Logs and app traces. The goal is broad
+app visibility with sanitized data, plus enough usage checks to avoid surprise
+spend or accidental loss of monitoring.
+
+Sentry pricing changes. The quota and price notes below were checked on
+2026-06-15 from:
+
+- <https://sentry.io/pricing/>
+- <https://docs.sentry.io/pricing/>
+- <https://docs.sentry.io/pricing/quotas/>
+- <https://docs.sentry.io/pricing/quotas/manage-logs-quota/>
+- <https://docs.sentry.io/pricing/quotas/manage-transaction-quota/>
+
+Before changing Sentry plan, PAYG budget, reserved volume, or sampling, verify
+current prices in Sentry.
+
+## Current Pricing Snapshot
+
+| Plan             | Included errors | Included logs | Included spans | Included replay | Included monitors                   |
+| ---------------- | --------------- | ------------- | -------------- | --------------- | ----------------------------------- |
+| Developer / Free | 5k errors       | 5GB logs      | 5M spans       | 50 replays      | 1 uptime monitor and 1 cron monitor |
+| Team             | 50k errors      | 5GB logs      | 5M spans       | 50 replays      | 1 uptime monitor and 1 cron monitor |
+| Business         | 50k errors      | 5GB logs      | 5M spans       | 50 replays      | 1 uptime monitor and 1 cron monitor |
+
+Observed PAYG units as of 2026-06-15:
+
+- Logs: `$0.50/GB`
+- Application metrics: `$0.50/GB`
+- Team spans, 5M-100M: `$0.0000020/span`
+- Business spans, 5M-100M: `$0.0000040/span`
+- Extra uptime monitors: `$1.00/monitor`
+- Extra cron monitors: `$0.78/monitor`
+
+Sentry docs say data sent after reserved volume and PAYG budget are exhausted
+is dropped for the rest of the billing cycle. Treat that as degraded monitoring,
+not a normal cost-control path.
+
+## What To Check
+
+The billed source of truth is Sentry's Usage page, not Fly logs and not a
+dashboard count widget.
+
+1. Open Sentry for the Fly-provisioned project:
+
+   ```bash
+   flyctl extensions sentry dashboard -a maz-squire
+   ```
+
+2. Go to `Stats & Usage`.
+3. Filter to the `maz-squire` project.
+4. Check these rows:
+   - Logs: accepted GB, dropped GB, filtered GB.
+   - Spans: accepted spans, dropped spans, filtered spans.
+   - Errors: accepted errors and top projects.
+5. Go to `Settings > Subscription`.
+6. Confirm the owner/billing user has quota emails and the PAYG budget set to
+   the intended monthly maximum. Leaving PAYG at `$0` is valid, but it means
+   Sentry can drop data after included volume is exhausted.
+
+Run this local command to print the checked-in query and guardrail inventory:
+
+```bash
+npm run sentry:usage-guardrails
+```
+
+The command does not read or print `SENTRY_TOKEN`.
+
+## Dashboard Queries
+
+Use these Sentry views for app-side volume and top-talker diagnosis. The first
+two are Usage-page checks because Sentry exposes billed log GB and accepted span
+volume there. The remaining rows are dashboard widgets or Discover queries.
+
+- `squire.usage.logs.accepted_gb`
+  Surface: Stats & Usage. Dataset: billing. Query:
+  `Stats & Usage > Logs > project=maz-squire > accepted log data`. Fields:
+  accepted GB, dropped GB, filtered GB, project.
+- `squire.usage.spans.accepted_count`
+  Surface: Stats & Usage. Dataset: billing. Query:
+  `Stats & Usage > Spans > project=maz-squire > accepted spans`. Fields:
+  accepted spans, dropped spans, filtered spans.
+- `squire.usage.logs.count`
+  Surface: dashboard. Dataset: logs. Query: `environment:production`. Field:
+  `count()`.
+- `squire.usage.spans.count`
+  Surface: dashboard. Dataset: spans. Query: `environment:production`. Field:
+  `count()`.
+- `squire.usage.errors.count`
+  Surface: dashboard. Dataset: error events. Query:
+  `environment:production level:error`. Field: `count()`.
+- `squire.usage.top_log_routes`
+  Surface: dashboard. Dataset: logs. Query: `environment:production route:*`.
+  Fields: `route`, `count()`.
+- `squire.usage.top_log_events`
+  Surface: dashboard. Dataset: logs. Query:
+  `environment:production event_type:*`. Fields: `event_type`, `count()`.
+- `squire.usage.top_span_routes`
+  Surface: dashboard. Dataset: spans. Query:
+  `environment:production http.route:*`. Fields: `http.route`, `count()`,
+  `p95(span.duration)`.
+- `squire.usage.top_error_routes`
+  Surface: dashboard. Dataset: error events. Query:
+  `environment:production route:* level:error`. Fields: `route`, `count()`.
+- `squire.usage.top_security_events`
+  Surface: dashboard. Dataset: logs. Query:
+  `environment:production surface:security_log security_event:*`. Fields:
+  `security_event`, `count()`.
+
+Keep these queries free of prompt text, answer text, email addresses, cookies,
+tokens, provider payloads, retrieved passages, source documents, and transcript
+content. They should use low-cardinality operational fields only.
+
+## Cost Controls
+
+Do use:
+
+- Sentry `Stats & Usage` for accepted/dropped/filtered logs and spans.
+- Sentry owner quota emails and PAYG budget in `Settings > Subscription`.
+- `SENTRY_TRACES_SAMPLE_RATE` when span volume is too high.
+- Sentry spike protection and inbound filters for emergency noise control when
+  the owner and rollback condition are recorded.
+
+Do not use:
+
+- A cost-based log allowlist.
+- Dropping safe production logs just because they are `info`.
+- Removing route, request, conversation, message, job, release, or environment
+  metadata to lower volume.
+- Copying raw prompts, model output, provider payloads, retrieved passages,
+  names, emails, cookies, tokens, or transcript text into Sentry.
+
+Privacy filtering is always allowed and required. Cost filtering is only an
+explicit emergency throttle with an owner, reason, start time, and rollback
+condition.
+
+## Trace Sampling
+
+`SENTRY_TRACES_SAMPLE_RATE` controls Sentry app-span volume. It accepts a number
+from `0` to `1`:
+
+- unset: do not export Sentry app spans
+- `0`: explicitly disable Sentry app spans
+- `0.10`: send roughly 10% of sampled app spans
+- `1`: send all sampled app spans
+
+LangSmith remains the trace and eval source for AI behavior. Lowering
+`SENTRY_TRACES_SAMPLE_RATE` should not reduce LangSmith tracing.
+
+Production should store the sample rate as a Fly secret so it can change without
+a code deploy:
+
+```bash
+fly secrets set SENTRY_TRACES_SAMPLE_RATE=0.10 -a maz-squire
+```
+
+After changing it:
+
+1. Note the old and new values in the deploy or incident log.
+2. Run `node scripts/check-deploy-health.ts --base-url https://maz-squire.fly.dev`.
+3. Verify Sentry spans change volume in `Stats & Usage`.
+4. Verify safe error and log events still arrive.
+5. Revert or tune again once the spike is understood.
+
+## Weekly Check
+
+Until the baseline is known, review this weekly:
+
+- Logs accepted GB and percent of included 5GB.
+- Spans accepted count and percent of included 5M.
+- Errors accepted count and percent of included plan quota.
+- Dropped or filtered rows for logs, spans, and errors.
+- Top routes and event families from the dashboard queries above.
+- Current PAYG budget and whether owner quota emails are going to the right
+  person.
+
+Move to monthly once usage is stable.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "e2e:browser": "npm run e2e:browser:prepare && playwright test --config=playwright.e2e.config.ts",
     "agent:check": "node scripts/check-agent-parity.ts",
     "sentry:test-event": "node scripts/send-sentry-safe-test-event.ts",
+    "sentry:usage-guardrails": "node scripts/print-sentry-usage-guardrails.ts",
     "security:alerts:dry-run": "SECURITY_ALERT_DRY_RUN=1 node scripts/sync-security-alerts-to-linear.ts",
     "security:alerts:validate-config": "node scripts/sync-security-alerts-to-linear.ts --validate-config",
     "lint": "eslint src/ test/ scripts/",

--- a/scripts/print-sentry-usage-guardrails.ts
+++ b/scripts/print-sentry-usage-guardrails.ts
@@ -1,0 +1,29 @@
+import {
+  SENTRY_USAGE_DASHBOARD_QUERIES,
+  SENTRY_USAGE_GUARDRAIL_ACTIONS,
+  SENTRY_USAGE_GUARDRAILS_AS_OF,
+  SENTRY_USAGE_GUARDRAILS_SOURCES,
+  SENTRY_USAGE_PRICING_SNAPSHOT,
+} from './sentry-usage-guardrails-config.ts';
+
+function main(): void {
+  if (process.argv.length > 2) {
+    throw new Error('Usage: node scripts/print-sentry-usage-guardrails.ts');
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        asOf: SENTRY_USAGE_GUARDRAILS_AS_OF,
+        sources: SENTRY_USAGE_GUARDRAILS_SOURCES,
+        pricing: SENTRY_USAGE_PRICING_SNAPSHOT,
+        queries: SENTRY_USAGE_DASHBOARD_QUERIES,
+        guardrails: SENTRY_USAGE_GUARDRAIL_ACTIONS,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main();

--- a/scripts/sentry-usage-guardrails-config.ts
+++ b/scripts/sentry-usage-guardrails-config.ts
@@ -1,0 +1,193 @@
+export const SENTRY_USAGE_GUARDRAILS_AS_OF = '2026-06-15';
+
+export const SENTRY_USAGE_GUARDRAILS_SOURCES = [
+  'https://sentry.io/pricing/',
+  'https://docs.sentry.io/pricing/',
+  'https://docs.sentry.io/pricing/quotas/',
+  'https://docs.sentry.io/pricing/quotas/manage-logs-quota/',
+  'https://docs.sentry.io/pricing/quotas/manage-transaction-quota/',
+] as const;
+
+export const SENTRY_USAGE_PRICING_SNAPSHOT = {
+  asOf: SENTRY_USAGE_GUARDRAILS_AS_OF,
+  includedMonthlyVolume: {
+    developer: {
+      errors: '5k errors',
+      logs: '5GB logs',
+      spans: '5M spans',
+      replays: '50 replays',
+      cronMonitors: '1 cron monitor',
+      uptimeMonitors: '1 uptime monitor',
+    },
+    team: {
+      errors: '50k errors',
+      logs: '5GB logs',
+      spans: '5M spans',
+      replays: '50 replays',
+      cronMonitors: '1 cron monitor',
+      uptimeMonitors: '1 uptime monitor',
+    },
+    business: {
+      errors: '50k errors',
+      logs: '5GB logs',
+      spans: '5M spans',
+      replays: '50 replays',
+      cronMonitors: '1 cron monitor',
+      uptimeMonitors: '1 uptime monitor',
+    },
+  },
+  payAsYouGo: {
+    logs: '$0.50/GB',
+    applicationMetrics: '$0.50/GB',
+    teamSpans: '$0.0000020/span for 5M-100M spans',
+    businessSpans: '$0.0000040/span for 5M-100M spans',
+    uptimeMonitor: '$1.00/monitor',
+    cronMonitor: '$0.78/monitor',
+  },
+  notes: [
+    'Verify pricing in Sentry before changing PAYG budget or reserved volume.',
+    'When reserved volume and PAYG budget are exhausted, Sentry drops later data for the billing cycle.',
+    'Owners receive quota emails for logs and spans when usage approaches or exceeds included volume.',
+  ],
+} as const;
+
+export type SentryUsageQuerySurface =
+  | 'stats_usage'
+  | 'dashboard'
+  | 'project_settings'
+  | 'org_billing';
+
+export type SentryUsageDataset = 'logs' | 'spans' | 'error-events' | 'billing';
+
+export interface SentryUsageGuardrailQuery {
+  name: string;
+  surface: SentryUsageQuerySurface;
+  dataset: SentryUsageDataset;
+  query: string;
+  fields: string[];
+  purpose: string;
+}
+
+export const SENTRY_USAGE_DASHBOARD_QUERIES: readonly SentryUsageGuardrailQuery[] = [
+  {
+    name: 'squire.usage.logs.accepted_gb',
+    surface: 'stats_usage',
+    dataset: 'billing',
+    query: 'Stats & Usage > Logs > project=maz-squire > accepted log data, shown in GB',
+    fields: ['accepted GB', 'dropped GB', 'filtered GB', 'project'],
+    purpose: 'Actual billed log volume. Use this for cost checks, not dashboard count proxies.',
+  },
+  {
+    name: 'squire.usage.spans.accepted_count',
+    surface: 'stats_usage',
+    dataset: 'billing',
+    query: 'Stats & Usage > Spans > project=maz-squire > accepted spans',
+    fields: ['accepted spans', 'dropped spans', 'filtered spans', 'project'],
+    purpose: 'Actual billed span count and dropped span visibility.',
+  },
+  {
+    name: 'squire.usage.logs.count',
+    surface: 'dashboard',
+    dataset: 'logs',
+    query: 'environment:production',
+    fields: ['count()'],
+    purpose: 'Production log entry trend. Pair with Usage accepted GB for cost.',
+  },
+  {
+    name: 'squire.usage.spans.count',
+    surface: 'dashboard',
+    dataset: 'spans',
+    query: 'environment:production',
+    fields: ['count()'],
+    purpose: 'Production span count trend.',
+  },
+  {
+    name: 'squire.usage.errors.count',
+    surface: 'dashboard',
+    dataset: 'error-events',
+    query: 'environment:production level:error',
+    fields: ['count()'],
+    purpose: 'Production error event count trend.',
+  },
+  {
+    name: 'squire.usage.top_log_routes',
+    surface: 'dashboard',
+    dataset: 'logs',
+    query: 'environment:production route:*',
+    fields: ['route', 'count()'],
+    purpose: 'Highest-volume log routes.',
+  },
+  {
+    name: 'squire.usage.top_log_events',
+    surface: 'dashboard',
+    dataset: 'logs',
+    query: 'environment:production event_type:*',
+    fields: ['event_type', 'count()'],
+    purpose: 'Highest-volume log event families.',
+  },
+  {
+    name: 'squire.usage.top_span_routes',
+    surface: 'dashboard',
+    dataset: 'spans',
+    query: 'environment:production http.route:*',
+    fields: ['http.route', 'count()', 'p95(span.duration)'],
+    purpose: 'Highest-volume traced routes and their latency.',
+  },
+  {
+    name: 'squire.usage.top_error_routes',
+    surface: 'dashboard',
+    dataset: 'error-events',
+    query: 'environment:production route:* level:error',
+    fields: ['route', 'count()'],
+    purpose: 'Highest-volume error routes.',
+  },
+  {
+    name: 'squire.usage.top_security_events',
+    surface: 'dashboard',
+    dataset: 'logs',
+    query: 'environment:production surface:security_log security_event:*',
+    fields: ['security_event', 'count()'],
+    purpose: 'Highest-volume auth, limiter, and budget accounting log families.',
+  },
+] as const;
+
+export const SENTRY_USAGE_GUARDRAIL_ACTIONS = [
+  {
+    name: 'review_sentry_usage',
+    owner: 'any member',
+    cadence: 'weekly until baseline is known, then monthly',
+    path: 'Sentry > Stats & Usage',
+    acceptance:
+      'Log accepted GB, accepted spans, and dropped/filtered rows are reviewed for maz-squire.',
+  },
+  {
+    name: 'confirm_spend_notifications',
+    owner: 'Sentry owner or billing member',
+    cadence: 'after setup and after plan changes',
+    path: 'Sentry > Settings > Subscription',
+    acceptance: 'Owner quota emails and PAYG budget are configured or explicitly left at $0.',
+  },
+  {
+    name: 'tune_trace_sample_rate',
+    owner: 'operator',
+    cadence: 'only when span volume is too high',
+    path: 'Fly secret SENTRY_TRACES_SAMPLE_RATE',
+    acceptance: 'Sample rate changes without a code deploy and is noted in the deploy log.',
+  },
+  {
+    name: 'emergency_throttle',
+    owner: 'operator',
+    cadence: 'only during a runaway event',
+    path: 'Fly secret or Sentry project setting',
+    acceptance:
+      'Throttle is explicit, reversible, and tracked with an owner, reason, start time, and rollback condition.',
+  },
+] as const;
+
+export const SENTRY_USAGE_FORBIDDEN_COST_CONTROL_TERMS = [
+  'cost-based log allowlist',
+  'drop info logs for cost',
+  'filter safe logs for cost',
+  'beforeSendLog returns null for budget',
+  'allow only error logs',
+] as const;

--- a/test/sentry-usage-guardrails.test.ts
+++ b/test/sentry-usage-guardrails.test.ts
@@ -1,0 +1,177 @@
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  SENTRY_USAGE_DASHBOARD_QUERIES,
+  SENTRY_USAGE_GUARDRAIL_ACTIONS,
+  SENTRY_USAGE_GUARDRAILS_AS_OF,
+  SENTRY_USAGE_GUARDRAILS_SOURCES,
+  SENTRY_USAGE_PRICING_SNAPSHOT,
+} from '../scripts/sentry-usage-guardrails-config.ts';
+
+const execFileAsync = promisify(execFile);
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+
+async function readProjectFile(path: string): Promise<string> {
+  return readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+const SENSITIVE_QUERY_TERMS = [
+  'answer',
+  'cookie',
+  'email',
+  'model_output',
+  'password',
+  'prompt',
+  'provider_payload',
+  'raw_source',
+  'retrieved_passage',
+  'secret',
+  'source_document',
+  'token',
+  'transcript',
+];
+
+describe('Sentry usage and spend guardrails', () => {
+  it('records a dated pricing snapshot with source links', () => {
+    expect(SENTRY_USAGE_GUARDRAILS_AS_OF).toBe('2026-06-15');
+    expect(SENTRY_USAGE_GUARDRAILS_SOURCES).toContain('https://sentry.io/pricing/');
+    expect(SENTRY_USAGE_GUARDRAILS_SOURCES).toContain('https://docs.sentry.io/pricing/');
+    expect(SENTRY_USAGE_GUARDRAILS_SOURCES).toContain(
+      'https://docs.sentry.io/pricing/quotas/manage-logs-quota/',
+    );
+
+    expect(SENTRY_USAGE_PRICING_SNAPSHOT.includedMonthlyVolume.developer).toMatchObject({
+      errors: '5k errors',
+      logs: '5GB logs',
+      spans: '5M spans',
+    });
+    expect(SENTRY_USAGE_PRICING_SNAPSHOT.includedMonthlyVolume.team).toMatchObject({
+      errors: '50k errors',
+      logs: '5GB logs',
+      spans: '5M spans',
+    });
+    expect(SENTRY_USAGE_PRICING_SNAPSHOT.payAsYouGo).toMatchObject({
+      logs: '$0.50/GB',
+      applicationMetrics: '$0.50/GB',
+      teamSpans: '$0.0000020/span for 5M-100M spans',
+      businessSpans: '$0.0000040/span for 5M-100M spans',
+    });
+    expect(SENTRY_USAGE_PRICING_SNAPSHOT.notes.join('\n')).toContain(
+      'drops later data for the billing cycle',
+    );
+  });
+
+  it('defines usage and dashboard queries for logs, spans, errors, and top talkers', () => {
+    const queryNames = SENTRY_USAGE_DASHBOARD_QUERIES.map((query) => query.name);
+
+    for (const expectedName of [
+      'squire.usage.logs.accepted_gb',
+      'squire.usage.spans.accepted_count',
+      'squire.usage.logs.count',
+      'squire.usage.spans.count',
+      'squire.usage.errors.count',
+      'squire.usage.top_log_routes',
+      'squire.usage.top_log_events',
+      'squire.usage.top_span_routes',
+      'squire.usage.top_error_routes',
+      'squire.usage.top_security_events',
+    ]) {
+      expect(queryNames).toContain(expectedName);
+    }
+
+    expect(
+      SENTRY_USAGE_DASHBOARD_QUERIES.find(
+        (query) => query.name === 'squire.usage.logs.accepted_gb',
+      ),
+    ).toMatchObject({
+      surface: 'stats_usage',
+      dataset: 'billing',
+      fields: expect.arrayContaining(['accepted GB', 'dropped GB', 'filtered GB']),
+    });
+
+    for (const query of SENTRY_USAGE_DASHBOARD_QUERIES) {
+      expect(query.name).toMatch(/^squire\.usage\./);
+      expect(query.purpose.length).toBeGreaterThan(20);
+      for (const term of SENSITIVE_QUERY_TERMS) {
+        expect(`${query.query} ${query.fields.join(' ')}`.toLowerCase()).not.toContain(term);
+      }
+    }
+  });
+
+  it('documents Sentry usage checks, trace sampling, and the no cost allowlist rule', async () => {
+    const runbook = await readProjectFile('docs/runbooks/sentry-usage-guardrails.md');
+    const development = await readProjectFile('docs/DEVELOPMENT.md');
+    const envExample = await readProjectFile('.env.example');
+    const observability = await readProjectFile('docs/runbooks/observability.md');
+
+    for (const expected of [
+      '# Sentry Usage And Spend Guardrails',
+      '2026-06-15',
+      '5GB logs',
+      '5M spans',
+      '$0.50/GB',
+      '$0.0000020/span',
+      '$0.0000040/span',
+      'Stats & Usage',
+      'Settings > Subscription',
+      'Sentry can drop data after included volume is exhausted',
+      'squire.usage.logs.accepted_gb',
+      'squire.usage.top_span_routes',
+      'SENTRY_TRACES_SAMPLE_RATE',
+      'fly secrets set SENTRY_TRACES_SAMPLE_RATE=0.10 -a maz-squire',
+      'Do not use:',
+      'A cost-based log allowlist',
+      'Dropping safe production logs just because they are `info`',
+      'Privacy filtering is always allowed and required',
+    ]) {
+      expect(runbook).toContain(expected);
+    }
+
+    expect(development).toContain('SENTRY_TRACES_SAMPLE_RATE');
+    expect(development).toContain('sentry-usage-guardrails.md');
+    expect(envExample).toContain('SENTRY_TRACES_SAMPLE_RATE=0.10');
+    expect(observability).toContain('sentry-usage-guardrails.md');
+  });
+
+  it('prints token-free guardrail inventory for operators and agents', async () => {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ['scripts/print-sentry-usage-guardrails.ts'],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          SENTRY_TOKEN: 'sentry-token-that-must-not-print',
+        },
+      },
+    );
+    const payload = JSON.parse(stdout) as {
+      asOf?: string;
+      queries?: Array<{ name?: string }>;
+      guardrails?: Array<{ name?: string }>;
+    };
+
+    expect(payload.asOf).toBe(SENTRY_USAGE_GUARDRAILS_AS_OF);
+    expect(payload.queries?.map((query) => query.name)).toContain('squire.usage.logs.accepted_gb');
+    expect(payload.guardrails?.map((guardrail) => guardrail.name)).toEqual(
+      SENTRY_USAGE_GUARDRAIL_ACTIONS.map((guardrail) => guardrail.name),
+    );
+    expect(stdout).not.toContain('sentry-token-that-must-not-print');
+  });
+
+  it('keeps runtime log handling focused on sanitization, not cost filtering', async () => {
+    const telemetry = await readProjectFile('src/telemetry.ts');
+    const runbook = await readProjectFile('docs/runbooks/sentry-usage-guardrails.md');
+
+    expect(telemetry).toContain('beforeSendLog: sanitizeSentryLog');
+    expect(telemetry).toContain("return sanitizeTelemetryPayload('log', log)");
+    expect(telemetry).not.toContain('beforeSendLog: (log)');
+    expect(runbook).toContain('Cost filtering is only an');
+    expect(runbook).toContain('explicit emergency throttle');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Sentry usage and spend guardrails runbook with a 2026-06-15 pricing snapshot and source links.
- Add a token-free `npm run sentry:usage-guardrails` inventory for Usage-page checks, dashboard queries, and operator guardrails.
- Document `SENTRY_TRACES_SAMPLE_RATE` as a Fly-secret tuning knob while keeping logs governed by sanitization, not cost-based allowlists.

## Validation
- `npm test -- --run test/sentry-usage-guardrails.test.ts test/telemetry.test.ts test/deployment-operations-docs.test.ts test/sentry-alerts.test.ts`
- `npm run typecheck`
- `npm run sentry:usage-guardrails`
- `npm run check`
- Pre-landing `/review`: clean, 0 findings. The installed skill's generated checklist path was stale, so I used the shared gstack checklist at `/Users/bcm/.codex/skills/gstack/review/checklist.md` and explicitly reviewed the new untracked files as part of the pass.

Fixes SQR-339


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on configuring Sentry span sampling to control tracing costs
  * Created new runbook covering Sentry usage monitoring, spend management, and cost-control practices

* **New Features**
  * Added npm script to review Sentry usage guardrails and monitoring configuration

* **Tests**
  * Added validation tests ensuring Sentry configuration and documentation consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->