### PR TITLE
Harden deploy health smoke retries

### DIFF
--- a/scripts/check-deploy-health.ts
+++ b/scripts/check-deploy-health.ts
@@ -2,14 +2,28 @@ import { pathToFileURL } from 'node:url';
 
 const DEFAULT_BASE_URL = 'https://maz-squire.fly.dev';
 const HEALTH_COMPONENTS = ['db', 'vector', 'embedder'] as const;
+const DEFAULT_RETRY_DELAYS_MS = [1000, 2000, 5000] as const;
+const TRANSIENT_HTTP_STATUSES = new Set([502, 503, 504]);
+const TRANSIENT_FETCH_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+  'ENOTFOUND',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
 
 type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
 type Logger = (message: string) => void;
+type Sleep = (milliseconds: number) => Promise<void>;
 
 interface CheckDeployHealthOptions {
   baseUrl?: string;
   fetch?: FetchLike;
   log?: Logger;
+  retryDelaysMs?: readonly number[];
+  sleep?: Sleep;
 }
 
 interface StatusPayload {
@@ -23,6 +37,12 @@ export interface CheckDeployHealthResult {
   baseUrl: string;
   liveUrl: string;
   healthUrl: string;
+}
+
+interface EndpointStatusResult {
+  attempt: number;
+  maxAttempts: number;
+  payload: StatusPayload;
 }
 
 function normalizeBaseUrl(rawBaseUrl: string): string {
@@ -41,21 +61,99 @@ async function readJson(response: Response, path: string): Promise<StatusPayload
   }
 }
 
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function errorCode(error: unknown, depth = 0): string | undefined {
+  if (depth > 4 || !isRecord(error)) return undefined;
+  const code = error.code;
+  if (typeof code === 'string' && code.trim().length > 0) return code.trim();
+  return errorCode(error.cause, depth + 1);
+}
+
+function errorMessage(error: unknown, depth = 0): string {
+  if (depth > 4 || !isRecord(error)) return '';
+  const message = error.message;
+  const causeMessage = errorMessage(error.cause, depth + 1);
+  return [typeof message === 'string' ? message : '', causeMessage].filter(Boolean).join(' ');
+}
+
+function transientFetchFailureReason(error: unknown): string | undefined {
+  const code = errorCode(error);
+  if (code && TRANSIENT_FETCH_ERROR_CODES.has(code)) return code;
+
+  const message = errorMessage(error).toLowerCase();
+  if (
+    /\bfetch failed\b/.test(message) ||
+    /network socket disconnected/.test(message) ||
+    /before secure tls connection was established/.test(message) ||
+    /socket hang up/.test(message)
+  ) {
+    return 'fetch_failed';
+  }
+
+  return undefined;
+}
+
 async function checkEndpointStatus(
   fetch: FetchLike,
   url: string,
   path: string,
-): Promise<StatusPayload> {
-  const response = await fetch(url);
+  options: {
+    log: Logger;
+    retryDelaysMs: readonly number[];
+    sleep: Sleep;
+  },
+): Promise<EndpointStatusResult> {
+  const maxAttempts = options.retryDelaysMs.length + 1;
 
-  if (!response.ok) {
-    throw new Error(`${path} returned ${response.status}`);
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        if (TRANSIENT_HTTP_STATUSES.has(response.status)) {
+          if (attempt < maxAttempts) {
+            const nextDelayMs = options.retryDelaysMs[attempt - 1] ?? 0;
+            options.log(
+              `Retry ${path} attempt=${attempt}/${maxAttempts} reason=HTTP ${response.status} nextDelayMs=${nextDelayMs}`,
+            );
+            await options.sleep(nextDelayMs);
+            continue;
+          }
+          throw new Error(`${path} returned ${response.status} after ${maxAttempts} attempts`);
+        }
+        throw new Error(`${path} returned ${response.status}`);
+      }
+
+      const payload = await readJson(response, path);
+      if (payload.status !== 'ok') {
+        throw new Error(`${path} status was ${String(payload.status)}`);
+      }
+      return { attempt, maxAttempts, payload };
+    } catch (error) {
+      const reason = transientFetchFailureReason(error);
+      if (!reason) throw error;
+      if (attempt >= maxAttempts) {
+        throw new Error(`${path} failed after ${maxAttempts} attempts: ${reason}`, {
+          cause: error,
+        });
+      }
+
+      const nextDelayMs = options.retryDelaysMs[attempt - 1] ?? 0;
+      options.log(
+        `Retry ${path} attempt=${attempt}/${maxAttempts} reason=${reason} nextDelayMs=${nextDelayMs}`,
+      );
+      await options.sleep(nextDelayMs);
+    }
   }
-  const payload = await readJson(response, path);
-  if (payload.status !== 'ok') {
-    throw new Error(`${path} status was ${String(payload.status)}`);
-  }
-  return payload;
+
+  throw new Error(`${path} failed after ${maxAttempts} attempts`);
 }
 
 function assertHealthComponents(payload: StatusPayload) {
@@ -72,19 +170,33 @@ export async function checkDeployHealth(
 ): Promise<CheckDeployHealthResult> {
   const fetch = options.fetch ?? globalThis.fetch;
   const log = options.log ?? console.log;
+  const retryDelaysMs = options.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
+  const sleepFn = options.sleep ?? sleep;
   const baseUrl = normalizeBaseUrl(options.baseUrl ?? DEFAULT_BASE_URL);
   const liveUrl = `${baseUrl}/api/live`;
   const healthUrl = `${baseUrl}/api/health`;
 
-  const live = await checkEndpointStatus(fetch, liveUrl, '/api/live');
-  log(`OK /api/live status=${String(live.status)}`);
-
-  const health = await checkEndpointStatus(fetch, healthUrl, '/api/health');
-  assertHealthComponents(health);
+  const live = await checkEndpointStatus(fetch, liveUrl, '/api/live', {
+    log,
+    retryDelaysMs,
+    sleep: sleepFn,
+  });
   log(
-    `OK /api/health status=${String(health.status)} db=${String(
-      health.db?.status,
-    )} vector=${String(health.vector?.status)} embedder=${String(health.embedder?.status)}`,
+    `OK /api/live status=${String(live.payload.status)} attempt=${live.attempt}/${live.maxAttempts}`,
+  );
+
+  const health = await checkEndpointStatus(fetch, healthUrl, '/api/health', {
+    log,
+    retryDelaysMs,
+    sleep: sleepFn,
+  });
+  assertHealthComponents(health.payload);
+  log(
+    `OK /api/health status=${String(health.payload.status)} attempt=${health.attempt}/${
+      health.maxAttempts
+    } db=${String(health.payload.db?.status)} vector=${String(
+      health.payload.vector?.status,
+    )} embedder=${String(health.payload.embedder?.status)}`,
   );
 
   return { baseUrl, liveUrl, healthUrl };

--- a/test/check-deploy-health.test.ts
+++ b/test/check-deploy-health.test.ts
@@ -12,6 +12,7 @@ function jsonResponse(status: number, body: unknown): Response {
 describe('checkDeployHealth', () => {
   it('passes when liveness and all readiness dependencies are healthy', async () => {
     const requested: string[] = [];
+    const logs: string[] = [];
     const result = await checkDeployHealth({
       baseUrl: 'https://maz-squire.fly.dev/',
       fetch: async (url) => {
@@ -26,7 +27,7 @@ describe('checkDeployHealth', () => {
           embedder: { status: 'ok' },
         });
       },
-      log: () => undefined,
+      log: (message) => logs.push(message),
     });
 
     expect(result).toEqual({
@@ -38,16 +39,179 @@ describe('checkDeployHealth', () => {
       'https://maz-squire.fly.dev/api/live',
       'https://maz-squire.fly.dev/api/health',
     ]);
+    expect(logs).toEqual([
+      'OK /api/live status=ok attempt=1/4',
+      'OK /api/health status=ok attempt=1/4 db=ok vector=ok embedder=ok',
+    ]);
   });
 
-  it('fails when the liveness endpoint is not ok', async () => {
+  it('retries a transient fetch failure and then succeeds', async () => {
+    const requested: string[] = [];
+    const sleeps: number[] = [];
+    const logs: string[] = [];
+
+    await expect(
+      checkDeployHealth({
+        baseUrl: 'https://maz-squire.fly.dev',
+        fetch: async (url) => {
+          requested.push(String(url));
+          if (requested.length === 1) {
+            throw Object.assign(new TypeError('fetch failed'), {
+              cause: Object.assign(new Error('socket reset'), { code: 'ECONNRESET' }),
+            });
+          }
+          if (String(url).endsWith('/api/live')) {
+            return jsonResponse(200, { status: 'ok' });
+          }
+          return jsonResponse(200, {
+            status: 'ok',
+            db: { status: 'ok' },
+            vector: { status: 'ok' },
+            embedder: { status: 'ok' },
+          });
+        },
+        log: (message) => logs.push(message),
+        sleep: async (milliseconds) => {
+          sleeps.push(milliseconds);
+        },
+      }),
+    ).resolves.toMatchObject({
+      liveUrl: 'https://maz-squire.fly.dev/api/live',
+      healthUrl: 'https://maz-squire.fly.dev/api/health',
+    });
+
+    expect(requested).toEqual([
+      'https://maz-squire.fly.dev/api/live',
+      'https://maz-squire.fly.dev/api/live',
+      'https://maz-squire.fly.dev/api/health',
+    ]);
+    expect(sleeps).toEqual([1000]);
+    expect(logs).toEqual([
+      'Retry /api/live attempt=1/4 reason=ECONNRESET nextDelayMs=1000',
+      'OK /api/live status=ok attempt=2/4',
+      'OK /api/health status=ok attempt=1/4 db=ok vector=ok embedder=ok',
+    ]);
+  });
+
+  it('retries a TLS setup network reset without logging the full URL', async () => {
+    const requested: string[] = [];
+    const logs: string[] = [];
+
+    await expect(
+      checkDeployHealth({
+        baseUrl: 'https://maz-squire.fly.dev',
+        fetch: async (url) => {
+          requested.push(String(url));
+          if (requested.length === 1) {
+            throw new TypeError(
+              'Client network socket disconnected before secure TLS connection was established',
+            );
+          }
+          if (String(url).endsWith('/api/live')) {
+            return jsonResponse(200, { status: 'ok' });
+          }
+          return jsonResponse(200, {
+            status: 'ok',
+            db: { status: 'ok' },
+            vector: { status: 'ok' },
+            embedder: { status: 'ok' },
+          });
+        },
+        log: (message) => logs.push(message),
+        sleep: async () => undefined,
+      }),
+    ).resolves.toMatchObject({
+      liveUrl: 'https://maz-squire.fly.dev/api/live',
+      healthUrl: 'https://maz-squire.fly.dev/api/health',
+    });
+
+    expect(requested).toHaveLength(3);
+    expect(logs[0]).toBe('Retry /api/live attempt=1/4 reason=fetch_failed nextDelayMs=1000');
+    expect(logs.join('\n')).not.toContain('https://maz-squire.fly.dev');
+  });
+
+  it('retries transient 502, 503, and 504 responses', async () => {
+    const responses = [
+      jsonResponse(502, { status: 'bad_gateway' }),
+      jsonResponse(503, { status: 'starting' }),
+      jsonResponse(504, { status: 'timeout' }),
+      jsonResponse(200, { status: 'ok' }),
+      jsonResponse(200, {
+        status: 'ok',
+        db: { status: 'ok' },
+        vector: { status: 'ok' },
+        embedder: { status: 'ok' },
+      }),
+    ];
+    const sleeps: number[] = [];
+
+    await expect(
+      checkDeployHealth({
+        baseUrl: 'https://maz-squire.fly.dev',
+        fetch: async () => responses.shift() ?? jsonResponse(500, { status: 'unexpected' }),
+        log: () => undefined,
+        sleep: async (milliseconds) => {
+          sleeps.push(milliseconds);
+        },
+      }),
+    ).resolves.toMatchObject({ baseUrl: 'https://maz-squire.fly.dev' });
+
+    expect(sleeps).toEqual([1000, 2000, 5000]);
+  });
+
+  it('fails after exhausting transient retries', async () => {
+    const sleeps: number[] = [];
+
+    await expect(
+      checkDeployHealth({
+        baseUrl: 'https://maz-squire.fly.dev',
+        fetch: async () => {
+          throw Object.assign(new TypeError('fetch failed'), {
+            cause: Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }),
+          });
+        },
+        log: () => undefined,
+        sleep: async (milliseconds) => {
+          sleeps.push(milliseconds);
+        },
+      }),
+    ).rejects.toThrow('/api/live failed after 4 attempts: ETIMEDOUT');
+
+    expect(sleeps).toEqual([1000, 2000, 5000]);
+  });
+
+  it('fails after exhausting transient HTTP status retries', async () => {
+    const sleeps: number[] = [];
+
     await expect(
       checkDeployHealth({
         baseUrl: 'https://maz-squire.fly.dev',
         fetch: async () => jsonResponse(503, { status: 'starting' }),
         log: () => undefined,
+        sleep: async (milliseconds) => {
+          sleeps.push(milliseconds);
+        },
       }),
-    ).rejects.toThrow('/api/live returned 503');
+    ).rejects.toThrow('/api/live returned 503 after 4 attempts');
+
+    expect(sleeps).toEqual([1000, 2000, 5000]);
+  });
+
+  it('does not retry permanent HTTP failures', async () => {
+    const requested: string[] = [];
+
+    await expect(
+      checkDeployHealth({
+        baseUrl: 'https://maz-squire.fly.dev',
+        fetch: async (url) => {
+          requested.push(String(url));
+          return jsonResponse(404, { status: 'not_found' });
+        },
+        log: () => undefined,
+      }),
+    ).rejects.toThrow('/api/live returned 404');
+
+    expect(requested).toEqual(['https://maz-squire.fly.dev/api/live']);
   });
 
   it('reports response status before parsing non-ok bodies', async () => {
@@ -56,12 +220,32 @@ describe('checkDeployHealth', () => {
         baseUrl: 'https://maz-squire.fly.dev',
         fetch: async () =>
           new Response('<html>temporarily unavailable</html>', {
-            status: 503,
+            status: 500,
             headers: { 'content-type': 'text/html' },
           }),
         log: () => undefined,
       }),
-    ).rejects.toThrow('/api/live returned 503');
+    ).rejects.toThrow('/api/live returned 500');
+  });
+
+  it('does not retry invalid JSON from a successful response', async () => {
+    const requested: string[] = [];
+
+    await expect(
+      checkDeployHealth({
+        baseUrl: 'https://maz-squire.fly.dev',
+        fetch: async (url) => {
+          requested.push(String(url));
+          return new Response('<html>bad gateway</html>', {
+            status: 200,
+            headers: { 'content-type': 'text/html' },
+          });
+        },
+        log: () => undefined,
+      }),
+    ).rejects.toThrow('/api/live did not return valid JSON');
+
+    expect(requested).toEqual(['https://maz-squire.fly.dev/api/live']);
   });
 
   it('fails when a readiness dependency is unhealthy', async () => {


### PR DESCRIPTION
## Summary

Fixes SQR-353.

- retry transient deploy health smoke failures with bounded 1s/2s/5s backoff
- retry fetch/TLS setup failures and HTTP 502/503/504 only
- keep permanent bad status, invalid JSON, and unhealthy readiness components failing without retry
- add attempt counts and endpoint paths to smoke logs without logging full URLs, headers, or secrets

## Verification

- `npm test -- --run test/check-deploy-health.test.ts`
- `npm test -- --run test/deployment-config.test.ts`
- `npm run typecheck`
- `npx prettier --check scripts/check-deploy-health.ts test/check-deploy-health.test.ts`
- `node scripts/check-deploy-health.ts --base-url https://maz-squire.fly.dev`
- `/review` pre-landing pass recorded clean after fixing one test coverage gap
- `npm run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deploy health checks now automatically retry on transient network and HTTP failures with configurable backoff delays
  * Improved error reporting includes attempt counts and specific retry reasons for better deployment troubleshooting
  * Support for customizing retry delays and sleep function behavior to match different deployment environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->