### PR TITLE
SQR-344 Speed up test reset and gate browser e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,6 @@ jobs:
 
   slow-pdf-extraction:
     name: Slow PDF extraction test
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -143,7 +142,6 @@ jobs:
 
   authenticated-api-agent-e2e:
     name: Authenticated API and agent E2E smoke
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  schedule:
-    - cron: '17 8 * * *'
   workflow_dispatch:
 
 permissions:
@@ -107,7 +105,7 @@ jobs:
 
   slow-pdf-extraction:
     name: Slow PDF extraction test
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -145,7 +143,7 @@ jobs:
 
   authenticated-api-agent-e2e:
     name: Authenticated API and agent E2E smoke
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
@@ -200,7 +198,6 @@ jobs:
 
   browser-e2e:
     name: Browser E2E smoke
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     services:

--- a/docs/plans/sqr-344-test-performance-report.md
+++ b/docs/plans/sqr-344-test-performance-report.md
@@ -66,10 +66,9 @@ belong in the browser-e2e suite, not the normal Vitest gate.
 
 The browser-e2e job existed in `.github/workflows/ci.yml`, but it was limited to
 scheduled and manual runs. PR CI ran Vitest coverage only, so it could not catch
-the SQR-11-to-SQR-24 browser-state leak. The job now runs on PRs and main
-pushes, and the duplicate daily CI schedule has been removed. The LLM-backed
-API-agent e2e and slow PDF extraction jobs remain manual-only because they are
-heavier and cover external or intentionally slow paths.
+the SQR-11-to-SQR-24 browser-state leak. The CI workflow now runs all current
+CI/e2e jobs on PRs and main pushes, and the duplicate daily CI schedule has
+been removed.
 
 ## Remaining Over-1s Test
 

--- a/docs/plans/sqr-344-test-performance-report.md
+++ b/docs/plans/sqr-344-test-performance-report.md
@@ -1,0 +1,120 @@
+# SQR-344 Test Performance Report
+
+Captured on 2026-06-16 from
+`bcm/sqr-344-deeply-audit-and-improve-test-suite-performance`.
+
+## Summary
+
+The main slowdown was DB cleanup. `resetTestDb()` used
+`TRUNCATE ... RESTART IDENTITY CASCADE` before every DB test. The mutable schema
+uses UUID primary keys, so identity resets bought nothing and made the serial DB
+slice pay expensive lock/FK work hundreds of times.
+
+The fix changes mutable DB cleanup to ordered `DELETE` statements and explicitly
+clears `message_stream_events`. The read-only card and scenario-section fixture
+tables still stay seeded once in global setup.
+
+## Before And After
+
+| Suite                                    |          Before wall |       After wall | Before tests >1s | After tests >1s |
+| ---------------------------------------- | -------------------: | ---------------: | ---------------: | --------------: |
+| `npm run test:unit -- --reporter=json`   |               26.40s |           16.23s |                1 |               0 |
+| `npm run test:db -- --reporter=json`     |              128.60s |           46.45s |                2 |               0 |
+| `npm test -- --reporter=json`            | about 2m45s baseline |           90.19s |     not captured |               1 |
+| `npm run e2e:browser -- --reporter=json` |     36.63s, 4 failed | 14.44s, 0 failed |                6 |               3 |
+
+The `npm test` after run passed 154 files and 1820 tests.
+
+## Slowest After Files
+
+### Unit
+
+| File                                      | Duration | Tests |
+| ----------------------------------------- | -------: | ----: |
+| `test/web-ui-layout.test.ts`              |  621.0ms |   107 |
+| `test/script-telemetry-real-otel.test.ts` |  556.9ms |     1 |
+| `test/sentry-usage-guardrails.test.ts`    |  420.1ms |     4 |
+| `test/service.test.ts`                    |  183.3ms |    22 |
+| `test/mcp-transport.test.ts`              |  167.7ms |     7 |
+
+### DB
+
+| File                                            | Duration | Tests |
+| ----------------------------------------------- | -------: | ----: |
+| `test/conversation.test.ts`                     |    4.97s |    69 |
+| `test/seed/seed-scenario-section-books.test.ts` |  927.8ms |     5 |
+| `test/campaign-live-migration.test.ts`          |  602.4ms |     4 |
+| `test/campaign-api.test.ts`                     |  513.4ms |    20 |
+| `test/unlock-graph-seed.test.ts`                |  478.5ms |     4 |
+
+No individual DB test is over 1s after the cleanup change. The remaining DB
+wall time is serial file setup and one-time global data seeding, not one slow
+assertion.
+
+### Browser E2E
+
+| File                                 | Duration | Tests |
+| ------------------------------------ | -------: | ----: |
+| `sqr-24-chat-game-selection.spec.ts` |    6.15s |     8 |
+| `sqr-11-campaign-picker.spec.ts`     |    2.35s |     2 |
+
+Browser e2e still has three tests over 1s. These are full browser flows with a
+real server, DB reset, login, DOM interaction, and mobile/desktop projects. They
+belong in the browser-e2e suite, not the normal Vitest gate.
+
+## CI Coverage Finding
+
+The browser-e2e job existed in `.github/workflows/ci.yml`, but it was limited to
+scheduled and manual runs. PR CI ran Vitest coverage only, so it could not catch
+the SQR-11-to-SQR-24 browser-state leak. The job now runs on PRs and main
+pushes, and the duplicate daily CI schedule has been removed. The LLM-backed
+API-agent e2e and slow PDF extraction jobs remain manual-only because they are
+heavier and cover external or intentionally slow paths.
+
+## Remaining Over-1s Test
+
+The combined `npm test` JSON report had one individual Vitest test over 1s:
+
+| File                                      | Duration | Reason                                                                                                                                                                                                                                                   |
+| ----------------------------------------- | -------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `test/script-telemetry-real-otel.test.ts` |    1.13s | Direct-process OpenTelemetry setup test. It starts script telemetry in a child-like Node path and validates the real instrumentation path. In the isolated unit timing run it measured 556.9ms, so this appears to be combined-run process/setup jitter. |
+
+## Browser E2E Isolation Finding
+
+The first browser-e2e timing run exposed a real order-dependent failure:
+
+1. `test/e2e/sqr-11-campaign-picker.spec.ts` created an active campaign for the
+   shared dev user.
+2. `test/e2e/sqr-24-chat-game-selection.spec.ts` then logged in as the same dev
+   user and expected `.squire-game-picker`.
+3. An active campaign intentionally hides the per-session game picker, so the
+   SQR-24 tests failed in both desktop and mobile projects.
+
+Evidence:
+
+- SQR-24 alone on a clean test DB passed.
+- SQR-11 followed by the SQR-24 first-turn test failed.
+- After adding e2e DB reset hooks, that ordered repro passed.
+- The full browser-e2e suite then passed 10/10 in 14.44s.
+
+This fixes SQR-347 in the same branch as the performance work because the bug
+was discovered by the SQR-344 timing audit and affected the same test gate.
+
+## Regression Guard
+
+Use:
+
+```bash
+npm run test:timing
+```
+
+That command runs unit and DB slices with JSON output under
+`.gstack/test-timings/`, prints the slowest files/tests, and fails if any unit or
+DB test exceeds 1000ms.
+
+For browser-e2e timing:
+
+```bash
+PLAYWRIGHT_JSON_OUTPUT_NAME=.gstack/test-timings/e2e-browser.json npm run e2e:browser -- --reporter=json
+node scripts/summarize-test-timings.ts e2e-browser=.gstack/test-timings/e2e-browser.json
+```

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:unit": "vitest run --config vitest.unit.config.ts",
     "test:db": "vitest run --config vitest.db.config.ts",
     "test:split": "vitest run --config vitest.split.config.ts",
+    "test:timing": "mkdir -p .gstack/test-timings && npm run test:unit -- --reporter=json --outputFile=.gstack/test-timings/unit.json && npm run test:db -- --reporter=json --outputFile=.gstack/test-timings/db.json && node scripts/summarize-test-timings.ts --fail-over-threshold unit=.gstack/test-timings/unit.json db=.gstack/test-timings/db.json",
     "test:coverage": "vitest run --coverage --config vitest.split.config.ts",
     "test:coverage:serial": "vitest run --coverage --exclude test/import-scenario-section-books.test.ts",
     "test:slow:pdf": "vitest run test/import-scenario-section-books.test.ts",

--- a/scripts/summarize-test-timings.ts
+++ b/scripts/summarize-test-timings.ts
@@ -1,0 +1,268 @@
+import { basename } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+interface TimedFile {
+  file: string;
+  durationMs: number;
+  tests: number;
+}
+
+interface TimedTest {
+  file: string;
+  name: string;
+  durationMs: number;
+  status: string;
+}
+
+interface TimingSummary {
+  label: string;
+  wallMs: number | null;
+  files: TimedFile[];
+  tests: TimedTest[];
+  failedTests: TimedTest[];
+}
+
+interface ParsedArgs {
+  failOverThreshold: boolean;
+  thresholdMs: number;
+  top: number;
+  reports: Array<{ label: string; path: string }>;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    failOverThreshold: false,
+    thresholdMs: 1_000,
+    top: 10,
+    reports: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--fail-over-threshold') {
+      parsed.failOverThreshold = true;
+      continue;
+    }
+    if (arg === '--threshold-ms') {
+      parsed.thresholdMs = Number(argv[++index]);
+      continue;
+    }
+    if (arg.startsWith('--threshold-ms=')) {
+      parsed.thresholdMs = Number(arg.slice('--threshold-ms='.length));
+      continue;
+    }
+    if (arg === '--top') {
+      parsed.top = Number(argv[++index]);
+      continue;
+    }
+    if (arg.startsWith('--top=')) {
+      parsed.top = Number(arg.slice('--top='.length));
+      continue;
+    }
+    const [label, path] = arg.includes('=') ? arg.split(/=(.*)/s, 2) : [basename(arg), arg];
+    parsed.reports.push({ label, path });
+  }
+
+  if (!Number.isFinite(parsed.thresholdMs) || parsed.thresholdMs < 0) {
+    throw new Error('--threshold-ms must be a non-negative number');
+  }
+  if (!Number.isInteger(parsed.top) || parsed.top < 1) {
+    throw new Error('--top must be a positive integer');
+  }
+  if (parsed.reports.length === 0) {
+    throw new Error(
+      'Usage: node scripts/summarize-test-timings.ts [--fail-over-threshold] [--threshold-ms 1000] [--top 10] label=report.json ...',
+    );
+  }
+
+  return parsed;
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function summarizeVitest(label: string, report: Record<string, unknown>): TimingSummary {
+  const cwd = `${process.cwd()}/`;
+  const testResults = Array.isArray(report.testResults) ? report.testResults : [];
+  const reportStartTime = Number(report.startTime);
+  const maxEndTime = testResults
+    .filter(isRecord)
+    .reduce((max, result) => Math.max(max, Number(result.endTime ?? 0)), 0);
+  const files = testResults
+    .filter(isRecord)
+    .map((result) => {
+      const name = String(result.name ?? 'unknown');
+      const assertions = Array.isArray(result.assertionResults) ? result.assertionResults : [];
+      return {
+        file: name.startsWith(cwd) ? name.slice(cwd.length) : name,
+        durationMs: Number(result.endTime) - Number(result.startTime),
+        tests: assertions.length,
+      };
+    })
+    .sort((a, b) => b.durationMs - a.durationMs);
+
+  const tests = testResults
+    .filter(isRecord)
+    .flatMap((result) => {
+      const name = String(result.name ?? 'unknown');
+      const file = name.startsWith(cwd) ? name.slice(cwd.length) : name;
+      const assertions = Array.isArray(result.assertionResults) ? result.assertionResults : [];
+      return assertions.filter(isRecord).map((assertion) => {
+        const ancestorTitles = Array.isArray(assertion.ancestorTitles)
+          ? assertion.ancestorTitles.map(String)
+          : [];
+        return {
+          file,
+          name: String(assertion.fullName ?? [...ancestorTitles, assertion.title].join(' ')),
+          durationMs: Number(assertion.duration ?? 0),
+          status: String(assertion.status ?? 'unknown'),
+        };
+      });
+    })
+    .sort((a, b) => b.durationMs - a.durationMs);
+
+  return {
+    label,
+    wallMs:
+      Number.isFinite(reportStartTime) && maxEndTime >= reportStartTime
+        ? maxEndTime - reportStartTime
+        : null,
+    files,
+    tests,
+    failedTests: tests.filter((test) => test.status !== 'passed'),
+  };
+}
+
+function summarizePlaywright(label: string, report: Record<string, unknown>): TimingSummary {
+  const tests: TimedTest[] = [];
+  const fileDurations = new Map<string, TimedFile>();
+  const suites = Array.isArray(report.suites) ? report.suites : [];
+
+  function visitSuite(suite: unknown, titles: string[] = []) {
+    if (!isRecord(suite)) return;
+    const suiteTitle = typeof suite.title === 'string' ? suite.title : '';
+    const nextTitles = suiteTitle ? [...titles, suiteTitle] : titles;
+    const specs = Array.isArray(suite.specs) ? suite.specs : [];
+    for (const spec of specs.filter(isRecord)) {
+      const specTitle = String(spec.title ?? 'unknown');
+      const specFile = String(spec.file ?? suite.file ?? 'unknown');
+      const specTests = Array.isArray(spec.tests) ? spec.tests : [];
+      for (const test of specTests.filter(isRecord)) {
+        const results = Array.isArray(test.results) ? test.results.filter(isRecord) : [];
+        const durationMs = results.reduce((sum, result) => sum + Number(result.duration ?? 0), 0);
+        const projectName = String(test.projectName ?? 'default');
+        const timedTest = {
+          file: specFile,
+          name: `[${projectName}] ${[...nextTitles, specTitle].join(' > ')}`,
+          durationMs,
+          status: String(test.status ?? 'unknown'),
+        };
+        tests.push(timedTest);
+        const file = fileDurations.get(specFile) ?? { file: specFile, durationMs: 0, tests: 0 };
+        file.durationMs += durationMs;
+        file.tests += 1;
+        fileDurations.set(specFile, file);
+      }
+    }
+    const childSuites = Array.isArray(suite.suites) ? suite.suites : [];
+    for (const child of childSuites) visitSuite(child, nextTitles);
+  }
+
+  for (const suite of suites) visitSuite(suite);
+  tests.sort((a, b) => b.durationMs - a.durationMs);
+  const stats = isRecord(report.stats) ? report.stats : {};
+
+  return {
+    label,
+    wallMs: Number.isFinite(Number(stats.duration)) ? Number(stats.duration) : null,
+    files: [...fileDurations.values()].sort((a, b) => b.durationMs - a.durationMs),
+    tests,
+    failedTests: tests.filter((test) => test.status !== 'expected' && test.status !== 'skipped'),
+  };
+}
+
+function summarizeReport(label: string, report: unknown): TimingSummary {
+  if (!isRecord(report)) throw new Error(`${label}: report is not a JSON object`);
+  if (Array.isArray(report.testResults)) return summarizeVitest(label, report);
+  if (Array.isArray(report.suites) && isRecord(report.stats)) {
+    return summarizePlaywright(label, report);
+  }
+  throw new Error(`${label}: unsupported timing report format`);
+}
+
+function formatMs(durationMs: number): string {
+  if (durationMs >= 1_000) return `${(durationMs / 1_000).toFixed(2)}s`;
+  return `${durationMs.toFixed(1)}ms`;
+}
+
+function table(headers: string[], rows: string[][]): string {
+  if (rows.length === 0) return '_None._\n';
+  return [
+    `| ${headers.join(' | ')} |`,
+    `| ${headers.map(() => '---').join(' | ')} |`,
+    ...rows.map((row) => `| ${row.join(' | ')} |`),
+    '',
+  ].join('\n');
+}
+
+function renderSummary(summary: TimingSummary, top: number, thresholdMs: number): string {
+  const overThreshold = summary.tests.filter((test) => test.durationMs > thresholdMs);
+  const totalDurationMs = summary.files.reduce((sum, file) => sum + file.durationMs, 0);
+  const lines = [
+    `## ${summary.label}`,
+    '',
+    `Files: ${summary.files.length}`,
+    `Tests: ${summary.tests.length}`,
+    `File-duration sum: ${formatMs(totalDurationMs)}`,
+    `Wall time: ${summary.wallMs === null ? 'not reported' : formatMs(summary.wallMs)}`,
+    `Failures: ${summary.failedTests.length}`,
+    `Tests over ${formatMs(thresholdMs)}: ${overThreshold.length}`,
+    '',
+    '### Slowest Files',
+    '',
+    table(
+      ['file', 'duration', 'tests'],
+      summary.files
+        .slice(0, top)
+        .map((file) => [file.file, formatMs(file.durationMs), String(file.tests)]),
+    ),
+    '### Slowest Tests',
+    '',
+    table(
+      ['file', 'duration', 'status', 'test'],
+      summary.tests
+        .slice(0, top)
+        .map((test) => [
+          test.file,
+          formatMs(test.durationMs),
+          test.status,
+          test.name.replaceAll('|', '\\|'),
+        ]),
+    ),
+  ];
+
+  return lines.join('\n');
+}
+
+const args = parseArgs(process.argv.slice(2));
+const summaries = args.reports.map(({ label, path }) => summarizeReport(label, readJson(path)));
+
+console.log(
+  summaries.map((summary) => renderSummary(summary, args.top, args.thresholdMs)).join('\n'),
+);
+
+if (
+  args.failOverThreshold &&
+  summaries.some((summary) => summary.tests.some((test) => test.durationMs > args.thresholdMs))
+) {
+  process.exitCode = 1;
+}
+
+if (summaries.some((summary) => summary.failedTests.length > 0)) {
+  process.exitCode = 1;
+}

--- a/scripts/summarize-test-timings.ts
+++ b/scripts/summarize-test-timings.ts
@@ -134,7 +134,7 @@ function summarizeVitest(label: string, report: Record<string, unknown>): Timing
         : null,
     files,
     tests,
-    failedTests: tests.filter((test) => test.status !== 'passed'),
+    failedTests: tests.filter((test) => test.status === 'failed'),
   };
 }
 

--- a/src/server-start.ts
+++ b/src/server-start.ts
@@ -1,6 +1,7 @@
 import type { Server } from 'node:net';
 
 import type { ServerConfig } from './config.ts';
+import { captureTelemetryError, flushTelemetry } from './telemetry.ts';
 import type { PortClaim, WorktreeRuntime } from './worktree-runtime.ts';
 
 type FetchHandler = (request: Request) => Response | Promise<Response>;
@@ -63,6 +64,22 @@ export async function startHttpServer({
   server.ref();
   startBootstrapLifecycle();
   log(`Squire server listening on port ${configuredPort}`);
+}
+
+export async function startHttpServerWithTelemetry(deps: StartHttpServerDeps): Promise<void> {
+  try {
+    await startHttpServer(deps);
+  } catch (error) {
+    captureTelemetryError(error, {
+      route: 'server.startup',
+      context: {
+        surface: 'server',
+        phase: 'startup',
+      },
+    });
+    await flushTelemetry(2_000);
+    throw error;
+  }
 }
 
 async function listen(server: Server, port: number, host?: string): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -81,7 +81,7 @@ import type { CardType } from './schemas.ts';
 import { availableModulesFor, gameDefinitionFor, normalizeGameId, requireGameId } from './game.ts';
 import { z } from 'zod';
 import { createMcpServer } from './mcp.ts';
-import { startHttpServer } from './server-start.ts';
+import { startHttpServerWithTelemetry } from './server-start.ts';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import {
   registerClient,
@@ -165,7 +165,6 @@ import {
   captureTelemetryFeedback,
   captureTelemetryLog,
   captureTelemetryMessage,
-  flushTelemetry,
   initTelemetry,
   type TelemetryCaptureInput,
   type TelemetryFeedbackInput,
@@ -4504,26 +4503,14 @@ app.delete('/api/characters/:id/cards/:cardId', async (c) => {
 
 export async function startServer(): Promise<void> {
   const { createAdaptorServer } = await import('@hono/node-server');
-  try {
-    await startHttpServer({
-      appFetch: app.fetch,
-      createAdaptorServer,
-      loadServerConfig,
-      getWorktreeRuntime,
-      claimWorktreePort,
-      startBootstrapLifecycle,
-    });
-  } catch (error) {
-    captureTelemetryError(error, {
-      route: 'server.startup',
-      context: {
-        surface: 'server',
-        phase: 'startup',
-      },
-    });
-    await flushTelemetry(2_000);
-    throw error;
-  }
+  await startHttpServerWithTelemetry({
+    appFetch: app.fetch,
+    createAdaptorServer,
+    loadServerConfig,
+    getWorktreeRuntime,
+    claimWorktreePort,
+    startBootstrapLifecycle,
+  });
 }
 
 // CLI entrypoint

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -88,12 +88,15 @@ describe('deployment configuration', () => {
     );
     expect(packageJson.scripts?.['test:full']).toBe('vitest run');
     expect(packageJson.scripts?.['test:coverage:full']).toBe('vitest run --coverage');
-    expect(workflow).toContain('cron:');
+    expect(workflow).not.toContain('cron:');
+    expect(workflow).not.toContain("github.event_name == 'schedule'");
     expect(workflow).toContain('workflow_dispatch:');
     expect(workflow).toContain('run: npm run test:coverage');
     expect(workflow).toContain('name: Slow PDF extraction test');
-    expect(workflow).toContain("github.event_name == 'schedule'");
+    expect(workflow).toContain("if: github.event_name == 'workflow_dispatch'");
     expect(workflow).toContain('run: npm run test:slow:pdf');
+    expect(workflow).toContain('name: Browser E2E smoke');
+    expect(workflow).toContain('run: npm run e2e:browser');
     expect(workflow).not.toContain('run: npx vitest run --coverage');
   });
 
@@ -134,7 +137,7 @@ describe('deployment configuration', () => {
     expect(workflow).toContain('actions/upload-artifact');
   });
 
-  it('defines the scheduled authenticated API and agent smoke command', async () => {
+  it('defines the manual authenticated API and agent smoke command', async () => {
     const packageJson = JSON.parse(await readProjectFile('package.json')) as {
       scripts?: Record<string, string>;
     };
@@ -142,8 +145,8 @@ describe('deployment configuration', () => {
 
     expect(packageJson.scripts?.['e2e:api-agent']).toBe('node scripts/e2e-api-agent-smoke.ts');
     expect(workflow).toContain('name: Authenticated API and agent E2E smoke');
-    expect(workflow).toContain("github.event_name == 'schedule'");
-    expect(workflow).toContain("github.event_name == 'workflow_dispatch'");
+    expect(workflow).not.toContain("github.event_name == 'schedule'");
+    expect(workflow).toContain("if: github.event_name == 'workflow_dispatch'");
     expect(workflow).toContain('ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}');
     expect(workflow).toContain('VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}');
     expect(workflow).toContain("SQUIRE_LLM_DAILY_BUDGET_USD: '0.25'");

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -93,7 +93,6 @@ describe('deployment configuration', () => {
     expect(workflow).toContain('workflow_dispatch:');
     expect(workflow).toContain('run: npm run test:coverage');
     expect(workflow).toContain('name: Slow PDF extraction test');
-    expect(workflow).toContain("if: github.event_name == 'workflow_dispatch'");
     expect(workflow).toContain('run: npm run test:slow:pdf');
     expect(workflow).toContain('name: Browser E2E smoke');
     expect(workflow).toContain('run: npm run e2e:browser');
@@ -146,7 +145,6 @@ describe('deployment configuration', () => {
     expect(packageJson.scripts?.['e2e:api-agent']).toBe('node scripts/e2e-api-agent-smoke.ts');
     expect(workflow).toContain('name: Authenticated API and agent E2E smoke');
     expect(workflow).not.toContain("github.event_name == 'schedule'");
-    expect(workflow).toContain("if: github.event_name == 'workflow_dispatch'");
     expect(workflow).toContain('ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}');
     expect(workflow).toContain('VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}');
     expect(workflow).toContain("SQUIRE_LLM_DAILY_BUDGET_USD: '0.25'");

--- a/test/e2e/helpers/db.ts
+++ b/test/e2e/helpers/db.ts
@@ -1,0 +1,21 @@
+import { seedDevUser } from '../../../src/seed/seed-dev-user.ts';
+import { resetTestDb, setupTestDb, teardownTestDb } from '../../helpers/db.ts';
+
+let db: Awaited<ReturnType<typeof setupTestDb>> | null = null;
+
+/**
+ * Browser E2E tests share one long-running server and the same dev user.
+ * Reset mutable state before each test so one spec cannot leave an active
+ * campaign, session, or conversation that changes the next spec's UI.
+ */
+export async function resetE2eDb(): Promise<void> {
+  process.env.VITEST = 'true';
+  db ??= await setupTestDb();
+  await resetTestDb();
+  await seedDevUser(db);
+}
+
+export async function teardownE2eDb(): Promise<void> {
+  await teardownTestDb();
+  db = null;
+}

--- a/test/e2e/sqr-11-campaign-picker.spec.ts
+++ b/test/e2e/sqr-11-campaign-picker.spec.ts
@@ -8,6 +8,8 @@
  */
 import { expect, type Page, test } from '@playwright/test';
 
+import { resetE2eDb, teardownE2eDb } from './helpers/db.ts';
+
 async function loginAsDevUser(page: Page): Promise<void> {
   await page.goto('/login');
   await expect(page.getByRole('button', { name: 'Sign in as Dev User' })).toBeVisible();
@@ -16,6 +18,16 @@ async function loginAsDevUser(page: Page): Promise<void> {
 }
 
 test.describe('campaign picker and context strip', () => {
+  test.beforeEach(async ({ page }) => {
+    await resetE2eDb();
+    await page.context().clearCookies();
+    await page.addInitScript(() => window.localStorage.clear());
+  });
+
+  test.afterAll(async () => {
+    await teardownE2eDb();
+  });
+
   test('creates a campaign, switches activation, and bridges via the strip', async ({ page }) => {
     await loginAsDevUser(page);
 

--- a/test/e2e/sqr-24-chat-game-selection.spec.ts
+++ b/test/e2e/sqr-24-chat-game-selection.spec.ts
@@ -1,5 +1,7 @@
 import { expect, type Page, type Request, test } from '@playwright/test';
 
+import { resetE2eDb, teardownE2eDb } from './helpers/db.ts';
+
 interface StreamFixture {
   answerText: string;
   finalHtml: string;
@@ -122,8 +124,13 @@ async function expectChatControlsUsable(page: Page): Promise<void> {
 
 test.describe('SQR-24 browser chat game selection', () => {
   test.beforeEach(async ({ page }) => {
+    await resetE2eDb();
     await page.context().clearCookies();
     await page.addInitScript(() => window.localStorage.clear());
+  });
+
+  test.afterAll(async () => {
+    await teardownE2eDb();
   });
 
   test('blocks logged-out chat actions and redirects protected chat pages', async ({ page }) => {

--- a/test/helpers/db.ts
+++ b/test/helpers/db.ts
@@ -40,8 +40,9 @@ export async function setupTestDb(): Promise<ReturnType<typeof createStandaloneD
 /**
  * Fast reset for mutable tables. Most DB tests create only a few rows, so
  * ordered DELETEs are far cheaper than TRUNCATE's lock-heavy FK/identity work.
- * Card and scenario-section tables are read-only test fixtures seeded once in
- * global setup and intentionally left alone here.
+ * Globally seeded card and scenario-section fixture tables are intentionally
+ * left alone here. Most tests read them only; tests that mutate fixture rows
+ * own local cleanup so the common reset path stays cheap.
  */
 export async function resetTestDb(): Promise<void> {
   if (!db) throw new Error('resetTestDb called before setupTestDb');

--- a/test/helpers/db.ts
+++ b/test/helpers/db.ts
@@ -38,19 +38,45 @@ export async function setupTestDb(): Promise<ReturnType<typeof createStandaloneD
 }
 
 /**
- * Fast reset: truncate in reverse-dependency order. Slower-but-safer
- * transaction-per-test is tracked in the tech spec as a future option.
+ * Fast reset for mutable tables. Most DB tests create only a few rows, so
+ * ordered DELETEs are far cheaper than TRUNCATE's lock-heavy FK/identity work.
+ * Card and scenario-section tables are read-only test fixtures seeded once in
+ * global setup and intentionally left alone here.
  */
 export async function resetTestDb(): Promise<void> {
   if (!db) throw new Error('resetTestDb called before setupTestDb');
-  await db.execute(sql`
-    TRUNCATE unlock_graph_threads, unlock_graph_scenarios, llm_budget_warnings, llm_budget_ledger, messages, conversations, rule_source_embeddings, embeddings,
-             mutation_idempotency_keys, pending_mutations, campaign_audit_log,
-             character_cards, character_items, characters, campaign_members, campaigns,
-             oauth_audit_log, oauth_tokens, oauth_authorization_codes, oauth_clients, sessions, users
-             RESTART IDENTITY CASCADE
-  `);
+  await db.transaction(async (tx) => {
+    for (const statement of RESET_TABLE_DELETES) {
+      await tx.execute(statement);
+    }
+  });
 }
+
+const RESET_TABLE_DELETES = [
+  sql`DELETE FROM message_stream_events`,
+  sql`DELETE FROM unlock_graph_threads`,
+  sql`DELETE FROM unlock_graph_scenarios`,
+  sql`DELETE FROM llm_budget_warnings`,
+  sql`DELETE FROM llm_budget_ledger`,
+  sql`DELETE FROM messages`,
+  sql`DELETE FROM conversations`,
+  sql`DELETE FROM rule_source_embeddings`,
+  sql`DELETE FROM embeddings`,
+  sql`DELETE FROM mutation_idempotency_keys`,
+  sql`DELETE FROM pending_mutations`,
+  sql`DELETE FROM campaign_audit_log`,
+  sql`DELETE FROM character_cards`,
+  sql`DELETE FROM character_items`,
+  sql`DELETE FROM characters`,
+  sql`DELETE FROM campaign_members`,
+  sql`DELETE FROM campaigns`,
+  sql`DELETE FROM oauth_audit_log`,
+  sql`DELETE FROM oauth_tokens`,
+  sql`DELETE FROM oauth_authorization_codes`,
+  sql`DELETE FROM oauth_clients`,
+  sql`DELETE FROM sessions`,
+  sql`DELETE FROM users`,
+];
 
 export async function teardownTestDb(): Promise<void> {
   if (closeDb) {

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -261,6 +261,14 @@ function installUnavailableLimiter(error = new Error('redis unavailable')) {
 
 function resetRouteMocks() {
   vi.clearAllMocks();
+  mockStartActiveSpan.mockReset();
+  mockStartActiveSpan.mockImplementation((_: string, ...args: unknown[]) => {
+    const callback = args.findLast(
+      (arg): arg is (span: typeof mockRequestSpan) => unknown => typeof arg === 'function',
+    );
+    if (!callback) throw new TypeError('startActiveSpan callback missing');
+    return callback(mockRequestSpan);
+  });
   mockInitialize.mockReset();
   mockEnsureBootstrapStatus.mockReset();
   mockGetBootstrapStatus.mockReset();

--- a/test/start-server.test.ts
+++ b/test/start-server.test.ts
@@ -1,5 +1,18 @@
 import { EventEmitter } from 'node:events';
+import type { Server } from 'node:net';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockCaptureTelemetryError, mockFlushTelemetry } = vi.hoisted(() => ({
+  mockCaptureTelemetryError: vi.fn(),
+  mockFlushTelemetry: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../src/telemetry.ts', () => ({
+  captureTelemetryError: mockCaptureTelemetryError,
+  flushTelemetry: mockFlushTelemetry,
+}));
+
+import { startHttpServer, startHttpServerWithTelemetry } from '../src/server-start.ts';
 
 class FakeServer extends EventEmitter {
   listenCalls: number[] = [];
@@ -24,183 +37,58 @@ class FakeServer extends EventEmitter {
   }
 }
 
-async function loadStartServer(options: {
-  configuredPort?: string;
+function createStartHttpServerHarness(options: {
+  configuredPort?: number;
   configuredHost?: string;
   claimedPort?: number;
-  bootstrapImpl?: () => unknown;
   listenError?: Error;
 }) {
-  vi.resetModules();
-
-  if (options.configuredPort === undefined) {
-    vi.unstubAllEnvs();
-    delete process.env.PORT;
-  } else {
-    vi.stubEnv('PORT', options.configuredPort);
-  }
-  if (options.configuredHost === undefined) {
-    delete process.env.HOST;
-  } else {
-    vi.stubEnv('HOST', options.configuredHost);
-  }
-  vi.stubEnv('NODE_ENV', 'test');
-  vi.stubEnv('VITEST', 'true');
-
   const fakeServer = new FakeServer();
   fakeServer.listenError = options.listenError ?? null;
-  const createAdaptorServer = vi.fn(() => fakeServer);
+  const createAdaptorServer = vi.fn(() => fakeServer as unknown as Server);
   const claimRelease = vi.fn().mockResolvedValue(undefined);
   const claimWorktreePort = vi.fn().mockResolvedValue({
     port: options.claimedPort ?? 4555,
     release: claimRelease,
   });
-  const startBootstrapLifecycle = vi.fn(options.bootstrapImpl ?? (() => undefined));
-  const initTelemetry = vi.fn(() => ({ enabled: false, reason: 'missing_dsn' }));
-  const captureTelemetryError = vi.fn();
-  const flushTelemetry = vi.fn().mockResolvedValue(true);
+  const startBootstrapLifecycle = vi.fn();
+  const log = vi.fn();
 
-  vi.doMock('@hono/node-server', () => ({
+  const deps = {
+    appFetch: vi.fn(),
     createAdaptorServer,
-  }));
-  vi.doMock('../src/instrumentation.ts', () => ({}));
-  vi.doMock('../src/telemetry.ts', () => ({
-    initTelemetry,
-    captureTelemetryError,
-    flushTelemetry,
-  }));
-  vi.doMock('../src/service.ts', () => ({
-    ask: vi.fn(),
-    ensureBootstrapStatus: vi.fn().mockResolvedValue({
-      lifecycle: 'boot_blocked',
-      ready: false,
-      bootstrapReady: false,
-      warmingUp: false,
-      indexSize: 0,
-      cardCount: 0,
-      ruleQueriesReady: false,
-      cardQueriesReady: false,
-      askReady: false,
-      missingBootstrapSteps: ['npm run index', 'npm run seed:cards'],
-      errors: [
-        'Rule-source embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        'No card data found in Postgres. Run `npm run seed:cards` first.',
-      ],
-      capabilities: {
-        rules: {
-          allowed: false,
-          reason: 'missing_index',
-          message:
-            'Rule-source embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        },
-        cards: {
-          allowed: false,
-          reason: 'missing_cards',
-          message: 'No card data found in Postgres. Run `npm run seed:cards` first.',
-        },
-        ask: {
-          allowed: false,
-          reason: 'missing_index',
-          message:
-            'Rule-source embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        },
-      },
-    }),
-    getBootstrapStatus: vi.fn().mockReturnValue({
-      lifecycle: 'boot_blocked',
-      ready: false,
-      bootstrapReady: false,
-      warmingUp: false,
-      indexSize: 0,
-      cardCount: 0,
-      ruleQueriesReady: false,
-      cardQueriesReady: false,
-      askReady: false,
-      missingBootstrapSteps: ['npm run index', 'npm run seed:cards'],
-      errors: [
-        'Rule-source embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        'No card data found in Postgres. Run `npm run seed:cards` first.',
-      ],
-      capabilities: {
-        rules: {
-          allowed: false,
-          reason: 'missing_index',
-          message:
-            'Rule-source embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        },
-        cards: {
-          allowed: false,
-          reason: 'missing_cards',
-          message: 'No card data found in Postgres. Run `npm run seed:cards` first.',
-        },
-        ask: {
-          allowed: false,
-          reason: 'missing_index',
-          message:
-            'Rule-source embeddings table is empty. Run `npm run index` to populate the rule-source vector store.',
-        },
-      },
-    }),
-    isReady: vi.fn().mockReturnValue(false),
-    startBootstrapLifecycle,
-  }));
-  vi.doMock('../src/db.ts', () => ({
+    loadServerConfig: vi.fn(() => ({
+      nodeEnv: 'test',
+      port: options.configuredPort,
+      host: options.configuredHost,
+    })),
     getWorktreeRuntime: vi.fn(() => ({
       checkoutRoot: '/tmp/squire',
       checkoutSlug: 'squire',
       isMainCheckout: false,
     })),
-    shutdownServerPool: vi.fn().mockResolvedValue(undefined),
-  }));
-  vi.doMock('../src/worktree-runtime.ts', () => ({
     claimWorktreePort,
-  }));
-  vi.doMock('../src/tools.ts', () => ({
-    searchRules: vi.fn(),
-    searchCards: vi.fn(),
-    listCardTypes: vi.fn(),
-    listCards: vi.fn(),
-    getCard: vi.fn(),
-  }));
-  vi.doMock('../src/health.ts', () => ({
-    runReadinessChecks: vi.fn().mockResolvedValue({
-      status: 'ok',
-      db: { status: 'ok' },
-      vector: { status: 'ok' },
-      embedder: { status: 'ok' },
-    }),
-  }));
-  vi.doMock('../src/auth.ts', () => ({
-    registerClient: vi.fn(),
-    createAuthorizationCode: vi.fn(),
-    exchangeAuthorizationCode: vi.fn(),
-    verifyAccessToken: vi.fn().mockResolvedValue({
-      token: 'stub',
-      clientId: 'stub-client',
-      scopes: [],
-      expiresAt: Math.floor(Date.now() / 1000) + 3600,
-    }),
-    getAuthProvider: vi.fn(),
-    resetAuthProvider: vi.fn(),
-    OAuthError: class OAuthError extends Error {},
-  }));
+    startBootstrapLifecycle,
+    log,
+  };
 
-  const mod = await import('../src/server.ts');
   return {
-    startServer: mod.startServer,
+    start: () => startHttpServer(deps),
+    startWithTelemetry: () => startHttpServerWithTelemetry(deps),
     fakeServer,
     createAdaptorServer,
     claimWorktreePort,
+    claimRelease,
     startBootstrapLifecycle,
-    initTelemetry,
-    captureTelemetryError,
-    flushTelemetry,
+    log,
   };
 }
 
 describe.sequential('startServer', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockCaptureTelemetryError.mockClear();
+    mockFlushTelemetry.mockClear();
   });
 
   afterEach(() => {
@@ -208,38 +96,34 @@ describe.sequential('startServer', () => {
   });
 
   it('binds the configured port and the claimed worktree port', async () => {
-    const configured = await loadStartServer({
-      configuredPort: '4123',
-    });
+    const configured = createStartHttpServerHarness({ configuredPort: 4123 });
 
-    await configured.startServer();
+    await configured.start();
 
     expect(configured.fakeServer.listenCalls).toContain(4123);
     expect(configured.fakeServer.refCalls).toBe(1);
     expect(configured.startBootstrapLifecycle).toHaveBeenCalled();
 
-    const claimed = await loadStartServer({
-      claimedPort: 4555,
-    });
+    const claimed = createStartHttpServerHarness({ claimedPort: 4555 });
 
-    await claimed.startServer();
+    await claimed.start();
 
     expect(claimed.claimWorktreePort).toHaveBeenCalled();
     expect(claimed.fakeServer.listenCalls).toContain(4555);
     expect(claimed.fakeServer.refCalls).toBe(1);
     expect(claimed.startBootstrapLifecycle).toHaveBeenCalled();
-  }, 60_000);
+  });
 
   it('captures and flushes startup failures before rethrowing', async () => {
     const listenError = Object.assign(new Error('address already in use'), { code: 'EADDRINUSE' });
-    const configured = await loadStartServer({
-      configuredPort: '4123',
+    const configured = createStartHttpServerHarness({
+      configuredPort: 4123,
       listenError,
     });
 
-    await expect(configured.startServer()).rejects.toBe(listenError);
+    await expect(configured.startWithTelemetry()).rejects.toBe(listenError);
 
-    expect(configured.captureTelemetryError).toHaveBeenCalledWith(
+    expect(mockCaptureTelemetryError).toHaveBeenCalledWith(
       listenError,
       expect.objectContaining({
         route: 'server.startup',
@@ -249,6 +133,6 @@ describe.sequential('startServer', () => {
         },
       }),
     );
-    expect(configured.flushTelemetry).toHaveBeenCalledWith(2_000);
-  }, 60_000);
+    expect(mockFlushTelemetry).toHaveBeenCalledWith(2_000);
+  });
 });


### PR DESCRIPTION
## Summary

- Replace per-test DB `TRUNCATE ... RESTART IDENTITY CASCADE` with ordered transactional deletes for mutable tables.
- Add a timing report command and SQR-344 performance notes.
- Refactor startup server tests to avoid importing the full server module.
- Isolate browser e2e DB state before relevant specs.
- Remove the duplicate scheduled CI run and run all current CI/e2e jobs on PRs and main pushes.

## Why

The DB reset path dominated the test suite. The browser e2e failure was real, not a flake: SQR-11 left an active campaign for the shared dev user, and SQR-24 then correctly hid the game picker. That leak was missed because browser e2e only ran on scheduled/manual CI, not PRs.

All CI e2e checks now live in the PR/main-push gate instead of being split between PR, scheduled, and manual paths.

## Validation

- `npm run test:timing`
- `npm run typecheck`
- `npx eslint scripts/summarize-test-timings.ts test/e2e/helpers/db.ts test/e2e/sqr-11-campaign-picker.spec.ts test/e2e/sqr-24-chat-game-selection.spec.ts test/helpers/db.ts test/start-server.test.ts test/server-api.test.ts src/server-start.ts src/server.ts`
- `npm run lint:actions`
- `npm run lint:md`
- `npx prettier --check .github/workflows/ci.yml docs/plans/sqr-344-test-performance-report.md scripts/summarize-test-timings.ts package.json`
- `npm run check`
- `npm test -- test/eval-matrix-runtime.test.ts test/deployment-config.test.ts`
- `PLAYWRIGHT_JSON_OUTPUT_NAME=/tmp/squire-sqr344-e2e-browser-after-fix.json npm run e2e:browser -- --reporter=json`

Fixes SQR-344
Fixes SQR-347
