### PR TITLE
Remove overfit Drifter eval name guard

### DIFF
--- a/eval/suites/frosthaven.json
+++ b/eval/suites/frosthaven.json
@@ -436,7 +436,7 @@
     "question": "Earlier you said the Frosthaven Drifter has no perk that ignores negative item effects. Check the Drifter character mat and answer plainly.",
     "finalAnswer": {
       "expected": "The Frosthaven Drifter character mat has a perk that says you may ignore negative item effects and the appearance of a cursed item.",
-      "grading": "Must state that Drifter has a perk that ignores negative item effects. Must not deny that Drifter has this perk. Must not name the perk unless directly supported by the opened Drifter source. Must not redirect the claim to another class unless directly supported by the opened Drifter source."
+      "grading": "Must answer from the supported Drifter perk effect text: Drifter has a perk that ignores negative item effects. Must not deny that Drifter has this perk. Must not invent unsupported source text. Must not redirect the claim to another class unless directly supported by the opened Drifter source."
     },
     "trajectory": {
       "requiredTools": ["lookup_entity"],
@@ -447,13 +447,12 @@
         "card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter"
       ],
       "maxToolCalls": 4,
-      "notes": "Regression for SQR-293: user correction should reopen the exact Drifter mat instead of repeating an unsupported denial. Per SQR-349, this case does not assert a printed perk name because the checked-in source data only supports the effect text."
+      "notes": "Regression for SQR-293: user correction should reopen the exact Drifter mat instead of repeating an unsupported denial. This case asserts only the effect text because that is all the checked-in source data supports."
     },
     "safety": {
       "requiredAnswerPatterns": ["ignore negative item effects"],
       "forbiddenAnswerPatterns": [
-        "drifter[^.]{0,80}(?:no|not|does not|doesn.t)[^.]{0,80}(?:ignore negative item effects|negative item)",
-        "\\bBlessed\\b"
+        "drifter[^.]{0,80}(?:no|not|does not|doesn.t)[^.]{0,80}(?:ignore negative item effects|negative item)"
       ],
       "requiredCanonicalRefPatterns": [
         "^card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter$"

--- a/src/import-character-mats.ts
+++ b/src/import-character-mats.ts
@@ -199,7 +199,7 @@ function pluralizeCard(count: number): string {
   return count === 1 ? 'card' : 'cards';
 }
 
-export function formatPerk(perk: GhsPerk, characterName: string, labels: LabelData): string {
+export function formatPerk(perk: GhsPerk, labels: LabelData): string {
   if (perk.type === 'custom' && perk.custom) {
     return resolvePerkText(perk.custom, labels);
   }
@@ -236,7 +236,7 @@ const DRIFTER_IGNORE_NEGATIVE_ITEM_EFFECTS_PERK =
 
 const CURATED_CHARACTER_MAT_PERKS: Record<string, readonly string[]> = {
   // GHS omits this Drifter perk text. Keep the curation local to the import
-  // boundary and avoid unsupported printed perk names.
+  // boundary and keep character-mat perks as effect text only.
   'gloomhavensecretariat:character-mat/drifter': [DRIFTER_IGNORE_NEGATIVE_ITEM_EFFECTS_PERK],
 };
 
@@ -280,7 +280,7 @@ export function convertCharacterMat(ghs: GhsCharacter, labels: LabelData): Extra
   const sourceId = `gloomhavensecretariat:character-mat/${ghs.name}`;
   const perks = applyCharacterMatCurations(
     sourceId,
-    ghs.perks.map((p) => formatPerk(p, ghs.name, labels)),
+    ghs.perks.map((p) => formatPerk(p, labels)),
   );
 
   const masteries = ghs.masteries.map((m) => resolvePerkText(m, labels));

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -365,20 +365,17 @@ describe('eval dataset', () => {
     );
 
     expect(evalCase?.question).toMatch(/Drifter/i);
-    expect(evalCase?.question).not.toMatch(/Blessed/i);
-    expect(evalCase?.finalAnswer?.expected).not.toMatch(/Blessed/i);
     expect(evalCase?.finalAnswer?.expected).toMatch(/ignore negative item effects/i);
     expect(evalCase?.finalAnswer?.grading).toMatch(/must not deny/i);
+    expect(evalCase?.finalAnswer?.grading).toMatch(/effect text/i);
+    expect(evalCase?.finalAnswer?.grading).toMatch(/unsupported source text/i);
     expect(evalCase?.trajectory?.requiredTools).toEqual(['lookup_entity']);
     expect(evalCase?.trajectory?.requiredRefs).toContain(
       'card:frosthaven/character-mats/gloomhavensecretariat:character-mat/drifter',
     );
-    expect(evalCase?.safety?.forbiddenAnswerPatterns).toEqual(
-      expect.arrayContaining([
-        'drifter[^.]{0,80}(?:no|not|does not|doesn.t)[^.]{0,80}(?:ignore negative item effects|negative item)',
-        '\\bBlessed\\b',
-      ]),
-    );
+    expect(evalCase?.safety?.forbiddenAnswerPatterns).toEqual([
+      'drifter[^.]{0,80}(?:no|not|does not|doesn.t)[^.]{0,80}(?:ignore negative item effects|negative item)',
+    ]);
   });
 
   it('defines flexible tool-path expectations for trajectory cases', () => {

--- a/test/import-character-mats.test.ts
+++ b/test/import-character-mats.test.ts
@@ -23,7 +23,17 @@ describe('formatPerk', () => {
       count: 1,
       cards: [{ count: 1, attackModifier: { type: 'minus2' } }],
     };
-    expect(formatPerk(perk, 'drifter', labels)).toBe('Remove 1 -2 card');
+    expect(formatPerk(perk, labels)).toBe('Remove 1 -2 card');
+  });
+
+  it('formats perk effect text without needing a character name', () => {
+    const perk = {
+      type: 'custom',
+      count: 1,
+      custom: '%data.custom.fh.blinkblade.5%',
+    };
+
+    expect(formatPerk(perk, labels)).toBe('Gain Advantage on the next three attacks you perform');
   });
 
   it('formats a replace perk with simple modifiers', () => {
@@ -35,7 +45,7 @@ describe('formatPerk', () => {
         { count: 1, attackModifier: { type: 'plus1' } },
       ],
     };
-    expect(formatPerk(perk, 'drifter', labels)).toBe('Replace 3 -1 cards with +1 cards');
+    expect(formatPerk(perk, labels)).toBe('Replace 3 -1 cards with +1 cards');
   });
 
   it('formats an add perk', () => {
@@ -59,7 +69,7 @@ describe('formatPerk', () => {
         },
       ],
     };
-    expect(formatPerk(perk, 'drifter', labels)).toBe('Add 2 Rolling +2 Regenerate Self cards');
+    expect(formatPerk(perk, labels)).toBe('Add 2 Rolling +2 Regenerate Self cards');
   });
 
   it('formats a perk with wound condition effect', () => {
@@ -77,7 +87,7 @@ describe('formatPerk', () => {
         },
       ],
     };
-    expect(formatPerk(perk, 'drifter', labels)).toBe('Replace 2 -1 cards with +0 Wound cards');
+    expect(formatPerk(perk, labels)).toBe('Replace 2 -1 cards with +0 Wound cards');
   });
 
   it('formats a custom perk by resolving label', () => {
@@ -86,9 +96,7 @@ describe('formatPerk', () => {
       count: 1,
       custom: '%data.custom.fh.blinkblade.5%',
     };
-    expect(formatPerk(perk, 'blinkblade', labels)).toBe(
-      'Gain Advantage on the next three attacks you perform',
-    );
+    expect(formatPerk(perk, labels)).toBe('Gain Advantage on the next three attacks you perform');
   });
 
   it('formats a perk with custom effect on card (label reference)', () => {
@@ -106,7 +114,7 @@ describe('formatPerk', () => {
         },
       ],
     };
-    expect(formatPerk(perk, 'drifter', labels)).toBe(
+    expect(formatPerk(perk, labels)).toBe(
       'Replace 2 +1 cards with two +0 Move one of your character tokens backward one slot cards',
     );
   });
@@ -118,9 +126,7 @@ describe('formatPerk', () => {
       immunity: 'immobilize',
       custom: '%data.custom.fh.blinkblade.5%',
     };
-    expect(formatPerk(perk, 'blinkblade', labels)).toBe(
-      'Gain Advantage on the next three attacks you perform',
-    );
+    expect(formatPerk(perk, labels)).toBe('Gain Advantage on the next three attacks you perform');
   });
 
   it('formats replace perk with multiple-count cards', () => {
@@ -132,7 +138,7 @@ describe('formatPerk', () => {
         { count: 2, attackModifier: { type: 'plus2' } },
       ],
     };
-    expect(formatPerk(perk, 'drifter', labels)).toBe('Replace 1 two +1 cards with two +2 cards');
+    expect(formatPerk(perk, labels)).toBe('Replace 1 two +1 cards with two +2 cards');
   });
 
   it('formats add perk with multiple card groups', () => {
@@ -158,7 +164,7 @@ describe('formatPerk', () => {
         },
       ],
     };
-    expect(formatPerk(perk, 'drifter', labels)).toBe(
+    expect(formatPerk(perk, labels)).toBe(
       'Add 2 Rolling +0 Disarm cards and Rolling +0 Muddle cards',
     );
   });
@@ -187,7 +193,7 @@ describe('formatPerk', () => {
         },
       ],
     };
-    expect(formatPerk(perk, 'drifter', labels)).toBe(
+    expect(formatPerk(perk, labels)).toBe(
       'Replace 2 two +0 cards with Rolling +0 Pierce 3 cards and Rolling +0 Retaliate 2 cards',
     );
   });
@@ -201,7 +207,7 @@ describe('formatPerk', () => {
         { count: 1, attackModifier: { type: 'plus1' } },
       ],
     };
-    expect(formatPerk(perk, 'drifter', labels)).toBe('Remove 1 -2 card and +1 card');
+    expect(formatPerk(perk, labels)).toBe('Remove 1 -2 card and +1 card');
   });
 });
 

--- a/test/import-character-mats.test.ts
+++ b/test/import-character-mats.test.ts
@@ -26,16 +26,6 @@ describe('formatPerk', () => {
     expect(formatPerk(perk, labels)).toBe('Remove 1 -2 card');
   });
 
-  it('formats perk effect text without needing a character name', () => {
-    const perk = {
-      type: 'custom',
-      count: 1,
-      custom: '%data.custom.fh.blinkblade.5%',
-    };
-
-    expect(formatPerk(perk, labels)).toBe('Gain Advantage on the next three attacks you perform');
-  });
-
   it('formats a replace perk with simple modifiers', () => {
     const perk = {
       type: 'replace',


### PR DESCRIPTION
## Summary
- remove the remaining literal-name guard from the Drifter correction eval
- make the eval grade only the supported ignore-negative-item-effects perk text
- drop the unused character-name parameter from `formatPerk` so perk formatting is effect-text only

## Validation
- `npm run check`
- `npx vitest run test/import-character-mats.test.ts test/eval-dataset.test.ts --config vitest.unit.config.ts`
- `npx vitest run test/tools.test.ts --config vitest.db.config.ts -t "Drifter|character-mat|ignore-negative-item-effects"`
- `npm run typecheck`
- `rg -n "Blessed|printed perk name|name the perk|perk names" src test eval data docs --glob '!test/fixtures/**'` returned no matches\n\nFixes SQR-350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified perk formatting by removing the character name input and keeping formatted output based on perk and label data only.

* **Tests**
  * Tightened evaluation rules for the Drifter “ignore negative item effects” scenario to require exact alignment with the checked-in Drifter perk text and to prevent unsupported denials/redirects.
  * Updated test cases and assertions to match the new perk formatting function signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->