### PR TITLE
Fix Sentry safe-test issue cleanup

### DIFF
--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -336,6 +336,7 @@ Local dry runs must not send to Sentry:
 ```bash
 npm run sentry:test-event -- --kind chat --dry-run
 npm run sentry:test-event -- --kind uptime --dry-run
+npm run sentry:test-event -- --cleanup --dry-run
 ```
 
 The safe verification commands print sanitized Sentry event/log search URLs and
@@ -343,6 +344,18 @@ a trace search URL. The trace URL is a search aid, not proof by itself. Copy the
 `traceProof` fields into the Linear Evidence section: use confirmed Sentry trace
 rows when available, or copy `traceSearchableReason` when the script reports
 trace searchability as unavailable or unverified.
+
+Safe test events must carry `safe_test=true`, `safe_test_kind=<kind>`, and
+`synthetic=true`. After production smoke, search Sentry Errors and Outages for
+`is:unresolved safe_test:true`. If every match is synthetic, resolve them with:
+
+```bash
+SENTRY_TOKEN=... npm run sentry:test-event -- --cleanup
+```
+
+Do not use the cleanup command for real production issues, and do not resolve
+all browser, cron, or deploy-regression groups just because one synthetic event
+used that surface.
 
 Browser replay and feedback smoke:
 
@@ -385,9 +398,11 @@ After observability changes deploy:
    `metadata.thread_id`, `metadata.userMessageId`, and `metadata.requestId`.
 4. Generate or preview safe Sentry test events for backend, chat, browser, cron,
    deploy-regression, scrub-canary, and uptime paths.
-5. Create or update a Linear bug with the required Evidence template, using
+5. Run `npm run sentry:test-event -- --cleanup --dry-run`, confirm all matches
+   are synthetic, then run `npm run sentry:test-event -- --cleanup`.
+6. Create or update a Linear bug with the required Evidence template, using
    unavailable reasons for anything not present.
-6. Check Sentry `Stats & Usage` for log accepted GB, accepted spans, dropped
+7. Check Sentry `Stats & Usage` for log accepted GB, accepted spans, dropped
    data, and the PAYG budget path in
    [sentry-usage-guardrails.md](sentry-usage-guardrails.md).
 

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -398,8 +398,9 @@ After observability changes deploy:
    `metadata.thread_id`, `metadata.userMessageId`, and `metadata.requestId`.
 4. Generate or preview safe Sentry test events for backend, chat, browser, cron,
    deploy-regression, scrub-canary, and uptime paths.
-5. Run `npm run sentry:test-event -- --cleanup --dry-run`, confirm all matches
-   are synthetic, then run `npm run sentry:test-event -- --cleanup`.
+5. Run `SENTRY_TOKEN=... npm run sentry:test-event -- --cleanup --dry-run`,
+   confirm all matches are synthetic, then run
+   `SENTRY_TOKEN=... npm run sentry:test-event -- --cleanup`.
 6. Create or update a Linear bug with the required Evidence template, using
    unavailable reasons for anything not present.
 7. Check Sentry `Stats & Usage` for log accepted GB, accepted spans, dropped

--- a/docs/runbooks/sentry-alerts.md
+++ b/docs/runbooks/sentry-alerts.md
@@ -151,8 +151,17 @@ evidence payloads without sending to Sentry:
 ```bash
 npm run sentry:test-event -- --kind chat --dry-run
 npm run sentry:test-event -- --kind uptime --dry-run
-npm run sentry:test-event -- --cleanup --dry-run
 npm run sentry:app-health -- --dry-run
+```
+
+The cleanup preview is separate from event dry-runs. Without `SENTRY_TOKEN`, it
+prints the cleanup query, Sentry issue-search URL, and commands. With
+`SENTRY_TOKEN`, it also queries Sentry and lists unresolved issues matching
+`safe_test:true` without resolving them:
+
+```bash
+npm run sentry:test-event -- --cleanup --dry-run
+SENTRY_TOKEN=... npm run sentry:test-event -- --cleanup --dry-run
 ```
 
 The safe test events use synthetic IDs only:

--- a/docs/runbooks/sentry-alerts.md
+++ b/docs/runbooks/sentry-alerts.md
@@ -151,6 +151,7 @@ evidence payloads without sending to Sentry:
 ```bash
 npm run sentry:test-event -- --kind chat --dry-run
 npm run sentry:test-event -- --kind uptime --dry-run
+npm run sentry:test-event -- --cleanup --dry-run
 npm run sentry:app-health -- --dry-run
 ```
 
@@ -159,12 +160,25 @@ The safe test events use synthetic IDs only:
 - `request_id=sentry-test-<kind>`
 - `conversation_id=sentry-test-conversation` for chat/browser tests
 - `user_message_id=sentry-test-user-message` for chat/browser tests
+- `safe_test=true`, `safe_test_kind=<kind>`, and `synthetic=true`
 - no cookies, auth headers, raw prompts, model output, provider payloads, or
   retrieved passages
 - dry-run and production output include Sentry event/log search URLs, a trace
   search URL, and `traceProof`
 - the trace search URL is not proof by itself; copy confirmed trace rows or
   `traceSearchableReason` into the Linear Evidence section
+
+After safe tests, open the Sentry Errors and Outages view with query
+`is:unresolved safe_test:true`. If the matching records are all synthetic, clean
+them up with:
+
+```bash
+SENTRY_TOKEN=... npm run sentry:test-event -- --cleanup
+```
+
+Never resolve broad production groups manually just because they share a surface
+such as browser, cron, or deploy-regression. Only use the cleanup command for
+records carrying `safe_test=true`.
 
 The uptime safe command proves app telemetry for the health-check path without
 breaking `/api/health`. For the uptime alert itself, prefer Sentry's monitor test
@@ -189,12 +203,18 @@ Alert filters depend on these stable tags:
 - `job_name`
 - `job_kind`
 - `security_event`
+- `safe_test`
+- `safe_test_kind`
+- `synthetic`
 - `status`
 - `duration_ms`
+- `squire.safe_test`
+- `squire.safe_test.kind`
 - `squire.surface`
 - `squire.request_id`
 - `squire.conversation_id`
 - `squire.user_message_id`
+- `squire.synthetic`
 - `squire.script_name`
 - `squire.script_kind`
 - `http.route`
@@ -213,6 +233,9 @@ After deploying log/trace telemetry:
 3. Send safe backend, chat, browser, cron, uptime, and deploy-regression events.
 4. Confirm the dashboard queries match on `environment`, `release`,
    `request_id`, `route`, `conversation_id`, `user_message_id`, `job_kind`,
-   `security_event`, and the relevant `squire.*` span fields.
+   `security_event`, `safe_test`, `safe_test_kind`, and the relevant `squire.*`
+   span fields.
 5. Confirm Sentry links to LangSmith for chat spans instead of copying prompts,
    model output, or retrieved passages.
+6. Run `npm run sentry:test-event -- --cleanup --dry-run`, confirm the matches
+   are synthetic, then run `npm run sentry:test-event -- --cleanup`.

--- a/scripts/send-sentry-safe-test-event.ts
+++ b/scripts/send-sentry-safe-test-event.ts
@@ -127,10 +127,10 @@ function safeTestInput(kind: SafeTestKind) {
   const userMessageId = 'sentry-test-user-message';
   const fingerprint = ['squire-safe-test', kind] as const;
   const context = (values: Record<string, unknown>) => ({
+    ...values,
     safeTest: 'true',
     safeTestKind: kind,
     synthetic: 'true',
-    ...values,
   });
 
   switch (kind) {
@@ -355,7 +355,12 @@ function safeTestIssueSummary(value: unknown): SafeTestIssueSummary | null {
   };
 }
 
-async function sentryJson<T>(fetch: FetchLike, token: string, url: string, init?: RequestInit) {
+async function sentryJsonWithHeaders<T>(
+  fetch: FetchLike,
+  token: string,
+  url: string,
+  init?: RequestInit,
+): Promise<{ body: T; headers: Headers }> {
   const response = await fetch(url, {
     ...init,
     headers: {
@@ -366,17 +371,57 @@ async function sentryJson<T>(fetch: FetchLike, token: string, url: string, init?
   if (!response.ok) {
     throw new Error(`Sentry API request failed: ${response.status} ${response.statusText}`);
   }
-  return (await response.json()) as T;
+  return {
+    body: (await response.json()) as T,
+    headers: response.headers,
+  };
+}
+
+async function sentryJson<T>(fetch: FetchLike, token: string, url: string, init?: RequestInit) {
+  return (await sentryJsonWithHeaders<T>(fetch, token, url, init)).body;
+}
+
+function sentryNextUrl(linkHeader: string | null): string | undefined {
+  if (!linkHeader) return undefined;
+
+  for (const part of linkHeader.split(/,\s*(?=<)/)) {
+    if (!/\brel="next"/.test(part) || !/\bresults="true"/.test(part)) continue;
+    const urlMatch = part.match(/<([^>]+)>/);
+    if (!urlMatch) continue;
+    try {
+      const url = new URL(urlMatch[1] ?? '');
+      if (url.origin !== 'https://sentry.io' || !url.pathname.startsWith('/api/0/')) continue;
+      return url.toString();
+    } catch {
+      continue;
+    }
+  }
+
+  return undefined;
 }
 
 async function listSafeTestIssues(
   fetch: FetchLike,
   token: string,
 ): Promise<SafeTestIssueSummary[]> {
-  const payload = await sentryJson<unknown[]>(fetch, token, sentryProjectIssuesApiUrl());
-  return payload
-    .map(safeTestIssueSummary)
-    .filter((issue): issue is SafeTestIssueSummary => issue !== null);
+  const issues: SafeTestIssueSummary[] = [];
+  const seenUrls = new Set<string>();
+  let nextUrl: string | undefined = sentryProjectIssuesApiUrl();
+
+  while (nextUrl) {
+    if (seenUrls.has(nextUrl)) throw new Error('Sentry safe-test cleanup pagination loop');
+    seenUrls.add(nextUrl);
+
+    const { body, headers } = await sentryJsonWithHeaders<unknown[]>(fetch, token, nextUrl);
+    issues.push(
+      ...body
+        .map(safeTestIssueSummary)
+        .filter((issue): issue is SafeTestIssueSummary => issue !== null),
+    );
+    nextUrl = sentryNextUrl(headers.get('link'));
+  }
+
+  return issues;
 }
 
 async function resolveSafeTestIssue(

--- a/scripts/send-sentry-safe-test-event.ts
+++ b/scripts/send-sentry-safe-test-event.ts
@@ -16,6 +16,7 @@ import {
   SENTRY_APP_HEALTH_ORG,
   SENTRY_APP_HEALTH_PROJECT_ID,
 } from './sentry-app-health-config.ts';
+import { DEFAULT_SENTRY_PROJECT_SLUG } from './sentry-scrubbing-config.ts';
 
 export const SAFE_TEST_KINDS = [
   'backend',
@@ -30,6 +31,7 @@ export const SAFE_TEST_KINDS = [
 type SafeTestKind = (typeof SAFE_TEST_KINDS)[number];
 type SafeVerificationKind = Exclude<SafeTestKind, 'scrub-canary'>;
 type TraceSearchable = true | false | null;
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
 
 interface SafeTraceProof {
   traceAttempted: boolean;
@@ -61,23 +63,44 @@ const SAFE_TEST_ERROR_NAMES: Record<SafeTestKind, string> = {
 
 const SENTRY_ORG_URL = `https://${SENTRY_APP_HEALTH_ORG}.sentry.io`;
 
-interface ParsedArgs {
+interface EmitArgs {
+  mode: 'emit';
   kind: SafeTestKind;
   dryRun: boolean;
 }
 
+interface CleanupArgs {
+  mode: 'cleanup';
+  dryRun: boolean;
+}
+
+type ParsedArgs = EmitArgs | CleanupArgs;
+
+export const SENTRY_SAFE_TEST_ISSUE_QUERY = 'is:unresolved safe_test:true';
+
+const SAFE_TEST_CLEANUP_COMMAND = 'npm run sentry:test-event -- --cleanup';
+const SAFE_TEST_CLEANUP_DRY_RUN_COMMAND = 'npm run sentry:test-event -- --cleanup --dry-run';
+
 function usage(): string {
-  return `Usage: node scripts/send-sentry-safe-test-event.ts --kind <${SAFE_TEST_KINDS.join('|')}> [--dry-run]`;
+  return [
+    `Usage: node scripts/send-sentry-safe-test-event.ts --kind <${SAFE_TEST_KINDS.join('|')}> [--dry-run]`,
+    '       node scripts/send-sentry-safe-test-event.ts --cleanup [--dry-run]',
+  ].join('\n');
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
   let kind: SafeTestKind | undefined;
   let dryRun = false;
+  let cleanup = false;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--dry-run') {
       dryRun = true;
+      continue;
+    }
+    if (arg === '--cleanup') {
+      cleanup = true;
       continue;
     }
     if (arg === '--kind') {
@@ -92,24 +115,34 @@ function parseArgs(argv: string[]): ParsedArgs {
     throw new Error(usage());
   }
 
+  if (cleanup && kind) throw new Error(usage());
+  if (cleanup) return { mode: 'cleanup', dryRun };
   if (!kind) throw new Error(usage());
-  return { kind, dryRun };
+  return { mode: 'emit', kind, dryRun };
 }
 
 function safeTestInput(kind: SafeTestKind) {
   const requestId = `sentry-test-${kind}`;
   const conversationId = 'sentry-test-conversation';
   const userMessageId = 'sentry-test-user-message';
+  const fingerprint = ['squire-safe-test', kind] as const;
+  const context = (values: Record<string, unknown>) => ({
+    safeTest: 'true',
+    safeTestKind: kind,
+    synthetic: 'true',
+    ...values,
+  });
 
   switch (kind) {
     case 'backend':
       return {
         route: '/__sentry-test/backend',
         requestId,
-        context: {
+        fingerprint,
+        context: context({
           surface: 'server',
           eventType: 'safe_test',
-        },
+        }),
       };
     case 'chat':
       return {
@@ -117,11 +150,12 @@ function safeTestInput(kind: SafeTestKind) {
         requestId,
         conversationId,
         userMessageId,
-        context: {
+        fingerprint,
+        context: context({
           surface: 'chat_sse',
           failureKind: 'assistant_turn',
           eventType: 'safe_test',
-        },
+        }),
       };
     case 'browser':
       return {
@@ -129,7 +163,8 @@ function safeTestInput(kind: SafeTestKind) {
         requestId,
         conversationId,
         userMessageId,
-        context: {
+        fingerprint,
+        context: context({
           surface: 'browser',
           eventType: 'browser_error',
           maskedReplay: {
@@ -137,36 +172,39 @@ function safeTestInput(kind: SafeTestKind) {
             attributesMasked: true,
             turns: { assistantTurnCount: 1, errorBannerCount: 1 },
           },
-        },
+        }),
       };
     case 'cron':
       return {
         route: '/scripts/sweep-expired-sessions',
         requestId,
-        context: {
+        fingerprint,
+        context: context({
           scriptName: 'sweep-expired-sessions',
           scriptKind: 'cron',
           eventType: 'safe_test',
-        },
+        }),
       };
     case 'uptime':
       return {
         route: '/api/health',
         requestId,
-        context: {
+        fingerprint,
+        context: context({
           surface: 'uptime',
           eventType: 'uptime_verification',
           checkSlug: 'production-health',
-        },
+        }),
       };
     case 'deploy-regression':
       return {
         route: '/__sentry-test/deploy-regression',
         requestId,
-        context: {
+        fingerprint,
+        context: context({
           surface: 'server',
           eventType: 'deploy_regression_test',
-        },
+        }),
       };
     case 'scrub-canary':
       return {
@@ -174,7 +212,8 @@ function safeTestInput(kind: SafeTestKind) {
         requestId,
         conversationId,
         userMessageId,
-        context: {
+        fingerprint,
+        context: context({
           surface: 'server',
           eventType: 'scrub_canary',
           emailAddress: 'sentry-scrub-canary@example.invalid',
@@ -195,7 +234,7 @@ function safeTestInput(kind: SafeTestKind) {
               answer: 'Synthetic response body answer for scrubbing verification',
             },
           },
-        },
+        }),
       };
   }
 }
@@ -227,6 +266,158 @@ function sentrySearchUrl(path: string, query: string): string {
   return `${SENTRY_ORG_URL}/${path}?${params.toString()}`;
 }
 
+function sentrySafeTestIssueSearchUrl(): string {
+  return sentrySearchUrl('issues/', SENTRY_SAFE_TEST_ISSUE_QUERY);
+}
+
+interface SafeTestIssueSummary {
+  id: string;
+  shortId: string | null;
+  title: string;
+  permalink: string | null;
+  status: string | null;
+}
+
+interface SafeTestIssueCleanupResult {
+  mode: 'cleanup';
+  dryRun: boolean;
+  query: string;
+  sentrySafeTestIssueSearchUrl: string;
+  cleanupCommand: string;
+  cleanupDryRunCommand: string;
+  issues: SafeTestIssueSummary[];
+  resolvedIssues: SafeTestIssueSummary[];
+}
+
+interface CleanupSafeTestIssuesOptions {
+  dryRun?: boolean;
+  fetch?: FetchLike;
+  token?: string;
+}
+
+export function safeTestCleanupDryRunPayload(): SafeTestIssueCleanupResult {
+  return {
+    mode: 'cleanup',
+    dryRun: true,
+    query: SENTRY_SAFE_TEST_ISSUE_QUERY,
+    sentrySafeTestIssueSearchUrl: sentrySafeTestIssueSearchUrl(),
+    cleanupCommand: SAFE_TEST_CLEANUP_COMMAND,
+    cleanupDryRunCommand: SAFE_TEST_CLEANUP_DRY_RUN_COMMAND,
+    issues: [],
+    resolvedIssues: [],
+  };
+}
+
+function sentryProjectIssuesApiUrl(): string {
+  const url = new URL(
+    `https://sentry.io/api/0/projects/${SENTRY_APP_HEALTH_ORG}/${DEFAULT_SENTRY_PROJECT_SLUG}/issues/`,
+  );
+  url.searchParams.set('query', SENTRY_SAFE_TEST_ISSUE_QUERY);
+  url.searchParams.set('environment', SENTRY_APP_HEALTH_ENVIRONMENT);
+  url.searchParams.set('statsPeriod', '14d');
+  url.searchParams.set('limit', '100');
+  return url.toString();
+}
+
+function sentryIssueApiUrl(issueId: string): string {
+  return `https://sentry.io/api/0/issues/${issueId}/`;
+}
+
+function sentryApiHeaders(token: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+function readSentryToken(token: string | undefined = process.env.SENTRY_TOKEN): string {
+  const value = token?.trim();
+  if (!value) throw new Error('SENTRY_TOKEN is required for --cleanup');
+  return value;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function safeTestIssueSummary(value: unknown): SafeTestIssueSummary | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const id = stringOrNull(record.id);
+  const title = stringOrNull(record.title);
+  if (!id || !title) return null;
+  return {
+    id,
+    shortId: stringOrNull(record.shortId),
+    title,
+    permalink: stringOrNull(record.permalink),
+    status: stringOrNull(record.status),
+  };
+}
+
+async function sentryJson<T>(fetch: FetchLike, token: string, url: string, init?: RequestInit) {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      ...sentryApiHeaders(token),
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Sentry API request failed: ${response.status} ${response.statusText}`);
+  }
+  return (await response.json()) as T;
+}
+
+async function listSafeTestIssues(
+  fetch: FetchLike,
+  token: string,
+): Promise<SafeTestIssueSummary[]> {
+  const payload = await sentryJson<unknown[]>(fetch, token, sentryProjectIssuesApiUrl());
+  return payload
+    .map(safeTestIssueSummary)
+    .filter((issue): issue is SafeTestIssueSummary => issue !== null);
+}
+
+async function resolveSafeTestIssue(
+  fetch: FetchLike,
+  token: string,
+  issue: SafeTestIssueSummary,
+): Promise<SafeTestIssueSummary> {
+  const payload = await sentryJson<unknown>(fetch, token, sentryIssueApiUrl(issue.id), {
+    method: 'PUT',
+    body: JSON.stringify({ status: 'resolved' }),
+  });
+  return safeTestIssueSummary(payload) ?? { ...issue, status: 'resolved' };
+}
+
+export async function cleanupSafeTestIssues(
+  options: CleanupSafeTestIssuesOptions = {},
+): Promise<SafeTestIssueCleanupResult> {
+  const fetch = options.fetch ?? globalThis.fetch;
+  const token = readSentryToken(options.token);
+  const issues = await listSafeTestIssues(fetch, token);
+
+  if (options.dryRun) {
+    return {
+      ...safeTestCleanupDryRunPayload(),
+      issues,
+    };
+  }
+
+  const resolvedIssues: SafeTestIssueSummary[] = [];
+  for (const issue of issues) {
+    resolvedIssues.push(await resolveSafeTestIssue(fetch, token, issue));
+  }
+
+  return {
+    ...safeTestCleanupDryRunPayload(),
+    dryRun: false,
+    issues,
+    resolvedIssues,
+  };
+}
+
 function sentryEvidence(kind: SafeVerificationKind, input: ReturnType<typeof safeTestInput>) {
   const requestId = requestIdFromInput(input);
   const eventSearchUrl = sentrySearchUrl('issues/', `request_id:${requestId}`);
@@ -237,6 +428,10 @@ function sentryEvidence(kind: SafeVerificationKind, input: ReturnType<typeof saf
 
   return {
     requestId,
+    cleanupCommand: SAFE_TEST_CLEANUP_COMMAND,
+    cleanupDryRunCommand: SAFE_TEST_CLEANUP_DRY_RUN_COMMAND,
+    safeTestIssueQuery: SENTRY_SAFE_TEST_ISSUE_QUERY,
+    sentrySafeTestIssueSearchUrl: sentrySafeTestIssueSearchUrl(),
     sentryEventSearchUrl: eventSearchUrl,
     sentryLogsSearchUrl: logsSearchUrl,
     sentryTraceSearchUrl: traceSearchUrl,
@@ -262,7 +457,7 @@ function sentryEvidence(kind: SafeVerificationKind, input: ReturnType<typeof saf
       'First files to inspect': 'scripts/send-sentry-safe-test-event.ts; src/telemetry.ts',
       Repro: `fly ssh console -a maz-squire -C 'node scripts/send-sentry-safe-test-event.ts --kind ${kind}'`,
       Acceptance:
-        'Copy the event and log search URLs plus either confirmed trace rows or traceProof unavailable reason into Linear evidence',
+        'Copy the event and log search URLs plus either confirmed trace rows or traceProof unavailable reason into Linear evidence, then run the safe-test cleanup command',
     },
   };
 }
@@ -289,6 +484,7 @@ function safeVerificationLog(kind: SafeVerificationKind, input: ReturnType<typeo
     message: `sentry.safe_test.${kind}`,
     attributes: {
       safe_test_kind: kind,
+      safe_test: true,
       status: 'error',
       synthetic: true,
       route: routeFromInput(input),
@@ -312,6 +508,7 @@ function safeVerificationTrace(
     name: `squire.safe_test.${kind}`,
     op: 'squire.safe_test',
     attributes: {
+      'squire.safe_test': true,
       'squire.safe_test.kind': kind,
       'squire.request_id': requestIdFromInput(input),
       'squire.route': routeFromInput(input),
@@ -487,6 +684,9 @@ function emitSafeVerificationTrace(
 
 function scrubCanaryAttributes(): Record<string, unknown> {
   return {
+    safe_test: true,
+    safe_test_kind: 'scrub-canary',
+    synthetic: true,
     emailAddress: 'sentry-scrub-canary@example.invalid',
     phoneNumber: '+1 415 555 0100',
     customerName: 'Sentry Scrub Canary',
@@ -513,6 +713,9 @@ function emitScrubCanaryTrace(): SafeTraceProof {
       'squire.safe_scrub_canary',
       {
         attributes: {
+          'squire.safe_test': true,
+          'squire.safe_test.kind': 'scrub-canary',
+          'squire.synthetic': true,
           'gen_ai.prompt': 'Synthetic prompt text for span scrubbing verification',
           'gen_ai.completion': 'Synthetic model output for span scrubbing verification',
           providerPayload: 'Synthetic provider payload for span scrubbing verification',
@@ -634,8 +837,25 @@ function dryRunPayload(kind: SafeTestKind, input: ReturnType<typeof safeTestInpu
     : scrubCanaryDryRun(kind, input);
 }
 
+export function safeTestDryRunPayload(kind: SafeTestKind) {
+  return dryRunPayload(kind, safeTestInput(kind));
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  if (args.mode === 'cleanup') {
+    const token = process.env.SENTRY_TOKEN?.trim();
+    if (args.dryRun && !token) {
+      console.log(JSON.stringify(safeTestCleanupDryRunPayload(), null, 2));
+      return;
+    }
+
+    console.log(
+      JSON.stringify(await cleanupSafeTestIssues({ dryRun: args.dryRun, token }), null, 2),
+    );
+    return;
+  }
+
   const input = safeTestInput(args.kind);
 
   if (args.dryRun) {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -315,6 +315,16 @@ const SQL_TEXT_ATTRIBUTE_KEYS = new Set([
   'querytext',
 ]);
 const ROUTE_ATTRIBUTE_KEYS = new Set(['httproute', 'route', 'squireroute']);
+const SAFE_FINGERPRINT_VALUES = new Set([
+  'squire-safe-test',
+  'backend',
+  'chat',
+  'browser',
+  'cron',
+  'uptime',
+  'deploy-regression',
+  'scrub-canary',
+]);
 
 function safeContextTag(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -348,6 +358,7 @@ function buildSafeFingerprint(fingerprint: readonly string[] | undefined): strin
   const safeFingerprint = fingerprint
     .map((value) => safeString(value))
     .filter((value): value is string => value !== undefined)
+    .filter((value) => SAFE_FINGERPRINT_VALUES.has(value))
     .map((value) => truncateTag(redactSensitiveString(value)));
 
   return safeFingerprint.length > 0 ? safeFingerprint : undefined;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -69,6 +69,11 @@ export interface TelemetryDiagnosticInput {
 
 export interface TelemetryCaptureInput extends TelemetryDiagnosticInput {
   /**
+   * Optional low-cardinality Sentry grouping key. Values are sanitized before
+   * they reach Sentry; never pass raw user text here.
+   */
+  fingerprint?: readonly string[];
+  /**
    * Operational context only. Never pass raw prompts, model output, provider
    * payloads, cookies, auth headers, or retrieved passages; the boundary still
    * redacts known protected keys as a backstop.
@@ -329,9 +334,23 @@ function contextTagPairs(input: { context?: Record<string, unknown> }): Array<[s
     ['job_name', safeContextTag(context.scriptName)],
     ['job_kind', safeContextTag(context.scriptKind)],
     ['security_event', safeContextTag(context.event)],
+    ['safe_test', safeContextTag(context.safeTest)],
+    ['safe_test_kind', safeContextTag(context.safeTestKind)],
+    ['synthetic', safeContextTag(context.synthetic)],
   ];
 
   return pairs.filter((pair): pair is [string, string] => pair[1] !== undefined);
+}
+
+function buildSafeFingerprint(fingerprint: readonly string[] | undefined): string[] | undefined {
+  if (!fingerprint || fingerprint.length === 0) return undefined;
+
+  const safeFingerprint = fingerprint
+    .map((value) => safeString(value))
+    .filter((value): value is string => value !== undefined)
+    .map((value) => truncateTag(redactSensitiveString(value)));
+
+  return safeFingerprint.length > 0 ? safeFingerprint : undefined;
 }
 
 function redactSensitiveString(value: string): string {
@@ -903,6 +922,8 @@ export function captureTelemetryError(
     Sentry.withScope((scope) => {
       scope.setTags(buildSafeTelemetryTags(input));
       scope.setContext('squire', buildSentryContext(input, process.env));
+      const fingerprint = buildSafeFingerprint(input.fingerprint);
+      if (fingerprint) scope.setFingerprint(fingerprint);
       const user = buildSafeUser(input);
       if (user) scope.setUser(user);
       eventId = Sentry.captureException(error);
@@ -930,6 +951,8 @@ export function captureTelemetryMessage(
     Sentry.withScope((scope) => {
       scope.setTags(buildSafeTelemetryTags(input));
       scope.setContext('squire', buildSentryContext(input, process.env));
+      const fingerprint = buildSafeFingerprint(input.fingerprint);
+      if (fingerprint) scope.setFingerprint(fingerprint);
       const user = buildSafeUser(input);
       if (user) scope.setUser(user);
       eventId = Sentry.captureMessage(redactSensitiveString(message), level);

--- a/test/sentry-alerts.test.ts
+++ b/test/sentry-alerts.test.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   SENTRY_EXISTING_APP_HEALTH_ALERTS,
   SENTRY_APP_HEALTH_MONITORS,
@@ -11,7 +11,11 @@ import {
   appHealthDetectorPayload,
 } from '../scripts/sentry-app-health-config.ts';
 import {
+  SENTRY_SAFE_TEST_ISSUE_QUERY,
+  SAFE_TEST_KINDS,
   SAFE_VERIFICATION_KINDS,
+  cleanupSafeTestIssues,
+  safeTestDryRunPayload,
   safeVerificationDryRunPayload,
 } from '../scripts/send-sentry-safe-test-event.ts';
 import {
@@ -46,9 +50,25 @@ describe('Sentry alert catalog', () => {
 
       expect(payload.kind).toBe(kind);
       expect(payload.input?.requestId).toBe(`sentry-test-${kind}`);
+      expect(payload.input?.fingerprint).toEqual(['squire-safe-test', kind]);
+      expect(payload.input?.context).toMatchObject({
+        safeTest: 'true',
+        safeTestKind: kind,
+        synthetic: 'true',
+      });
       expect(payload.event).toMatchObject({ level: 'error' });
       expect(payload.log?.message).toBe(`sentry.safe_test.${kind}`);
+      expect(payload.log?.attributes).toMatchObject({
+        safe_test: true,
+        safe_test_kind: kind,
+        synthetic: true,
+      });
       expect(payload.trace?.name).toBe(`squire.safe_test.${kind}`);
+      expect(payload.trace?.attributes).toMatchObject({
+        'squire.safe_test': true,
+        'squire.safe_test.kind': kind,
+        'squire.synthetic': true,
+      });
       expect(payload.traceProof).toMatchObject({
         traceAttempted: false,
         traceSpanStarted: false,
@@ -59,6 +79,9 @@ describe('Sentry alert catalog', () => {
       });
       expect(payload.evidence).toMatchObject({
         requestId: `sentry-test-${kind}`,
+        cleanupCommand: 'npm run sentry:test-event -- --cleanup',
+        safeTestIssueQuery: SENTRY_SAFE_TEST_ISSUE_QUERY,
+        sentrySafeTestIssueSearchUrl: expect.stringContaining('safe_test%3Atrue'),
         sentryEventSearchUrl: expect.stringContaining(`request_id%3Asentry-test-${kind}`),
         sentryLogsSearchUrl: expect.stringContaining(`request_id%3Asentry-test-${kind}`),
         sentryTraceSearchUrl: expect.stringContaining(`sentry-test-${kind}`),
@@ -87,6 +110,84 @@ describe('Sentry alert catalog', () => {
         expect(stdout).not.toContain(forbidden);
       }
     }
+  });
+
+  it('marks every safe-test kind with synthetic cleanup metadata', () => {
+    for (const kind of SAFE_TEST_KINDS) {
+      const payload = safeTestDryRunPayload(kind);
+
+      expect(payload.input).toMatchObject({
+        requestId: `sentry-test-${kind}`,
+        fingerprint: ['squire-safe-test', kind],
+        context: {
+          safeTest: 'true',
+          safeTestKind: kind,
+          synthetic: 'true',
+        },
+      });
+    }
+  });
+
+  it('cleans up unresolved safe-test Sentry issues by synthetic query only', async () => {
+    const calls: Array<{ method: string; url: string }> = [];
+    const fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      const url = String(input);
+      calls.push({ method, url });
+
+      if (method === 'PUT') {
+        return new Response(JSON.stringify({ id: url.split('/').at(-2), status: 'resolved' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return new Response(
+        JSON.stringify([
+          {
+            id: '7555295841',
+            shortId: 'MAZ-SQUIRE-6',
+            title: 'browser.browser_stream_error',
+            permalink: 'https://brian-moseley.sentry.io/issues/7555295841/',
+            status: 'unresolved',
+          },
+          {
+            id: '7551288604',
+            shortId: 'MAZ-SQUIRE-1',
+            title: 'Error: SquireSafeScrubCanary',
+            permalink: 'https://brian-moseley.sentry.io/issues/7551288604/',
+            status: 'unresolved',
+          },
+        ]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+
+    const dryRun = await cleanupSafeTestIssues({ token: 'token', dryRun: true, fetch });
+
+    expect(dryRun).toMatchObject({
+      mode: 'cleanup',
+      dryRun: true,
+      query: SENTRY_SAFE_TEST_ISSUE_QUERY,
+      resolvedIssues: [],
+    });
+    expect(dryRun.issues.map((issue) => issue.id)).toEqual(['7555295841', '7551288604']);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe('GET');
+    expect(calls[0]?.url).toContain('query=is%3Aunresolved+safe_test%3Atrue');
+
+    calls.length = 0;
+    const applied = await cleanupSafeTestIssues({ token: 'token', dryRun: false, fetch });
+
+    expect(applied).toMatchObject({
+      mode: 'cleanup',
+      dryRun: false,
+      query: SENTRY_SAFE_TEST_ISSUE_QUERY,
+    });
+    expect(applied.resolvedIssues.map((issue) => issue.id)).toEqual(['7555295841', '7551288604']);
+    expect(calls.map((call) => call.method)).toEqual(['GET', 'PUT', 'PUT']);
+    expect(calls[1]?.url).toBe('https://sentry.io/api/0/issues/7555295841/');
+    expect(calls[2]?.url).toBe('https://sentry.io/api/0/issues/7551288604/');
   });
 
   it('exposes the app-health dashboard and alert sync dry run', async () => {

--- a/test/sentry-alerts.test.ts
+++ b/test/sentry-alerts.test.ts
@@ -142,6 +142,21 @@ describe('Sentry alert catalog', () => {
         });
       }
 
+      if (url.includes('cursor=page-2')) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: '7551288604',
+              shortId: 'MAZ-SQUIRE-1',
+              title: 'Error: SquireSafeScrubCanary',
+              permalink: 'https://brian-moseley.sentry.io/issues/7551288604/',
+              status: 'unresolved',
+            },
+          ]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+
       return new Response(
         JSON.stringify([
           {
@@ -152,14 +167,20 @@ describe('Sentry alert catalog', () => {
             status: 'unresolved',
           },
           {
-            id: '7551288604',
-            shortId: 'MAZ-SQUIRE-1',
-            title: 'Error: SquireSafeScrubCanary',
-            permalink: 'https://brian-moseley.sentry.io/issues/7551288604/',
+            id: '7557533332',
+            shortId: 'MAZ-SQUIRE-8',
+            title: 'uptime.monitor_flap',
+            permalink: 'https://brian-moseley.sentry.io/issues/7557533332/',
             status: 'unresolved',
           },
         ]),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            Link: '<https://sentry.io/api/0/projects/brian-moseley/maz-squire/issues/?cursor=page-2&limit=100>; rel="next"; results="true"; cursor="page-2"',
+          },
+        },
       );
     });
 
@@ -171,10 +192,16 @@ describe('Sentry alert catalog', () => {
       query: SENTRY_SAFE_TEST_ISSUE_QUERY,
       resolvedIssues: [],
     });
-    expect(dryRun.issues.map((issue) => issue.id)).toEqual(['7555295841', '7551288604']);
-    expect(calls).toHaveLength(1);
+    expect(dryRun.issues.map((issue) => issue.id)).toEqual([
+      '7555295841',
+      '7557533332',
+      '7551288604',
+    ]);
+    expect(calls).toHaveLength(2);
     expect(calls[0]?.method).toBe('GET');
     expect(calls[0]?.url).toContain('query=is%3Aunresolved+safe_test%3Atrue');
+    expect(calls[1]?.method).toBe('GET');
+    expect(calls[1]?.url).toContain('cursor=page-2');
 
     calls.length = 0;
     const applied = await cleanupSafeTestIssues({ token: 'token', dryRun: false, fetch });
@@ -184,10 +211,15 @@ describe('Sentry alert catalog', () => {
       dryRun: false,
       query: SENTRY_SAFE_TEST_ISSUE_QUERY,
     });
-    expect(applied.resolvedIssues.map((issue) => issue.id)).toEqual(['7555295841', '7551288604']);
-    expect(calls.map((call) => call.method)).toEqual(['GET', 'PUT', 'PUT']);
-    expect(calls[1]?.url).toBe('https://sentry.io/api/0/issues/7555295841/');
-    expect(calls[2]?.url).toBe('https://sentry.io/api/0/issues/7551288604/');
+    expect(applied.resolvedIssues.map((issue) => issue.id)).toEqual([
+      '7555295841',
+      '7557533332',
+      '7551288604',
+    ]);
+    expect(calls.map((call) => call.method)).toEqual(['GET', 'GET', 'PUT', 'PUT', 'PUT']);
+    expect(calls[2]?.url).toBe('https://sentry.io/api/0/issues/7555295841/');
+    expect(calls[3]?.url).toBe('https://sentry.io/api/0/issues/7557533332/');
+    expect(calls[4]?.url).toBe('https://sentry.io/api/0/issues/7551288604/');
   });
 
   it('exposes the app-health dashboard and alert sync dry run', async () => {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -939,7 +939,7 @@ describe('telemetry boundary', () => {
     expect(sentry.captureException).toHaveBeenCalledWith(error);
   });
 
-  it('sets a sanitized fingerprint when callers provide a safe grouping key', () => {
+  it('sets only allowlisted low-cardinality fingerprint values', () => {
     process.env.SENTRY_DSN = 'https://public@example.sentry.io/123';
     process.env.SENTRY_RELEASE = 'abc123';
     process.env.SQUIRE_ENV = 'production';
@@ -947,14 +947,10 @@ describe('telemetry boundary', () => {
 
     captureTelemetryError(new Error('safe test'), {
       requestId: 'req-1',
-      fingerprint: ['squire-safe-test', 'browser', 'alice@example.com'],
+      fingerprint: ['squire-safe-test', 'browser', 'alice@example.com', 'req-1'],
     });
 
-    expect(sentry.scope.setFingerprint).toHaveBeenCalledWith([
-      'squire-safe-test',
-      'browser',
-      TELEMETRY_REDACTED,
-    ]);
+    expect(sentry.scope.setFingerprint).toHaveBeenCalledWith(['squire-safe-test', 'browser']);
   });
 
   it('redacts breadcrumb data and flushes when enabled', async () => {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -4,11 +4,13 @@ const sentry = vi.hoisted(() => {
   const scope = {
     setTags: vi.fn(),
     setContext: vi.fn(),
+    setFingerprint: vi.fn(),
     setUser: vi.fn(),
   };
   type Scope = {
     setTags: typeof scope.setTags;
     setContext: typeof scope.setContext;
+    setFingerprint: typeof scope.setFingerprint;
     setUser: typeof scope.setUser;
   };
 
@@ -935,6 +937,24 @@ describe('telemetry boundary', () => {
     );
     expect(sentry.scope.setUser).toHaveBeenCalledWith({ id: 'user-1' });
     expect(sentry.captureException).toHaveBeenCalledWith(error);
+  });
+
+  it('sets a sanitized fingerprint when callers provide a safe grouping key', () => {
+    process.env.SENTRY_DSN = 'https://public@example.sentry.io/123';
+    process.env.SENTRY_RELEASE = 'abc123';
+    process.env.SQUIRE_ENV = 'production';
+    initTelemetry(process.env);
+
+    captureTelemetryError(new Error('safe test'), {
+      requestId: 'req-1',
+      fingerprint: ['squire-safe-test', 'browser', 'alice@example.com'],
+    });
+
+    expect(sentry.scope.setFingerprint).toHaveBeenCalledWith([
+      'squire-safe-test',
+      'browser',
+      TELEMETRY_REDACTED,
+    ]);
   });
 
   it('redacts breadcrumb data and flushes when enabled', async () => {


### PR DESCRIPTION
## Summary

Fixes SQR-354.

- mark safe Sentry test events with stable `safe_test`, `safe_test_kind`, and `synthetic` metadata across error/message captures, logs, and traces
- add safe Sentry fingerprints so repeated test events group predictably by test kind
- add `npm run sentry:test-event -- --cleanup [--dry-run]` to find and resolve only unresolved production issues carrying `safe_test:true`
- document the exact safe-test query and cleanup path in the Sentry runbooks

## Verification

- `npm test -- --run test/sentry-alerts.test.ts test/telemetry.test.ts`
- `npm run typecheck`
- `npx markdownlint-cli2 docs/runbooks/sentry-alerts.md docs/runbooks/observability.md`
- `env -u SENTRY_TOKEN npm run sentry:test-event -- --cleanup --dry-run`
- `set -a; source ~/.config/maz/squire.env; set +a; npm run sentry:test-event -- --cleanup --dry-run`
- `npm run sentry:test-event -- --kind browser --dry-run`
- `git diff --check`
- `npm run check`

Live Sentry cleanup dry-run returned no unresolved safe-test issues at the time of verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated observability and Sentry alerts runbooks with safer Safe Test verification guidance, including synthetic-only cleanup, dry-run vs cleanup separation, required metadata, and expanded tag/evidence instructions.

* **New Features**
  * Added Safe Test issue cleanup workflow with a dry-run preview and a production cleanup mode that resolves only eligible synthetic matches.
  * Enhanced telemetry by supporting low-cardinality fingerprint grouping with automatic sanitization for better deduplication.

* **Tests**
  * Expanded Safe Test payload and cleanup dry-run/cleanup coverage, plus telemetry fingerprint behavior tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->