### PR TITLE
Remove unsupported Drifter perk name assumptions

### DIFF
--- a/data/extracted/character-mats.json
+++ b/data/extracted/character-mats.json
@@ -264,7 +264,7 @@
       "Whenever you long rest, you may move one of your characters token backward one slot",
       "You may bring one additional One Hand item into each scenario",
       "At the end of each scenario you may discard up to two loot cards, except Random Item, to draw that many new loot cards",
-      "Blessed: You may ignore negative item effects and the appearance of a cursed item"
+      "You may ignore negative item effects and the appearance of a cursed item"
     ],
     "masteries": [
       "End a scenario with your character tokens on the last slots of four persistent abilities",

--- a/eval/suites/frosthaven.json
+++ b/eval/suites/frosthaven.json
@@ -431,12 +431,12 @@
     "caseCategory": "trajectory"
   },
   {
-    "id": "drifter-blessed-correction",
+    "id": "drifter-ignore-negative-item-effects-correction",
     "category": "character-mats",
-    "question": "Earlier you said the Frosthaven Drifter has no perk named Blessed. The perk is called Blessed and it ignores negative item effects. Check the Drifter character mat and answer plainly.",
+    "question": "Earlier you said the Frosthaven Drifter has no perk that ignores negative item effects. Check the Drifter character mat and answer plainly.",
     "finalAnswer": {
-      "expected": "The Frosthaven Drifter character mat has a perk named Blessed: you may ignore negative item effects and the appearance of a cursed item.",
-      "grading": "Must identify Drifter's Blessed perk and state that it ignores negative item effects. Must not deny that Drifter has Blessed. Must not redirect the claim to another class unless directly supported by the opened Drifter source."
+      "expected": "The Frosthaven Drifter character mat has a perk that says you may ignore negative item effects and the appearance of a cursed item.",
+      "grading": "Must state that Drifter has a perk that ignores negative item effects. Must not deny that Drifter has this perk. Must not name the perk unless directly supported by the opened Drifter source. Must not redirect the claim to another class unless directly supported by the opened Drifter source."
     },
     "trajectory": {
       "requiredTools": ["lookup_entity"],
@@ -447,13 +447,13 @@
         "card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter"
       ],
       "maxToolCalls": 4,
-      "notes": "Regression for SQR-293: user correction should reopen the exact Drifter mat instead of repeating an unsupported denial."
+      "notes": "Regression for SQR-293: user correction should reopen the exact Drifter mat instead of repeating an unsupported denial. Per SQR-349, this case does not assert a printed perk name because the checked-in source data only supports the effect text."
     },
     "safety": {
-      "requiredAnswerPatterns": ["\\bBlessed\\b", "ignore negative item effects"],
+      "requiredAnswerPatterns": ["ignore negative item effects"],
       "forbiddenAnswerPatterns": [
-        "drifter[^.]{0,80}(?:no|not|does not|doesn.t)[^.]{0,80}blessed",
-        "banner spear[^.]{0,120}blessed"
+        "drifter[^.]{0,80}(?:no|not|does not|doesn.t)[^.]{0,80}(?:ignore negative item effects|negative item)",
+        "\\bBlessed\\b"
       ],
       "requiredCanonicalRefPatterns": [
         "^card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter$"

--- a/src/import-character-mats.ts
+++ b/src/import-character-mats.ts
@@ -231,13 +231,13 @@ export function formatPerk(perk: GhsPerk, characterName: string, labels: LabelDa
   return `${capitalize(perk.type)} ${perk.count} cards`;
 }
 
-const DRIFTER_BLESSED_PERK =
-  'Blessed: You may ignore negative item effects and the appearance of a cursed item';
+const DRIFTER_IGNORE_NEGATIVE_ITEM_EFFECTS_PERK =
+  'You may ignore negative item effects and the appearance of a cursed item';
 
 const CURATED_CHARACTER_MAT_PERKS: Record<string, readonly string[]> = {
-  // GHS omits the printed Drifter Blessed perk, which caused Squire to deny a
-  // real table correction. Keep this curation local to the import boundary.
-  'gloomhavensecretariat:character-mat/drifter': [DRIFTER_BLESSED_PERK],
+  // GHS omits this Drifter perk text. Keep the curation local to the import
+  // boundary and avoid unsupported printed perk names.
+  'gloomhavensecretariat:character-mat/drifter': [DRIFTER_IGNORE_NEGATIVE_ITEM_EFFECTS_PERK],
 };
 
 function applyCharacterMatCurations(sourceId: string, perks: string[]): string[] {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -796,7 +796,7 @@ type CharacterMatFallbackReason = 'explicit-mat' | 'class-data';
 
 function characterMatFallbackReason(query: string): CharacterMatFallbackReason | null {
   if (/\b(?:character\s+mat|mat)\b/i.test(query)) return 'explicit-mat';
-  if (/\b(?:perks?|blessed|negative item effects?)\b/i.test(query)) return 'class-data';
+  if (/\b(?:perks?|negative item effects?)\b/i.test(query)) return 'class-data';
   return null;
 }
 

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -359,12 +359,14 @@ describe('eval dataset', () => {
     expect(spyglassCase?.finalAnswer?.expected).not.toMatch(/40 gold|small item slot|2 uses/i);
   });
 
-  it('guards the Drifter Blessed user-correction regression', () => {
-    const evalCase = cases.find((candidate) => candidate.id === 'drifter-blessed-correction');
+  it('guards the Drifter ignore-negative-item-effects user-correction regression', () => {
+    const evalCase = cases.find(
+      (candidate) => candidate.id === 'drifter-ignore-negative-item-effects-correction',
+    );
 
     expect(evalCase?.question).toMatch(/Drifter/i);
-    expect(evalCase?.question).toMatch(/Blessed/i);
-    expect(evalCase?.finalAnswer?.expected).toMatch(/Blessed/i);
+    expect(evalCase?.question).not.toMatch(/Blessed/i);
+    expect(evalCase?.finalAnswer?.expected).not.toMatch(/Blessed/i);
     expect(evalCase?.finalAnswer?.expected).toMatch(/ignore negative item effects/i);
     expect(evalCase?.finalAnswer?.grading).toMatch(/must not deny/i);
     expect(evalCase?.trajectory?.requiredTools).toEqual(['lookup_entity']);
@@ -372,7 +374,10 @@ describe('eval dataset', () => {
       'card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter',
     );
     expect(evalCase?.safety?.forbiddenAnswerPatterns).toEqual(
-      expect.arrayContaining(['drifter[^.]{0,80}(?:no|not|does not|doesn.t)[^.]{0,80}blessed']),
+      expect.arrayContaining([
+        'drifter[^.]{0,80}(?:no|not|does not|doesn.t)[^.]{0,80}(?:ignore negative item effects|negative item)',
+        '\\bBlessed\\b',
+      ]),
     );
   });
 

--- a/test/import-character-mats.test.ts
+++ b/test/import-character-mats.test.ts
@@ -289,11 +289,11 @@ describe('convertCharacterMat', () => {
     });
   });
 
-  it('formats perks as human-readable strings and applies the Drifter Blessed curation', () => {
+  it('formats perks as human-readable strings and applies the Drifter item-effect curation', () => {
     const result = convertCharacterMat(ghsDrifter, labels);
     expect(result.perks).toEqual([
       'Remove 1 -2 card',
-      'Blessed: You may ignore negative item effects and the appearance of a cursed item',
+      'You may ignore negative item effects and the appearance of a cursed item',
     ]);
   });
 

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1792,15 +1792,15 @@ describe('knowledge discovery tools', () => {
           sourceId: 'gloomhavensecretariat:character-mat/drifter',
           displayName: 'Drifter',
           perks: expect.arrayContaining([
-            'Blessed: You may ignore negative item effects and the appearance of a cursed item',
+            'You may ignore negative item effects and the appearance of a cursed item',
           ]),
         },
       },
     });
   });
 
-  it('lookupEntity resolves Drifter Blessed perk text to the character mat', async () => {
-    const result = await lookupEntity('Drifter Blessed perk ignore negative item effects', {
+  it('lookupEntity resolves Drifter ignore-negative-item-effects perk text to the character mat', async () => {
+    const result = await lookupEntity('Drifter perk ignore negative item effects', {
       kinds: ['character'],
     });
 
@@ -1811,7 +1811,7 @@ describe('knowledge discovery tools', () => {
         ref: 'card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter',
         data: {
           perks: expect.arrayContaining([
-            'Blessed: You may ignore negative item effects and the appearance of a cursed item',
+            'You may ignore negative item effects and the appearance of a cursed item',
           ]),
         },
       },


### PR DESCRIPTION
## Summary

Fixes SQR-349 and SQR-350.

This removes the unsupported `Blessed:` name assertion from Drifter perk data. The checked-in source supports the effect text, not a printed perk name, so the importer, extracted data, lookup routing, and eval all now use the sourceable text only.

## Changes

- Store the Drifter missing perk curation as effect text only.
- Remove `blessed` as a special character-mat routing signal.
- Rename/rewrite the Frosthaven eval case so it guards the correction path without requiring `Blessed`.
- Keep lookup coverage for `Drifter perk ignore negative item effects`.

## Verification

- `npx vitest run test/import-character-mats.test.ts test/eval-dataset.test.ts --config vitest.unit.config.ts`
- `npx vitest run test/tools.test.ts --config vitest.db.config.ts -t "Drifter|character-mat"`
- `npm run typecheck`
- `npx prettier --check src/import-character-mats.ts src/tools.ts test/import-character-mats.test.ts test/tools.test.ts test/eval-dataset.test.ts eval/suites/frosthaven.json data/extracted/character-mats.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the Drifter character's perk description for consistency and accuracy across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->