### PR TITLE
Fix Drifter Blessed perk lookup

### DIFF
--- a/data/extracted/character-mats.json
+++ b/data/extracted/character-mats.json
@@ -263,7 +263,8 @@
       "Add 1 +1 card",
       "Whenever you long rest, you may move one of your characters token backward one slot",
       "You may bring one additional One Hand item into each scenario",
-      "At the end of each scenario you may discard up to two loot cards, except Random Item, to draw that many new loot cards"
+      "At the end of each scenario you may discard up to two loot cards, except Random Item, to draw that many new loot cards",
+      "Blessed: You may ignore negative item effects and the appearance of a cursed item"
     ],
     "masteries": [
       "End a scenario with your character tokens on the last slots of four persistent abilities",

--- a/eval/suites/frosthaven.json
+++ b/eval/suites/frosthaven.json
@@ -429,5 +429,44 @@
     "suite": "trajectory",
     "runtime": "langgraph",
     "caseCategory": "trajectory"
+  },
+  {
+    "id": "drifter-blessed-correction",
+    "category": "character-mats",
+    "question": "Earlier you said the Frosthaven Drifter has no perk named Blessed. The perk is called Blessed and it ignores negative item effects. Check the Drifter character mat and answer plainly.",
+    "finalAnswer": {
+      "expected": "The Frosthaven Drifter character mat has a perk named Blessed: you may ignore negative item effects and the appearance of a cursed item.",
+      "grading": "Must identify Drifter's Blessed perk and state that it ignores negative item effects. Must not deny that Drifter has Blessed. Must not redirect the claim to another class unless directly supported by the opened Drifter source."
+    },
+    "trajectory": {
+      "requiredTools": ["lookup_entity"],
+      "requiredToolKinds": ["open"],
+      "forbiddenTools": [],
+      "forbiddenToolKinds": [],
+      "requiredRefs": [
+        "card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter"
+      ],
+      "maxToolCalls": 4,
+      "notes": "Regression for SQR-293: user correction should reopen the exact Drifter mat instead of repeating an unsupported denial."
+    },
+    "safety": {
+      "requiredAnswerPatterns": ["\\bBlessed\\b", "ignore negative item effects"],
+      "forbiddenAnswerPatterns": [
+        "drifter[^.]{0,80}(?:no|not|does not|doesn.t)[^.]{0,80}blessed",
+        "banner spear[^.]{0,120}blessed"
+      ],
+      "requiredCanonicalRefPatterns": [
+        "^card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter$"
+      ],
+      "forbiddenCanonicalRefPatterns": [],
+      "requiredSourceLabelPatterns": ["Card Index"],
+      "forbiddenSourceLabelPatterns": [],
+      "notes": "The answer may mention data conflict only when the opened source lacks the curation; after SQR-292 it should answer from Drifter data."
+    },
+    "source": "data/extracted/character-mats.json",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "character-mats"
   }
 ]

--- a/src/import-character-mats.ts
+++ b/src/import-character-mats.ts
@@ -231,6 +231,23 @@ export function formatPerk(perk: GhsPerk, characterName: string, labels: LabelDa
   return `${capitalize(perk.type)} ${perk.count} cards`;
 }
 
+const DRIFTER_BLESSED_PERK =
+  'Blessed: You may ignore negative item effects and the appearance of a cursed item';
+
+const CURATED_CHARACTER_MAT_PERKS: Record<string, readonly string[]> = {
+  // GHS omits the printed Drifter Blessed perk, which caused Squire to deny a
+  // real table correction. Keep this curation local to the import boundary.
+  'gloomhavensecretariat:character-mat/drifter': [DRIFTER_BLESSED_PERK],
+};
+
+function applyCharacterMatCurations(sourceId: string, perks: string[]): string[] {
+  const curated = CURATED_CHARACTER_MAT_PERKS[sourceId] ?? [];
+  if (curated.length === 0 || perks.length === 0) return perks;
+
+  const existing = new Set(perks.map((perk) => perk.toLowerCase()));
+  return [...perks, ...curated.filter((perk) => !existing.has(perk.toLowerCase()))];
+}
+
 // ─── Conversion ──────────────────────────────────────────────────────────────
 
 /**
@@ -260,7 +277,11 @@ export function convertCharacterMat(ghs: GhsCharacter, labels: LabelData): Extra
     hp[String(stat.level)] = stat.health;
   }
 
-  const perks = ghs.perks.map((p) => formatPerk(p, ghs.name, labels));
+  const sourceId = `gloomhavensecretariat:character-mat/${ghs.name}`;
+  const perks = applyCharacterMatCurations(
+    sourceId,
+    ghs.perks.map((p) => formatPerk(p, ghs.name, labels)),
+  );
 
   const masteries = ghs.masteries.map((m) => resolvePerkText(m, labels));
 
@@ -272,7 +293,7 @@ export function convertCharacterMat(ghs: GhsCharacter, labels: LabelData): Extra
     hp,
     perks,
     masteries,
-    sourceId: `gloomhavensecretariat:character-mat/${ghs.name}`,
+    sourceId,
   };
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -792,6 +792,14 @@ function cardTypesForKinds(kinds?: string[]): CardType[] {
   return [...out];
 }
 
+type CharacterMatFallbackReason = 'explicit-mat' | 'class-data';
+
+function characterMatFallbackReason(query: string): CharacterMatFallbackReason | null {
+  if (/\b(?:character\s+mat|mat)\b/i.test(query)) return 'explicit-mat';
+  if (/\b(?:perks?|blessed|negative item effects?)\b/i.test(query)) return 'class-data';
+  return null;
+}
+
 function displayTitleForCard(record: Record<string, unknown>, type: CardType): string {
   if (typeof record.name === 'string') return record.name;
   if (typeof record.cardName === 'string') return record.cardName;
@@ -1550,7 +1558,34 @@ export async function resolveEntity(
 
   // Campaign-state kinds resolve only within the caller's memberships; with
   // no identity they contribute nothing (SQR-269, ADR 0021).
-  candidates.push(...(await resolveCampaignEntities(options.userId, game, query, kinds, limit)));
+  const campaignCandidates = await resolveCampaignEntities(
+    options.userId,
+    game,
+    query,
+    kinds,
+    limit,
+  );
+  candidates.push(...campaignCandidates);
+
+  const matFallbackReason = kinds.includes('character') ? characterMatFallbackReason(query) : null;
+  if (
+    matFallbackReason &&
+    !kinds.includes('card') &&
+    (matFallbackReason === 'explicit-mat' || campaignCandidates.length === 0)
+  ) {
+    const matCandidates = await resolveCards(query, ['character-mats'], limit, normalizedOptions);
+    candidates.push(
+      ...matCandidates.map((candidate) => ({
+        ...candidate,
+        confidence:
+          matFallbackReason === 'explicit-mat'
+            ? Math.max(candidate.confidence, 0.94)
+            : candidate.confidence,
+        matchReason:
+          matFallbackReason === 'explicit-mat' ? 'Character mat match' : candidate.matchReason,
+      })),
+    );
+  }
 
   return {
     ok: true,

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -72,10 +72,10 @@ describe('eval dataset', () => {
   });
 
   it('keeps the existing final-answer cases and adds enough trajectory coverage', () => {
-    expect(cases).toHaveLength(80);
-    expect(cases.filter(evalCaseHasFinalAnswer)).toHaveLength(56);
+    expect(cases).toHaveLength(81);
+    expect(cases.filter(evalCaseHasFinalAnswer)).toHaveLength(57);
     expect(countTrajectoryCases(cases)).toBeGreaterThanOrEqual(25);
-    expect(cases.filter(evalCaseHasSafety)).toHaveLength(13);
+    expect(cases.filter(evalCaseHasSafety)).toHaveLength(14);
   });
 
   it('requires explicit eval metadata on cases', () => {
@@ -129,8 +129,8 @@ describe('eval dataset', () => {
   it('derives the Frosthaven parity baseline from fixture metadata', () => {
     expect(baselineCountsFor(cases, 'frosthaven')).toEqual({
       game: 'frosthaven',
-      finalAnswerCases: 17,
-      trajectoryCases: 11,
+      finalAnswerCases: 18,
+      trajectoryCases: 12,
       boundaryCases: 1,
     });
     expect(baselineCountsFor(cases, 'gloomhaven-2e')).toEqual({
@@ -357,6 +357,23 @@ describe('eval dataset', () => {
     expect(spyglassCase?.finalAnswer?.expected).toMatch(/head slot/i);
     expect(spyglassCase?.finalAnswer?.expected).toMatch(/craft cost 1 metal/i);
     expect(spyglassCase?.finalAnswer?.expected).not.toMatch(/40 gold|small item slot|2 uses/i);
+  });
+
+  it('guards the Drifter Blessed user-correction regression', () => {
+    const evalCase = cases.find((candidate) => candidate.id === 'drifter-blessed-correction');
+
+    expect(evalCase?.question).toMatch(/Drifter/i);
+    expect(evalCase?.question).toMatch(/Blessed/i);
+    expect(evalCase?.finalAnswer?.expected).toMatch(/Blessed/i);
+    expect(evalCase?.finalAnswer?.expected).toMatch(/ignore negative item effects/i);
+    expect(evalCase?.finalAnswer?.grading).toMatch(/must not deny/i);
+    expect(evalCase?.trajectory?.requiredTools).toEqual(['lookup_entity']);
+    expect(evalCase?.trajectory?.requiredRefs).toContain(
+      'card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter',
+    );
+    expect(evalCase?.safety?.forbiddenAnswerPatterns).toEqual(
+      expect.arrayContaining(['drifter[^.]{0,80}(?:no|not|does not|doesn.t)[^.]{0,80}blessed']),
+    );
   });
 
   it('defines flexible tool-path expectations for trajectory cases', () => {

--- a/test/import-character-mats.test.ts
+++ b/test/import-character-mats.test.ts
@@ -289,9 +289,12 @@ describe('convertCharacterMat', () => {
     });
   });
 
-  it('formats perks as human-readable strings', () => {
+  it('formats perks as human-readable strings and applies the Drifter Blessed curation', () => {
     const result = convertCharacterMat(ghsDrifter, labels);
-    expect(result.perks).toEqual(['Remove 1 -2 card']);
+    expect(result.perks).toEqual([
+      'Remove 1 -2 card',
+      'Blessed: You may ignore negative item effects and the appearance of a cursed item',
+    ]);
   });
 
   it('resolves mastery label references', () => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1779,6 +1779,45 @@ describe('knowledge discovery tools', () => {
     });
   });
 
+  it('lookupEntity opens character-mat card records when character kind is used with mat phrasing', async () => {
+    const result = await lookupEntity('Drifter character mat', { kinds: ['character'] });
+
+    expect(result).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'card',
+        ref: 'card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter',
+        data: {
+          name: 'Drifter',
+          sourceId: 'gloomhavensecretariat:character-mat/drifter',
+          displayName: 'Drifter',
+          perks: expect.arrayContaining([
+            'Blessed: You may ignore negative item effects and the appearance of a cursed item',
+          ]),
+        },
+      },
+    });
+  });
+
+  it('lookupEntity resolves Drifter Blessed perk text to the character mat', async () => {
+    const result = await lookupEntity('Drifter Blessed perk ignore negative item effects', {
+      kinds: ['character'],
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      entity: {
+        kind: 'card',
+        ref: 'card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter',
+        data: {
+          perks: expect.arrayContaining([
+            'Blessed: You may ignore negative item effects and the appearance of a cursed item',
+          ]),
+        },
+      },
+    });
+  });
+
   it('lookupEntity asks for clarification instead of opening tied monster records', async () => {
     const result = await lookupEntity('Living Spirit monster', {
       kinds: ['monster'],


### PR DESCRIPTION
## Summary

- Add the missing printed Drifter Blessed perk to the character-mat import path and checked-in extracted data.
- Let `lookup_entity` resolve public character-mat/perk queries when the planner passes `kinds: ["character"]`.
- Add a Drifter Blessed correction eval case so the agent must reopen the Drifter mat and not repeat the false denial.

## Verification

- `npx vitest run test/import-character-mats.test.ts test/tools.test.ts test/eval-dataset.test.ts --reporter=dot`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` — 154 files, 1,823 tests passed in 80.49s
- `npm run lint:css`
- `npm run lint:md`
- `npm run seed:cards`
- `npm run eval -- --matrix --id=drifter-blessed-correction --agent-runtime=langgraph --local-report=/tmp/squire-drifter-blessed-correction-eval-after-seed.json --run-label=sqr-292-293-294-drifter-blessed-after-seed --max-estimated-cost-usd=1` — pass=true, score=1

LangSmith trace: https://smith.langchain.com/o/44be4d80-ba50-4833-ae22-6e176be2dbf2/projects/p/1bbc3ab0-f01c-482d-be67-2704e172cd79/r/019ed132-5962-7000-8000-013202925e45?poll=true

Fixes SQR-292
Fixes SQR-293
Fixes SQR-294
