### PR TITLE
Label unlabeled tool failures in work logs

### DIFF
--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -612,6 +612,63 @@ function answerWorkArtifactMessage(title: string, sourceLabel: ToolSourceLabel |
   return `Found ${title || 'source'}${sourceLabel ? ` in ${physicalToolSourceLabel(sourceLabel)}` : ''}`;
 }
 
+function failedToolProgressMessage(detail: string): string | null {
+  const resolveMatch = detail.match(/^Resolving\s+(.+)$/i);
+  if (resolveMatch) return `Couldn't resolve ${resolveMatch[1]!.trim()}`;
+
+  const lookupMatch = detail.match(/^(?:Looking up|Looked up)\s+(.+)$/i);
+  if (lookupMatch) return `Couldn't look up ${lookupMatch[1]!.trim()}`;
+
+  const openMatch = detail.match(/^Opening\s+(.+)$/i);
+  if (openMatch) return `Couldn't open ${openMatch[1]!.trim()}`;
+
+  if (/^Search(?:ing|ed)\s+available sources$/i.test(detail)) {
+    return "Couldn't search available sources";
+  }
+  if (/^Search(?:ing|ed)\s+selected sources$/i.test(detail)) {
+    return "Couldn't search selected sources";
+  }
+
+  return null;
+}
+
+function failedToolNameMessage(rawName: string | null): string | null {
+  if (!rawName) return null;
+  const normalized = rawName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+  if (normalized.includes('lookup_entity')) return "Couldn't look up entity";
+  if (normalized.includes('resolve_entity')) return "Couldn't resolve entity";
+  if (normalized.includes('open_entity')) return "Couldn't open reference";
+  if (normalized.includes('search_knowledge')) return "Couldn't search sources";
+  if (normalized.includes('search_rules')) return "Couldn't search rules";
+  if (normalized.includes('search_cards')) return "Couldn't search cards";
+  if (normalized.includes('inspect_sources')) return "Couldn't inspect sources";
+  if (normalized.includes('neighbors')) return "Couldn't follow reference links";
+
+  return null;
+}
+
+function failedUnlabeledToolResultMessage(payload: Record<string, unknown>): string {
+  const resultDetail = payloadString(payload, 'message');
+  if (resultDetail) {
+    const rawFailedProgressDetail = failedToolProgressMessage(resultDetail);
+    if (rawFailedProgressDetail) return rawFailedProgressDetail;
+
+    const progressDetail = genericAnswerWorkProgressDetail(resultDetail);
+    const failedProgressDetail = failedToolProgressMessage(progressDetail);
+    if (failedProgressDetail) return failedProgressDetail;
+  }
+
+  return (
+    failedToolNameMessage(payloadString(payload, 'name')) ??
+    failedToolNameMessage(payloadString(payload, 'id')) ??
+    "Couldn't check sources"
+  );
+}
+
 function addCompletedAnswerWorkRow(
   rows: Map<string, CompletedAnswerWorkRow>,
   input: Omit<CompletedAnswerWorkRow, 'ordinal'>,
@@ -806,7 +863,7 @@ function buildCompletedAnswerWorkTimeline(
         if (ok) continue;
         addCompletedAnswerWorkRow(rows, {
           id: payloadString(payload, 'id') ?? `failed-source-${event.sequence}`,
-          detail: "Couldn't check source index",
+          detail: failedUnlabeledToolResultMessage(payload),
           sourceLabels: [],
           state: 'error',
           sort: 90,

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -1484,6 +1484,40 @@ describe('GET / — SQR-107 purpose-built landing', () => {
       expect(body).not.toContain('Looked up Bandit Archer');
     });
 
+    it('renders failed unlabeled lookup results with a useful public label', () => {
+      const body = renderTranscriptAnswer(
+        answerWith(null, {
+          publicWorkEvents: [
+            {
+              sequence: 1,
+              event: 'tool-result',
+              payload: {
+                id: 'lookup_entity',
+                name: 'lookup_entity',
+                ok: false,
+              },
+              createdAt: new Date('2026-04-20T00:00:01.000Z'),
+            },
+            {
+              sequence: 2,
+              event: 'tool-result',
+              payload: {
+                id: 'lookup_entity-drifter',
+                name: 'lookup_entity',
+                ok: false,
+                message: 'Resolving Drifter character mat',
+              },
+              createdAt: new Date('2026-04-20T00:00:02.000Z'),
+            },
+          ],
+        }),
+      );
+
+      expect(body).toContain('Couldn&#39;t look up entity');
+      expect(body).toContain('Couldn&#39;t resolve Drifter character mat');
+      expect(body).not.toContain('Couldn&#39;t check source index');
+    });
+
     it('renders completed persisted work with the elapsed disclosure title', () => {
       const body = renderTranscriptAnswer(
         answerWith(null, {


### PR DESCRIPTION
## Summary

Fixes SQR-296.

Historical or malformed persisted work-log rows can contain failed `tool-result` events with no source labels. The reload renderer used to show those as `Couldn't check source index`, which did not say what failed.

## Changes

- Add safe public fallback wording for unlabeled failed tool results.
- Prefer a browser-safe `message` when available, so `Resolving Drifter character mat` becomes `Couldn't resolve Drifter character mat`.
- Fall back from stable tool identifiers such as `lookup_entity` to useful text like `Couldn't look up entity`.
- Keep the final fallback generic but clearer: `Couldn't check sources`.
- Add regression coverage for unlabeled failed `lookup_entity` rows.

## Verification

- `npx vitest run test/web-ui-layout.test.ts --config vitest.unit.config.ts`
- `npm run typecheck`
- `npx prettier --check src/web-ui/layout.ts test/web-ui-layout.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error messaging for failed tool operations with context-specific details instead of generic messages
  * Failed lookups and searches now display more descriptive failure reasons to help users understand what went wrong

<!-- end of auto-generated comment: release notes by coderabbit.ai -->