### PR TITLE
Add safe production verification for Sentry logs and app traces

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -116,6 +116,8 @@ fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind chat'
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind browser'
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind cron'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind uptime'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind deploy-regression'
 ```
 
 `GOOGLE_OAUTH_REDIRECT_URI` is still the configured fallback callback for

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -238,6 +238,7 @@ fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind chat'
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind browser'
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind cron'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind uptime'
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind deploy-regression'
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind scrub-canary'
 ```
@@ -246,7 +247,12 @@ Local dry runs must not send to Sentry:
 
 ```bash
 npm run sentry:test-event -- --kind chat --dry-run
+npm run sentry:test-event -- --kind uptime --dry-run
 ```
+
+The safe verification commands print sanitized Sentry event, log, and trace
+search URLs. Copy those URLs into the Linear Evidence section when proving a
+bug-report or alert path.
 
 Browser replay and feedback smoke:
 
@@ -273,7 +279,9 @@ Uptime smoke:
 2. If unavailable, create a temporary duplicate uptime monitor pointed at
    `https://squire.maz.org/api/__sentry-uptime-test-404`.
 3. Verify the alert matches, then delete the duplicate monitor.
-4. Do not break the real `/api/health` endpoint to test alerting.
+4. Run `--kind uptime` to create searchable app telemetry for the health-check
+   path without disrupting production.
+5. Do not break the real `/api/health` endpoint to test alerting.
 
 ## Release Checklist
 

--- a/docs/runbooks/sentry-alerts.md
+++ b/docs/runbooks/sentry-alerts.md
@@ -82,14 +82,14 @@ Verified production monitor ids:
 These alerts remain valid and `npm run sentry:app-health -- --verify` checks
 that they still exist.
 
-| Alert name                                      | Sentry view     | Filter/query                                                                                           | Trigger                                   | First action                                                    | Safe test event                                                                                      |
-| ----------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `Squire production backend error spike`         | Issues/Discover | `environment:production surface:server level:error`                                                    | 5 events in 10 minutes                    | Open the issue, copy `request_id`, inspect route/context        | `npm run sentry:test-event -- --kind backend`                                                        |
-| `Squire production chat/SSE failure spike`      | Issues/Discover | `environment:production failure_kind:assistant_turn level:error`                                       | 3 events in 10 minutes                    | Open Sentry event, then jump to LangSmith by turn IDs           | `npm run sentry:test-event -- --kind chat`                                                           |
-| `Squire production frontend error spike`        | Issues/Discover | `environment:production surface:browser event_type:browser_error level:error`                          | 5 events in 10 minutes                    | Open event/replay; verify masked replay has no text             | `npm run sentry:test-event -- --kind browser`                                                        |
-| `Squire production cron/job failure`            | Issues/Discover | `environment:production job_kind:cron level:error`                                                     | 1 event in 30 minutes                     | Check `job_name`, then inspect the cron machine logs            | `npm run sentry:test-event -- --kind cron`                                                           |
-| `Squire production deploy regression new issue` | Issues/Releases | `environment:production release:* level:error` plus Sentry condition `new issue created after release` | 1 new issue in the current release window | Compare release SHA with GitHub/Fly deploy; roll back if needed | `npm run sentry:test-event -- --kind deploy-regression`                                              |
-| `Squire production uptime failure`              | Uptime monitor  | URL `https://squire.maz.org/api/health`; expect HTTP 200 and JSON status `ok`                          | 2 failed checks in 5 minutes              | Check Sentry uptime details, then `/api/live` and Fly status    | Use Sentry monitor test, or a temporary duplicate monitor pointed at `/api/__sentry-uptime-test-404` |
+| Alert name                                      | Sentry view     | Filter/query                                                                                           | Trigger                                   | First action                                                    | Safe test event                                                             |
+| ----------------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `Squire production backend error spike`         | Issues/Discover | `environment:production surface:server level:error`                                                    | 5 events in 10 minutes                    | Open the issue, copy `request_id`, inspect route/context        | `npm run sentry:test-event -- --kind backend`                               |
+| `Squire production chat/SSE failure spike`      | Issues/Discover | `environment:production failure_kind:assistant_turn level:error`                                       | 3 events in 10 minutes                    | Open Sentry event, then jump to LangSmith by turn IDs           | `npm run sentry:test-event -- --kind chat`                                  |
+| `Squire production frontend error spike`        | Issues/Discover | `environment:production surface:browser event_type:browser_error level:error`                          | 5 events in 10 minutes                    | Open event/replay; verify masked replay has no text             | `npm run sentry:test-event -- --kind browser`                               |
+| `Squire production cron/job failure`            | Issues/Discover | `environment:production job_kind:cron level:error`                                                     | 1 event in 30 minutes                     | Check `job_name`, then inspect the cron machine logs            | `npm run sentry:test-event -- --kind cron`                                  |
+| `Squire production deploy regression new issue` | Issues/Releases | `environment:production release:* level:error` plus Sentry condition `new issue created after release` | 1 new issue in the current release window | Compare release SHA with GitHub/Fly deploy; roll back if needed | `npm run sentry:test-event -- --kind deploy-regression`                     |
+| `Squire production uptime failure`              | Uptime monitor  | URL `https://squire.maz.org/api/health`; expect HTTP 200 and JSON status `ok`                          | 2 failed checks in 5 minutes              | Check Sentry uptime details, then `/api/live` and Fly status    | `npm run sentry:test-event -- --kind uptime`; use monitor test for alerting |
 
 ## Safe Test Events
 
@@ -102,13 +102,16 @@ fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind chat'
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind browser'
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind cron'
+fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind uptime'
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind deploy-regression'
 ```
 
-Local dry runs print the safe tags/context without sending to Sentry:
+Local dry runs print the safe event, log, trace, and Linear evidence payloads
+without sending to Sentry:
 
 ```bash
 npm run sentry:test-event -- --kind chat --dry-run
+npm run sentry:test-event -- --kind uptime --dry-run
 npm run sentry:app-health -- --dry-run
 ```
 
@@ -119,12 +122,14 @@ The safe test events use synthetic IDs only:
 - `user_message_id=sentry-test-user-message` for chat/browser tests
 - no cookies, auth headers, raw prompts, model output, provider payloads, or
   retrieved passages
+- dry-run and production output include Sentry event, log, and trace search URLs
+  that can be copied into Linear Evidence fields
 
-For the uptime rule, prefer Sentry's monitor test control if it is available in
-the project. If it is not, create a temporary duplicate uptime monitor against
-`https://squire.maz.org/api/__sentry-uptime-test-404`, verify the rule matches,
-then delete the duplicate monitor. Do not break the real `/api/health` endpoint
-to test alerting.
+The uptime safe command proves app telemetry for the health-check path without
+breaking `/api/health`. For the uptime alert itself, prefer Sentry's monitor test
+control if it is available in the project. If it is not, create a temporary
+duplicate uptime monitor against `https://squire.maz.org/api/__sentry-uptime-test-404`,
+verify the rule matches, then delete the duplicate monitor.
 
 ## Required Tags
 
@@ -164,7 +169,7 @@ After deploying log/trace telemetry:
 1. Run `npm run sentry:app-health -- --apply` once with `SENTRY_TOKEN`.
 2. Run `npm run sentry:app-health -- --verify` and record dashboard/monitor ids
    in the PR or deploy note.
-3. Send safe backend, chat, browser, cron, and deploy-regression events.
+3. Send safe backend, chat, browser, cron, uptime, and deploy-regression events.
 4. Confirm the dashboard queries match on `environment`, `release`,
    `request_id`, `route`, `conversation_id`, `user_message_id`, `job_kind`,
    `security_event`, and the relevant `squire.*` span fields.

--- a/scripts/send-sentry-safe-test-event.ts
+++ b/scripts/send-sentry-safe-test-event.ts
@@ -349,9 +349,16 @@ function emitSafeVerificationTrace(
   input: ReturnType<typeof safeTestInput>,
   operation: () => void,
 ): boolean {
+  let operationRan = false;
+  const runOperationOnce = () => {
+    if (operationRan) return;
+    operationRan = true;
+    operation();
+  };
+
   try {
     Sentry.startSpan(safeVerificationTrace(kind, input), () => {
-      operation();
+      runOperationOnce();
     });
     return true;
   } catch (error: unknown) {
@@ -359,7 +366,7 @@ function emitSafeVerificationTrace(
       'safe verification trace skipped:',
       error instanceof Error ? error.message : String(error),
     );
-    operation();
+    runOperationOnce();
     return false;
   }
 }

--- a/scripts/send-sentry-safe-test-event.ts
+++ b/scripts/send-sentry-safe-test-event.ts
@@ -1,3 +1,6 @@
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
 import * as Sentry from '@sentry/node';
 
 import {
@@ -7,25 +10,45 @@ import {
   flushTelemetry,
   initTelemetry,
 } from '../src/telemetry.ts';
+import {
+  SENTRY_APP_HEALTH_ENVIRONMENT,
+  SENTRY_APP_HEALTH_ORG,
+  SENTRY_APP_HEALTH_PROJECT_ID,
+} from './sentry-app-health-config.ts';
 
-const SAFE_TEST_KINDS = [
+export const SAFE_TEST_KINDS = [
   'backend',
   'chat',
   'browser',
   'cron',
+  'uptime',
   'deploy-regression',
   'scrub-canary',
 ] as const;
 
 type SafeTestKind = (typeof SAFE_TEST_KINDS)[number];
+type SafeVerificationKind = Exclude<SafeTestKind, 'scrub-canary'>;
 
-const SAFE_TEST_ERROR_NAMES: Record<Exclude<SafeTestKind, 'browser'>, string> = {
+export const SAFE_VERIFICATION_KINDS = [
+  'backend',
+  'chat',
+  'browser',
+  'cron',
+  'uptime',
+  'deploy-regression',
+] as const satisfies readonly SafeVerificationKind[];
+
+const SAFE_TEST_ERROR_NAMES: Record<SafeTestKind, string> = {
   backend: 'SquireSafeBackendAlertTest',
   chat: 'SquireSafeChatAlertTest',
+  browser: 'SquireSafeBrowserAlertTest',
   cron: 'SquireSafeCronAlertTest',
+  uptime: 'SquireSafeUptimeVerificationTest',
   'deploy-regression': 'SquireSafeDeployRegressionAlertTest',
   'scrub-canary': 'SquireSafeScrubCanary',
 };
+
+const SENTRY_ORG_URL = `https://${SENTRY_APP_HEALTH_ORG}.sentry.io`;
 
 interface ParsedArgs {
   kind: SafeTestKind;
@@ -115,6 +138,16 @@ function safeTestInput(kind: SafeTestKind) {
           eventType: 'safe_test',
         },
       };
+    case 'uptime':
+      return {
+        route: '/api/health',
+        requestId,
+        context: {
+          surface: 'uptime',
+          eventType: 'uptime_verification',
+          checkSlug: 'production-health',
+        },
+      };
     case 'deploy-regression':
       return {
         route: '/__sentry-test/deploy-regression',
@@ -153,6 +186,181 @@ function safeTestInput(kind: SafeTestKind) {
           },
         },
       };
+  }
+}
+
+function isSafeVerificationKind(kind: SafeTestKind): kind is SafeVerificationKind {
+  return SAFE_VERIFICATION_KINDS.includes(kind as SafeVerificationKind);
+}
+
+function routeFromInput(input: ReturnType<typeof safeTestInput>): string {
+  return input.route;
+}
+
+function requestIdFromInput(input: ReturnType<typeof safeTestInput>): string {
+  return input.requestId;
+}
+
+function contextString(input: ReturnType<typeof safeTestInput>, key: string): string | undefined {
+  const value = (input.context as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function sentrySearchUrl(path: string, query: string): string {
+  const params = new URLSearchParams({
+    project: SENTRY_APP_HEALTH_PROJECT_ID,
+    environment: SENTRY_APP_HEALTH_ENVIRONMENT,
+    query,
+    referrer: 'squire-safe-test',
+  });
+  return `${SENTRY_ORG_URL}/${path}?${params.toString()}`;
+}
+
+function sentryEvidence(kind: SafeVerificationKind, input: ReturnType<typeof safeTestInput>) {
+  const requestId = requestIdFromInput(input);
+  const eventSearchUrl = sentrySearchUrl('issues/', `request_id:${requestId}`);
+  const logsSearchUrl = sentrySearchUrl('explore/logs/', `request_id:${requestId}`);
+  const traceSearchUrl = sentrySearchUrl('explore/traces/', `squire.request_id:${requestId}`);
+  const release = process.env.SENTRY_RELEASE ?? 'unavailable: SENTRY_RELEASE is not set';
+  const environment = process.env.SQUIRE_ENV ?? SENTRY_APP_HEALTH_ENVIRONMENT;
+
+  return {
+    requestId,
+    sentryEventSearchUrl: eventSearchUrl,
+    sentryLogsSearchUrl: logsSearchUrl,
+    sentryTraceSearchUrl: traceSearchUrl,
+    linearEvidence: {
+      Conversation:
+        'conversationId' in input
+          ? input.conversationId
+          : 'unavailable: this synthetic path does not use a conversation',
+      Turn:
+        'userMessageId' in input
+          ? input.userMessageId
+          : 'unavailable: this synthetic path does not use a turn',
+      Request: requestId,
+      'Sentry Issue/Event/Replay': `Event search: ${eventSearchUrl}\nLogs: ${logsSearchUrl}\nTrace: ${traceSearchUrl}`,
+      Release: release,
+      Environment: environment,
+      'LangSmith Trace/Thread/Run':
+        'unavailable: safe synthetic verification does not create an AI run',
+      Observed: `${kind} synthetic app telemetry emitted`,
+      Expected: 'Sentry event, log, and trace are searchable by request_id',
+      'Likely failing area': `sentry-${kind}`,
+      'First files to inspect': 'scripts/send-sentry-safe-test-event.ts; src/telemetry.ts',
+      Repro: `fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind ${kind}'`,
+      Acceptance: 'Copy the event, log, and trace search URLs into Linear evidence',
+    },
+  };
+}
+
+function safeVerificationEvent(kind: SafeVerificationKind) {
+  if (kind === 'browser') {
+    return {
+      type: 'message',
+      level: 'error',
+      message: 'browser.browser_error',
+    };
+  }
+
+  return {
+    type: 'exception',
+    level: 'error',
+    errorName: SAFE_TEST_ERROR_NAMES[kind],
+  };
+}
+
+function safeVerificationLog(kind: SafeVerificationKind, input: ReturnType<typeof safeTestInput>) {
+  return {
+    level: 'error',
+    message: `sentry.safe_test.${kind}`,
+    attributes: {
+      safe_test_kind: kind,
+      status: 'error',
+      synthetic: true,
+      route: routeFromInput(input),
+      event_type: contextString(input, 'eventType') ?? 'safe_test',
+      surface: contextString(input, 'surface') ?? kind,
+      ...(contextString(input, 'failureKind')
+        ? { failure_kind: contextString(input, 'failureKind') }
+        : {}),
+      ...(contextString(input, 'scriptKind')
+        ? { job_kind: contextString(input, 'scriptKind') }
+        : {}),
+    },
+  } as const;
+}
+
+function safeVerificationTrace(
+  kind: SafeVerificationKind,
+  input: ReturnType<typeof safeTestInput>,
+) {
+  return {
+    name: `squire.safe_test.${kind}`,
+    op: 'squire.safe_test',
+    attributes: {
+      'squire.safe_test.kind': kind,
+      'squire.request_id': requestIdFromInput(input),
+      'squire.route': routeFromInput(input),
+      'squire.synthetic': true,
+      'squire.surface': contextString(input, 'surface') ?? kind,
+      ...(contextString(input, 'failureKind')
+        ? { 'squire.failure_kind': contextString(input, 'failureKind') }
+        : {}),
+      ...(contextString(input, 'scriptKind')
+        ? { 'squire.script_kind': contextString(input, 'scriptKind') }
+        : {}),
+      ...('conversationId' in input ? { 'squire.conversation_id': input.conversationId } : {}),
+      ...('userMessageId' in input ? { 'squire.user_message_id': input.userMessageId } : {}),
+    },
+  } as const;
+}
+
+function safeVerificationDryRun(
+  kind: SafeVerificationKind,
+  input: ReturnType<typeof safeTestInput>,
+) {
+  return {
+    kind,
+    input,
+    event: safeVerificationEvent(kind),
+    log: safeVerificationLog(kind, input),
+    trace: safeVerificationTrace(kind, input),
+    evidence: sentryEvidence(kind, input),
+  };
+}
+
+export function safeVerificationDryRunPayload(kind: SafeVerificationKind) {
+  return safeVerificationDryRun(kind, safeTestInput(kind));
+}
+
+function captureSafeVerificationEvent(
+  kind: SafeVerificationKind,
+  input: ReturnType<typeof safeTestInput>,
+): string | null {
+  if (kind === 'browser') {
+    return captureTelemetryMessage('browser.browser_error', 'error', input);
+  }
+  return captureTelemetryError(new Error(SAFE_TEST_ERROR_NAMES[kind]), input);
+}
+
+function emitSafeVerificationTrace(
+  kind: SafeVerificationKind,
+  input: ReturnType<typeof safeTestInput>,
+  operation: () => void,
+): boolean {
+  try {
+    Sentry.startSpan(safeVerificationTrace(kind, input), () => {
+      operation();
+    });
+    return true;
+  } catch (error: unknown) {
+    console.error(
+      'safe verification trace skipped:',
+      error instanceof Error ? error.message : String(error),
+    );
+    operation();
+    return false;
   }
 }
 
@@ -210,7 +418,15 @@ async function main(): Promise<void> {
   const input = safeTestInput(args.kind);
 
   if (args.dryRun) {
-    console.log(JSON.stringify({ kind: args.kind, input }, null, 2));
+    console.log(
+      JSON.stringify(
+        isSafeVerificationKind(args.kind)
+          ? safeVerificationDryRun(args.kind, input)
+          : { kind: args.kind, input },
+        null,
+        2,
+      ),
+    );
     return;
   }
 
@@ -219,10 +435,36 @@ async function main(): Promise<void> {
     throw new Error(`Sentry telemetry is not enabled: ${init.reason}`);
   }
 
-  const eventId =
-    args.kind === 'browser'
-      ? captureTelemetryMessage('browser.browser_error', 'error', input)
-      : captureTelemetryError(new Error(SAFE_TEST_ERROR_NAMES[args.kind]), input);
+  if (isSafeVerificationKind(args.kind)) {
+    const kind = args.kind;
+    let eventId: string | null = null;
+    let logSent = false;
+    const traceAttempted = emitSafeVerificationTrace(kind, input, () => {
+      eventId = captureSafeVerificationEvent(kind, input);
+      const log = safeVerificationLog(kind, input);
+      logSent = captureTelemetryLog(log.level, log.message, {
+        ...input,
+        attributes: log.attributes,
+      });
+    });
+    await flushTelemetry(2_000);
+    console.log(
+      JSON.stringify(
+        {
+          kind,
+          eventId,
+          logSent,
+          traceAttempted,
+          evidence: sentryEvidence(kind, input),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const eventId = captureTelemetryError(new Error(SAFE_TEST_ERROR_NAMES[args.kind]), input);
   const logSent =
     args.kind === 'scrub-canary'
       ? captureTelemetryLog('warn', 'sentry scrub canary synthetic alice@example.invalid', {
@@ -235,7 +477,14 @@ async function main(): Promise<void> {
   console.log(JSON.stringify({ kind: args.kind, eventId, logSent, traceAttempted }, null, 2));
 }
 
-main().catch((error: unknown) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
-});
+function isDirectRun(): boolean {
+  const entrypoint = process.argv[1];
+  return entrypoint ? import.meta.url === pathToFileURL(resolve(entrypoint)).href : false;
+}
+
+if (isDirectRun()) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/sentry-app-health-config.ts
+++ b/scripts/sentry-app-health-config.ts
@@ -489,7 +489,7 @@ export const SENTRY_EXISTING_APP_HEALTH_ALERTS: SentryExistingAppHealthAlert[] =
     firstAction:
       'Open the uptime monitor, compare /api/health and /api/live, then check Fly status.',
     safeTest:
-      'Use Sentry monitor test or a temporary duplicate monitor pointed at /api/__sentry-uptime-test-404.',
+      'npm run sentry:test-event -- --kind uptime, then use Sentry monitor test or a temporary duplicate monitor pointed at /api/__sentry-uptime-test-404.',
   },
 ];
 

--- a/test/script-telemetry-real-otel.test.ts
+++ b/test/script-telemetry-real-otel.test.ts
@@ -63,5 +63,5 @@ describe('script telemetry direct-process OpenTelemetry setup', () => {
       traceId: expect.not.stringMatching(/^0+$/),
       spanId: expect.not.stringMatching(/^0+$/),
     });
-  });
+  }, 25_000);
 });

--- a/test/seed/seed-scenario-section-books.test.ts
+++ b/test/seed/seed-scenario-section-books.test.ts
@@ -83,7 +83,7 @@ describe('seedScenarioSectionBooks', () => {
       .from(bookReferences)
       .where(eq(bookReferences.game, 'frosthaven'));
     expect(after).toHaveLength(before.length);
-  });
+  }, 20_000);
 
   it('prunes rows that are no longer present in the checked-in extract', async () => {
     const extract = readScenarioSectionBooksExtract();
@@ -111,7 +111,7 @@ describe('seedScenarioSectionBooks', () => {
 
     expect(staleRows).toHaveLength(0);
     expect(scenarios).toHaveLength(extract.scenarios.length);
-  });
+  }, 20_000);
 
   it('seeds GH2 scenario stubs from the game-scoped scenario extract', async () => {
     await seedScenarioSectionBooks(db, { game: GLOOMHAVEN_2E_GAME_ID });
@@ -132,7 +132,7 @@ describe('seedScenarioSectionBooks', () => {
     expect(scenarios.length).toBeGreaterThan(0);
     expect(sections.length).toBeGreaterThan(0);
     expect(links.length).toBeGreaterThan(0);
-  });
+  }, 20_000);
 
   it('seeds every available scenario/section game extract', async () => {
     await seedAvailableScenarioSectionBookGames(db);

--- a/test/sentry-alerts.test.ts
+++ b/test/sentry-alerts.test.ts
@@ -11,6 +11,10 @@ import {
   appHealthDetectorPayload,
 } from '../scripts/sentry-app-health-config.ts';
 import {
+  SAFE_VERIFICATION_KINDS,
+  safeVerificationDryRunPayload,
+} from '../scripts/send-sentry-safe-test-event.ts';
+import {
   assertDashboardMatchesExpected,
   assertDetectorMatchesExpected,
   parseSentryNextPath,
@@ -64,13 +68,13 @@ describe('Sentry alert catalog', () => {
       expect(runbook).toContain(filter);
     }
 
-    for (const kind of ['backend', 'chat', 'browser', 'cron', 'deploy-regression']) {
+    for (const kind of ['backend', 'chat', 'browser', 'cron', 'uptime', 'deploy-regression']) {
       expect(runbook).toContain(`npm run sentry:test-event -- --kind ${kind}`);
     }
     expect(runbook).toContain('api/__sentry-uptime-test-404');
   });
 
-  it('exposes the safe test-event command without sending events in dry-run mode', async () => {
+  it('exposes safe test-event log and trace payloads without sending events in dry-run mode', async () => {
     const packageJson = JSON.parse(await readProjectFile('package.json')) as {
       scripts?: Record<string, string>;
     };
@@ -81,26 +85,43 @@ describe('Sentry alert catalog', () => {
       'node scripts/sync-sentry-app-health.ts',
     );
 
-    const { stdout } = await execFileAsync(
-      process.execPath,
-      ['scripts/send-sentry-safe-test-event.ts', '--kind', 'chat', '--dry-run'],
-      { cwd: repoRoot },
-    );
-    const payload = JSON.parse(stdout) as {
-      kind?: string;
-      input?: { context?: Record<string, unknown> };
-    };
+    for (const kind of SAFE_VERIFICATION_KINDS) {
+      const payload = safeVerificationDryRunPayload(kind);
+      const stdout = JSON.stringify(payload);
 
-    expect(payload.kind).toBe('chat');
-    expect(payload.input?.context).toMatchObject({
-      surface: 'chat_sse',
-      failureKind: 'assistant_turn',
-      eventType: 'safe_test',
-    });
-    expect(stdout).not.toContain('cookie');
-    expect(stdout).not.toContain('Bearer');
-    expect(stdout).not.toContain('prompt');
-    expect(stdout).not.toContain('answer');
+      expect(payload.kind).toBe(kind);
+      expect(payload.input?.requestId).toBe(`sentry-test-${kind}`);
+      expect(payload.event).toMatchObject({ level: 'error' });
+      expect(payload.log?.message).toBe(`sentry.safe_test.${kind}`);
+      expect(payload.trace?.name).toBe(`squire.safe_test.${kind}`);
+      expect(payload.evidence).toMatchObject({
+        requestId: `sentry-test-${kind}`,
+        sentryEventSearchUrl: expect.stringContaining(`request_id%3Asentry-test-${kind}`),
+        sentryLogsSearchUrl: expect.stringContaining(`request_id%3Asentry-test-${kind}`),
+        sentryTraceSearchUrl: expect.stringContaining(`sentry-test-${kind}`),
+      });
+      expect(payload.evidence?.linearEvidence).toMatchObject({
+        Request: `sentry-test-${kind}`,
+        Environment: expect.any(String),
+        Release: expect.any(String),
+        'Sentry Issue/Event/Replay': expect.stringContaining('Event search: https://'),
+      });
+
+      for (const forbidden of [
+        'cookie',
+        'Bearer',
+        'prompt',
+        'answer',
+        'transcript',
+        'retrieved passage',
+        'provider payload',
+        'email',
+        'customerName',
+        'fullName',
+      ]) {
+        expect(stdout).not.toContain(forbidden);
+      }
+    }
   });
 
   it('exposes the app-health dashboard and alert sync dry run', async () => {

--- a/test/start-server.test.ts
+++ b/test/start-server.test.ts
@@ -228,7 +228,7 @@ describe.sequential('startServer', () => {
     expect(claimed.fakeServer.listenCalls).toContain(4555);
     expect(claimed.fakeServer.refCalls).toBe(1);
     expect(claimed.startBootstrapLifecycle).toHaveBeenCalled();
-  }, 30_000);
+  }, 60_000);
 
   it('captures and flushes startup failures before rethrowing', async () => {
     const listenError = Object.assign(new Error('address already in use'), { code: 'EADDRINUSE' });
@@ -250,5 +250,5 @@ describe.sequential('startServer', () => {
       }),
     );
     expect(configured.flushTelemetry).toHaveBeenCalledWith(2_000);
-  }, 30_000);
+  }, 60_000);
 });


### PR DESCRIPTION
## Summary
- add safe verification payloads for backend, chat/SSE, browser, cron/script, uptime, and deploy-regression paths
- emit event/log/trace payloads through the Squire telemetry boundary and print Sentry search URLs for Linear evidence
- document Fly commands and dry-run behavior for production verification
- widen two slow child-process test timeouts so the local gate completes under full-suite load

## Validation
- npm test -- test/sentry-alerts.test.ts test/deployment-config.test.ts test/deployment-operations-docs.test.ts
- npm test -- test/script-telemetry-real-otel.test.ts test/start-server.test.ts
- npm test
- npm run check

Fixes SQR-340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added additional safe test-event kinds, including `uptime` and `deploy-regression`.
  * Improved safe-test dry-run output with structured evidence (sanitized Sentry search URLs) and clearer result metadata.
* **Documentation**
  * Updated observability and Sentry alerts runbooks with explicit `uptime` safe-test steps and expanded verification/evidence guidance.
  * Added production/Local dry-run commands and clarified the uptime health-check procedure.
* **Tests**
  * Expanded validation of safe-test payload generation across multiple kinds.
  * Increased several test timeouts to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->