### PR TITLE
Fix mobile transcript input overlap

### DIFF
--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -1917,14 +1917,50 @@ function renderAnswerArtifact(artifactsEl, artifactEntries, payload) {
   if (bodyEl) bodyEl.textContent = payload.body;
 }
 
-// SQR-108 / ADR 0012 D-3: pin-to-bottom helpers. Use page-level scroll
-// (the conversation page scrolls the document body — `.squire-frame` is
-// `min-height: 100vh` and the input dock sticky-pins to the viewport).
+// SQR-108 / ADR 0012 D-3 plus SQR-297: pin-to-bottom helpers. Transcript
+// pages scroll `.squire-surface` so the input dock does not overlay answer
+// text; non-transcript pages still fall back to document-level scroll.
+var transcriptScrollRoot = null;
+
+function getTranscriptScrollRoot() {
+  if (typeof document === 'undefined' || !document.querySelector) return null;
+  var transcript = document.querySelector('.squire-transcript');
+  if (!transcript || typeof transcript.closest !== 'function') return null;
+  var surface = transcript.closest('.squire-surface');
+  if (
+    !surface ||
+    typeof surface.scrollHeight !== 'number' ||
+    typeof surface.scrollTop !== 'number' ||
+    typeof surface.clientHeight !== 'number'
+  ) {
+    return null;
+  }
+  return surface;
+}
+
+function getScrollRoot() {
+  return getTranscriptScrollRoot() || document.documentElement;
+}
+
+function updatePinToBottomFromScroll() {
+  pinToBottom = isNearBottom();
+}
+
+function syncTranscriptScrollRoot() {
+  var root = getTranscriptScrollRoot();
+  if (!root || root === transcriptScrollRoot || typeof root.addEventListener !== 'function') return;
+  transcriptScrollRoot = root;
+  root.addEventListener('scroll', updatePinToBottomFromScroll, { passive: true });
+}
+
 function isNearBottom(threshold) {
   if (typeof window === 'undefined' || typeof document === 'undefined') return true;
-  var doc = document.documentElement;
-  if (!doc) return true;
-  var distance = doc.scrollHeight - (window.scrollY + window.innerHeight);
+  var root = getScrollRoot();
+  if (!root) return true;
+  var distance =
+    root === document.documentElement
+      ? root.scrollHeight - (window.scrollY + window.innerHeight)
+      : root.scrollHeight - (root.scrollTop + root.clientHeight);
   return distance <= (threshold == null ? SCROLL_PIN_THRESHOLD_PX : threshold);
 }
 
@@ -1940,16 +1976,29 @@ function scrollToBottom() {
   if (typeof window === 'undefined' || typeof document === 'undefined') return;
   if (scrollToBottomScheduled) return;
   if (typeof window.requestAnimationFrame !== 'function') {
-    var doc = document.documentElement;
-    if (doc) window.scrollTo({ top: doc.scrollHeight, behavior: 'auto' });
+    var immediateRoot = getScrollRoot();
+    if (!immediateRoot) return;
+    if (immediateRoot === document.documentElement) {
+      window.scrollTo({ top: immediateRoot.scrollHeight, behavior: 'auto' });
+    } else if (typeof immediateRoot.scrollTo === 'function') {
+      immediateRoot.scrollTo({ top: immediateRoot.scrollHeight, behavior: 'auto' });
+    } else {
+      immediateRoot.scrollTop = immediateRoot.scrollHeight;
+    }
     return;
   }
   scrollToBottomScheduled = true;
   window.requestAnimationFrame(function () {
     scrollToBottomScheduled = false;
-    var doc = document.documentElement;
-    if (!doc) return;
-    window.scrollTo({ top: doc.scrollHeight, behavior: 'auto' });
+    var root = getScrollRoot();
+    if (!root) return;
+    if (root === document.documentElement) {
+      window.scrollTo({ top: root.scrollHeight, behavior: 'auto' });
+    } else if (typeof root.scrollTo === 'function') {
+      root.scrollTo({ top: root.scrollHeight, behavior: 'auto' });
+    } else {
+      root.scrollTop = root.scrollHeight;
+    }
   });
 }
 
@@ -2199,13 +2248,7 @@ function renderProposalBlock(answerEl, payload) {
 // returns true and the pin stays on. Genuine user-initiated scroll-up
 // drops below the threshold and disables pin.
 if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
-  window.addEventListener(
-    'scroll',
-    function () {
-      pinToBottom = isNearBottom();
-    },
-    { passive: true },
-  );
+  window.addEventListener('scroll', updatePinToBottomFromScroll, { passive: true });
 }
 
 function attachPendingAnswerStream(answerEl) {
@@ -2735,6 +2778,7 @@ document.addEventListener('htmx:afterSwap', function (event) {
   if (questionInput) questionInput.value = '';
   syncChatFormAction();
   syncActiveGameControls();
+  syncTranscriptScrollRoot();
 
   var swapTarget = event.detail && event.detail.target;
   var pending = findActivePendingAnswer(swapTarget) || findActivePendingAnswer(document);
@@ -2765,6 +2809,7 @@ document.addEventListener('htmx:afterSwap', function (event) {
 document.addEventListener('DOMContentLoaded', function () {
   syncChatFormAction();
   syncActiveGameControls();
+  syncTranscriptScrollRoot();
   openSheetSectionFromHash();
   // SQR-108 / ADR 0012 D-2: the browser preserves last scroll natively on
   // back/forward navigation and refresh, so we don't pin or auto-scroll on

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -462,6 +462,27 @@ html {
   margin: 0 auto;
 }
 
+/* SQR-297: once a surface contains a transcript, the transcript scrolls
+   inside the viewport space above the input dock. Keeping the dock in normal
+   flex flow prevents the reloaded mobile transcript from sliding underneath
+   a sticky footer while preserving the home page's sticky first-submit dock. */
+.squire-column:has(> .squire-surface > .squire-transcript) {
+  height: 100vh;
+  height: 100dvh;
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow: hidden;
+}
+
+.squire-column:has(> .squire-surface > .squire-transcript) .squire-surface {
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.squire-column:has(> .squire-surface > .squire-transcript) .squire-input-dock {
+  position: static;
+}
+
 .squire-column--wide {
   max-width: 1120px;
 }

--- a/test/e2e/sqr-297-mobile-transcript-layout.spec.ts
+++ b/test/e2e/sqr-297-mobile-transcript-layout.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+
+const appCss = readFileSync(new URL('../../src/web-ui/styles.css', import.meta.url), 'utf8');
+
+function renderReloadedConversationFixture(): string {
+  const longAnswerItems = Array.from({ length: 13 }, (_unused, index) => {
+    const n = index + 1;
+    return `<li>Drifter perk entry ${n} with enough text to wrap into the next line on a phone viewport.</li>`;
+  }).join('');
+
+  return `<!doctype html>
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+        <style>${appCss}</style>
+      </head>
+      <body class="squire-body">
+        <div class="squire-frame">
+          <div class="squire-column">
+            <header class="squire-header">
+              <span class="squire-monogram" aria-hidden="true">S</span>
+              <span class="squire-wordmark">Squire</span>
+              <span class="squire-context">GH2 TABLETOP CAMPAIGN</span>
+            </header>
+            <main id="squire-surface" class="squire-surface" aria-live="off" aria-atomic="true">
+              <section class="squire-transcript" data-testid="conversation-transcript" role="log" aria-live="polite">
+                <article class="squire-turn">
+                  <h2 class="squire-question">what perks does the drifter have?</h2>
+                </article>
+                <article class="squire-turn squire-answer squire-markdown" data-testid="answer-turn">
+                  <details class="squire-answer-work">
+                    <summary class="squire-answer-work__summary">Worked for 0s</summary>
+                  </details>
+                  <div class="squire-answer__content squire-markdown" data-testid="answer-content">
+                    <p>Here are the Drifter's perks from the character mat:</p>
+                    <ol>${longAnswerItems}</ol>
+                    <p>That's 13 perk entries in total, with the +1 card appearing twice as separate perks.</p>
+                  </div>
+                </article>
+              </section>
+            </main>
+            <form class="squire-input-dock" method="post" action="/chat/conversation-123/messages">
+              <input id="squire-input" name="question" type="text" autocomplete="off" placeholder="Ask a question..." />
+              <button type="submit" class="squire-input-dock__submit" aria-label="Ask">
+                <span aria-hidden="true">S</span>
+              </button>
+            </form>
+          </div>
+        </div>
+      </body>
+    </html>`;
+}
+
+test.describe('SQR-297 mobile transcript layout', () => {
+  test('keeps a reloaded transcript scroll surface above the input dock at phone size', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'desktop',
+      'static phone layout check only needs one browser',
+    );
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.setContent(renderReloadedConversationFixture());
+
+    const geometry = await page.evaluate(() => {
+      const surface = document.querySelector('.squire-surface');
+      const dock = document.querySelector('.squire-input-dock');
+      if (!(surface instanceof HTMLElement) || !(dock instanceof HTMLElement)) {
+        throw new Error('missing Squire transcript fixture elements');
+      }
+
+      const surfaceRect = surface.getBoundingClientRect();
+      const dockRect = dock.getBoundingClientRect();
+      const surfaceStyle = window.getComputedStyle(surface);
+
+      return {
+        dockTop: dockRect.top,
+        surfaceBottom: surfaceRect.bottom,
+        surfaceClientHeight: surface.clientHeight,
+        surfaceOverflowY: surfaceStyle.overflowY,
+        surfaceScrollHeight: surface.scrollHeight,
+      };
+    });
+
+    expect(geometry.surfaceBottom).toBeLessThanOrEqual(geometry.dockTop + 1);
+    expect(geometry.surfaceOverflowY).toBe('auto');
+    expect(geometry.surfaceScrollHeight).toBeGreaterThan(geometry.surfaceClientHeight);
+  });
+});

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -1928,6 +1928,108 @@ describe('squire.js chat form retargeting', () => {
       expect(harness.scrollToCalls[0]).toMatchObject({ top: 2000, behavior: 'auto' });
     });
 
+    it('uses the transcript surface as the scroll root when the page has a transcript', () => {
+      const docListeners = new Map<string, Array<() => void>>();
+      const surfaceListeners = new Map<string, Array<() => void>>();
+      const noopElement = { setAttribute() {}, removeAttribute() {}, textContent: '' };
+      const contentEl = new FakeElement('div');
+      contentEl.classList.add('squire-answer__content');
+      const toolsEl = new FakeElement('div');
+      toolsEl.classList.add('squire-answer__tools');
+      const skeletonEl = new FakeElement('div');
+      skeletonEl.classList.add('squire-answer__skeleton');
+      const answerEl = new FakeElement('article');
+      answerEl.classList.add('squire-answer--pending');
+      answerEl.setAttribute('data-stream-url', '/chat/surface/messages/m1/stream');
+      answerEl.appendChild(contentEl);
+      answerEl.appendChild(toolsEl);
+      answerEl.appendChild(skeletonEl);
+
+      const transcript = new FakeElement('section');
+      transcript.classList.add('squire-transcript');
+      transcript.appendChild(answerEl);
+      const surface = new FakeElement('main');
+      surface.classList.add('squire-surface');
+      surface.appendChild(transcript);
+
+      const surfaceScrollToCalls: Array<{ top?: number; behavior?: string }> = [];
+      Object.assign(surface, {
+        clientHeight: 700,
+        scrollHeight: 1600,
+        scrollTop: 850,
+        addEventListener(event: string, cb: () => void) {
+          surfaceListeners.set(event, [...(surfaceListeners.get(event) ?? []), cb]);
+        },
+        scrollTo(opts: { top?: number; behavior?: string }) {
+          surfaceScrollToCalls.push(opts);
+          if (typeof opts.top === 'number') {
+            (surface as unknown as { scrollTop: number }).scrollTop = opts.top;
+          }
+        },
+      });
+
+      const form = {
+        setAttribute() {},
+        dataset: {} as Record<string, string>,
+        querySelector(sel: string) {
+          if (sel === 'input[name="question"]') return noopElement;
+          if (sel === 'button[type="submit"]') return noopElement;
+          return null;
+        },
+      };
+      const document = {
+        addEventListener(event: string, cb: () => void) {
+          docListeners.set(event, [...(docListeners.get(event) ?? []), cb]);
+        },
+        createElement(t: string) {
+          return new FakeElement(t);
+        },
+        querySelector(sel: string) {
+          if (sel === '.squire-input-dock') return form;
+          if (sel === '.squire-transcript') return transcript;
+          return null;
+        },
+        querySelectorAll(sel: string) {
+          return sel === '.squire-answer--pending[data-stream-url]' ? [answerEl] : [];
+        },
+        documentElement: { scrollHeight: 10000 },
+      };
+
+      const windowScrollToCalls: Array<unknown> = [];
+      const win = {
+        location: { pathname: '/chat/surface' },
+        crypto: {},
+        EventSource: FakeEventSource,
+        scrollY: 0,
+        innerHeight: 800,
+        scrollTo: (opts: unknown) => {
+          windowScrollToCalls.push(opts);
+        },
+        addEventListener: () => {},
+        requestAnimationFrame: (cb: () => void) => {
+          cb();
+          return 0;
+        },
+      };
+      const ctx = vm.createContext({ document, window: win });
+      vm.runInContext(scriptSource, ctx);
+      for (const cb of docListeners.get('DOMContentLoaded') ?? []) cb();
+
+      const source = FakeEventSource.latest!;
+      source.emit('text-delta', { delta: 'Streaming in the surface.' });
+
+      expect(surfaceScrollToCalls).toHaveLength(1);
+      expect(surfaceScrollToCalls[0]).toMatchObject({ top: 1600, behavior: 'auto' });
+      expect(windowScrollToCalls).toHaveLength(0);
+
+      (surface as unknown as { scrollTop: number }).scrollTop = 500;
+      for (const cb of surfaceListeners.get('scroll') ?? []) cb();
+      source.emit('text-delta', { delta: 'The user is reading earlier text.' });
+
+      expect(surfaceScrollToCalls).toHaveLength(1);
+      expect(windowScrollToCalls).toHaveLength(0);
+    });
+
     it('coalesces multiple text-delta scrolls into a single scrollTo per animation frame (I5 perf fix)', () => {
       // With rAF-throttled scrollToBottom, ten deltas in one synchronous
       // batch should result in ONE scrollTo call (per frame), not ten.


### PR DESCRIPTION
## Summary
- make transcript pages use an internal scroll surface above the input dock
- update streaming auto-scroll to target that transcript surface when present
- add mobile browser and stream-controller regressions for SQR-297

## Validation
- npm run check
- npx playwright test --config=playwright.e2e.config.ts test/e2e/sqr-297-mobile-transcript-layout.spec.ts --project=desktop --reporter=list
- /browse visual check at 390x844: surface bottom equals dock top, bottom paragraph clears the dock

Fixes SQR-297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed transcript scrolling behavior to properly handle scroll containers when transcripts are present.
  * Improved auto-scroll and pin-to-bottom functionality for transcripts.
  * Fixed layout issue where transcript content could slide beneath the input dock on mobile.

* **Tests**
  * Added regression test for transcript scroll controller behavior.
  * Added end-to-end test for mobile transcript layout verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->