### PR TITLE
Preserve reloaded chat work durations

### DIFF
--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -853,11 +853,14 @@ export async function loadConversation(input: {
   ];
   const publicWorkEventsByUserMessage =
     await MessageStreamEventRepository.listPublicWorkEventsByUserMessageIds(responseUserMessageIds);
+  const terminalEventsByUserMessage =
+    await MessageStreamEventRepository.listTerminalEventsByUserMessageIds(responseUserMessageIds);
   const messagesWithPublicWorkEvents = messages.map((message) =>
     message.role === 'assistant' && message.responseToMessageId
       ? {
           ...message,
           publicWorkEvents: publicWorkEventsByUserMessage.get(message.responseToMessageId) ?? [],
+          workCompletedAt: terminalEventsByUserMessage.get(message.responseToMessageId)?.createdAt,
         }
       : message,
   );

--- a/src/db/repositories/message-stream-event-repository.ts
+++ b/src/db/repositories/message-stream-event-repository.ts
@@ -121,6 +121,31 @@ export async function listPublicWorkEventsByUserMessageIds(
   return eventsByUserMessage;
 }
 
+export async function listTerminalEventsByUserMessageIds(
+  userMessageIds: string[],
+): Promise<Map<string, MessageStreamEvent>> {
+  const terminalEventsByUserMessage = new Map<string, MessageStreamEvent>();
+  if (userMessageIds.length === 0) return terminalEventsByUserMessage;
+
+  const { db } = getDb('server');
+  const rows = await db
+    .select()
+    .from(messageStreamEvents)
+    .where(
+      and(
+        inArray(messageStreamEvents.userMessageId, userMessageIds),
+        inArray(messageStreamEvents.event, ['done', 'error']),
+      ),
+    )
+    .orderBy(asc(messageStreamEvents.userMessageId), asc(messageStreamEvents.sequence));
+
+  for (const row of rows) {
+    terminalEventsByUserMessage.set(row.userMessageId, toDomain(row));
+  }
+
+  return terminalEventsByUserMessage;
+}
+
 async function insertNext(input: {
   conversationId: string;
   userMessageId: string;

--- a/src/db/repositories/types.ts
+++ b/src/db/repositories/types.ts
@@ -329,6 +329,13 @@ export interface ConversationMessage {
    * not raw tool payloads or hidden model reasoning.
    */
   publicWorkEvents?: ConversationMessagePublicWorkEvent[];
+  /**
+   * Timestamp of the persisted terminal stream event (`done` or `error`) for
+   * this assistant turn. Reloaded work-log durations use this instead of
+   * `createdAt`, because Postgres `now()` is transaction-scoped and assistant
+   * rows can otherwise look like they completed at turn start.
+   */
+  workCompletedAt?: Date;
   createdAt: Date;
 }
 

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -926,7 +926,7 @@ function renderCompletedAnswerWork(message: ConversationMessage): HtmlEscapedStr
   }
   const persistedTimeline = buildCompletedAnswerWorkTimeline(
     message.publicWorkEvents,
-    message.createdAt,
+    message.workCompletedAt ?? message.createdAt,
   );
   if (persistedTimeline.rows.length > 0) {
     return renderCompletedAnswerWorkTimeline(persistedTimeline);

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -3105,6 +3105,70 @@ describe('conversation web backend', () => {
 });
 
 describe('conversation loading', () => {
+  it('loads terminal stream event timestamps for persisted work duration after reload', async () => {
+    const auth = await createAuthContext();
+    const { db } = getDb('server');
+    const [conversation] = await db
+      .insert(conversations)
+      .values({ userId: auth.userId })
+      .returning();
+    const [userMessage] = await db
+      .insert(messages)
+      .values({
+        conversationId: conversation.id,
+        role: 'user',
+        content: 'How long did the agent work?',
+        createdAt: new Date('2026-04-20T00:00:00.000Z'),
+      })
+      .returning();
+    await db.insert(messages).values({
+      conversationId: conversation.id,
+      role: 'assistant',
+      content: 'It worked for a while.',
+      responseToMessageId: userMessage.id,
+      createdAt: new Date('2026-04-20T00:00:01.000Z'),
+    });
+    await db.insert(messageStreamEvents).values([
+      {
+        conversationId: conversation.id,
+        userMessageId: userMessage.id,
+        sequence: 1,
+        event: 'tool-progress',
+        payload: { id: 'search_knowledge-progress-1', message: 'Searching the rulebook' },
+        createdAt: new Date('2026-04-20T00:00:01.000Z'),
+      },
+      {
+        conversationId: conversation.id,
+        userMessageId: userMessage.id,
+        sequence: 2,
+        event: 'tool-result',
+        payload: { id: 'search_knowledge', labels: ['RULEBOOK'], ok: true },
+        createdAt: new Date('2026-04-20T00:00:03.000Z'),
+      },
+      {
+        conversationId: conversation.id,
+        userMessageId: userMessage.id,
+        sequence: 3,
+        event: 'done',
+        payload: {},
+        createdAt: new Date('2026-04-20T00:00:09.000Z'),
+      },
+    ]);
+
+    const loaded = await loadConversation({
+      conversationId: conversation.id,
+      userId: auth.userId,
+    });
+
+    expect(loaded).not.toBeNull();
+    const assistant = loaded!.messages.find((message) => message.role === 'assistant');
+    expect(assistant?.publicWorkEvents?.map((event) => event.event)).toEqual([
+      'tool-progress',
+      'tool-result',
+    ]);
+    expect(assistant?.workCompletedAt).toEqual(new Date('2026-04-20T00:00:09.000Z'));
+  });
+
   it('pads the load window when the limit cuts between a user message and its assistant reply (CR PR #274)', async () => {
     // Without padding, a window that starts at an assistant message whose
     // paired user is older than the cap would silently drop the assistant

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -1514,6 +1514,36 @@ describe('GET / — SQR-107 purpose-built landing', () => {
       expect(body).toContain('Searched the rulebook');
     });
 
+    it('uses the persisted terminal event time for completed work duration after reload', () => {
+      const body = renderTranscriptAnswer(
+        answerWith(null, {
+          createdAt: new Date('2026-04-20T00:00:01.000Z'),
+          workCompletedAt: new Date('2026-04-20T00:00:09.000Z'),
+          publicWorkEvents: [
+            {
+              sequence: 1,
+              event: 'tool-progress',
+              payload: {
+                id: 'search_knowledge-progress-1',
+                label: 'RULEBOOK',
+                message: 'Searching the rulebook',
+              },
+              createdAt: new Date('2026-04-20T00:00:01.000Z'),
+            },
+            {
+              sequence: 2,
+              event: 'tool-result',
+              payload: { id: 'search_knowledge', labels: ['RULEBOOK'], ok: true },
+              createdAt: new Date('2026-04-20T00:00:03.000Z'),
+            },
+          ],
+        }),
+      );
+
+      expect(body).toContain('Worked for 8s');
+      expect(body).not.toContain('Worked for 0s');
+    });
+
     it('replays persisted agent intent rows in the completed work timeline', () => {
       const body = renderTranscriptAnswer(
         answerWith(null, {


### PR DESCRIPTION
## Summary

Fixes SQR-295.

Reloaded conversations were showing `Worked for 0s` because the server rendered completed work duration from the first public work event to the assistant message `createdAt`. Assistant rows can be inserted inside a long transaction, so that timestamp can reflect turn start rather than completion.

## Changes

- Load persisted terminal stream events (`done` / `error`) beside public work events during `loadConversation`.
- Thread the terminal timestamp through `ConversationMessage.workCompletedAt`.
- Render completed work duration from `workCompletedAt` when present, with `message.createdAt` as the legacy fallback.
- Add tests for the service reload data and the visible disclosure title.

## Verification

- `npx vitest run test/web-ui-layout.test.ts --config vitest.unit.config.ts`
- `npx vitest run test/conversation.test.ts --config vitest.db.config.ts`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant work completion times are now more precisely tracked and displayed in conversation history for accurate "Worked for X seconds" duration information.

* **Tests**
  * Added tests verifying work completion timestamp persistence and accurate duration calculations in conversation reload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->