### PR TITLE
SQR-346 Report Sentry trace proof separately

### DIFF
--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -332,9 +332,11 @@ npm run sentry:test-event -- --kind chat --dry-run
 npm run sentry:test-event -- --kind uptime --dry-run
 ```
 
-The safe verification commands print sanitized Sentry event, log, and trace
-search URLs. Copy those URLs into the Linear Evidence section when proving a
-bug-report or alert path.
+The safe verification commands print sanitized Sentry event/log search URLs and
+a trace search URL. The trace URL is a search aid, not proof by itself. Copy the
+`traceProof` fields into the Linear Evidence section: use confirmed Sentry trace
+rows when available, or copy `traceSearchableReason` when the script reports
+trace searchability as unavailable or unverified.
 
 Browser replay and feedback smoke:
 
@@ -361,8 +363,9 @@ Uptime smoke:
 2. If unavailable, create a temporary duplicate uptime monitor pointed at
    `https://squire.maz.org/api/__sentry-uptime-test-404`.
 3. Verify the alert matches, then delete the duplicate monitor.
-4. Run `--kind uptime` to create searchable app telemetry for the health-check
-   path without disrupting production.
+4. Run `--kind uptime` to create safe app telemetry for the health-check path
+   without disrupting production. Treat the printed trace URL as searchable only
+   after Sentry returns matching rows or the command reports trace proof.
 5. Do not break the real `/api/health` endpoint to test alerting.
 
 ## Release Checklist

--- a/docs/runbooks/sentry-alerts.md
+++ b/docs/runbooks/sentry-alerts.md
@@ -159,7 +159,6 @@ The safe test events use synthetic IDs only:
   search URL, and `traceProof`
 - the trace search URL is not proof by itself; copy confirmed trace rows or
   `traceSearchableReason` into the Linear Evidence section
-  that can be copied into Linear Evidence fields
 
 The uptime safe command proves app telemetry for the health-check path without
 breaking `/api/health`. For the uptime alert itself, prefer Sentry's monitor test

--- a/docs/runbooks/sentry-alerts.md
+++ b/docs/runbooks/sentry-alerts.md
@@ -139,8 +139,8 @@ fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --
 fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind deploy-regression'
 ```
 
-Local dry runs print the safe event, log, trace, and Linear evidence payloads
-without sending to Sentry:
+Local dry runs print the safe event, log, trace-search, `traceProof`, and Linear
+evidence payloads without sending to Sentry:
 
 ```bash
 npm run sentry:test-event -- --kind chat --dry-run
@@ -155,7 +155,10 @@ The safe test events use synthetic IDs only:
 - `user_message_id=sentry-test-user-message` for chat/browser tests
 - no cookies, auth headers, raw prompts, model output, provider payloads, or
   retrieved passages
-- dry-run and production output include Sentry event, log, and trace search URLs
+- dry-run and production output include Sentry event/log search URLs, a trace
+  search URL, and `traceProof`
+- the trace search URL is not proof by itself; copy confirmed trace rows or
+  `traceSearchableReason` into the Linear Evidence section
   that can be copied into Linear Evidence fields
 
 The uptime safe command proves app telemetry for the health-check path without

--- a/docs/runbooks/sentry-scrubbing.md
+++ b/docs/runbooks/sentry-scrubbing.md
@@ -123,9 +123,10 @@ Expected results:
   masked, removed, or replaced. Confirm structured log attributes such as
   `providerPayload`, `retrievedPassages`, `request_body`, and `response_body`
   are removed or scrubbed, not merely nested under another serialized value.
-- If `SENTRY_TRACES_SAMPLE_RATE` is greater than `0`, the
-  `squire.safe_scrub_canary` span is present and the same fake values are
-  masked, removed, or replaced.
+- If `SENTRY_TRACES_SAMPLE_RATE` is greater than `0`, confirm Sentry has a
+  `squire.safe_scrub_canary` span before treating span scrubbing as proven. The
+  command's `traceProof.traceSearchableReason` is the evidence to copy when
+  searchability is unavailable or unverified.
 - Stable diagnostics remain searchable: `environment`, `release`, `route`,
   `request_id`, `conversation_id`, `user_message_id`, and
   `sentry_trace_id` when present.

--- a/scripts/send-sentry-safe-test-event.ts
+++ b/scripts/send-sentry-safe-test-event.ts
@@ -1,15 +1,16 @@
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import * as Sentry from '@sentry/node';
+import { trace, type Attributes } from '@opentelemetry/api';
 
 import {
   captureTelemetryError,
   captureTelemetryLog,
   captureTelemetryMessage,
-  flushTelemetry,
   initTelemetry,
+  sentryTraceSampleRateFromEnv,
 } from '../src/telemetry.ts';
+import { runScriptWithTelemetry } from '../src/script-telemetry.ts';
 import {
   SENTRY_APP_HEALTH_ENVIRONMENT,
   SENTRY_APP_HEALTH_ORG,
@@ -28,6 +29,16 @@ export const SAFE_TEST_KINDS = [
 
 type SafeTestKind = (typeof SAFE_TEST_KINDS)[number];
 type SafeVerificationKind = Exclude<SafeTestKind, 'scrub-canary'>;
+type TraceSearchable = true | false | null;
+
+interface SafeTraceProof {
+  traceAttempted: boolean;
+  traceSpanStarted: boolean;
+  traceSearchable: TraceSearchable;
+  traceSearchableReason: string;
+  traceId: string | null;
+  spanId: string | null;
+}
 
 export const SAFE_VERIFICATION_KINDS = [
   'backend',
@@ -245,11 +256,13 @@ function sentryEvidence(kind: SafeVerificationKind, input: ReturnType<typeof saf
       'LangSmith Trace/Thread/Run':
         'unavailable: safe synthetic verification does not create an AI run',
       Observed: `${kind} synthetic app telemetry emitted`,
-      Expected: 'Sentry event, log, and trace are searchable by request_id',
+      Expected:
+        'Sentry event and log are searchable by request_id; trace rows require traceProof or manual Sentry confirmation',
       'Likely failing area': `sentry-${kind}`,
       'First files to inspect': 'scripts/send-sentry-safe-test-event.ts; src/telemetry.ts',
       Repro: `fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind ${kind}'`,
-      Acceptance: 'Copy the event, log, and trace search URLs into Linear evidence',
+      Acceptance:
+        'Copy the event and log search URLs plus either confirmed trace rows or traceProof unavailable reason into Linear evidence',
     },
   };
 }
@@ -316,6 +329,89 @@ function safeVerificationTrace(
   } as const;
 }
 
+function safeVerificationTraceAttributes(
+  kind: SafeVerificationKind,
+  input: ReturnType<typeof safeTestInput>,
+): Attributes {
+  return safeVerificationTrace(kind, input).attributes;
+}
+
+function sentryTraceDisabledReason(): string | undefined {
+  const tracesSampleRate = sentryTraceSampleRateFromEnv(process.env);
+  if (tracesSampleRate === undefined) {
+    return 'SENTRY_TRACES_SAMPLE_RATE is unset or invalid, so Sentry app-span export is disabled';
+  }
+  if (tracesSampleRate <= 0) {
+    return 'SENTRY_TRACES_SAMPLE_RATE is 0, so Sentry app-span export is disabled';
+  }
+  return undefined;
+}
+
+function dryRunTraceProof(): SafeTraceProof {
+  return {
+    traceAttempted: false,
+    traceSpanStarted: false,
+    traceSearchable: null,
+    traceSearchableReason:
+      'dry-run: telemetry is not sent, so Sentry span searchability is not checked',
+    traceId: null,
+    spanId: null,
+  };
+}
+
+function traceProof(input: {
+  spanStarted: boolean;
+  traceId: string | null;
+  spanId: string | null;
+  startError?: unknown;
+}): SafeTraceProof {
+  const disabledReason = sentryTraceDisabledReason();
+  if (disabledReason) {
+    return {
+      traceAttempted: false,
+      traceSpanStarted: input.spanStarted,
+      traceSearchable: false,
+      traceSearchableReason: `unavailable: ${disabledReason}`,
+      traceId: input.traceId,
+      spanId: input.spanId,
+    };
+  }
+
+  if (input.startError) {
+    return {
+      traceAttempted: true,
+      traceSpanStarted: input.spanStarted,
+      traceSearchable: false,
+      traceSearchableReason: `unavailable: OpenTelemetry span start failed: ${
+        input.startError instanceof Error ? input.startError.message : String(input.startError)
+      }`,
+      traceId: input.traceId,
+      spanId: input.spanId,
+    };
+  }
+
+  if (!input.spanStarted) {
+    return {
+      traceAttempted: true,
+      traceSpanStarted: false,
+      traceSearchable: false,
+      traceSearchableReason: 'unavailable: OpenTelemetry did not start a local span',
+      traceId: input.traceId,
+      spanId: input.spanId,
+    };
+  }
+
+  return {
+    traceAttempted: true,
+    traceSpanStarted: true,
+    traceSearchable: null,
+    traceSearchableReason:
+      'unavailable: OpenTelemetry span was emitted, but this script does not query Sentry after ingestion; confirm rows with sentryTraceSearchUrl',
+    traceId: input.traceId,
+    spanId: input.spanId,
+  };
+}
+
 function safeVerificationDryRun(
   kind: SafeVerificationKind,
   input: ReturnType<typeof safeTestInput>,
@@ -326,6 +422,7 @@ function safeVerificationDryRun(
     event: safeVerificationEvent(kind),
     log: safeVerificationLog(kind, input),
     trace: safeVerificationTrace(kind, input),
+    traceProof: dryRunTraceProof(),
     evidence: sentryEvidence(kind, input),
   };
 }
@@ -348,8 +445,11 @@ function emitSafeVerificationTrace(
   kind: SafeVerificationKind,
   input: ReturnType<typeof safeTestInput>,
   operation: () => void,
-): boolean {
+): SafeTraceProof {
   let operationRan = false;
+  let spanStarted = false;
+  let traceId: string | null = null;
+  let spanId: string | null = null;
   const runOperationOnce = () => {
     if (operationRan) return;
     operationRan = true;
@@ -357,17 +457,31 @@ function emitSafeVerificationTrace(
   };
 
   try {
-    Sentry.startSpan(safeVerificationTrace(kind, input), () => {
-      runOperationOnce();
-    });
-    return true;
+    trace
+      .getTracer('squire.safe-test')
+      .startActiveSpan(
+        safeVerificationTrace(kind, input).name,
+        { attributes: safeVerificationTraceAttributes(kind, input) },
+        (span) => {
+          spanStarted = true;
+          const context = span.spanContext();
+          traceId = context.traceId;
+          spanId = context.spanId;
+          try {
+            runOperationOnce();
+          } finally {
+            span.end();
+          }
+        },
+      );
+    return traceProof({ spanStarted, traceId, spanId });
   } catch (error: unknown) {
     console.error(
       'safe verification trace skipped:',
       error instanceof Error ? error.message : String(error),
     );
     runOperationOnce();
-    return false;
+    return traceProof({ spanStarted, traceId, spanId, startError: error });
   }
 }
 
@@ -390,12 +504,14 @@ function scrubCanaryAttributes(): Record<string, unknown> {
   };
 }
 
-function emitScrubCanaryTrace(): boolean {
+function emitScrubCanaryTrace(): SafeTraceProof {
+  let spanStarted = false;
+  let traceId: string | null = null;
+  let spanId: string | null = null;
   try {
-    Sentry.startSpan(
+    trace.getTracer('squire.safe-test').startActiveSpan(
+      'squire.safe_scrub_canary',
       {
-        name: 'squire.safe_scrub_canary',
-        op: 'squire.scrub_canary',
         attributes: {
           'gen_ai.prompt': 'Synthetic prompt text for span scrubbing verification',
           'gen_ai.completion': 'Synthetic model output for span scrubbing verification',
@@ -408,16 +524,114 @@ function emitScrubCanaryTrace(): boolean {
           authorization: 'Bearer sentry_scrub_canary_token_1234567890',
         },
       },
-      () => undefined,
+      (span) => {
+        spanStarted = true;
+        const context = span.spanContext();
+        traceId = context.traceId;
+        spanId = context.spanId;
+        span.end();
+      },
     );
-    return true;
+    return traceProof({ spanStarted, traceId, spanId });
   } catch (error: unknown) {
     console.error(
       'scrub-canary trace skipped:',
       error instanceof Error ? error.message : String(error),
     );
-    return false;
+    return traceProof({ spanStarted, traceId, spanId, startError: error });
   }
+}
+
+function scriptTelemetryOptions(kind: SafeTestKind, input: ReturnType<typeof safeTestInput>) {
+  return {
+    scriptName: 'send-sentry-safe-test-event',
+    scriptKind: kind === 'cron' ? ('cron' as const) : ('script' as const),
+    route: routeFromInput(input),
+    requestId: requestIdFromInput(input),
+    flushTimeoutMs: 2_000,
+  };
+}
+
+function serializeTraceProof(proof: SafeTraceProof) {
+  return {
+    traceAttempted: proof.traceAttempted,
+    traceSpanStarted: proof.traceSpanStarted,
+    traceSearchable: proof.traceSearchable,
+    traceSearchableReason: proof.traceSearchableReason,
+    traceId: proof.traceId,
+    spanId: proof.spanId,
+  };
+}
+
+function scrubCanaryDryRun(kind: SafeTestKind, input: ReturnType<typeof safeTestInput>) {
+  return {
+    kind,
+    input,
+    traceProof: dryRunTraceProof(),
+  };
+}
+
+async function emitSafeVerification(
+  kind: SafeVerificationKind,
+  input: ReturnType<typeof safeTestInput>,
+) {
+  return runScriptWithTelemetry(
+    async () => {
+      let eventId: string | null = null;
+      let logSent = false;
+      const traceProofResult = emitSafeVerificationTrace(kind, input, () => {
+        eventId = captureSafeVerificationEvent(kind, input);
+        const log = safeVerificationLog(kind, input);
+        logSent = captureTelemetryLog(log.level, log.message, {
+          ...input,
+          attributes: log.attributes,
+        });
+      });
+
+      return {
+        kind,
+        eventId,
+        logSent,
+        ...serializeTraceProof(traceProofResult),
+        traceProof: traceProofResult,
+        evidence: sentryEvidence(kind, input),
+      };
+    },
+    scriptTelemetryOptions(kind, input),
+  );
+}
+
+async function emitScrubCanary(input: ReturnType<typeof safeTestInput>, kind: SafeTestKind) {
+  return runScriptWithTelemetry(
+    async () => {
+      const eventId = captureTelemetryError(new Error(SAFE_TEST_ERROR_NAMES[kind]), input);
+      const logSent = captureTelemetryLog(
+        'warn',
+        'sentry scrub canary synthetic alice@example.invalid',
+        {
+          ...input,
+          attributes: {
+            ...scrubCanaryAttributes(),
+          },
+        },
+      );
+      const traceProofResult = emitScrubCanaryTrace();
+      return {
+        kind,
+        eventId,
+        logSent,
+        ...serializeTraceProof(traceProofResult),
+        traceProof: traceProofResult,
+      };
+    },
+    scriptTelemetryOptions(kind, input),
+  );
+}
+
+function dryRunPayload(kind: SafeTestKind, input: ReturnType<typeof safeTestInput>) {
+  return isSafeVerificationKind(kind)
+    ? safeVerificationDryRun(kind, input)
+    : scrubCanaryDryRun(kind, input);
 }
 
 async function main(): Promise<void> {
@@ -425,15 +639,7 @@ async function main(): Promise<void> {
   const input = safeTestInput(args.kind);
 
   if (args.dryRun) {
-    console.log(
-      JSON.stringify(
-        isSafeVerificationKind(args.kind)
-          ? safeVerificationDryRun(args.kind, input)
-          : { kind: args.kind, input },
-        null,
-        2,
-      ),
-    );
+    console.log(JSON.stringify(dryRunPayload(args.kind, input), null, 2));
     return;
   }
 
@@ -443,45 +649,11 @@ async function main(): Promise<void> {
   }
 
   if (isSafeVerificationKind(args.kind)) {
-    const kind = args.kind;
-    let eventId: string | null = null;
-    let logSent = false;
-    const traceAttempted = emitSafeVerificationTrace(kind, input, () => {
-      eventId = captureSafeVerificationEvent(kind, input);
-      const log = safeVerificationLog(kind, input);
-      logSent = captureTelemetryLog(log.level, log.message, {
-        ...input,
-        attributes: log.attributes,
-      });
-    });
-    await flushTelemetry(2_000);
-    console.log(
-      JSON.stringify(
-        {
-          kind,
-          eventId,
-          logSent,
-          traceAttempted,
-          evidence: sentryEvidence(kind, input),
-        },
-        null,
-        2,
-      ),
-    );
+    console.log(JSON.stringify(await emitSafeVerification(args.kind, input), null, 2));
     return;
   }
 
-  const eventId = captureTelemetryError(new Error(SAFE_TEST_ERROR_NAMES[args.kind]), input);
-  const logSent =
-    args.kind === 'scrub-canary'
-      ? captureTelemetryLog('warn', 'sentry scrub canary synthetic alice@example.invalid', {
-          ...input,
-          attributes: scrubCanaryAttributes(),
-        })
-      : false;
-  const traceAttempted = args.kind === 'scrub-canary' ? emitScrubCanaryTrace() : false;
-  await flushTelemetry(2_000);
-  console.log(JSON.stringify({ kind: args.kind, eventId, logSent, traceAttempted }, null, 2));
+  console.log(JSON.stringify(await emitScrubCanary(input, args.kind), null, 2));
 }
 
 function isDirectRun(): boolean {

--- a/test/sentry-alerts.test.ts
+++ b/test/sentry-alerts.test.ts
@@ -49,6 +49,14 @@ describe('Sentry alert catalog', () => {
       expect(payload.event).toMatchObject({ level: 'error' });
       expect(payload.log?.message).toBe(`sentry.safe_test.${kind}`);
       expect(payload.trace?.name).toBe(`squire.safe_test.${kind}`);
+      expect(payload.traceProof).toMatchObject({
+        traceAttempted: false,
+        traceSpanStarted: false,
+        traceSearchable: null,
+        traceSearchableReason: expect.stringContaining('dry-run'),
+        traceId: null,
+        spanId: null,
+      });
       expect(payload.evidence).toMatchObject({
         requestId: `sentry-test-${kind}`,
         sentryEventSearchUrl: expect.stringContaining(`request_id%3Asentry-test-${kind}`),
@@ -60,6 +68,8 @@ describe('Sentry alert catalog', () => {
         Environment: expect.any(String),
         Release: expect.any(String),
         'Sentry Issue/Event/Replay': expect.stringContaining('Event search: https://'),
+        Expected: expect.stringContaining('trace rows require traceProof'),
+        Acceptance: expect.stringContaining('traceProof unavailable reason'),
       });
 
       for (const forbidden of [


### PR DESCRIPTION
## Summary
- Route safe Sentry test spans through the same direct-script OpenTelemetry setup used by other production scripts.
- Add `traceProof` output fields so `traceAttempted`, local span startup, and Sentry searchability are reported separately.
- Update Linear evidence/runbook wording so trace search URLs are not treated as proof without matching Sentry rows or an unavailable reason.

## Verification
- `npm test -- test/sentry-alerts.test.ts test/script-telemetry-real-otel.test.ts test/script-telemetry.test.ts --reporter=dot`
- `npx eslint scripts/send-sentry-safe-test-event.ts test/sentry-alerts.test.ts`
- `npm run lint:md`
- `npm run typecheck`
- `node scripts/send-sentry-safe-test-event.ts --kind chat --dry-run`
- `node scripts/send-sentry-safe-test-event.ts --kind scrub-canary --dry-run`
- `npm run check` (154 files, 1820 tests, 164.63s)
- `/review` clean, logged for `1beafdd7`

Fixes SQR-346


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated runbook guidance for safe test cases, uptime smoke, and trace/scrub verification to clarify when trace URLs are searchable and what evidence must be copied (trace proof vs. searchable reasons).
* **Refactor**
  * Improved trace capture and verification output using enriched trace proof details.
  * In dry-run mode, outputs now include structured `traceProof` information instead of a simpler trace flag.
* **Tests**
  * Extended Sentry alert catalog tests to validate `traceProof` fields and the associated acceptance messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->