### PR TITLE
docs: add observability telemetry guidance

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -733,21 +733,31 @@ traces include request ID and any caller-provided user/campaign IDs. The
 browser response includes `X-Request-ID`; the web chat URL and stream URL expose
 the conversation and user-message IDs needed to find the persisted turn.
 
-**App observability: Sentry.** Sentry owns app observability for backend
+**App observability: Sentry.** Sentry owns app logs, app traces, app errors,
+browser diagnostics, release health, alerting, and uptime. It covers backend
 errors, swallowed chat failures, SSE failures, browser errors, cron/script
-failures, uptime checks, release health, and alerts. Events must use safe tags
-and context: environment, release SHA, request ID, route, conversation ID, user
-message ID, and LangSmith thread/run links when available. Sentry must not store
-raw prompts, full model answers, provider payloads, cookies, bearer tokens,
-OAuth tokens, secrets, or retrieved source passages.
+failures, uptime checks, release regressions, structured operational logs, and
+app spans. App event and log capture goes through Squire's telemetry boundary.
+Do not call `@sentry/node` directly for capture outside `src/telemetry.ts`;
+`src/instrumentation.ts` may wire Sentry's OpenTelemetry integration, and
+`scripts/send-sentry-safe-test-event.ts` may emit documented safe test events.
+Events, logs, and spans must use safe tags and context: environment, release
+SHA, request ID, route, conversation ID, user message ID, and LangSmith
+thread/run links when available. Sentry must not store raw prompts, full model
+answers, provider payloads, cookies, bearer tokens, OAuth tokens, secrets,
+request bodies, emails, structured names, full transcripts, or retrieved source
+passages.
 
 Browser feedback is categorical and tied to Sentry event ids when available.
 Browser replay data is masked structural context only: approved selectors,
 turn/input/history counts, viewport, and route ids. Raw transcript text and
 free-form feedback prose stay out of Sentry.
 
-LangSmith remains the owner for LLM traces and evals. Sentry links to LangSmith
-instead of duplicating prompt, model-output, or retrieved-context payloads.
+LangSmith remains the owner for LLM traces and evals; specifically, LangSmith
+owns AI traces, evals, prompts, model output, tool calls, and retrieval
+debugging. Sentry links to LangSmith instead of duplicating prompt,
+model-output, or retrieved-context payloads.
+
 Operators start in Sentry for app/runtime errors and release regressions, then
 jump to LangSmith when the question is whether the agent reasoned correctly,
 retrieved the right sources, or passed eval expectations.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -120,6 +120,137 @@ fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind deploy-regression'
 ```
 
+### Adding telemetry for new features
+
+Sentry owns app logs, app traces, app errors, browser diagnostics, release
+health, alerting, and uptime. LangSmith owns AI traces, evals, prompts, model
+output, tool calls, and retrieval debugging. A Sentry event may link to a
+LangSmith run, thread, or trace, but it must not copy AI payloads from
+LangSmith. Keep raw prompts, model output, retrieved passages, full
+transcripts, cookies, tokens, emails, structured names, request bodies, and
+provider payloads out of Sentry.
+
+Do not call `@sentry/node` directly for app event or log capture outside
+`src/telemetry.ts`. `src/instrumentation.ts` may wire Sentry's OpenTelemetry
+integration, and `scripts/send-sentry-safe-test-event.ts` may emit documented
+safe test events. New server and script telemetry should use the helpers in
+`src/telemetry.ts` or `src/script-telemetry.ts`. New browser telemetry should
+post sanitized payloads through the existing `/api/browser-telemetry` path so
+server-side redaction and Sentry configuration remain centralized.
+
+For a new server route or domain operation, emit a stable log label and safe
+attributes:
+
+```ts
+captureTelemetryLog('info', 'feature.lifecycle', {
+  route: '/api/example',
+  requestId,
+  conversationId,
+  userMessageId,
+  langsmithRunUrl,
+  context: {
+    surface: 'api_example',
+    status: 'ok',
+  },
+  attributes: {
+    event_type: 'feature.lifecycle',
+    surface: 'api_example',
+    status: 'ok',
+    duration_ms: durationMs,
+  },
+});
+```
+
+Use stable labels and low-cardinality fields for alerts. Put operational facts
+in `attributes`; put only the diagnostic IDs needed by a bug ticket in the
+top-level helper input. Do not put raw request bodies, user text, prompt text,
+model output, provider payloads, retrieved source text, cookies, auth headers,
+emails, or names into either place. The telemetry boundary redacts known
+protected keys as a backstop, but callers should still pass safe data.
+
+For a new app span, use OpenTelemetry and Squire-prefixed attributes that match
+the alert and evidence fields:
+
+```ts
+await trace
+  .getTracer('squire.feature')
+  .startActiveSpan('squire.feature.operation', async (span) => {
+    span.setAttributes({
+      'http.route': '/api/example',
+      'squire.surface': 'api_example',
+      'squire.request_id': requestId,
+      'squire.conversation_id': conversationId,
+      'squire.user_message_id': userMessageId,
+    });
+
+    try {
+      return await runOperation();
+    } finally {
+      span.end();
+    }
+  });
+```
+
+For a cron, migration, release command, or one-off script, wrap the main
+operation instead of hand-writing Sentry calls:
+
+```ts
+await runScriptWithTelemetry(
+  async () => {
+    await main();
+  },
+  {
+    scriptName: 'example-job',
+    scriptKind: 'cron',
+    requestId: 'example-job-' + Date.now(),
+  },
+);
+```
+
+For a new alert or dashboard query, update
+`scripts/sentry-app-health-config.ts` first. Add a new area to
+`SENTRY_APP_HEALTH_AREAS` when the area is new, add a widget when operators need
+a dashboard entry, and add a monitor to `SENTRY_APP_HEALTH_MONITORS` when it
+should page or email. Update [docs/runbooks/sentry-alerts.md](runbooks/sentry-alerts.md)
+in the same PR, then run:
+
+```bash
+npm run sentry:app-health -- --dry-run
+```
+
+For a new bug-evidence field, update `src/diagnostic-bundle.ts` and
+`src/linear-bug-report-template.ts` together. The field must have a
+`DiagnosticBundleSchema` entry, a safe value sanitizer, an unavailable reason,
+and rendering through `createLinearBugReportBody()`. When an agent already has
+safe links, it can assemble evidence with:
+
+```ts
+const bundle = buildDiagnosticBundle({
+  requestId,
+  conversationId,
+  userMessageId,
+  sentryEventUrl,
+  sentryLogsUrl,
+  sentryTraceUrl,
+  langsmithRunUrl,
+});
+
+const body = createLinearBugReportBody({
+  kind: 'app_runtime',
+  bundle,
+  observed,
+  expected,
+  likelyFailingArea,
+  firstFilesToInspect,
+  reproSteps,
+  acceptanceCriteria,
+});
+```
+
+Tests should cover the contract that matters: no-DSN local behavior, redaction,
+stable field names, alert filters, dry-run output, and generated Linear evidence
+with explicit unavailable reasons.
+
 `GOOGLE_OAUTH_REDIRECT_URI` is still the configured fallback callback for
 production and non-local hosts. In local development, `/auth/google/start` and
 `/auth/google/callback` reuse the current `localhost` origin so linked

--- a/docs/agent/bug-reporting.md
+++ b/docs/agent/bug-reporting.md
@@ -53,6 +53,23 @@ passages, cookies, auth headers, OAuth tokens, or secrets into Linear. If a
 piece of evidence cannot be safely gathered, leave it unavailable with the
 reason from the bundle.
 
+## Sentry logs/traces into Linear bug evidence
+
+When the report came from a production conversation, gather the Sentry links
+before creating the Linear issue whenever they exist:
+
+- Sentry issue or event URL for grouped app/runtime errors
+- Sentry replay URL for browser/layout/stream-state reports
+- Sentry logs query URL filtered by `request_id`, `conversation_id`,
+  `user_message_id`, `route`, or `event_type`
+- Sentry trace URL or trace ID for app latency and request/span debugging
+- LangSmith trace/thread/run URL for answer-quality or tool/retrieval debugging
+
+Pass those safe links into `buildDiagnosticBundle()` and render the issue with
+`createLinearBugReportBody()`. If a link is not available, do not omit the
+field. Let the diagnostic bundle render `Unavailable: <reason>` so the missing
+evidence is explicit.
+
 ## SQR-298 And SQR-299
 
 SQR-298's in-chat bug report flow should create the same `DiagnosticBundle` and

--- a/docs/agent/diagnostic-bundle.md
+++ b/docs/agent/diagnostic-bundle.md
@@ -46,3 +46,24 @@ SQR-310's Linear Evidence template renders this bundle with
 `createLinearBugReportBody()` in `src/linear-bug-report-template.ts`. New
 in-chat or agent-created bug report paths should call that helper rather than
 inventing ad hoc field names.
+
+## Extending The Bundle
+
+When adding a new diagnostic field, update the schema, sanitizer, collector,
+builder, and Linear rendering path in the same PR:
+
+- Add the field to `DiagnosticBundleSchema` and the TypeScript shape.
+- Accept only low-cardinality IDs, URLs, timestamps, booleans, counts, or other
+  values that are safe to copy into Linear.
+- Add an unavailable reason for every path where the field cannot be collected.
+- Render the field through `createLinearBugReportBody()` or explain why it is
+  internal-only.
+- Add tests for a full bundle, a missing-field bundle, and redaction of unsafe
+  input.
+
+Every new diagnostic field must add an unavailable reason before it can ship.
+
+Do not add fields for raw prompts, model output, retrieved passages, full
+transcripts, request bodies, cookies, tokens, emails, names, or provider
+payloads. Those belong in LangSmith or the original source system, not in a
+Linear bug ticket.

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -70,6 +70,88 @@ If the user report is ambiguous, start with the conversation URL and timestamp,
 then gather a diagnostic bundle. The bundle should tell the bug ticket which
 Sentry and LangSmith links are present and which are unavailable.
 
+## Adding Or Changing Telemetry
+
+Use this checklist when a feature, fix, route, browser flow, or script needs new
+observability:
+
+1. Decide whether the question belongs in Sentry or LangSmith. Sentry owns app
+   logs, app traces, app errors, browser diagnostics, release health, alerting,
+   and uptime. LangSmith owns AI traces, evals, prompts, model output, tool
+   calls, and retrieval debugging.
+2. Add server-side Sentry events/logs through `src/telemetry.ts`. Do not call
+   `@sentry/node` directly for app event or log capture outside
+   `src/telemetry.ts`; `src/instrumentation.ts` may wire Sentry's OpenTelemetry
+   integration, and `scripts/send-sentry-safe-test-event.ts` may emit documented
+   safe test events.
+3. Add script lifecycle coverage through `runScriptWithTelemetry()` in
+   `src/script-telemetry.ts`.
+4. Add app spans with OpenTelemetry and stable `squire.*` attributes. Sentry may
+   ingest the span, but LangSmith remains the place to inspect AI payloads.
+5. Add browser diagnostics through `/api/browser-telemetry`; keep replay and
+   feedback masked and categorical.
+6. Add alert/dashboard coverage in `scripts/sentry-app-health-config.ts` and
+   update [sentry-alerts.md](sentry-alerts.md) in the same PR.
+7. If a bug ticket needs a new field, add it to `DiagnosticBundleSchema`, give
+   it a sanitizer, render it through `createLinearBugReportBody()`, and add an
+   unavailable reason.
+
+Safe telemetry payloads can include stable IDs, route patterns, operational
+status, durations, counters, error class names, release SHA, and links to
+Sentry or LangSmith. They must not include raw prompts, model output, retrieved
+passages, full transcripts, cookies, tokens, emails, structured names, request
+bodies, or provider payloads.
+
+Example log pattern:
+
+```ts
+captureTelemetryLog('info', 'feature.lifecycle', {
+  route: '/api/example',
+  requestId,
+  conversationId,
+  userMessageId,
+  context: { surface: 'api_example', status: 'ok' },
+  attributes: {
+    event_type: 'feature.lifecycle',
+    surface: 'api_example',
+    status: 'ok',
+    duration_ms: durationMs,
+  },
+});
+```
+
+Example span pattern:
+
+```ts
+await trace
+  .getTracer('squire.feature')
+  .startActiveSpan('squire.feature.operation', async (span) => {
+    span.setAttributes({
+      'http.route': '/api/example',
+      'squire.surface': 'api_example',
+      'squire.request_id': requestId,
+    });
+    try {
+      return await runOperation();
+    } finally {
+      span.end();
+    }
+  });
+```
+
+Example diagnostic bundle pattern:
+
+```ts
+const bundle = buildDiagnosticBundle({
+  requestId,
+  conversationId,
+  userMessageId,
+  sentryLogsUrl,
+  sentryTraceUrl,
+  langsmithRunUrl,
+});
+```
+
 ## User Report To Linear
 
 1. Capture the conversation URL, selected turn URL if available, user-reported

--- a/docs/runbooks/sentry-alerts.md
+++ b/docs/runbooks/sentry-alerts.md
@@ -31,6 +31,39 @@ Thresholds are still documented here so they can be reviewed without opening
 Sentry. If Sentry thresholds are tuned in the UI, update
 `scripts/sentry-app-health-config.ts` and this runbook in the same PR.
 
+## Adding A New Alert Or Monitor
+
+Start with the symptom and the dataset:
+
+- Use error events for grouped exceptions, deploy regressions, browser
+  exceptions, and uptime alerts.
+- Use logs for lifecycle failures, swallowed chat failures, browser transport
+  failures, auth/rate-limit events, budget/accounting events, and other
+  countable operational states.
+- Use spans for latency and dependency timing.
+
+Then update the checked-in config before changing Sentry by hand:
+
+1. Add the area to `SENTRY_APP_HEALTH_AREAS` in
+   `scripts/sentry-app-health-config.ts` if this is a new app-health area.
+2. Add or update a dashboard widget in `SENTRY_APP_HEALTH_DASHBOARD_WIDGETS`
+   when the signal should be visible during triage.
+3. Add the monitor to `SENTRY_APP_HEALTH_MONITORS` for log or span alerts that
+   should notify.
+4. For existing event or uptime alerts that cannot be managed through the
+   detector endpoint yet, update `SENTRY_EXISTING_APP_HEALTH_ALERTS`.
+5. Add a safe test event or a written safe-test path in the same change.
+6. Run `npm run sentry:app-health -- --dry-run`, then use `--apply` only when
+   you intend to change Sentry resources.
+7. Update this runbook with the alert name, dataset, filter, trigger, first
+   action, and safe test event.
+
+Do not add alert filters that match raw prompt, answer, transcript, source
+passage, email, name, token, cookie, or request-body fields. Filters should use
+stable tags and attributes such as `environment`, `release`, `route`,
+`request_id`, `conversation_id`, `user_message_id`, `surface`, `event_type`,
+`status`, `job_kind`, `security_event`, and `squire.*` span fields.
+
 ## Dashboard
 
 Create or update the dashboard named `Squire - Production App Health`.


### PR DESCRIPTION
## Summary

- Documents Sentry as the app logs, traces, errors, browser diagnostics, release health, alerting, and uptime surface while keeping LangSmith as the AI trace/eval source of truth.
- Adds future-agent guidance for safe telemetry fields, app spans, script telemetry, alert/monitor config, and diagnostic bundle evidence.
- Extends the bug-reporting and diagnostic-bundle docs with Sentry logs/traces links and explicit unavailable-field handling.

## Validation

- `npm run lint:md`
- `npm run format:check`
- `npm run agent:check`
- `npm test -- test/deployment-config.test.ts test/deployment-operations-docs.test.ts`
- `npm run check`
- gstack `/review` clean after one docs consistency auto-fix

## Notes

- This PR intentionally does not add new documentation-content tests. SQR-345 tracks removing the existing brittle docs-content tests.
- SQR-344 tracks the separate test-suite performance audit.

Fixes SQR-341


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced observability and telemetry documentation with clearer implementation guidelines and data safety requirements.
  * Added comprehensive guides for integrating telemetry into new features.
  * Improved bug reporting and diagnostic procedures with evidence-gathering documentation.
  * Added runbook sections for telemetry configuration and alert management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->