### PR TITLE
Add in-chat Linear bug reports

### DIFF
--- a/.claude/skills/squire-bug-report/SKILL.md
+++ b/.claude/skills/squire-bug-report/SKILL.md
@@ -1,0 +1,29 @@
+# Squire Bug Report
+
+Use this skill when filing a Squire bug from a user report, QA run, production
+probe, or agent investigation.
+
+## Required Reading
+
+Read these repo docs before creating or updating a Linear bug:
+
+- `docs/agent/bug-reporting.md`
+- `docs/agent/diagnostic-bundle.md`
+
+## Workflow
+
+1. Gather safe IDs and links only: conversation URL, conversation ID, user
+   message ID, assistant message ID, request ID, Sentry issue/event/replay/logs
+   URLs, Sentry event/trace IDs, LangSmith trace/thread/run URLs, release,
+   environment, viewport, and screenshot or masked replay IDs when available.
+2. Do not copy raw prompts, full answers, provider payloads, cookies, auth
+   headers, OAuth tokens, secrets, retrieved passages, or full conversations.
+3. Build a `DiagnosticBundle`.
+4. Use `buildLinearBugReportDraft()` for a dry run or `submitLinearBugReport()`
+   to file the issue.
+5. Search by the dedupe marker before creating a ticket:
+   `squire-bug:<env>:<conversationId>:<userMessageId>`.
+6. File in Linear team `SQR`, project `Squire · Bugs`, state `Todo`, label
+   `Bug`, assigned to the Linear token owner.
+
+If evidence is missing, keep the field and state the exact unavailable reason.

--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,16 @@ SESSION_SECRET=replace_with_random_32_plus_character_string
 # Comma-separated email allowlist for web UI login
 SQUIRE_ALLOWED_EMAILS=your-email@example.com
 
+# Linear bug-report intake.
+# Needs issue read/create/update plus comments:create for diagnostic evidence
+# comments and file upload for screenshot attachments.
+# LINEAR_API_KEY=
+
 # LangSmith tracing / observability
 LANGSMITH_API_KEY=
 LANGSMITH_PROJECT=squire-evals
+# LangSmith project UUID used to build trace/thread/run links in bug evidence.
+# LANGSMITH_PROJECT_ID=
 # LANGSMITH_ENDPOINT=https://api.smith.langchain.com
 # LANGSMITH_WORKSPACE_ID=
 
@@ -31,6 +38,12 @@ LANGSMITH_PROJECT=squire-evals
 # Missing SENTRY_DSN is a local/test no-op. Production DSNs are Fly secrets.
 # SENTRY_DSN=
 # SENTRY_RELEASE=local-dev
+# Sentry URL metadata used to build issue/log/trace links in bug evidence.
+# Defaults match the current Squire project, but set them explicitly for local
+# testing if you use a different Sentry org or project.
+# SENTRY_ORG_SLUG=brian-moseley
+# SENTRY_PROJECT_ID=4511564194643969
+# SENTRY_ENVIRONMENT=development
 # Optional Sentry app-span sampling. Unset or 0 disables Sentry span export.
 # Keep LangSmith as the source of truth for AI traces/evals.
 # SENTRY_TRACES_SAMPLE_RATE=0.10

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -726,10 +726,13 @@ Squire emits OpenTelemetry traces from the agent loop, tool calls, and HTTP hand
 
 Runtime agent traces carry safe correlation metadata so an operator can follow
 one user-visible answer without reading PII from stdout logs. Web-chat traces
-include request ID, conversation ID, LangSmith `thread_id` equal to the
-conversation ID, user-message ID, user ID, `SQUIRE_ENV`, provider/model, tool
-surface, stop reason, token usage, and compact tool summaries. REST `/api/ask`
-traces include request ID and any caller-provided user/campaign IDs. The
+include request ID, conversation ID, user-message ID, user ID, `SQUIRE_ENV`,
+provider/model, tool surface, stop reason, token usage, and compact tool
+summaries. Assistant message rows persist the LangSmith root run ID and run URL
+when the agent exposes them, so reloaded conversations can still produce bug
+reports with LLM trace links. If LangSmith provides an actual thread ID, Squire
+can include that ID as evidence, but the Squire conversation ID is not treated
+as a LangSmith thread ID. REST `/api/ask` traces include request ID and any caller-provided user/campaign IDs. The
 browser response includes `X-Request-ID`; the web chat URL and stream URL expose
 the conversation and user-message IDs needed to find the persisted turn.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -38,10 +38,13 @@ LANGSMITH_PROJECT=squire-evals
 LANGSMITH_TRACING=true
 # LANGSMITH_ENDPOINT=https://api.smith.langchain.com
 # LANGSMITH_WORKSPACE_ID=...
+# LANGSMITH_PROJECT_ID=...
 
 # Optional Sentry app observability. Leave unset for normal local dev/tests.
 # SENTRY_DSN=...
 # SENTRY_RELEASE=local-dev
+# SENTRY_ORG_SLUG=brian-moseley
+# SENTRY_PROJECT_ID=4511564194643969
 
 # Trace environment label for LangSmith; defaults to NODE_ENV.
 SQUIRE_ENV=development
@@ -229,6 +232,7 @@ const bundle = buildDiagnosticBundle({
   requestId,
   conversationId,
   userMessageId,
+  sentryEventId,
   sentryEventUrl,
   sentryLogsUrl,
   sentryTraceUrl,
@@ -246,6 +250,12 @@ const body = createLinearBugReportBody({
   acceptanceCriteria,
 });
 ```
+
+For an in-chat or agent-filed Linear bug, prefer
+`buildLinearBugReportDraft()` for dry runs and `submitLinearBugReport()` for
+live filing. Both helpers live in `src/linear-bug-intake.ts`; they own the
+`squire-bug:<env>:<conversationId>:<userMessageId>` dedupe marker, priority
+mapping, Squire Bugs target, and redacted diagnostic JSON comment.
 
 Tests should cover the contract that matters: no-DSN local behavior, redaction,
 stable field names, alert filters, dry-run output, and generated Linear evidence

--- a/docs/agent/bug-reporting.md
+++ b/docs/agent/bug-reporting.md
@@ -69,8 +69,9 @@ body by hand.
    Production Linear calls must go through `SquireLinearClient` in
    `src/linear-client.ts`; do not add new hand-written Linear GraphQL calls.
 4. Dedupe before creating anything. The marker is
-   `squire-bug:<env>:<conversationId>:<userMessageId>` and is embedded in the
-   Linear description.
+   `squire-bug:<env>:<conversationId>:<messageId>` and is embedded in the Linear
+   description. The message component prefers `userMessageId`, then
+   `assistantMessageId`, then `requestId` when earlier IDs are unavailable.
 5. File in Linear team `SQR`, project `Squire · Bugs`, state `Todo`, assigned
    to the Linear token owner, label `Bug`.
 

--- a/docs/agent/bug-reporting.md
+++ b/docs/agent/bug-reporting.md
@@ -45,7 +45,7 @@ Build the evidence bundle with:
 - `collectDiagnosticBundle()` when the caller has an authenticated user and a
   conversation URL, conversation ID, or user-message ID.
 - `buildDiagnosticBundle()` when the agent already gathered safe links and IDs,
-  such as Sentry issue/event/replay/trace/logs URLs, Sentry trace IDs, or
+  such as Sentry issue/event/replay/trace/logs URLs, Sentry event/trace IDs, or
   LangSmith trace/run URLs.
 
 Do not paste raw prompts, full model output, provider payloads, retrieved
@@ -53,12 +53,62 @@ passages, cookies, auth headers, OAuth tokens, or secrets into Linear. If a
 piece of evidence cannot be safely gathered, leave it unavailable with the
 reason from the bundle.
 
+## Codex And Claude Workflow
+
+Use this same workflow for agent-filed bugs. Do not write a separate Linear
+body by hand.
+
+1. Pick the report kind:
+   `bad_answer`, `broken_stream`, `visual_issue`, `wrong_source`, or `other`.
+2. Build evidence with `collectDiagnosticBundle()` when you have an
+   authenticated user and a conversation/message locator. Use
+   `buildDiagnosticBundle()` when you already gathered safe links and IDs.
+3. Call `buildLinearBugReportDraft()` for dry runs or
+   `submitLinearBugReport()` for live filing. Both live in
+   `src/linear-bug-intake.ts` and call `createLinearBugReportBody()`.
+   Production Linear calls must go through `SquireLinearClient` in
+   `src/linear-client.ts`; do not add new hand-written Linear GraphQL calls.
+4. Dedupe before creating anything. The marker is
+   `squire-bug:<env>:<conversationId>:<userMessageId>` and is embedded in the
+   Linear description.
+5. File in Linear team `SQR`, project `Squire · Bugs`, state `Todo`, assigned
+   to the Linear token owner, label `Bug`.
+
+Priority defaults:
+
+- High (`2`): `bad_answer`, `broken_stream`, `wrong_source`
+- Medium (`3`): `visual_issue`, `other`
+- Low (`4`): only use for polish or no-repro follow-ups when filing manually
+
+If a required field is missing, keep the field and write the exact unavailable
+reason from the bundle. Do not hide gaps by deleting fields.
+
+## In-Chat Flow
+
+The product flow posts to `POST /api/bug-reports` with the web session cookie
+and `x-csrf-token`. The endpoint collects the same diagnostic bundle, creates
+or dedupes a Linear issue through `submitLinearBugReport()`, and adds the
+redacted diagnostic JSON payload as a Linear comment. The browser receives only
+the Linear identifier, URL, and dedupe marker.
+
+The browser does not talk to Linear directly. It sends safe IDs, short
+observed/expected text, browser metadata, and an optional user-approved
+screenshot to Squire. Squire derives Sentry and LangSmith links from configured
+server IDs where possible, uploads the screenshot to Linear if present, and
+marks missing fields as unavailable when it cannot derive them.
+
+The answer-turn button is the first product entrypoint. Conversation-level
+menus should dispatch the same `squire:bug-report` browser event or post the
+same JSON shape rather than inventing a second endpoint.
+
 ## Sentry logs/traces into Linear bug evidence
 
 When the report came from a production conversation, gather the Sentry links
 before creating the Linear issue whenever they exist:
 
 - Sentry issue or event URL for grouped app/runtime errors
+- Sentry event ID when the browser captured a feedback/error event but cannot
+  construct the full Sentry event URL
 - Sentry replay URL for browser/layout/stream-state reports
 - Sentry logs query URL filtered by `request_id`, `conversation_id`,
   `user_message_id`, `route`, or `event_type`
@@ -70,6 +120,11 @@ Pass those safe links into `buildDiagnosticBundle()` and render the issue with
 field. Let the diagnostic bundle render `Unavailable: <reason>` so the missing
 evidence is explicit.
 
+If the reporter checks the screenshot option, attach only the single bounded
+image captured by the browser. Do not add automatic screenshots without user
+action. The screenshot is user-approved evidence and can show visible
+conversation UI text; keep automatic Sentry replay and diagnostic JSON masked.
+
 ## SQR-298 And SQR-299
 
 SQR-298's in-chat bug report flow should create the same `DiagnosticBundle` and
@@ -79,3 +134,38 @@ pass the user's short observed/expected text into
 SQR-299's shared Codex/Claude bug-reporting skill should use the same helper
 for dry runs and issue creation. The skill can own dedupe, priority, labels, and
 Linear calls, but it should not own a separate issue-body template.
+
+## Dry-Run Examples
+
+Chat-answer bug:
+
+```md
+Title: [Bad answer] 829e3da3-e63 / msg-user-1
+Marker: squire-bug:production:829e3da3-e638-4eea-808c-fb8418c0abcf:msg-user-1
+Priority: 2
+Kind: answer_quality
+Observed: Squire said the Drifter had no perk that ignored item effects.
+Expected: Squire should account for the reported perk interaction or mark the
+evidence unavailable.
+First files:
+
+- src/agent-langgraph.ts
+- src/vector-store.ts
+- src/chat/conversation-service.ts
+```
+
+UI bug:
+
+```md
+Title: [Visual issue] conv-1 / msg-user-1
+Marker: squire-bug:production:conv-1:msg-user-1
+Priority: 3
+Kind: app_runtime
+Observed: The report action overlaps answer prose on mobile.
+Expected: The action stays below the answer without covering content.
+First files:
+
+- src/web-ui/layout.ts
+- src/web-ui/squire.js
+- src/web-ui/styles.css
+```

--- a/docs/agent/diagnostic-bundle.md
+++ b/docs/agent/diagnostic-bundle.md
@@ -20,9 +20,10 @@ Top-level fields:
 - `request`: request ID and route
 - `conversation`: conversation URL, conversation ID, turn IDs, safe user ID/hash,
   game/campaign IDs, message timestamps, assistant error flag
-- `sentry`: issue, event, replay, trace, logs-query URLs, and trace ID
+- `sentry`: issue, event, replay, trace, logs-query URLs, event ID, and trace ID
 - `langsmith`: trace/thread/run URLs and IDs
-- `browser`: safe browser URL, user agent, viewport, replay snapshot ID
+- `browser`: safe browser URL, user agent, viewport, timezone, replay snapshot
+  ID
 - `stream`: terminal status, event count, and safe work-log rows
 - `sourceIndex`: embedding version plus consulted/work-log source labels
 - `unavailable`: flattened list of missing field paths and reasons
@@ -41,6 +42,14 @@ loads messages or stream events.
 Use `buildDiagnosticBundle()` when the caller already has safe evidence, such as
 a Sentry issue/event/replay/trace/logs URL or LangSmith URL supplied by an
 agent workflow. Missing fields are not omitted; they are marked unavailable.
+When explicit links are not supplied, the builder derives Sentry issue/log/trace
+search links from safe request, conversation, and turn IDs using
+`SENTRY_ORG_SLUG`/`SENTRY_PROJECT_ID` plus the environment. It derives a
+LangSmith run/trace link from `LANGSMITH_WORKSPACE_ID`,
+`LANGSMITH_PROJECT_ID`, and an explicit or persisted LangSmith run ID. It does
+not derive LangSmith thread URLs from thread IDs; only include a thread URL when
+LangSmith or an agent workflow supplied a known-good URL. Do not use the Squire
+conversation ID as a LangSmith thread ID.
 
 SQR-310's Linear Evidence template renders this bundle with
 `createLinearBugReportBody()` in `src/linear-bug-report-template.ts`. New

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -40,8 +40,11 @@ Linear:
 - `conversation_id`: the `/chat/<conversationId>` UUID
 - `user_message_id`: the `/messages/<userMessageId>/stream` UUID for the turn
 - `assistant_message_id`: the persisted assistant row when available
-- `langsmith_thread_id`: equal to `conversation_id` for web chat
-- `langsmith_trace_url`, `langsmith_thread_url`, or `langsmith_run_url`
+- `langsmith_run_id`: persisted on assistant messages when the agent run
+  exposes a LangSmith root run ID
+- `langsmith_thread_id`: only when LangSmith supplied a real thread ID
+- `langsmith_trace_url`, `langsmith_thread_url`, or `langsmith_run_url`; thread
+  URLs must be explicit known-good URLs, not derived from Squire conversation IDs
 - `sentry_issue_url`, `sentry_event_url`, and `sentry_replay_url`
 
 If a field is missing, do not leave the ticket blank. Mark it as unavailable
@@ -84,6 +87,8 @@ observability:
    `src/telemetry.ts`; `src/instrumentation.ts` may wire Sentry's OpenTelemetry
    integration, and `scripts/send-sentry-safe-test-event.ts` may emit documented
    safe test events.
+   Sentry admin/config scripts should use `scripts/sentry-admin-client.ts`
+   instead of adding one-off `fetch` wrappers.
 3. Add script lifecycle coverage through `runScriptWithTelemetry()` in
    `src/script-telemetry.ts`.
 4. Add app spans with OpenTelemetry and stable `squire.*` attributes. Sentry may
@@ -163,16 +168,20 @@ const bundle = buildDiagnosticBundle({
    authenticated user and a conversation URL, conversation ID, or user-message
    ID. Use `buildDiagnosticBundle()` when you already have safe links and IDs
    from Sentry, LangSmith, logs, or screenshots.
-4. Render the Linear issue body with `createLinearBugReportBody()`.
-   `kind: "app_runtime"` puts Sentry first. `kind: "answer_quality"` puts
-   LangSmith first.
+4. For in-chat or agent-filed bugs, use `buildLinearBugReportDraft()` for a
+   dry run or `submitLinearBugReport()` to file. These helpers call
+   `createLinearBugReportBody()`, add the dedupe marker, and attach the
+   redacted diagnostic JSON comment. If you only need the body, call
+   `createLinearBugReportBody()` directly. `kind: "app_runtime"` puts Sentry
+   first. `kind: "answer_quality"` puts LangSmith first.
 5. Keep every required Evidence field in the issue:
    `Conversation`, `Turn`, `Request`, `Sentry Issue/Event/Replay`, `Release`,
    `Environment`, `LangSmith Trace/Thread/Run`, `Observed`, `Expected`,
    `Likely failing area`, `First files to inspect`, `Repro`, and `Acceptance`.
-6. Attach screenshots only if they do not show raw user prompts, model answers,
-   secrets, cookies, or private source passages. Prefer masked Sentry replay for
-   layout and stream-state reports.
+6. Prefer masked Sentry replay for automatic layout and stream-state evidence.
+   If the user explicitly opts into a screenshot from the bug dialog, Squire may
+   attach that single bounded conversation UI image to Linear. Do not attach
+   automatic screenshots without user action.
 
 ## Bad Answer
 
@@ -258,8 +267,8 @@ reports, and feedback events.
    transcript turn counts, input state, and route IDs, not raw transcript text.
 4. Confirm browser context has safe URL path, viewport, user agent, release,
    conversation ID, and user-message ID when available.
-5. If a user screenshot is needed, ask for the smallest crop that shows layout
-   or state without private text.
+5. If a user screenshot is needed, use the bug dialog screenshot checkbox or ask
+   for the smallest crop that shows the layout/state the user wants to share.
 6. File the bug as `kind: "app_runtime"`.
 
 Likely first files:

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@langchain/anthropic": "^1.4.0",
         "@langchain/core": "^1.1.44",
         "@langchain/langgraph": "^1.3.6",
+        "@linear/sdk": "^86.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.219.0",
@@ -1437,6 +1438,15 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
@@ -1768,6 +1778,18 @@
       "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.16.tgz",
       "integrity": "sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==",
       "license": "MIT"
+    },
+    "node_modules/@linear/sdk": {
+      "version": "86.0.0",
+      "resolved": "https://registry.npmjs.org/@linear/sdk/-/sdk-86.0.0.tgz",
+      "integrity": "sha512-Lr47874CGGPCDiPQoKYjcZDWyyu18N8zzEGvss86uzjZaeZrhNsuwKTARswG27VAJ3fPVJAvl/5dPl8QwndSlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -6004,6 +6026,16 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.1.tgz",
+      "integrity": "sha512-8eWbg5Zcv/8o20nzEjHUGPTj20MLFJjc5kagbIPxbaeGxvFwpitJhemEC/k17n5+UD4M/9ea5rTuce78mELujQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@langchain/anthropic": "^1.4.0",
     "@langchain/core": "^1.1.44",
     "@langchain/langgraph": "^1.3.6",
+    "@linear/sdk": "^86.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/instrumentation": "^0.219.0",

--- a/scripts/configure-sentry-scrubbing.ts
+++ b/scripts/configure-sentry-scrubbing.ts
@@ -4,6 +4,7 @@ import {
   buildSentryRelayPiiConfig,
   buildSentryScrubbingProjectSettings,
 } from './sentry-scrubbing-config.ts';
+import { SentryAdminClient } from './sentry-admin-client.ts';
 
 type Mode = 'dry-run' | 'apply' | 'verify';
 
@@ -111,24 +112,6 @@ function verifyProjectSettings(project: SentryProjectPrivacySettings): string[] 
   return issues;
 }
 
-async function sentryRequest<T>(token: string, path: string, init: RequestInit = {}): Promise<T> {
-  const response = await fetch(`https://sentry.io/api/0${path}`, {
-    ...init,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-      ...init.headers,
-    },
-  });
-
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Sentry API ${response.status} ${response.statusText}: ${body}`);
-  }
-
-  return (await response.json()) as T;
-}
-
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const endpoint = `/projects/${args.orgSlug}/${args.projectSlug}/`;
@@ -155,15 +138,16 @@ async function main(): Promise<void> {
   }
 
   const token = readSentryToken();
+  const sentry = new SentryAdminClient({ token });
 
   if (args.mode === 'apply') {
-    await sentryRequest<SentryProjectPrivacySettings>(token, endpoint, {
+    await sentry.request<SentryProjectPrivacySettings>(endpoint, {
       method: 'PUT',
       body: JSON.stringify(payload),
     });
   }
 
-  const project = await sentryRequest<SentryProjectPrivacySettings>(token, endpoint);
+  const project = await sentry.request<SentryProjectPrivacySettings>(endpoint);
   const issues = verifyProjectSettings(project);
   console.log(
     JSON.stringify(

--- a/scripts/send-sentry-safe-test-event.ts
+++ b/scripts/send-sentry-safe-test-event.ts
@@ -16,6 +16,7 @@ import {
   SENTRY_APP_HEALTH_ORG,
   SENTRY_APP_HEALTH_PROJECT_ID,
 } from './sentry-app-health-config.ts';
+import { SentryAdminClient, parseSentryNextPath } from './sentry-admin-client.ts';
 import { DEFAULT_SENTRY_PROJECT_SLUG } from './sentry-scrubbing-config.ts';
 
 export const SAFE_TEST_KINDS = [
@@ -323,13 +324,6 @@ function sentryIssueApiUrl(issueId: string): string {
   return `https://sentry.io/api/0/issues/${issueId}/`;
 }
 
-function sentryApiHeaders(token: string): HeadersInit {
-  return {
-    Authorization: `Bearer ${token}`,
-    'Content-Type': 'application/json',
-  };
-}
-
 function readSentryToken(token: string | undefined = process.env.SENTRY_TOKEN): string {
   const value = token?.trim();
   if (!value) throw new Error('SENTRY_TOKEN is required for --cleanup');
@@ -355,55 +349,7 @@ function safeTestIssueSummary(value: unknown): SafeTestIssueSummary | null {
   };
 }
 
-async function sentryJsonWithHeaders<T>(
-  fetch: FetchLike,
-  token: string,
-  url: string,
-  init?: RequestInit,
-): Promise<{ body: T; headers: Headers }> {
-  const response = await fetch(url, {
-    ...init,
-    headers: {
-      ...sentryApiHeaders(token),
-      ...(init?.headers ?? {}),
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`Sentry API request failed: ${response.status} ${response.statusText}`);
-  }
-  return {
-    body: (await response.json()) as T,
-    headers: response.headers,
-  };
-}
-
-async function sentryJson<T>(fetch: FetchLike, token: string, url: string, init?: RequestInit) {
-  return (await sentryJsonWithHeaders<T>(fetch, token, url, init)).body;
-}
-
-function sentryNextUrl(linkHeader: string | null): string | undefined {
-  if (!linkHeader) return undefined;
-
-  for (const part of linkHeader.split(/,\s*(?=<)/)) {
-    if (!/\brel="next"/.test(part) || !/\bresults="true"/.test(part)) continue;
-    const urlMatch = part.match(/<([^>]+)>/);
-    if (!urlMatch) continue;
-    try {
-      const url = new URL(urlMatch[1] ?? '');
-      if (url.origin !== 'https://sentry.io' || !url.pathname.startsWith('/api/0/')) continue;
-      return url.toString();
-    } catch {
-      continue;
-    }
-  }
-
-  return undefined;
-}
-
-async function listSafeTestIssues(
-  fetch: FetchLike,
-  token: string,
-): Promise<SafeTestIssueSummary[]> {
+async function listSafeTestIssues(sentry: SentryAdminClient): Promise<SafeTestIssueSummary[]> {
   const issues: SafeTestIssueSummary[] = [];
   const seenUrls = new Set<string>();
   let nextUrl: string | undefined = sentryProjectIssuesApiUrl();
@@ -412,24 +358,23 @@ async function listSafeTestIssues(
     if (seenUrls.has(nextUrl)) throw new Error('Sentry safe-test cleanup pagination loop');
     seenUrls.add(nextUrl);
 
-    const { body, headers } = await sentryJsonWithHeaders<unknown[]>(fetch, token, nextUrl);
+    const { body, headers } = await sentry.requestWithHeaders<unknown[]>(nextUrl);
     issues.push(
       ...body
         .map(safeTestIssueSummary)
         .filter((issue): issue is SafeTestIssueSummary => issue !== null),
     );
-    nextUrl = sentryNextUrl(headers.get('link'));
+    nextUrl = parseSentryNextPath(headers.get('link'));
   }
 
   return issues;
 }
 
 async function resolveSafeTestIssue(
-  fetch: FetchLike,
-  token: string,
+  sentry: SentryAdminClient,
   issue: SafeTestIssueSummary,
 ): Promise<SafeTestIssueSummary> {
-  const payload = await sentryJson<unknown>(fetch, token, sentryIssueApiUrl(issue.id), {
+  const payload = await sentry.request<unknown>(sentryIssueApiUrl(issue.id), {
     method: 'PUT',
     body: JSON.stringify({ status: 'resolved' }),
   });
@@ -441,7 +386,8 @@ export async function cleanupSafeTestIssues(
 ): Promise<SafeTestIssueCleanupResult> {
   const fetch = options.fetch ?? globalThis.fetch;
   const token = readSentryToken(options.token);
-  const issues = await listSafeTestIssues(fetch, token);
+  const sentry = new SentryAdminClient({ token, fetch });
+  const issues = await listSafeTestIssues(sentry);
 
   if (options.dryRun) {
     return {
@@ -452,7 +398,7 @@ export async function cleanupSafeTestIssues(
 
   const resolvedIssues: SafeTestIssueSummary[] = [];
   for (const issue of issues) {
-    resolvedIssues.push(await resolveSafeTestIssue(fetch, token, issue));
+    resolvedIssues.push(await resolveSafeTestIssue(sentry, issue));
   }
 
   return {

--- a/scripts/sentry-admin-client.ts
+++ b/scripts/sentry-admin-client.ts
@@ -1,0 +1,141 @@
+export const SENTRY_API_BASE = 'https://sentry.io/api/0';
+
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export interface SentryAdminClientOptions {
+  token: string;
+  fetch?: FetchLike;
+  apiBase?: string;
+}
+
+export interface SentryListClient {
+  list(path: string): Promise<unknown[]>;
+}
+
+export function parseSentryNextPath(linkHeader: string | null): string | undefined {
+  if (!linkHeader) return undefined;
+
+  for (const part of linkHeader.split(/,\s*(?=<)/)) {
+    if (!/\brel="next"/.test(part) || !/\bresults="true"/.test(part)) continue;
+    const urlMatch = part.match(/<([^>]+)>/);
+    if (!urlMatch) continue;
+    try {
+      const url = new URL(urlMatch[1] ?? '');
+      const apiBase = new URL(SENTRY_API_BASE);
+      if (url.origin !== apiBase.origin) continue;
+      const relativePath = url.pathname.startsWith(`${apiBase.pathname}/`)
+        ? url.pathname.slice(apiBase.pathname.length)
+        : url.pathname;
+      return `${relativePath}${url.search}`;
+    } catch {
+      continue;
+    }
+  }
+
+  return undefined;
+}
+
+function pathWithListPageSize(path: string, apiBase: string): string {
+  const url = sentryApiUrl(path, apiBase);
+  if (!url.searchParams.has('per_page') && !url.searchParams.has('limit')) {
+    url.searchParams.set('per_page', '100');
+  }
+  const apiBaseUrl = new URL(apiBase);
+  if (url.origin === apiBaseUrl.origin && url.pathname.startsWith(`${apiBaseUrl.pathname}/`)) {
+    return `${url.pathname.slice(apiBaseUrl.pathname.length)}${url.search}`;
+  }
+  return url.toString();
+}
+
+function sentryApiUrl(path: string | URL, apiBase: string): URL {
+  if (path instanceof URL) return path;
+  if (/^https?:\/\//i.test(path)) return new URL(path);
+  const base = apiBase.replace(/\/$/, '');
+  if (path.startsWith('/api/0/')) return new URL(path, new URL(base).origin);
+  if (path.startsWith('/')) return new URL(`${base}${path}`);
+  return new URL(`${base}/${path}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeHeaders(token: string, init: RequestInit | undefined): Headers {
+  const headers = new Headers(init?.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+  if (!headers.has('Accept')) headers.set('Accept', 'application/json');
+  if (init?.body !== undefined && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  return headers;
+}
+
+async function responseBody(response: Response, context: string): Promise<unknown> {
+  const text = await response.text();
+  if (text.length === 0) return undefined;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new Error(`${context} returned invalid JSON`, { cause: error });
+  }
+}
+
+export class SentryAdminClient implements SentryListClient {
+  private readonly token: string;
+  private readonly fetch: FetchLike;
+  private readonly apiBase: string;
+
+  constructor(options: SentryAdminClientOptions) {
+    this.token = options.token;
+    this.fetch = options.fetch ?? globalThis.fetch;
+    this.apiBase = options.apiBase ?? SENTRY_API_BASE;
+  }
+
+  async request<T>(path: string | URL, init: RequestInit = {}): Promise<T> {
+    return (await this.requestWithHeaders<T>(path, init)).body;
+  }
+
+  async requestWithHeaders<T>(
+    path: string | URL,
+    init: RequestInit = {},
+  ): Promise<{ body: T; headers: Headers }> {
+    const url = sentryApiUrl(path, this.apiBase);
+    const response = await this.fetch(url, {
+      ...init,
+      headers: mergeHeaders(this.token, init),
+    });
+    const context = `Sentry API ${init.method ?? 'GET'} ${url.toString()}`;
+    const body = await responseBody(response, context);
+    if (!response.ok) {
+      throw new Error(
+        `${context} returned ${String(response.status)} ${response.statusText}: ${JSON.stringify(
+          body,
+        )}`,
+      );
+    }
+    return { body: body as T, headers: response.headers };
+  }
+
+  async list(path: string): Promise<unknown[]> {
+    const records: unknown[] = [];
+    const seenPaths = new Set<string>();
+    let nextPath: string | undefined = pathWithListPageSize(path, this.apiBase);
+
+    while (nextPath) {
+      if (seenPaths.has(nextPath)) throw new Error(`Sentry pagination loop at ${nextPath}`);
+      seenPaths.add(nextPath);
+
+      const { body, headers } = await this.requestWithHeaders<unknown>(nextPath);
+      if (Array.isArray(body)) {
+        records.push(...body);
+      } else if (isRecord(body) && Array.isArray(body.results)) {
+        records.push(...body.results);
+      } else {
+        throw new Error(`Expected Sentry list response for ${nextPath}`);
+      }
+      nextPath = parseSentryNextPath(headers.get('link'));
+    }
+
+    return records;
+  }
+}

--- a/scripts/sync-security-alerts-to-linear.ts
+++ b/scripts/sync-security-alerts-to-linear.ts
@@ -2,6 +2,12 @@ import 'dotenv/config';
 
 import { pathToFileURL } from 'node:url';
 
+import {
+  createLinearClient,
+  type LinearTargets,
+  type SquireLinearClient,
+} from '../src/linear-client.ts';
+
 type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
 type Logger = (message: string) => void;
 
@@ -23,6 +29,7 @@ interface SyncSecurityAlertsOptions extends CollectAlertsOptions {
   linearLabelName?: string;
   dryRun: boolean;
   validateConfigOnly?: boolean;
+  linearClient?: SquireLinearClient;
 }
 
 export interface RoutableSecurityAlert {
@@ -89,21 +96,7 @@ interface GitHubSecretScanningAlert {
   validity?: unknown;
 }
 
-interface LinearIssueRef {
-  id: string;
-  identifier: string;
-  url: string;
-}
-
-interface LinearTargets {
-  teamId: string;
-  projectId?: string;
-  labelIds: string[];
-  labelName: string;
-}
-
 const GITHUB_API_VERSION = '2022-11-28';
-const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql';
 const DEFAULT_LINEAR_TEAM_KEY = 'SQR';
 const DEFAULT_LINEAR_PROJECT_NAME = 'Squire · Security Alert Automation';
 const DEFAULT_LINEAR_LABEL_NAME = 'Security';
@@ -406,159 +399,10 @@ export async function collectRoutableAlerts(
   ];
 }
 
-async function linearGraphql<T>(
-  fetch: FetchLike,
-  linearApiKey: string,
-  operationName: string,
-  query: string,
-  variables: Record<string, unknown>,
-  timeoutMs = DEFAULT_HTTP_TIMEOUT_MS,
-): Promise<T> {
-  const response = await fetchWithTimeout(
-    fetch,
-    LINEAR_GRAPHQL_URL,
-    {
-      method: 'POST',
-      headers: {
-        authorization: linearApiKey,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({ operationName, query, variables }),
-    },
-    `Linear ${operationName}`,
-    timeoutMs,
-  );
-
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Linear ${operationName} returned ${response.status}: ${body}`);
-  }
-
-  const payload = (await readJson(response, `Linear ${operationName}`)) as {
-    data?: T;
-    errors?: { message?: string }[];
-  };
-  if (payload.errors?.length) {
-    throw new Error(
-      `Linear ${operationName} failed: ${payload.errors
-        .map((error) => error.message ?? 'unknown error')
-        .join('; ')}`,
-    );
-  }
-  if (!payload.data) {
-    throw new Error(`Linear ${operationName} returned no data`);
-  }
-  return payload.data;
-}
-
-async function resolveLinearTargets(
-  fetch: FetchLike,
-  linearApiKey: string,
-  linearTeamKey: string,
-  linearProjectName: string | undefined,
-  linearLabelName: string | undefined,
-  timeoutMs = DEFAULT_HTTP_TIMEOUT_MS,
-): Promise<LinearTargets> {
-  const data = await linearGraphql<{
-    teams: { nodes: { id: string; key: string; name: string }[] };
-    projects: { nodes: { id: string; name: string }[] };
-    issueLabels: {
-      nodes: { id: string; name: string; team: { id: string; key: string } | null }[];
-    };
-  }>(
-    fetch,
-    linearApiKey,
-    'ResolveLinearTargets',
-    `query ResolveLinearTargets($teamKey: String!, $projectName: String!, $labelName: String!) {
-      teams(first: 1, filter: { key: { eq: $teamKey } }) {
-        nodes { id key name }
-      }
-      projects(
-        first: 1
-        filter: {
-          name: { eq: $projectName }
-          accessibleTeams: { some: { key: { eq: $teamKey } } }
-        }
-      ) {
-        nodes { id name }
-      }
-      issueLabels(
-        first: 10
-        filter: {
-          name: { eqIgnoreCase: $labelName }
-          or: [{ team: { null: true } }, { team: { key: { eq: $teamKey } } }]
-        }
-      ) {
-        nodes { id name team { id key } }
-      }
-    }`,
-    {
-      teamKey: linearTeamKey,
-      projectName: linearProjectName ?? DEFAULT_LINEAR_PROJECT_NAME,
-      labelName: linearLabelName ?? DEFAULT_LINEAR_LABEL_NAME,
-    },
-    timeoutMs,
-  );
-
-  const team = data.teams.nodes[0];
-  if (!team) {
-    throw new Error(`Linear team ${linearTeamKey} was not found`);
-  }
-
-  const project = data.projects.nodes[0];
-  if (!project) {
-    throw new Error(
-      `Linear project ${linearProjectName ?? DEFAULT_LINEAR_PROJECT_NAME} was not found for team ${linearTeamKey}`,
-    );
-  }
-
-  const label =
-    data.issueLabels.nodes.find((candidate) => candidate.team === null) ??
-    data.issueLabels.nodes[0];
-  if (!label) {
-    throw new Error(
-      `Linear label ${linearLabelName ?? DEFAULT_LINEAR_LABEL_NAME} was not found as a workspace or ${linearTeamKey} team label`,
-    );
-  }
-
-  return { teamId: team.id, projectId: project?.id, labelIds: [label.id], labelName: label.name };
-}
-
 function logValidatedLinearTarget(log: Logger, targets: LinearTargets): void {
   log(
     `Validated Linear target team=${targets.teamId} project=${targets.projectId ?? 'none'} label=${targets.labelName}`,
   );
-}
-
-async function findExistingIssue(
-  fetch: FetchLike,
-  linearApiKey: string,
-  linearTeamKey: string,
-  marker: string,
-  timeoutMs = DEFAULT_HTTP_TIMEOUT_MS,
-): Promise<LinearIssueRef | undefined> {
-  const data = await linearGraphql<{
-    issues: { nodes: LinearIssueRef[] };
-  }>(
-    fetch,
-    linearApiKey,
-    'FindIssueByAlertMarker',
-    `query FindIssueByAlertMarker($teamKey: String!, $marker: String!) {
-      issues(
-        first: 1
-        filter: {
-          team: { key: { eq: $teamKey } }
-          description: { contains: $marker }
-        }
-      ) {
-        nodes { id identifier url }
-      }
-    }`,
-    { teamKey: linearTeamKey, marker },
-    timeoutMs,
-  );
-
-  return data.issues.nodes[0];
 }
 
 function issueDescription(alert: RoutableSecurityAlert): string {
@@ -578,80 +422,33 @@ function issueDescription(alert: RoutableSecurityAlert): string {
   ].join('\n');
 }
 
-async function createIssue(
-  fetch: FetchLike,
-  linearApiKey: string,
-  targets: LinearTargets,
-  alert: RoutableSecurityAlert,
-  timeoutMs = DEFAULT_HTTP_TIMEOUT_MS,
-): Promise<LinearIssueRef> {
-  const input: Record<string, unknown> = {
+function createSecurityIssueInput(targets: LinearTargets, alert: RoutableSecurityAlert) {
+  return {
     teamId: targets.teamId,
     title: alert.title,
     description: issueDescription(alert),
     priority: 2,
+    projectId: targets.projectId,
+    labelIds: targets.labelIds,
   };
-  if (targets.projectId) input.projectId = targets.projectId;
-  input.labelIds = targets.labelIds;
-
-  const data = await linearGraphql<{
-    issueCreate: { success: boolean; issue: LinearIssueRef };
-  }>(
-    fetch,
-    linearApiKey,
-    'CreateSecurityAlertIssue',
-    `mutation CreateSecurityAlertIssue($input: IssueCreateInput!) {
-      issueCreate(input: $input) {
-        success
-        issue { id identifier url }
-      }
-    }`,
-    { input },
-    timeoutMs,
-  );
-
-  if (!data.issueCreate.success) {
-    throw new Error(`Linear issueCreate returned success=false for ${alert.key}`);
-  }
-  return data.issueCreate.issue;
 }
 
-async function updateIssue(
-  fetch: FetchLike,
-  linearApiKey: string,
-  targets: LinearTargets,
-  existingIssueId: string,
-  alert: RoutableSecurityAlert,
-  timeoutMs = DEFAULT_HTTP_TIMEOUT_MS,
-): Promise<LinearIssueRef> {
-  const input: Record<string, unknown> = {
+function updateSecurityIssueInput(targets: LinearTargets, alert: RoutableSecurityAlert) {
+  return {
     title: alert.title,
     description: issueDescription(alert),
     priority: 2,
+    projectId: targets.projectId,
+    labelIds: targets.labelIds,
   };
-  if (targets.projectId) input.projectId = targets.projectId;
-  input.labelIds = targets.labelIds;
+}
 
-  const data = await linearGraphql<{
-    issueUpdate: { success: boolean; issue: LinearIssueRef };
-  }>(
-    fetch,
-    linearApiKey,
-    'UpdateSecurityAlertIssue',
-    `mutation UpdateSecurityAlertIssue($id: String!, $input: IssueUpdateInput!) {
-      issueUpdate(id: $id, input: $input) {
-        success
-        issue { id identifier url }
-      }
-    }`,
-    { id: existingIssueId, input },
-    timeoutMs,
-  );
-
-  if (!data.issueUpdate.success) {
-    throw new Error(`Linear issueUpdate returned success=false for ${alert.key}`);
+function linearClientFromOptions(options: SyncSecurityAlertsOptions): SquireLinearClient {
+  if (options.linearClient) return options.linearClient;
+  if (!options.linearApiKey) {
+    throw new Error('LINEAR_API_KEY is required unless SECURITY_ALERT_DRY_RUN=1');
   }
-  return data.issueUpdate.issue;
+  return createLinearClient(options.linearApiKey);
 }
 
 export async function syncSecurityAlertsToLinear(
@@ -661,17 +458,15 @@ export async function syncSecurityAlertsToLinear(
   const log = options.log ?? console.log;
 
   if (options.validateConfigOnly) {
-    if (!options.linearApiKey) {
+    if (!options.linearApiKey && !options.linearClient) {
       throw new Error('LINEAR_API_KEY is required for --validate-config');
     }
-    const targets = await resolveLinearTargets(
-      fetch,
-      options.linearApiKey,
-      options.linearTeamKey,
-      options.linearProjectName,
-      options.linearLabelName,
-      options.httpTimeoutMs,
-    );
+    const linearClient = linearClientFromOptions(options);
+    const targets = await linearClient.resolveTargets({
+      teamKey: options.linearTeamKey,
+      projectName: options.linearProjectName ?? DEFAULT_LINEAR_PROJECT_NAME,
+      labelName: options.linearLabelName ?? DEFAULT_LINEAR_LABEL_NAME,
+    });
     logValidatedLinearTarget(log, targets);
     return { alerts: 0, created: 0, updated: 0, dryRun: 0 };
   }
@@ -701,18 +496,16 @@ export async function syncSecurityAlertsToLinear(
     return result;
   }
 
-  if (!options.linearApiKey) {
+  if (!options.linearApiKey && !options.linearClient) {
     throw new Error('LINEAR_API_KEY is required unless SECURITY_ALERT_DRY_RUN=1');
   }
 
-  const targets = await resolveLinearTargets(
-    fetch,
-    options.linearApiKey,
-    options.linearTeamKey,
-    options.linearProjectName,
-    options.linearLabelName,
-    options.httpTimeoutMs,
-  );
+  const linearClient = linearClientFromOptions(options);
+  const targets = await linearClient.resolveTargets({
+    teamKey: options.linearTeamKey,
+    projectName: options.linearProjectName ?? DEFAULT_LINEAR_PROJECT_NAME,
+    labelName: options.linearLabelName ?? DEFAULT_LINEAR_LABEL_NAME,
+  });
   logValidatedLinearTarget(log, targets);
 
   if (alerts.length === 0) {
@@ -721,33 +514,17 @@ export async function syncSecurityAlertsToLinear(
   }
 
   for (const alert of alerts) {
-    const existing = await findExistingIssue(
-      fetch,
-      options.linearApiKey,
-      options.linearTeamKey,
-      alert.key,
-      options.httpTimeoutMs,
-    );
+    const existing = await linearClient.findIssueByMarker(options.linearTeamKey, alert.key);
 
     if (existing) {
-      const updated = await updateIssue(
-        fetch,
-        options.linearApiKey,
-        targets,
+      const updated = await linearClient.updateIssue(
         existing.id,
-        alert,
-        options.httpTimeoutMs,
+        updateSecurityIssueInput(targets, alert),
       );
       log(`Updated ${updated.identifier} for ${alert.key}: ${updated.url}`);
       result.updated += 1;
     } else {
-      const created = await createIssue(
-        fetch,
-        options.linearApiKey,
-        targets,
-        alert,
-        options.httpTimeoutMs,
-      );
+      const created = await linearClient.createIssue(createSecurityIssueInput(targets, alert));
       log(`Created ${created.identifier} for ${alert.key}: ${created.url}`);
       result.created += 1;
     }

--- a/scripts/sync-sentry-app-health.ts
+++ b/scripts/sync-sentry-app-health.ts
@@ -11,6 +11,11 @@ import {
   sentryDashboardUrl,
   sentryDetectorUrl,
 } from './sentry-app-health-config.ts';
+import {
+  SentryAdminClient,
+  type SentryListClient,
+  parseSentryNextPath,
+} from './sentry-admin-client.ts';
 import { pathToFileURL } from 'node:url';
 
 type Mode = 'apply' | 'dry-run' | 'verify';
@@ -19,10 +24,6 @@ interface SentryRecord {
   id?: unknown;
   name?: unknown;
   title?: unknown;
-}
-
-interface SentryListClient {
-  list(path: string): Promise<unknown[]>;
 }
 
 interface SyncResult {
@@ -46,8 +47,6 @@ interface SyncResult {
     name: string;
   }>;
 }
-
-const API_BASE = 'https://sentry.io/api/0';
 
 function usage(): string {
   return 'Usage: node scripts/sync-sentry-app-health.ts --dry-run | --apply | --verify';
@@ -312,95 +311,9 @@ function findRoutingWorkflowId(workflows: unknown[]): string {
   return workflowId;
 }
 
-function pathWithListPageSize(path: string): string {
-  const url = new URL(path, API_BASE);
-  if (!url.searchParams.has('per_page')) url.searchParams.set('per_page', '100');
-  return `${url.pathname}${url.search}`;
-}
+export { parseSentryNextPath };
 
-export function parseSentryNextPath(linkHeader: string | null): string | undefined {
-  if (!linkHeader) return undefined;
-
-  for (const part of linkHeader.split(/,\s*(?=<)/)) {
-    if (!/\brel="next"/.test(part) || !/\bresults="true"/.test(part)) continue;
-    const urlMatch = part.match(/<([^>]+)>/);
-    if (!urlMatch) continue;
-    try {
-      const url = new URL(urlMatch[1] ?? '');
-      const apiBasePath = new URL(API_BASE).pathname;
-      const relativePath = url.pathname.startsWith(`${apiBasePath}/`)
-        ? url.pathname.slice(apiBasePath.length)
-        : url.pathname;
-      return `${relativePath}${url.search}`;
-    } catch {
-      continue;
-    }
-  }
-
-  return undefined;
-}
-
-class SentryApi {
-  private readonly token: string;
-
-  constructor(token: string) {
-    this.token = token;
-  }
-
-  private async requestWithResponse<T>(
-    path: string,
-    options: RequestInit = {},
-  ): Promise<{ body: T; headers: Headers }> {
-    const headers = new Headers(options.headers);
-    headers.set('Authorization', `Bearer ${this.token}`);
-    headers.set('Accept', 'application/json');
-    if (options.body) headers.set('Content-Type', 'application/json');
-
-    const response = await fetch(`${API_BASE}${path}`, {
-      ...options,
-      headers,
-    });
-    const text = await response.text();
-    if (!response.ok) {
-      throw new Error(
-        `${options.method ?? 'GET'} ${path} failed with ${response.status}: ${text.slice(0, 800)}`,
-      );
-    }
-    return {
-      body: (text.length > 0 ? JSON.parse(text) : null) as T,
-      headers: response.headers,
-    };
-  }
-
-  async request<T>(path: string, options: RequestInit = {}): Promise<T> {
-    return (await this.requestWithResponse<T>(path, options)).body;
-  }
-
-  async list(path: string): Promise<unknown[]> {
-    const records: unknown[] = [];
-    const seenPaths = new Set<string>();
-    let nextPath: string | undefined = pathWithListPageSize(path);
-
-    while (nextPath) {
-      if (seenPaths.has(nextPath)) throw new Error(`Sentry pagination loop for ${path}`);
-      seenPaths.add(nextPath);
-
-      const { body, headers } = await this.requestWithResponse<unknown>(nextPath);
-      if (Array.isArray(body)) {
-        records.push(...body);
-      } else if (isRecord(body) && Array.isArray(body.results)) {
-        records.push(...body.results);
-      } else {
-        throw new Error(`Expected Sentry list response for ${path}`);
-      }
-      nextPath = parseSentryNextPath(headers.get('link'));
-    }
-
-    return records;
-  }
-}
-
-async function syncDashboard(api: SentryApi, mode: Mode): Promise<SyncResult['dashboard']> {
+async function syncDashboard(api: SentryAdminClient, mode: Mode): Promise<SyncResult['dashboard']> {
   const dashboards = await api.list(`/organizations/${SENTRY_APP_HEALTH_ORG}/dashboards/`);
   const existing = titled(dashboards, SENTRY_APP_HEALTH_DASHBOARD_TITLE);
   const existingId = stringField(existing, 'id');
@@ -459,7 +372,7 @@ async function syncDashboard(api: SentryApi, mode: Mode): Promise<SyncResult['da
   };
 }
 
-async function syncDetectors(api: SentryApi, mode: Mode): Promise<SyncResult['detectors']> {
+async function syncDetectors(api: SentryAdminClient, mode: Mode): Promise<SyncResult['detectors']> {
   const detectors = await api.list(`/organizations/${SENTRY_APP_HEALTH_ORG}/detectors/`);
   const workflows = await api.list(`/organizations/${SENTRY_APP_HEALTH_ORG}/workflows/`);
   const routingWorkflowId = findRoutingWorkflowId(workflows);
@@ -597,7 +510,7 @@ async function main(): Promise<void> {
   const token = process.env.SENTRY_TOKEN;
   if (!token) throw new Error('SENTRY_TOKEN is required for --apply and --verify');
 
-  const api = new SentryApi(token);
+  const api = new SentryAdminClient({ token });
   const result: SyncResult = {
     detectors: [],
     existingAlerts: [],

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -44,6 +44,7 @@ import {
   activeWorkLogProgressMessageFromCompleted,
   humanizeWorkLogProgressMessage,
 } from './work-log-display.ts';
+import { langSmithRunReferenceFromSpan } from './langsmith-links.ts';
 
 type Message = Anthropic.Message;
 type MessageParam = Anthropic.MessageParam;
@@ -1016,6 +1017,7 @@ async function runLangGraphAgentLoop(
       const result = {
         answer: finalState.finalAnswer,
         trajectory: trajectoryFromState(finalState, config.model),
+        observability: langSmithRunReferenceFromSpan(span),
       };
       span.setAttributes(
         langgraphRunTraceAttributes({

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -36,6 +36,7 @@ import {
 import { resolveSquireEnv } from './squire-env.ts';
 import { requireGameId } from './game.ts';
 import * as WriteTools from './campaign/write-tools.ts';
+import { langSmithRunReferenceFromSpan, type LangSmithRunReference } from './langsmith-links.ts';
 
 type MessageParam = Anthropic.MessageParam;
 type Tool = Anthropic.Tool;
@@ -718,6 +719,7 @@ export interface AgentRunTrajectory {
 export interface AgentRunResult {
   answer: string;
   trajectory: AgentRunTrajectory;
+  observability?: LangSmithRunReference;
 }
 
 export interface EvalAgentLoopOptions {
@@ -1434,7 +1436,10 @@ export async function runAgentLoopWithTrajectory(
           result.trajectory.tokenUsage.cacheCreationInputTokens,
         'squire.agent.cache_read_input_tokens': result.trajectory.tokenUsage.cacheReadInputTokens,
       });
-      return result;
+      return {
+        ...result,
+        observability: langSmithRunReferenceFromSpan(runSpan),
+      };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       runSpan.setAttributes({

--- a/src/chat/chat-observability.ts
+++ b/src/chat/chat-observability.ts
@@ -78,9 +78,6 @@ function lifecycleAttributes(
     replay: input.replay,
     retry: input.retry,
     game: input.game,
-    // LangSmith uses conversationId/userMessageId as the thread id today.
-    // This is an id hint, not a prompt/model payload.
-    langsmith_thread_id: input.conversationId ?? input.userMessageId,
   }) as Record<string, string | number | boolean>;
 }
 
@@ -132,7 +129,6 @@ function spanAttributes(input: ChatLifecycleInput): Attributes {
     'squire.replay': input.replay,
     'squire.retry': input.retry,
     'squire.game': input.game,
-    'langsmith.thread_id': input.conversationId ?? input.userMessageId,
     'langsmith.thread_url': input.langsmithThreadUrl,
     'langsmith.run_url': input.langsmithRunUrl,
   }) as Attributes;

--- a/src/chat/chat-telemetry.ts
+++ b/src/chat/chat-telemetry.ts
@@ -51,7 +51,6 @@ export function captureChatFailureTelemetry(
     failureKind: input.failureKind,
     game: input.game ?? null,
     originalErrorName: originalErrorName(error),
-    langsmithThreadId: input.conversationId ?? input.userMessageId ?? null,
     ...(safeErrorCode(error) ? { originalErrorCode: safeErrorCode(error) } : {}),
   };
 

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm';
 
-import { ask, type HistoryMessage, type EmitFn } from '../service.ts';
+import { askWithResult, type HistoryMessage, type EmitFn } from '../service.ts';
 import { getDb } from '../db.ts';
 import * as ConversationRepository from '../db/repositories/conversation-repository.ts';
 import * as MessageRepository from '../db/repositories/message-repository.ts';
@@ -264,7 +264,14 @@ async function generateAssistantReply(
   } = {
     retryOnTransportError: true,
   },
-) {
+): Promise<{
+  answer: string;
+  observability?: {
+    langsmithRunId?: string;
+    langsmithRunUrl?: string;
+    langsmithTraceUrl?: string;
+  };
+}> {
   const baseOptions = () =>
     agentOptions({
       history,
@@ -275,7 +282,11 @@ async function generateAssistantReply(
       emit,
     });
   try {
-    return await ask(question, baseOptions());
+    const result = await askWithResult(question, baseOptions());
+    return {
+      answer: result.answer,
+      observability: result.observability,
+    };
   } catch (err) {
     if (!isRetryableTransportError(err) || !options.retryOnTransportError) {
       throw err;
@@ -287,7 +298,11 @@ async function generateAssistantReply(
     // accumulator state populated by the failed first attempt.
     options.onRetry?.();
     await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-    return ask(question, baseOptions());
+    const result = await askWithResult(question, baseOptions());
+    return {
+      answer: result.answer,
+      observability: result.observability,
+    };
   }
 }
 
@@ -388,7 +403,7 @@ async function persistAssistantOutcome(input: {
           status: 'started',
           retry: input.onEvent === undefined,
         });
-        const answer = await generateAssistantReply(
+        const generated = await generateAssistantReply(
           input.question,
           history,
           input.userId,
@@ -415,13 +430,16 @@ async function persistAssistantOutcome(input: {
         const assistantMessage = await MessageRepository.createResponse(tx, {
           conversationId: input.conversationId,
           role: 'assistant',
-          content: answer,
+          content: generated.answer,
           responseToMessageId: input.currentUserMessageId,
           // Null when the agent used no source tools. Pre-SQR-98 rows and
           // tool-free answers both render with footer hidden — indistinguishable
           // at the render layer, which is correct: both states mean "no
           // provenance to show."
           consultedSources: capturedSources.length > 0 ? capturedSources : null,
+          langsmithRunId: generated.observability?.langsmithRunId ?? null,
+          langsmithRunUrl: generated.observability?.langsmithRunUrl ?? null,
+          langsmithTraceUrl: generated.observability?.langsmithTraceUrl ?? null,
         });
         await ConversationRepository.touchLastMessageAt(
           tx,

--- a/src/db/migrations/20260617193000_message_langsmith_links/migration.sql
+++ b/src/db/migrations/20260617193000_message_langsmith_links/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "messages" ADD COLUMN "langsmith_run_id" text;
+ALTER TABLE "messages" ADD COLUMN "langsmith_run_url" text;
+ALTER TABLE "messages" ADD COLUMN "langsmith_trace_url" text;

--- a/src/db/repositories/message-repository.ts
+++ b/src/db/repositories/message-repository.ts
@@ -21,6 +21,9 @@ function toDomain(row: MessageRow): ConversationMessage {
     // Post-SQR-105: may contain ToolSourceLabel strings for search_rules hits
     // or AgentToolName strings for other tools. aggregateSourceLabels handles both.
     consultedSources: (row.consultedSources as string[] | null) ?? null,
+    langsmithRunId: row.langsmithRunId,
+    langsmithRunUrl: row.langsmithRunUrl,
+    langsmithTraceUrl: row.langsmithTraceUrl,
     createdAt: row.createdAt,
   };
 }
@@ -40,6 +43,9 @@ export async function create(
       isError: input.isError ?? false,
       responseToMessageId: input.responseToMessageId ?? null,
       consultedSources: input.consultedSources ?? null,
+      langsmithRunId: input.langsmithRunId ?? null,
+      langsmithRunUrl: input.langsmithRunUrl ?? null,
+      langsmithTraceUrl: input.langsmithTraceUrl ?? null,
     })
     .returning();
   return toDomain(row);
@@ -60,6 +66,9 @@ export async function createResponse(
       isError: input.isError ?? false,
       responseToMessageId: input.responseToMessageId,
       consultedSources: input.consultedSources ?? null,
+      langsmithRunId: input.langsmithRunId ?? null,
+      langsmithRunUrl: input.langsmithRunUrl ?? null,
+      langsmithTraceUrl: input.langsmithTraceUrl ?? null,
     })
     .onConflictDoNothing({
       target: messages.responseToMessageId,

--- a/src/db/repositories/types.ts
+++ b/src/db/repositories/types.ts
@@ -322,6 +322,12 @@ export interface ConversationMessage {
    * render time — no migration is needed.
    */
   consultedSources: string[] | null;
+  /** LangSmith root run id for this assistant turn, when tracing was active. */
+  langsmithRunId?: string | null;
+  /** LangSmith root run URL for this assistant turn, when derivable at write time. */
+  langsmithRunUrl?: string | null;
+  /** LangSmith trace URL for this assistant turn, usually the root run URL. */
+  langsmithTraceUrl?: string | null;
   /**
    * Completed browser-safe work timeline for this assistant turn, loaded from
    * `message_stream_events` by conversation-service on page-render paths.
@@ -347,6 +353,9 @@ export interface CreateConversationMessageInput {
   campaignId?: string | null;
   isError?: boolean;
   responseToMessageId?: string | null;
+  langsmithRunId?: string | null;
+  langsmithRunUrl?: string | null;
+  langsmithTraceUrl?: string | null;
   /**
    * Write-side accepts plain strings because the capture wrapper in
    * persistAssistantOutcome reads raw tool names off the agent's emit

--- a/src/db/schema/conversations.ts
+++ b/src/db/schema/conversations.ts
@@ -61,6 +61,9 @@ export const messages = pgTable(
     // message written before SQR-98 landed (pre-migration rows); both
     // render with footer hidden.
     consultedSources: jsonb('consulted_sources').$type<string[] | null>().default(null),
+    langsmithRunId: text('langsmith_run_id'),
+    langsmithRunUrl: text('langsmith_run_url'),
+    langsmithTraceUrl: text('langsmith_trace_url'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [

--- a/src/diagnostic-bundle.ts
+++ b/src/diagnostic-bundle.ts
@@ -14,6 +14,7 @@ import {
   TELEMETRY_UNAVAILABLE,
   type TelemetryUserIdentity,
 } from './telemetry.ts';
+import { langSmithRunUrlFromRunId } from './langsmith-links.ts';
 import { EMBEDDING_VERSION } from './vector-store.ts';
 
 type DiagnosticPrimitive = string | number | boolean | null;
@@ -28,11 +29,13 @@ export interface DiagnosticBrowserMetadata {
   userAgent?: string;
   viewport?: { width: number; height: number };
   replaySnapshotId?: string;
+  timezone?: string;
 }
 
 export interface DiagnosticBundleLinkInput {
   sentryIssueUrl?: string;
   sentryEventUrl?: string;
+  sentryEventId?: string;
   sentryReplayUrl?: string;
   sentryTraceUrl?: string;
   sentryLogsUrl?: string;
@@ -150,6 +153,7 @@ export const DiagnosticBundleSchema = z
       .object({
         issueUrl: DiagnosticFieldSchema,
         eventUrl: DiagnosticFieldSchema,
+        eventId: DiagnosticFieldSchema,
         replayUrl: DiagnosticFieldSchema,
         traceUrl: DiagnosticFieldSchema,
         logsUrl: DiagnosticFieldSchema,
@@ -171,6 +175,7 @@ export const DiagnosticBundleSchema = z
         userAgent: DiagnosticFieldSchema,
         viewport: DiagnosticFieldSchema,
         replaySnapshotId: DiagnosticFieldSchema,
+        timezone: DiagnosticFieldSchema,
       })
       .strict(),
     stream: z
@@ -209,12 +214,15 @@ const DEFAULT_DATA_SOURCE: DiagnosticBundleDataSource = {
 };
 
 const TOKEN_PATTERN = /^[A-Za-z0-9._:-]{1,256}$/;
+const URL_TOKEN_PATTERN = /^[A-Za-z0-9._:-]{1,256}$/;
 const SAFE_REF_PATTERN =
   /^(?:rules|scenario|section|card|source):[A-Za-z0-9._:-]+(?:\/[A-Za-z0-9._:-]+)+(?:#chunk=\d+)?$/;
 const SAFE_SENTRY_LOG_QUERY_KEYS = new Set([
   'environment',
   'field',
+  'project',
   'query',
+  'referrer',
   'sort',
   'statsPeriod',
 ]);
@@ -252,6 +260,9 @@ const UNSAFE_QUERY_VALUE_PARTS = [
   'session',
   'token',
 ];
+const DEFAULT_SENTRY_ORG_SLUG = 'brian-moseley';
+const DEFAULT_SENTRY_PROJECT_ID = '4511564194643969';
+const SENTRY_BUG_REPORT_REFERRER = 'squire-bug-report';
 const PUBLIC_WORK_EVENTS = new Set<string>([
   'tool-plan',
   'tool-progress',
@@ -275,6 +286,20 @@ function safeToken(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed || !TOKEN_PATTERN.test(trimmed)) return undefined;
   return trimmed;
+}
+
+function safeUrlToken(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !URL_TOKEN_PATTERN.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+function safeTimezone(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.length > 64) return undefined;
+  return /^(?:UTC|[A-Za-z]+(?:[._+-]?[A-Za-z0-9]+)*(?:\/[A-Za-z0-9._+-]+)+)$/.test(trimmed)
+    ? trimmed
+    : undefined;
 }
 
 function safeSourceLabel(value: unknown): string | null {
@@ -347,6 +372,34 @@ function safeSentryLogsUrl(value: string | undefined): string | undefined {
   }
 }
 
+function safeSentrySearchUrl(value: string | undefined): string | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined;
+    if (!/\/(?:issues|explore\/traces)\//.test(url.pathname)) return undefined;
+    const safeParams = new URLSearchParams();
+    for (const [key, paramValue] of url.searchParams.entries()) {
+      if (!SAFE_SENTRY_LOG_QUERY_KEYS.has(key)) continue;
+      if (key === 'query') {
+        const safeQuery = safeSentryLogsQuery(paramValue);
+        if (safeQuery) safeParams.append(key, safeQuery);
+        continue;
+      }
+      const valueLower = paramValue.toLowerCase();
+      if (UNSAFE_QUERY_VALUE_PARTS.some((part) => valueLower.includes(part))) continue;
+      if (!SAFE_SENTRY_LOG_QUERY_VALUE_PATTERN.test(paramValue)) continue;
+      safeParams.append(key, paramValue);
+    }
+    const query = safeParams.toString();
+    return `${url.origin}${url.pathname}${query ? `?${query}` : ''}`;
+  } catch {
+    return undefined;
+  }
+}
+
 function safeSentryLogsQuery(value: string): string | undefined {
   const query = value.trim();
   if (!query) return undefined;
@@ -367,6 +420,75 @@ function safeSentryLogsQuery(value: string): string | undefined {
   return terms.join(' ');
 }
 
+function envValue(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> | undefined,
+  key: string,
+): string | undefined {
+  const raw = (env ?? process.env)[key];
+  return typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : undefined;
+}
+
+function sentryOrgSlug(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> | undefined,
+): string | undefined {
+  return (
+    safeUrlToken(envValue(env, 'SENTRY_ORG_SLUG') ?? envValue(env, 'SENTRY_ORG')) ??
+    DEFAULT_SENTRY_ORG_SLUG
+  );
+}
+
+function sentryProjectId(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> | undefined,
+): string | undefined {
+  return safeUrlToken(envValue(env, 'SENTRY_PROJECT_ID')) ?? DEFAULT_SENTRY_PROJECT_ID;
+}
+
+function sentryEnvironment(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> | undefined,
+  metadataEnvironment: string,
+): string | undefined {
+  const configured = safeUrlToken(envValue(env, 'SENTRY_ENVIRONMENT'));
+  if (configured) return configured;
+  return metadataEnvironment === TELEMETRY_UNAVAILABLE
+    ? undefined
+    : safeUrlToken(metadataEnvironment);
+}
+
+function sentrySearchUrl(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> | undefined,
+  metadataEnvironment: string,
+  path: string,
+  query: string,
+): string | undefined {
+  const org = sentryOrgSlug(env);
+  const project = sentryProjectId(env);
+  const environment = sentryEnvironment(env, metadataEnvironment);
+  if (!org || !project || !environment) return undefined;
+  const params = new URLSearchParams({
+    project,
+    environment,
+    query,
+    referrer: SENTRY_BUG_REPORT_REFERRER,
+  });
+  return `https://${org}.sentry.io/${path}?${params.toString()}`;
+}
+
+function sentryQueryTerms(input: {
+  requestId?: string;
+  conversationId?: string;
+  userMessageId?: string;
+  assistantMessageId?: string;
+}): string {
+  return [
+    ['request_id', safeToken(input.requestId)],
+    ['conversation_id', safeToken(input.conversationId)],
+    ['user_message_id', safeToken(input.userMessageId)],
+    ['assistant_message_id', safeToken(input.assistantMessageId)],
+  ]
+    .flatMap(([key, value]) => (value ? [`${key}:${value}`] : []))
+    .join(' ');
+}
+
 function isoDate(value: Date | undefined): string | undefined {
   if (!value || Number.isNaN(value.getTime())) return undefined;
   return value.toISOString();
@@ -376,6 +498,16 @@ function field<T>(value: T | undefined | null, unavailableReason: string): Diagn
   if (value === undefined || value === null) return unavailable(unavailableReason);
   if (typeof value === 'string' && value.trim().length === 0) return unavailable(unavailableReason);
   return available(value);
+}
+
+function urlField(
+  value: string | undefined | null,
+  unavailableReason: string,
+): DiagnosticField<string> {
+  if (value === undefined || value === null || value.trim().length === 0) {
+    return unavailable(unavailableReason);
+  }
+  return { status: 'available', value };
 }
 
 function parseLocator(input: DiagnosticBundleInput): {
@@ -577,6 +709,51 @@ export function buildDiagnosticBundle(input: DiagnosticBundleInput = {}): Diagno
     input.conversation?.id ??
     userMessage?.conversationId ??
     assistantMessage?.conversationId;
+  const derivedSentryQuery = sentryQueryTerms({
+    requestId: metadata.requestId === TELEMETRY_UNAVAILABLE ? input.requestId : metadata.requestId,
+    conversationId,
+    userMessageId: userMessage?.id ?? locator.userMessageId,
+    assistantMessageId: assistantMessage?.id ?? explicitAssistantId,
+  });
+  const derivedSentryIssueUrl =
+    derivedSentryQuery.length > 0
+      ? sentrySearchUrl(input.env, metadata.environment, 'issues/', derivedSentryQuery)
+      : undefined;
+  const derivedSentryLogsUrl =
+    derivedSentryQuery.length > 0
+      ? sentrySearchUrl(input.env, metadata.environment, 'explore/logs/', derivedSentryQuery)
+      : undefined;
+  const derivedSentryTraceUrl =
+    derivedSentryQuery.length > 0
+      ? sentrySearchUrl(
+          input.env,
+          metadata.environment,
+          'explore/traces/',
+          derivedSentryQuery
+            .split(/\s+/)
+            .filter(Boolean)
+            .map((term) => {
+              const separator = term.indexOf(':');
+              return separator > 0
+                ? `squire.${term.slice(0, separator)}:${term.slice(separator + 1)}`
+                : term;
+            })
+            .join(' '),
+        )
+      : undefined;
+  const langsmithThreadId = safeToken(input.langsmithThreadId);
+  const langsmithRunId = safeToken(
+    input.langsmithRunId ?? assistantMessage?.langsmithRunId ?? undefined,
+  );
+  const derivedLangSmithRunUrl = langSmithRunUrlFromRunId(langsmithRunId, input.env);
+  const langsmithRunUrl =
+    safeExternalUrl(input.langsmithRunUrl) ??
+    safeExternalUrl(assistantMessage?.langsmithRunUrl ?? undefined) ??
+    safeExternalUrl(derivedLangSmithRunUrl);
+  const langsmithTraceUrl =
+    safeExternalUrl(input.langsmithTraceUrl) ??
+    safeExternalUrl(assistantMessage?.langsmithTraceUrl ?? undefined) ??
+    langsmithRunUrl;
 
   const bundleWithoutUnavailable = {
     schemaVersion: 1 as const,
@@ -633,34 +810,38 @@ export function buildDiagnosticBundle(input: DiagnosticBundleInput = {}): Diagno
           : available(assistantMessage.isError),
     },
     sentry: {
-      issueUrl: field(safeExternalUrl(input.sentryIssueUrl), 'Sentry issue URL was not provided'),
-      eventUrl: field(safeExternalUrl(input.sentryEventUrl), 'Sentry event URL was not provided'),
-      replayUrl: field(
+      issueUrl: urlField(
+        safeExternalUrl(input.sentryIssueUrl) ?? safeSentrySearchUrl(derivedSentryIssueUrl),
+        'Sentry issue URL was not provided or derivable',
+      ),
+      eventUrl: urlField(
+        safeExternalUrl(input.sentryEventUrl),
+        'Sentry event URL was not provided',
+      ),
+      eventId: field(safeToken(input.sentryEventId), 'Sentry event ID was not provided'),
+      replayUrl: urlField(
         safeExternalUrl(input.sentryReplayUrl),
         'Sentry replay URL was not provided',
       ),
-      traceUrl: field(safeExternalUrl(input.sentryTraceUrl), 'Sentry trace URL was not provided'),
-      logsUrl: field(
-        safeSentryLogsUrl(input.sentryLogsUrl),
-        'Sentry logs query URL was not provided',
+      traceUrl: urlField(
+        safeExternalUrl(input.sentryTraceUrl) ?? safeSentrySearchUrl(derivedSentryTraceUrl),
+        'Sentry trace URL was not provided or derivable',
+      ),
+      logsUrl: urlField(
+        safeSentryLogsUrl(input.sentryLogsUrl) ?? safeSentryLogsUrl(derivedSentryLogsUrl),
+        'Sentry logs query URL was not provided or derivable',
       ),
       traceId: field(safeToken(input.sentryTraceId), 'Sentry trace ID was not provided'),
     },
     langsmith: {
-      traceUrl: field(
-        safeExternalUrl(input.langsmithTraceUrl),
-        'LangSmith trace URL was not provided',
-      ),
-      threadUrl: field(
+      traceUrl: urlField(langsmithTraceUrl, 'LangSmith trace URL was not provided'),
+      threadUrl: urlField(
         safeExternalUrl(input.langsmithThreadUrl),
         'LangSmith thread URL was not provided',
       ),
-      threadId: field(
-        safeToken(input.langsmithThreadId) ?? safeToken(conversationId),
-        'LangSmith thread id was not provided or derivable',
-      ),
-      runUrl: field(safeExternalUrl(input.langsmithRunUrl), 'LangSmith run URL was not provided'),
-      runId: field(safeToken(input.langsmithRunId), 'LangSmith run id was not provided'),
+      threadId: field(langsmithThreadId, 'LangSmith thread id was not provided'),
+      runUrl: urlField(langsmithRunUrl, 'LangSmith run URL was not provided or derivable'),
+      runId: field(langsmithRunId, 'LangSmith run id was not provided'),
     },
     browser: {
       url: field(locator.browserUrl, 'browser URL was not provided'),
@@ -681,6 +862,7 @@ export function buildDiagnosticBundle(input: DiagnosticBundleInput = {}): Diagno
         safeToken(input.browser?.replaySnapshotId),
         'browser replay snapshot id was not provided',
       ),
+      timezone: field(safeTimezone(input.browser?.timezone), 'browser timezone was not provided'),
     },
     stream: {
       status: status.status,

--- a/src/diagnostic-bundle.ts
+++ b/src/diagnostic-bundle.ts
@@ -260,8 +260,6 @@ const UNSAFE_QUERY_VALUE_PARTS = [
   'session',
   'token',
 ];
-const DEFAULT_SENTRY_ORG_SLUG = 'brian-moseley';
-const DEFAULT_SENTRY_PROJECT_ID = '4511564194643969';
 const SENTRY_BUG_REPORT_REFERRER = 'squire-bug-report';
 const PUBLIC_WORK_EVENTS = new Set<string>([
   'tool-plan',
@@ -432,16 +430,13 @@ function envValue(
 function sentryOrgSlug(
   env: NodeJS.ProcessEnv | Record<string, string | undefined> | undefined,
 ): string | undefined {
-  return (
-    safeUrlToken(envValue(env, 'SENTRY_ORG_SLUG') ?? envValue(env, 'SENTRY_ORG')) ??
-    DEFAULT_SENTRY_ORG_SLUG
-  );
+  return safeUrlToken(envValue(env, 'SENTRY_ORG_SLUG') ?? envValue(env, 'SENTRY_ORG'));
 }
 
 function sentryProjectId(
   env: NodeJS.ProcessEnv | Record<string, string | undefined> | undefined,
 ): string | undefined {
-  return safeUrlToken(envValue(env, 'SENTRY_PROJECT_ID')) ?? DEFAULT_SENTRY_PROJECT_ID;
+  return safeUrlToken(envValue(env, 'SENTRY_PROJECT_ID'));
 }
 
 function sentryEnvironment(

--- a/src/diagnostic-bundle.ts
+++ b/src/diagnostic-bundle.ts
@@ -297,9 +297,10 @@ function safeUrlToken(value: string | undefined): string | undefined {
 function safeTimezone(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed || trimmed.length > 64) return undefined;
-  return /^(?:UTC|[A-Za-z]+(?:[._+-]?[A-Za-z0-9]+)*(?:\/[A-Za-z0-9._+-]+)+)$/.test(trimmed)
-    ? trimmed
-    : undefined;
+  if (trimmed === 'UTC') return trimmed;
+  const parts = trimmed.split('/');
+  if (parts.length < 2) return undefined;
+  return parts.every((part) => /^[A-Za-z][A-Za-z0-9._+-]*$/.test(part)) ? trimmed : undefined;
 }
 
 function safeSourceLabel(value: unknown): string | null {

--- a/src/langsmith-links.ts
+++ b/src/langsmith-links.ts
@@ -1,0 +1,66 @@
+import type { Span } from '@opentelemetry/api';
+
+type Env = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+export interface LangSmithRunReference {
+  langsmithRunId?: string;
+  langsmithRunUrl?: string;
+  langsmithTraceUrl?: string;
+}
+
+const URL_TOKEN_PATTERN = /^[A-Za-z0-9._:-]{1,256}$/;
+const OTEL_SPAN_ID_PATTERN = /^[a-f0-9]{16}$/;
+
+function envValue(env: Env | undefined, key: string): string | undefined {
+  const value = env?.[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function safeUrlToken(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || !URL_TOKEN_PATTERN.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+export function langSmithProjectUrlFromEnv(env: Env | undefined = process.env): string | undefined {
+  const workspaceId = safeUrlToken(envValue(env, 'LANGSMITH_WORKSPACE_ID'));
+  const projectId = safeUrlToken(
+    envValue(env, 'LANGSMITH_PROJECT_ID') ?? envValue(env, 'LANGSMITH_PROJECT_UUID'),
+  );
+  if (!workspaceId || !projectId) return undefined;
+  return `https://smith.langchain.com/o/${workspaceId}/projects/p/${projectId}`;
+}
+
+export function langSmithRunIdFromOtelSpanId(spanId: string | undefined): string | undefined {
+  const normalized = spanId?.trim().toLowerCase();
+  if (!normalized || !OTEL_SPAN_ID_PATTERN.test(normalized)) return undefined;
+  return `00000000-0000-0000-${normalized.slice(0, 4)}-${normalized.slice(4)}`;
+}
+
+export function langSmithRunUrlFromRunId(
+  runId: string | undefined,
+  env: Env | undefined = process.env,
+): string | undefined {
+  const safeRunId = safeUrlToken(runId);
+  const projectUrl = langSmithProjectUrlFromEnv(env);
+  if (!safeRunId || !projectUrl) return undefined;
+  return `${projectUrl}/r/${safeRunId}?poll=true`;
+}
+
+export function langSmithRunReferenceFromSpan(
+  span: Span,
+  env: Env | undefined = process.env,
+): LangSmithRunReference | undefined {
+  const langsmithRunId = langSmithRunIdFromOtelSpanId(span.spanContext().spanId);
+  if (!langsmithRunId) return undefined;
+  const langsmithRunUrl = langSmithRunUrlFromRunId(langsmithRunId, env);
+  return {
+    langsmithRunId,
+    ...(langsmithRunUrl
+      ? {
+          langsmithRunUrl,
+          langsmithTraceUrl: langsmithRunUrl,
+        }
+      : {}),
+  };
+}

--- a/src/linear-bug-intake.ts
+++ b/src/linear-bug-intake.ts
@@ -1,0 +1,379 @@
+import { z } from 'zod';
+
+import type { DiagnosticBundle, DiagnosticField } from './diagnostic-bundle.ts';
+import {
+  createLinearBugReportBody,
+  type LinearBugReportKind,
+} from './linear-bug-report-template.ts';
+import {
+  createLinearClient,
+  type LinearIssueRef,
+  type SquireLinearClient,
+} from './linear-client.ts';
+import { redactTelemetryValue } from './telemetry.ts';
+
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export const InChatBugReportKindSchema = z.enum([
+  'bad_answer',
+  'broken_stream',
+  'visual_issue',
+  'wrong_source',
+  'other',
+]);
+
+export type InChatBugReportKind = z.infer<typeof InChatBugReportKindSchema>;
+
+export interface LinearBugReportDraftInput {
+  bundle: DiagnosticBundle;
+  kind: InChatBugReportKind;
+  observed?: string;
+  expected?: string;
+  likelyFailingArea?: string;
+  firstFilesToInspect?: string[];
+  reproSteps?: string[];
+  acceptanceCriteria?: string[];
+}
+
+export interface LinearBugReportDraft {
+  title: string;
+  description: string;
+  diagnosticCommentBody: string;
+  marker: string;
+  priority: number;
+  labelName: string;
+  templateKind: LinearBugReportKind;
+}
+
+export type SubmitLinearBugReportResult =
+  | { status: 'disabled'; reason: string; marker: string }
+  | { status: 'existing'; issue: LinearIssueRef; marker: string; warnings?: string[] }
+  | { status: 'created'; issue: LinearIssueRef; marker: string; warnings?: string[] };
+
+export interface SubmitLinearBugReportInput extends LinearBugReportDraftInput {
+  attachments?: LinearBugReportAttachment[];
+  linearApiKey?: string;
+  linearTeamKey?: string;
+  linearProjectName?: string;
+  linearStateName?: string;
+  fetch?: FetchLike;
+  linearClient?: SquireLinearClient;
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+}
+
+export interface LinearBugReportAttachment {
+  filename: string;
+  contentType: 'image/jpeg' | 'image/png';
+  base64Content: string;
+  title?: string;
+  subtitle?: string;
+}
+
+const DEFAULT_LINEAR_TEAM_KEY = 'SQR';
+const DEFAULT_LINEAR_PROJECT_NAME = 'Squire · Bugs';
+const DEFAULT_LINEAR_LABEL_NAME = 'Bug';
+const DEFAULT_LINEAR_STATE_NAME = 'Todo';
+const MAX_ATTACHMENT_BYTES = 1_500_000;
+const ATTACHMENT_FILENAME_PATTERN = /^[A-Za-z0-9._-]{1,96}\.(?:jpe?g|png)$/i;
+const ATTACHMENT_BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+const KIND_TITLE: Record<InChatBugReportKind, string> = {
+  bad_answer: 'Bad answer',
+  broken_stream: 'Broken stream',
+  visual_issue: 'Visual issue',
+  wrong_source: 'Wrong source',
+  other: 'Conversation bug',
+};
+
+const LIKELY_FAILING_AREA: Record<InChatBugReportKind, string> = {
+  bad_answer: 'Answer synthesis, retrieval selection, or tool/source interpretation.',
+  broken_stream: 'SSE transport or conversation-service stream persistence.',
+  visual_issue: 'Conversation UI layout, browser script, or CSS.',
+  wrong_source: 'Source selection, consulted-source persistence, or final citation rendering.',
+  other: 'Unknown from report; start from the evidence bundle and reported turn.',
+};
+
+const FIRST_FILES: Record<InChatBugReportKind, string[]> = {
+  bad_answer: ['src/agent-langgraph.ts', 'src/vector-store.ts', 'src/chat/conversation-service.ts'],
+  broken_stream: ['src/chat/conversation-service.ts', 'src/server.ts', 'src/web-ui/squire.js'],
+  visual_issue: ['src/web-ui/layout.ts', 'src/web-ui/squire.js', 'src/web-ui/styles.css'],
+  wrong_source: [
+    'src/agent-langgraph.ts',
+    'src/vector-store.ts',
+    'src/chat/conversation-service.ts',
+  ],
+  other: ['src/server.ts', 'src/web-ui/squire.js', 'src/chat/conversation-service.ts'],
+};
+
+function fieldString(field: DiagnosticField<unknown>): string | undefined {
+  if (field.status !== 'available') return undefined;
+  if (typeof field.value === 'string') return field.value;
+  if (typeof field.value === 'number' || typeof field.value === 'boolean') {
+    return String(field.value);
+  }
+  return undefined;
+}
+
+export function bugReportDedupeMarker(bundle: DiagnosticBundle): string {
+  const environment = fieldString(bundle.report.environment) ?? 'unknown';
+  const conversationId = fieldString(bundle.conversation.id) ?? 'conversation-unavailable';
+  const turnId =
+    fieldString(bundle.conversation.userMessageId) ??
+    fieldString(bundle.conversation.assistantMessageId) ??
+    fieldString(bundle.request.requestId) ??
+    'turn-unavailable';
+  return `squire-bug:${environment}:${conversationId}:${turnId}`;
+}
+
+function templateKindForBug(kind: InChatBugReportKind): LinearBugReportKind {
+  return kind === 'bad_answer' || kind === 'wrong_source' ? 'answer_quality' : 'app_runtime';
+}
+
+function priorityForBug(kind: InChatBugReportKind): number {
+  if (kind === 'bad_answer' || kind === 'broken_stream' || kind === 'wrong_source') return 2;
+  return 3;
+}
+
+function defaultReproSteps(bundle: DiagnosticBundle): string[] {
+  const conversationUrl = fieldString(bundle.conversation.url);
+  return [
+    conversationUrl ? `Open ${conversationUrl}.` : 'Open the conversation URL from Evidence.',
+    'Find the reported turn from the Evidence section.',
+    'Compare the observed behavior with the expected behavior.',
+  ];
+}
+
+function defaultAcceptanceCriteria(kind: InChatBugReportKind): string[] {
+  const lane =
+    kind === 'bad_answer' || kind === 'wrong_source'
+      ? 'The corrected answer is backed by the right LangSmith trace and source evidence.'
+      : 'The same repro path no longer produces the reported app/runtime failure.';
+  return [
+    lane,
+    'The fix preserves the redaction contract for Sentry, LangSmith, and Linear evidence.',
+  ];
+}
+
+export function buildLinearBugReportDraft(input: LinearBugReportDraftInput): LinearBugReportDraft {
+  const marker = bugReportDedupeMarker(input.bundle);
+  const templateKind = templateKindForBug(input.kind);
+  const body = createLinearBugReportBody({
+    bundle: input.bundle,
+    kind: templateKind,
+    reportTypeLabel: KIND_TITLE[input.kind],
+    observed: input.observed,
+    expected: input.expected,
+    likelyFailingArea: input.likelyFailingArea ?? LIKELY_FAILING_AREA[input.kind],
+    firstFilesToInspect: input.firstFilesToInspect ?? FIRST_FILES[input.kind],
+    reproSteps: input.reproSteps ?? defaultReproSteps(input.bundle),
+    acceptanceCriteria: input.acceptanceCriteria ?? defaultAcceptanceCriteria(input.kind),
+  });
+  const diagnosticPayload = redactTelemetryValue({
+    kind: input.kind,
+    marker,
+    diagnosticBundle: input.bundle,
+  });
+
+  return {
+    title: `[User submitted bug] ${KIND_TITLE[input.kind]}`,
+    description: `${body}\n\n<!-- ${marker} -->`,
+    diagnosticCommentBody: [
+      '## Redacted Diagnostic JSON',
+      '',
+      '```json',
+      JSON.stringify(diagnosticPayload, null, 2),
+      '```',
+    ].join('\n'),
+    marker,
+    priority: priorityForBug(input.kind),
+    labelName: DEFAULT_LINEAR_LABEL_NAME,
+    templateKind,
+  };
+}
+
+async function addDiagnosticComment(
+  linearClient: SquireLinearClient,
+  issueId: string,
+  body: string,
+): Promise<void> {
+  await linearClient.createComment(issueId, body);
+}
+
+function attachmentBytes(attachment: LinearBugReportAttachment): Buffer | undefined {
+  if (!ATTACHMENT_FILENAME_PATTERN.test(attachment.filename)) return undefined;
+  if (!ATTACHMENT_BASE64_PATTERN.test(attachment.base64Content)) return undefined;
+  const bytes = Buffer.from(attachment.base64Content, 'base64');
+  if (bytes.byteLength === 0 || bytes.byteLength > MAX_ATTACHMENT_BYTES) return undefined;
+  return bytes;
+}
+
+async function uploadAttachmentToLinear(
+  fetch: FetchLike,
+  linearClient: SquireLinearClient,
+  attachment: LinearBugReportAttachment,
+): Promise<string> {
+  const bytes = attachmentBytes(attachment);
+  if (!bytes) throw new Error(`Invalid attachment ${attachment.filename}`);
+
+  const uploadFile = await linearClient.requestFileUpload({
+    filename: attachment.filename,
+    contentType: attachment.contentType,
+    size: bytes.byteLength,
+  });
+
+  const headers = new Headers();
+  headers.set('Content-Type', attachment.contentType);
+  headers.set('Cache-Control', 'public, max-age=31536000');
+  for (const header of uploadFile.headers) headers.set(header.key, header.value);
+  const uploadBody = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(uploadBody).set(bytes);
+
+  const response = await fetch(uploadFile.uploadUrl, {
+    method: 'PUT',
+    headers,
+    body: uploadBody,
+  });
+  if (!response.ok) {
+    throw new Error(`Linear attachment upload returned ${String(response.status)}`);
+  }
+
+  return uploadFile.assetUrl;
+}
+
+function attachmentMarkdown(
+  attachment: LinearBugReportAttachment,
+  assetUrl: string | undefined,
+  unavailableReason: string | undefined,
+): string {
+  const title = attachment.title?.trim() || attachment.filename;
+  const subtitle = attachment.subtitle?.trim();
+  if (!assetUrl) {
+    return `- ${title}: Unavailable: ${unavailableReason ?? 'upload failed'}`;
+  }
+  return [`![${title}](${assetUrl})`, subtitle ? `_${subtitle}_` : undefined]
+    .filter((line): line is string => Boolean(line))
+    .join('\n');
+}
+
+async function addAttachmentComment(
+  fetch: FetchLike,
+  linearClient: SquireLinearClient,
+  issueId: string,
+  attachments: LinearBugReportAttachment[] | undefined,
+): Promise<void> {
+  const bounded = (attachments ?? []).slice(0, 1);
+  if (bounded.length === 0) return;
+
+  const lines: string[] = ['## User-Attached Evidence', ''];
+  for (const attachment of bounded) {
+    try {
+      const assetUrl = await uploadAttachmentToLinear(fetch, linearClient, attachment);
+      lines.push(attachmentMarkdown(attachment, assetUrl, undefined));
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : 'upload failed';
+      lines.push(attachmentMarkdown(attachment, undefined, reason));
+    }
+    lines.push('');
+  }
+
+  await addDiagnosticComment(linearClient, issueId, lines.join('\n').trimEnd());
+}
+
+function warningForOptionalLinearStep(step: string, error: unknown): string {
+  const message = error instanceof Error ? error.message : 'unknown error';
+  return `${step}: ${message}`;
+}
+
+async function tryOptionalLinearStep(
+  warnings: string[],
+  step: string,
+  action: () => Promise<void>,
+): Promise<boolean> {
+  try {
+    await action();
+    return true;
+  } catch (error) {
+    warnings.push(warningForOptionalLinearStep(step, error));
+    return false;
+  }
+}
+
+function linearApiKeyFromInput(input: SubmitLinearBugReportInput): string | undefined {
+  const env = input.env ?? process.env;
+  return input.linearApiKey?.trim() || env.LINEAR_API_KEY?.trim() || undefined;
+}
+
+function linearClientFromInput(
+  input: SubmitLinearBugReportInput,
+  linearApiKey: string,
+): SquireLinearClient {
+  return input.linearClient ?? createLinearClient(linearApiKey);
+}
+
+export async function submitLinearBugReport(
+  input: SubmitLinearBugReportInput,
+): Promise<SubmitLinearBugReportResult> {
+  const draft = buildLinearBugReportDraft(input);
+  const linearApiKey = linearApiKeyFromInput(input);
+  if (!linearApiKey) {
+    return {
+      status: 'disabled',
+      reason: 'LINEAR_API_KEY is not configured',
+      marker: draft.marker,
+    };
+  }
+
+  const fetch = input.fetch ?? globalThis.fetch;
+  const teamKey = input.linearTeamKey ?? DEFAULT_LINEAR_TEAM_KEY;
+  const linearClient = linearClientFromInput(input, linearApiKey);
+  const targets = await linearClient.resolveTargets({
+    teamKey,
+    projectName: input.linearProjectName ?? DEFAULT_LINEAR_PROJECT_NAME,
+    labelName: DEFAULT_LINEAR_LABEL_NAME,
+    stateName: input.linearStateName ?? DEFAULT_LINEAR_STATE_NAME,
+    assignViewer: true,
+  });
+  const existing = await linearClient.findIssueByMarker(teamKey, draft.marker);
+  if (existing) {
+    const warnings: string[] = [];
+    await tryOptionalLinearStep(warnings, 'Add user-attached evidence comment', () =>
+      addAttachmentComment(fetch, linearClient, existing.id, input.attachments),
+    );
+    return {
+      status: 'existing',
+      issue: existing,
+      marker: draft.marker,
+      ...(warnings.length > 0 ? { warnings } : {}),
+    };
+  }
+
+  const issue = await linearClient.createIssue({
+    teamId: targets.teamId,
+    title: draft.title,
+    description: draft.description,
+    priority: draft.priority,
+    projectId: targets.projectId,
+    assigneeId: targets.assigneeId,
+    stateId: targets.stateId,
+    labelIds: targets.labelIds,
+  });
+  const warnings: string[] = [];
+  const canComment = await tryOptionalLinearStep(warnings, 'Add redacted diagnostic comment', () =>
+    addDiagnosticComment(linearClient, issue.id, draft.diagnosticCommentBody),
+  );
+  if (canComment) {
+    await tryOptionalLinearStep(warnings, 'Add user-attached evidence comment', () =>
+      addAttachmentComment(fetch, linearClient, issue.id, input.attachments),
+    );
+  } else if (input.attachments?.length) {
+    warnings.push(
+      'Add user-attached evidence comment: skipped because Linear comments are unavailable',
+    );
+  }
+  return {
+    status: 'created',
+    issue,
+    marker: draft.marker,
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+}

--- a/src/linear-bug-report-template.ts
+++ b/src/linear-bug-report-template.ts
@@ -6,6 +6,7 @@ export type LinearBugReportKind = 'app_runtime' | 'answer_quality';
 export interface LinearBugReportTemplateInput {
   bundle: DiagnosticBundle;
   kind: LinearBugReportKind;
+  reportTypeLabel?: string;
   observed?: string;
   expected?: string;
   likelyFailingArea?: string;
@@ -14,10 +15,16 @@ export interface LinearBugReportTemplateInput {
   acceptanceCriteria?: string[];
 }
 
-const KIND_COPY: Record<LinearBugReportKind, string> = {
-  app_runtime: 'App/runtime bug. Start in Sentry, then use LangSmith only for LLM trace context.',
+const DEFAULT_REPORT_TYPE: Record<LinearBugReportKind, string> = {
+  app_runtime: 'App/runtime bug',
+  answer_quality: 'Answer-quality bug',
+};
+
+const DIAGNOSTIC_STARTING_POINT: Record<LinearBugReportKind, string> = {
+  app_runtime:
+    'Start in Sentry for app errors, logs, traces, or replay. Use LangSmith only if the failure involves answer generation.',
   answer_quality:
-    'Answer-quality bug. Start in LangSmith, then use Sentry only if there was an app/runtime error.',
+    'Start in LangSmith for the answer trace. Use Sentry only if the app also reported an error, failed stream, replay, or log event.',
 };
 
 function toSafeText(value: unknown): string {
@@ -52,6 +59,7 @@ function renderSentryEvidence(bundle: DiagnosticBundle): string {
     'Sentry:',
     `- Issue: ${fieldText(bundle.sentry.issueUrl)}`,
     `- Event: ${fieldText(bundle.sentry.eventUrl)}`,
+    `- Event ID: ${fieldText(bundle.sentry.eventId)}`,
     `- Replay: ${fieldText(bundle.sentry.replayUrl)}`,
     `- Trace: ${fieldText(bundle.sentry.traceUrl)}`,
     `- Logs: ${fieldText(bundle.sentry.logsUrl)}`,
@@ -68,43 +76,50 @@ function renderLangSmithEvidence(bundle: DiagnosticBundle): string {
     `- Thread: ${fieldText(bundle.langsmith.threadId)}`,
     `- Thread URL: ${fieldText(bundle.langsmith.threadUrl)}`,
     `- Run ID: ${fieldText(bundle.langsmith.runId)}`,
+    `- Run URL: ${fieldText(bundle.langsmith.runUrl)}`,
   ].join('\n');
 }
 
-function renderEvidence(input: LinearBugReportTemplateInput): string {
+function reportTypeLabel(input: LinearBugReportTemplateInput): string {
+  const text = toSafeText(input.reportTypeLabel ?? '').trim();
+  return text.length > 0 ? text : DEFAULT_REPORT_TYPE[input.kind];
+}
+
+function renderDiagnosticEvidence(input: LinearBugReportTemplateInput): string {
   const coreEvidence = [
-    `Debug lane: ${KIND_COPY[input.kind]}`,
     `Conversation: ${fieldText(input.bundle.conversation.url)}`,
     `Turn: userMessageId=${fieldText(input.bundle.conversation.userMessageId)}, assistantMessageId=${fieldText(
       input.bundle.conversation.assistantMessageId,
     )}`,
     `Request: ${fieldText(input.bundle.request.requestId)}`,
+    `Suggested diagnostic starting point: ${DIAGNOSTIC_STARTING_POINT[input.kind]}`,
   ].join('\n');
   const orderedToolEvidence =
     input.kind === 'answer_quality'
       ? [renderLangSmithEvidence(input.bundle), renderSentryEvidence(input.bundle)]
       : [renderSentryEvidence(input.bundle), renderLangSmithEvidence(input.bundle)];
 
-  return ['## Evidence', '', coreEvidence, '', ...orderedToolEvidence].join('\n\n');
+  return ['## Diagnostic Evidence', '', coreEvidence, '', ...orderedToolEvidence].join('\n\n');
 }
 
 export function createLinearBugReportBody(input: LinearBugReportTemplateInput): string {
   return [
-    renderEvidence(input),
-    '## Observed Behavior',
+    '## User Report',
     '',
+    `Type: ${reportTypeLabel(input)}`,
+    '',
+    'Observed:',
     optionalText(input.observed, 'observed behavior was not provided'),
     '',
-    '## Expected Behavior',
-    '',
+    'Expected:',
     optionalText(input.expected, 'expected behavior was not provided'),
     '',
-    '## Why This Is Likely Failing',
+    '## Triage Notes',
     '',
+    'Likely failing area:',
     optionalText(input.likelyFailingArea, 'likely failing area was not provided'),
     '',
-    '## First Files To Inspect',
-    '',
+    'First files to inspect:',
     bulletList(input.firstFilesToInspect, 'first files to inspect were not provided'),
     '',
     '## Repro Steps',
@@ -114,5 +129,7 @@ export function createLinearBugReportBody(input: LinearBugReportTemplateInput): 
     '## Acceptance Criteria',
     '',
     bulletList(input.acceptanceCriteria, 'acceptance criteria were not provided'),
+    '',
+    renderDiagnosticEvidence(input),
   ].join('\n');
 }

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -142,13 +142,15 @@ class LinearSdkIssueClient implements SquireLinearClient {
   async resolveTargets(input: LinearTargetInput): Promise<LinearTargets> {
     const [teams, projects, labels, states, viewer] = await Promise.all([
       this.sdk.teams({ first: 1, filter: { key: { eq: input.teamKey } } }),
-      this.sdk.projects({
-        first: 1,
-        filter: {
-          name: { eq: input.projectName },
-          accessibleTeams: { some: { key: { eq: input.teamKey } } },
-        },
-      }),
+      input.projectName
+        ? this.sdk.projects({
+            first: 1,
+            filter: {
+              name: { eq: input.projectName },
+              accessibleTeams: { some: { key: { eq: input.teamKey } } },
+            },
+          })
+        : Promise.resolve({ nodes: [] }),
       this.sdk.issueLabels({
         first: 10,
         filter: {

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -1,0 +1,264 @@
+import { LinearClient } from '@linear/sdk';
+
+export interface LinearIssueRef {
+  id: string;
+  identifier: string;
+  url: string;
+}
+
+export interface LinearTargetInput {
+  teamKey: string;
+  projectName?: string;
+  labelName: string;
+  stateName?: string;
+  assignViewer?: boolean;
+}
+
+export interface LinearTargets {
+  teamId: string;
+  projectId?: string;
+  labelIds: string[];
+  labelName: string;
+  assigneeId?: string;
+  stateId?: string;
+}
+
+export interface LinearUploadFile {
+  uploadUrl: string;
+  assetUrl: string;
+  headers: { key: string; value: string }[];
+}
+
+export interface LinearIssueCreateInput {
+  teamId: string;
+  title: string;
+  description?: string;
+  priority?: number;
+  projectId?: string;
+  assigneeId?: string;
+  stateId?: string;
+  labelIds?: string[];
+}
+
+export interface LinearIssueUpdateInput {
+  title?: string;
+  description?: string;
+  priority?: number;
+  projectId?: string;
+  labelIds?: string[];
+}
+
+export interface SquireLinearClient {
+  resolveTargets(input: LinearTargetInput): Promise<LinearTargets>;
+  findIssueByMarker(teamKey: string, marker: string): Promise<LinearIssueRef | undefined>;
+  createIssue(input: LinearIssueCreateInput): Promise<LinearIssueRef>;
+  updateIssue(id: string, input: LinearIssueUpdateInput): Promise<LinearIssueRef>;
+  createComment(issueId: string, body: string): Promise<void>;
+  requestFileUpload(input: {
+    filename: string;
+    contentType: string;
+    size: number;
+  }): Promise<LinearUploadFile>;
+}
+
+interface LinearSdkRecord {
+  id?: unknown;
+  key?: unknown;
+  name?: unknown;
+  identifier?: unknown;
+  url?: unknown;
+  team?: { id?: unknown; key?: unknown } | null;
+}
+
+interface LinearSdkConnection<T extends LinearSdkRecord> {
+  nodes?: T[];
+}
+
+interface LinearSdkIssuePayload {
+  success?: unknown;
+  issue?: LinearSdkRecord | PromiseLike<LinearSdkRecord | undefined> | undefined;
+}
+
+interface LinearSdkCommentPayload {
+  success?: unknown;
+}
+
+interface LinearSdkUploadPayload {
+  success?: unknown;
+  uploadFile?: LinearUploadFile | null;
+}
+
+interface LinearSdkClient {
+  viewer: PromiseLike<{ id?: unknown }>;
+  teams(variables?: unknown): PromiseLike<LinearSdkConnection<LinearSdkRecord>>;
+  projects(variables?: unknown): PromiseLike<LinearSdkConnection<LinearSdkRecord>>;
+  issueLabels(variables?: unknown): PromiseLike<LinearSdkConnection<LinearSdkRecord>>;
+  workflowStates(variables?: unknown): PromiseLike<LinearSdkConnection<LinearSdkRecord>>;
+  issues(variables?: unknown): PromiseLike<LinearSdkConnection<LinearSdkRecord>>;
+  issue(id: string): PromiseLike<LinearSdkRecord>;
+  createIssue(input: Record<string, unknown>): PromiseLike<LinearSdkIssuePayload>;
+  updateIssue(id: string, input: Record<string, unknown>): PromiseLike<LinearSdkIssuePayload>;
+  createComment(input: { issueId: string; body: string }): PromiseLike<LinearSdkCommentPayload>;
+  fileUpload(
+    contentType: string,
+    filename: string,
+    size: number,
+  ): PromiseLike<LinearSdkUploadPayload>;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function issueRef(record: LinearSdkRecord | undefined, context: string): LinearIssueRef {
+  const id = stringField(record?.id);
+  const identifier = stringField(record?.identifier);
+  const url = stringField(record?.url);
+  if (!id || !identifier || !url) {
+    throw new Error(`Linear ${context} did not include id, identifier, and url`);
+  }
+  return { id, identifier, url };
+}
+
+async function maybeAwait<T>(value: T | PromiseLike<T> | undefined): Promise<T | undefined> {
+  return value === undefined ? undefined : await value;
+}
+
+function recordId(record: LinearSdkRecord | undefined): string | undefined {
+  return stringField(record?.id);
+}
+
+export function createLinearClient(apiKey: string): SquireLinearClient {
+  return new LinearSdkIssueClient(apiKey);
+}
+
+class LinearSdkIssueClient implements SquireLinearClient {
+  private readonly sdk: LinearSdkClient;
+
+  constructor(apiKey: string) {
+    this.sdk = new LinearClient({ apiKey }) as unknown as LinearSdkClient;
+  }
+
+  async resolveTargets(input: LinearTargetInput): Promise<LinearTargets> {
+    const [teams, projects, labels, states, viewer] = await Promise.all([
+      this.sdk.teams({ first: 1, filter: { key: { eq: input.teamKey } } }),
+      this.sdk.projects({
+        first: 1,
+        filter: {
+          name: { eq: input.projectName },
+          accessibleTeams: { some: { key: { eq: input.teamKey } } },
+        },
+      }),
+      this.sdk.issueLabels({
+        first: 10,
+        filter: {
+          name: { eqIgnoreCase: input.labelName },
+          or: [{ team: { null: true } }, { team: { key: { eq: input.teamKey } } }],
+        },
+      }),
+      input.stateName
+        ? this.sdk.workflowStates({
+            first: 1,
+            filter: {
+              team: { key: { eq: input.teamKey } },
+              name: { eqIgnoreCase: input.stateName },
+            },
+          })
+        : Promise.resolve({ nodes: [] }),
+      input.assignViewer ? this.sdk.viewer : Promise.resolve(undefined),
+    ]);
+
+    const team = teams.nodes?.[0];
+    const teamId = stringField(team?.id);
+    if (!teamId) throw new Error(`Linear team ${input.teamKey} was not found`);
+
+    const project = projects.nodes?.[0];
+    const projectId = stringField(project?.id);
+    if (input.projectName && !projectId) {
+      throw new Error(`Linear project ${input.projectName} was not found`);
+    }
+
+    const label = labels.nodes?.find((candidate) => candidate.team === null) ?? labels.nodes?.[0];
+    const labelId = stringField(label?.id);
+    const labelName = stringField(label?.name);
+    if (!labelId || !labelName) throw new Error(`Linear label ${input.labelName} was not found`);
+
+    const state = states.nodes?.[0];
+    const stateId = input.stateName ? stringField(state?.id) : undefined;
+    if (input.stateName && !stateId) {
+      throw new Error(`Linear state ${input.stateName} was not found`);
+    }
+
+    const assigneeId = input.assignViewer ? stringField(viewer?.id) : undefined;
+    if (input.assignViewer && !assigneeId) throw new Error('Linear viewer id was not returned');
+
+    return {
+      teamId,
+      ...(projectId ? { projectId } : {}),
+      labelIds: [labelId],
+      labelName,
+      ...(stateId ? { stateId } : {}),
+      ...(assigneeId ? { assigneeId } : {}),
+    };
+  }
+
+  async findIssueByMarker(teamKey: string, marker: string): Promise<LinearIssueRef | undefined> {
+    const issues = await this.sdk.issues({
+      first: 1,
+      filter: {
+        team: { key: { eq: teamKey } },
+        description: { contains: marker },
+      },
+    });
+    const issue = issues.nodes?.[0];
+    return issue ? issueRef(issue, 'issue search result') : undefined;
+  }
+
+  async createIssue(input: LinearIssueCreateInput): Promise<LinearIssueRef> {
+    const payload = await this.sdk.createIssue({ ...input });
+    if (payload.success !== true) throw new Error('Linear issueCreate returned success=false');
+    return this.issueFromPayload(payload, 'created issue');
+  }
+
+  async updateIssue(id: string, input: LinearIssueUpdateInput): Promise<LinearIssueRef> {
+    const payload = await this.sdk.updateIssue(id, { ...input });
+    if (payload.success !== true) {
+      throw new Error(`Linear issueUpdate returned success=false for ${id}`);
+    }
+    return this.issueFromPayload(payload, 'updated issue');
+  }
+
+  async createComment(issueId: string, body: string): Promise<void> {
+    const payload = await this.sdk.createComment({ issueId, body });
+    if (payload.success !== true) {
+      throw new Error(`Linear commentCreate returned success=false for issue ${issueId}`);
+    }
+  }
+
+  async requestFileUpload(input: {
+    filename: string;
+    contentType: string;
+    size: number;
+  }): Promise<LinearUploadFile> {
+    const payload = await this.sdk.fileUpload(input.contentType, input.filename, input.size);
+    if (payload.success !== true || !payload.uploadFile) {
+      throw new Error(`Linear fileUpload returned success=false for ${input.filename}`);
+    }
+    return payload.uploadFile;
+  }
+
+  private async issueFromPayload(
+    payload: LinearSdkIssuePayload,
+    context: string,
+  ): Promise<LinearIssueRef> {
+    const issue = await maybeAwait(payload.issue);
+    const id = recordId(issue);
+    if (issue && stringField(issue.identifier) && stringField(issue.url)) {
+      return issueRef(issue, context);
+    }
+    if (id) {
+      return issueRef(await this.sdk.issue(id), context);
+    }
+    throw new Error(`Linear ${context} payload did not include an issue`);
+  }
+}

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -89,6 +89,12 @@ export const API_ASK_RATE_LIMIT_POLICY: RateLimitPolicy = {
   windowMs: 60 * 1000,
 };
 
+export const BUG_REPORT_RATE_LIMIT_POLICY: RateLimitPolicy = {
+  name: 'bug_report_create',
+  limit: 10,
+  windowMs: 60 * 60 * 1000,
+};
+
 /** Campaign-state reads, per user (ADR 0018 inventory, eng decision E7). */
 export const CAMPAIGN_READ_RATE_LIMIT_POLICY: RateLimitPolicy = {
   name: 'campaign_read',

--- a/src/server.ts
+++ b/src/server.ts
@@ -179,6 +179,12 @@ import {
   type ChatLifecycleInput,
 } from './chat/chat-observability.ts';
 import { resolveSquireEnv } from './squire-env.ts';
+import { collectDiagnosticBundle } from './diagnostic-bundle.ts';
+import {
+  InChatBugReportKindSchema,
+  submitLinearBugReport,
+  type LinearBugReportAttachment,
+} from './linear-bug-intake.ts';
 
 initTelemetry(process.env);
 
@@ -625,6 +631,89 @@ const BrowserTelemetrySchema = z
 
 type BrowserTelemetryEvent = z.infer<typeof BrowserTelemetrySchema>;
 
+const BrowserBugReportScreenshotSchema = z
+  .object({
+    filename: z
+      .string()
+      .min(1)
+      .max(96)
+      .regex(/^[A-Za-z0-9._-]+\.(?:jpe?g|png)$/i),
+    contentType: z.enum(['image/jpeg', 'image/png']),
+    base64Content: z
+      .string()
+      .min(1)
+      .max(2_000_000)
+      .regex(/^[A-Za-z0-9+/]+={0,2}$/),
+    width: z.number().int().positive().max(4_000).optional(),
+    height: z.number().int().positive().max(4_000).optional(),
+    byteSize: z.number().int().positive().max(1_500_000).optional(),
+  })
+  .strict();
+
+const BrowserBugReportPayloadSchema = z
+  .object({
+    kind: InChatBugReportKindSchema,
+    conversationId: BrowserTelemetryTokenSchema.optional(),
+    userMessageId: BrowserTelemetryTokenSchema.optional(),
+    assistantMessageId: BrowserTelemetryTokenSchema.optional(),
+    observed: z.string().max(2_000).optional(),
+    expected: z.string().max(2_000).optional(),
+    associatedEventId: BrowserTelemetryEventIdSchema.optional(),
+    sentryIssueUrl: z.string().min(1).max(2048).optional(),
+    sentryEventUrl: z.string().min(1).max(2048).optional(),
+    sentryEventId: BrowserTelemetryEventIdSchema.optional(),
+    sentryReplayUrl: z.string().min(1).max(2048).optional(),
+    sentryTraceUrl: z.string().min(1).max(2048).optional(),
+    sentryLogsUrl: z.string().min(1).max(2048).optional(),
+    sentryTraceId: BrowserTelemetryEventIdSchema.optional(),
+    langsmithTraceUrl: z.string().min(1).max(2048).optional(),
+    langsmithThreadUrl: z.string().min(1).max(2048).optional(),
+    langsmithThreadId: BrowserTelemetryTokenSchema.optional(),
+    langsmithRunUrl: z.string().min(1).max(2048).optional(),
+    langsmithRunId: BrowserTelemetryTokenSchema.optional(),
+    screenshot: BrowserBugReportScreenshotSchema.optional(),
+    browser: z
+      .object({
+        url: z.string().min(1).max(2048).optional(),
+        userAgent: z.string().min(1).max(512).optional(),
+        viewport: z
+          .object({
+            width: z.number().int().positive().max(20_000),
+            height: z.number().int().positive().max(20_000),
+          })
+          .strict()
+          .optional(),
+        replaySnapshotId: BrowserTelemetryTokenSchema.optional(),
+        timezone: z.string().min(1).max(64).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+type BrowserBugReportPayload = z.infer<typeof BrowserBugReportPayloadSchema>;
+
+function linearBugReportAttachmentFromScreenshot(
+  report: BrowserBugReportPayload,
+): LinearBugReportAttachment[] | undefined {
+  if (!report.screenshot) return undefined;
+  const decodedBytes = Buffer.from(report.screenshot.base64Content, 'base64');
+  if (decodedBytes.byteLength === 0 || decodedBytes.byteLength > 1_500_000) return undefined;
+  const dimensions =
+    report.screenshot.width && report.screenshot.height
+      ? `${String(report.screenshot.width)}x${String(report.screenshot.height)}`
+      : 'dimensions unavailable';
+  return [
+    {
+      filename: report.screenshot.filename,
+      contentType: report.screenshot.contentType,
+      base64Content: report.screenshot.base64Content,
+      title: 'Conversation UI screenshot',
+      subtitle: `Opt-in screenshot from ${report.kind} report (${dimensions}).`,
+    },
+  ];
+}
+
 const browserTelemetryTracer = trace.getTracer('squire.browser-telemetry');
 
 function browserTelemetryLevel(event: BrowserTelemetryEvent): 'info' | 'error' {
@@ -762,6 +851,25 @@ function buildBrowserFeedbackInput(
     feedbackKind: event.feedbackKind,
     associatedEventId: event.associatedEventId,
   };
+}
+
+function optionalBugReportText(value: string | undefined): string | undefined {
+  const text = value?.trim();
+  return text && text.length > 0 ? text : undefined;
+}
+
+function bugReportConversationUrl(report: BrowserBugReportPayload): string | undefined {
+  if (report.browser?.url) return report.browser.url;
+  if (report.conversationId) return `/chat/${report.conversationId}`;
+  return undefined;
+}
+
+function linearBugReportApiKey(): string | undefined {
+  return process.env.LINEAR_API_KEY?.trim() || undefined;
+}
+
+function bugReportStatusCode(status: 'created' | 'existing'): 200 | 201 {
+  return status === 'created' ? 201 : 200;
 }
 
 async function checkRegisterRateLimit(c: Context): Promise<RateLimitDecision> {
@@ -3590,6 +3698,83 @@ app.post('/api/browser-telemetry', optionalSession(), async (c) => {
         finishBrowserTelemetrySpan(span, logLevel);
       }
     },
+  );
+});
+
+app.post('/api/bug-reports', requireSession(), requireCsrf(), async (c) => {
+  c.header('Cache-Control', 'no-store');
+  c.header('Vary', 'Cookie');
+  const requestId = correlateRequest(c);
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json(jsonError('Invalid JSON body', 400), 400);
+  }
+
+  const result = BrowserBugReportPayloadSchema.safeParse(body);
+  if (!result.success) return c.json(jsonError('Invalid bug report payload', 400), 400);
+
+  const report = result.data;
+  const session = c.get('session') as { userId?: unknown } | undefined;
+  const userId = typeof session?.userId === 'string' ? session.userId : undefined;
+  if (!userId) return c.json(jsonError('Authentication required', 401), 401);
+
+  const bundle = await collectDiagnosticBundle({
+    route: '/api/bug-reports',
+    requestId,
+    conversationId: report.conversationId,
+    userMessageId: report.userMessageId,
+    assistantMessageId: report.assistantMessageId,
+    conversationUrl: bugReportConversationUrl(report),
+    browserUrl: report.browser?.url,
+    user: { id: userId },
+    browser: report.browser,
+    sentryIssueUrl: report.sentryIssueUrl,
+    sentryEventUrl: report.sentryEventUrl,
+    sentryEventId: report.sentryEventId ?? report.associatedEventId,
+    sentryReplayUrl: report.sentryReplayUrl,
+    sentryTraceUrl: report.sentryTraceUrl,
+    sentryLogsUrl: report.sentryLogsUrl,
+    sentryTraceId: report.sentryTraceId,
+    langsmithTraceUrl: report.langsmithTraceUrl,
+    langsmithThreadUrl: report.langsmithThreadUrl,
+    langsmithThreadId: report.langsmithThreadId,
+    langsmithRunUrl: report.langsmithRunUrl,
+    langsmithRunId: report.langsmithRunId,
+  });
+
+  const submission = await submitLinearBugReport({
+    bundle,
+    kind: report.kind,
+    observed: optionalBugReportText(report.observed),
+    expected: optionalBugReportText(report.expected),
+    attachments: linearBugReportAttachmentFromScreenshot(report),
+    linearApiKey: linearBugReportApiKey(),
+  });
+
+  if (submission.status === 'disabled') {
+    return c.json(
+      {
+        error: 'Bug reporting is not configured',
+        status: 503,
+        marker: submission.marker,
+      },
+      503,
+    );
+  }
+
+  return c.json(
+    {
+      status: submission.status,
+      issue: {
+        identifier: submission.issue.identifier,
+        url: submission.issue.url,
+      },
+      marker: submission.marker,
+      ...(submission.warnings?.length ? { warnings: submission.warnings } : {}),
+    },
+    bugReportStatusCode(submission.status),
   );
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,7 @@ import {
   API_ASK_RATE_LIMIT_POLICY,
   API_CARD_SEARCH_RATE_LIMIT_POLICY,
   API_RULE_SEARCH_RATE_LIMIT_POLICY,
+  BUG_REPORT_RATE_LIMIT_POLICY,
   CAMPAIGN_READ_RATE_LIMIT_POLICY,
   CAMPAIGN_WRITE_RATE_LIMIT_POLICY,
   GOOGLE_OAUTH_CALLBACK_RATE_LIMIT_POLICY,
@@ -68,6 +69,7 @@ import { itemCostWarnings, levelXpWarnings } from './campaign/write-validation.t
 import { renderCharacterSheetContent } from './web-ui/character-sheet.ts';
 import { renderProfileContent } from './web-ui/profile-page.ts';
 import * as CharacterRepository from './db/repositories/character-repository.ts';
+import * as ConversationRepository from './db/repositories/conversation-repository.ts';
 import {
   findCardByName,
   findItemByNumber,
@@ -3705,6 +3707,32 @@ app.post('/api/bug-reports', requireSession(), requireCsrf(), async (c) => {
   c.header('Cache-Control', 'no-store');
   c.header('Vary', 'Cookie');
   const requestId = correlateRequest(c);
+  const session = c.get('session') as { userId?: unknown } | undefined;
+  const userId = typeof session?.userId === 'string' ? session.userId : undefined;
+  if (!userId) return c.json(jsonError('Authentication required', 401), 401);
+
+  let rateLimit: RateLimitDecision;
+  try {
+    rateLimit = await getDefaultRateLimiter().consume({
+      policy: BUG_REPORT_RATE_LIMIT_POLICY,
+      identity: `user:${userId}`,
+    });
+  } catch (error) {
+    return apiRateLimitUnavailableResponse(
+      c,
+      error,
+      '/api/bug-reports',
+      BUG_REPORT_RATE_LIMIT_POLICY,
+    );
+  }
+  if (!rateLimit.allowed) {
+    return apiRateLimitedResponse(
+      c,
+      { decision: rateLimit, identityKind: 'user' },
+      '/api/bug-reports',
+    );
+  }
+
   let body: unknown;
   try {
     body = await c.req.json();
@@ -3716,19 +3744,23 @@ app.post('/api/bug-reports', requireSession(), requireCsrf(), async (c) => {
   if (!result.success) return c.json(jsonError('Invalid bug report payload', 400), 400);
 
   const report = result.data;
-  const session = c.get('session') as { userId?: unknown } | undefined;
-  const userId = typeof session?.userId === 'string' ? session.userId : undefined;
-  if (!userId) return c.json(jsonError('Authentication required', 401), 401);
+  const conversation = report.conversationId
+    ? await ConversationRepository.findOwnedById(userId, report.conversationId)
+    : null;
+  if (report.conversationId && !conversation) {
+    return c.json(jsonError('Conversation not found', 404), 404);
+  }
 
   const bundle = await collectDiagnosticBundle({
     route: '/api/bug-reports',
     requestId,
-    conversationId: report.conversationId,
-    userMessageId: report.userMessageId,
-    assistantMessageId: report.assistantMessageId,
+    conversationId: conversation?.id,
+    userMessageId: conversation ? report.userMessageId : undefined,
+    assistantMessageId: conversation ? report.assistantMessageId : undefined,
     conversationUrl: bugReportConversationUrl(report),
     browserUrl: report.browser?.url,
     user: { id: userId },
+    conversation,
     browser: report.browser,
     sentryIssueUrl: report.sentryIssueUrl,
     sentryEventUrl: report.sentryEventUrl,

--- a/src/service.ts
+++ b/src/service.ts
@@ -11,6 +11,7 @@ import {
   initializeRetrieval,
 } from './vector-store.ts';
 import { listCardTypes } from './tools.ts';
+import type { AgentRunResult } from './agent.ts';
 import { runLangGraphAgentLoopWithTrajectory } from './agent-langgraph.ts';
 import { applyCampaignContextToAskOptions, type CampaignContextView } from './campaign/context.ts';
 import { assertLlmBudgetAvailable, recordLlmUsage } from './llm-budget.ts';
@@ -628,7 +629,10 @@ export async function ensureAskBudgetAvailable(userId?: string | null): Promise<
  * The agent decides which tools to call based on the question,
  * iterates until it has enough context, then produces a grounded answer.
  */
-export async function ask(question: string, options?: AskOptions): Promise<string> {
+export async function askWithResult(
+  question: string,
+  options?: AskOptions,
+): Promise<AgentRunResult> {
   if (!isReady()) await initialize();
   const {
     budgetPrechecked,
@@ -669,5 +673,10 @@ export async function ask(question: string, options?: AskOptions): Promise<strin
       },
     });
   }
+  return result;
+}
+
+export async function ask(question: string, options?: AskOptions): Promise<string> {
+  const result = await askWithResult(question, options);
   return result.answer;
 }

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -991,6 +991,37 @@ function renderCompletedAnswerWork(message: ConversationMessage): HtmlEscapedStr
   return renderCompletedAnswerWorkTimeline(timelineFromConsultedSources(message.consultedSources));
 }
 
+function renderAnswerReportAction(options: {
+  userMessageId?: string | null;
+  assistantMessageId?: string | null;
+  langsmithRunId?: string | null;
+  langsmithRunUrl?: string | null;
+  langsmithTraceUrl?: string | null;
+  defaultKind: 'bad_answer' | 'broken_stream';
+}): HtmlEscapedString {
+  return html`<div class="squire-answer__actions">
+    <button
+      type="button"
+      class="squire-answer__report"
+      data-squire-report-bug
+      ${options.userMessageId ? html`data-user-message-id="${options.userMessageId}"` : html``}
+      ${options.assistantMessageId
+        ? html`data-assistant-message-id="${options.assistantMessageId}"`
+        : html``}
+      ${options.langsmithRunId ? html`data-langsmith-run-id="${options.langsmithRunId}"` : html``}
+      ${options.langsmithRunUrl
+        ? html`data-langsmith-run-url="${options.langsmithRunUrl}"`
+        : html``}
+      ${options.langsmithTraceUrl
+        ? html`data-langsmith-trace-url="${options.langsmithTraceUrl}"`
+        : html``}
+      data-bug-report-default-kind="${options.defaultKind}"
+    >
+      Report bug
+    </button>
+  </div>` as HtmlEscapedString;
+}
+
 function renderAnswerTurn(message: ConversationMessage): HtmlEscapedString {
   const content = message.isError
     ? (html`<p>${message.content}</p>` as HtmlEscapedString)
@@ -1007,6 +1038,14 @@ function renderAnswerTurn(message: ConversationMessage): HtmlEscapedString {
   >
     <h2 class="sr-only" id="${labelId}">Squire answer</h2>
     ${renderCompletedAnswerWork(message)} ${renderAnswerContent(content)}
+    ${renderAnswerReportAction({
+      userMessageId: message.responseToMessageId,
+      assistantMessageId: message.id,
+      langsmithRunId: message.langsmithRunId,
+      langsmithRunUrl: message.langsmithRunUrl,
+      langsmithTraceUrl: message.langsmithTraceUrl,
+      defaultKind: message.isError ? 'broken_stream' : 'bad_answer',
+    })}
   </article>` as HtmlEscapedString;
 }
 
@@ -1049,6 +1088,11 @@ function renderPendingAnswerSkeleton(streamUrl: string): HtmlEscapedString {
       <div class="squire-answer__skeleton-line squire-answer__skeleton-line--mid"></div>
       <div class="squire-answer__skeleton-line squire-answer__skeleton-line--short"></div>
     </div>
+    ${renderAnswerReportAction({
+      userMessageId,
+      assistantMessageId: null,
+      defaultKind: 'broken_stream',
+    })}
   </article>` as HtmlEscapedString;
 }
 

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -20,6 +20,7 @@ var activeGame = defaultActiveGame;
 var activeGameInitialized = false;
 var browserTelemetryConfig = null;
 var lastBrowserTelemetryEventId = null;
+var BUG_REPORT_SCREENSHOT_MAX_BYTES = 1500000;
 
 var MASKED_REPLAY_MASK_SELECTORS = [
   '.squire-transcript',
@@ -46,6 +47,20 @@ var ALLOWED_BROWSER_FEEDBACK_KINDS = {
   ui_broken: true,
   source_problem: true,
   other: true,
+};
+var ALLOWED_BUG_REPORT_KINDS = {
+  bad_answer: true,
+  broken_stream: true,
+  visual_issue: true,
+  wrong_source: true,
+  other: true,
+};
+var BUG_REPORT_FEEDBACK_KIND = {
+  bad_answer: 'wrong_answer',
+  broken_stream: 'stream_failed',
+  visual_issue: 'ui_broken',
+  wrong_source: 'source_problem',
+  other: 'other',
 };
 
 function safePathOnly(raw) {
@@ -239,6 +254,16 @@ function browserFeedbackKind(value) {
   return 'other';
 }
 
+function bugReportKind(value) {
+  if (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(ALLOWED_BUG_REPORT_KINDS, value)
+  ) {
+    return value;
+  }
+  return 'other';
+}
+
 function rememberBrowserTelemetryEventId(response, rememberEventId) {
   if (!response || typeof response.json !== 'function') return null;
   try {
@@ -354,7 +379,620 @@ function reportBrowserFeedback(details) {
   };
   if (eventId) payload.associatedEventId = eventId;
   if (details && details.streamUrl) payload.streamUrl = details.streamUrl;
-  sendBrowserTelemetry('browser_feedback', payload);
+  return sendBrowserTelemetry('browser_feedback', payload);
+}
+
+function bugReportCsrfToken() {
+  var meta = document.querySelector ? document.querySelector('meta[name="csrf-token"]') : null;
+  return meta && typeof meta.getAttribute === 'function' ? meta.getAttribute('content') || '' : '';
+}
+
+function currentBrowserUrl() {
+  if (window.location && typeof window.location.href === 'string') return window.location.href;
+  return currentRoutePath();
+}
+
+function browserTimezone() {
+  try {
+    var formatter =
+      window.Intl && typeof window.Intl.DateTimeFormat === 'function'
+        ? window.Intl.DateTimeFormat()
+        : null;
+    var options = formatter && formatter.resolvedOptions ? formatter.resolvedOptions() : null;
+    return typeof (options && options.timeZone) === 'string' ? options.timeZone : null;
+  } catch {
+    return null;
+  }
+}
+
+function bugReportText(value) {
+  if (typeof value !== 'string') return null;
+  var trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, 2000) : null;
+}
+
+function bugReportUrl(value) {
+  if (typeof value !== 'string') return null;
+  var trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, 2048) : null;
+}
+
+function bugReportToken(value) {
+  return telemetryToken(value, '');
+}
+
+function bugReportBase64ByteSize(value) {
+  if (typeof value !== 'string') return 0;
+  var padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0;
+  return Math.floor((value.length * 3) / 4) - padding;
+}
+
+function bugReportScreenshot(value) {
+  if (!value || typeof value !== 'object') return null;
+  if (value.contentType !== 'image/jpeg' && value.contentType !== 'image/png') return null;
+  if (
+    typeof value.filename !== 'string' ||
+    !/^[A-Za-z0-9._-]{1,96}\.(?:jpe?g|png)$/i.test(value.filename)
+  ) {
+    return null;
+  }
+  if (
+    typeof value.base64Content !== 'string' ||
+    !/^[A-Za-z0-9+/]+={0,2}$/.test(value.base64Content)
+  ) {
+    return null;
+  }
+  var byteSize = bugReportBase64ByteSize(value.base64Content);
+  if (byteSize <= 0 || byteSize > BUG_REPORT_SCREENSHOT_MAX_BYTES) return null;
+  var screenshot = {
+    filename: value.filename,
+    contentType: value.contentType,
+    base64Content: value.base64Content,
+    byteSize: byteSize,
+  };
+  if (Number.isInteger(value.width) && value.width > 0 && value.width <= 4000) {
+    screenshot.width = value.width;
+  }
+  if (Number.isInteger(value.height) && value.height > 0 && value.height <= 4000) {
+    screenshot.height = value.height;
+  }
+  return screenshot;
+}
+
+function bugReportScreenshotFilename() {
+  var suffix = Date.now().toString(36);
+  return 'squire-bug-' + suffix + '.jpg';
+}
+
+function hideDuringScreenshot(element, callback) {
+  if (!element || !element.style) return callback();
+  var previousVisibility = element.style.visibility;
+  element.style.visibility = 'hidden';
+  return Promise.resolve()
+    .then(callback)
+    .finally(function () {
+      element.style.visibility = previousVisibility;
+    });
+}
+
+function screenshotAttempts(sourceWidth, sourceHeight) {
+  var attempts = [
+    { edge: 1280, quality: 0.72 },
+    { edge: 960, quality: 0.66 },
+    { edge: 720, quality: 0.6 },
+  ];
+  return attempts.map(function (attempt) {
+    var scale = Math.min(1, attempt.edge / Math.max(sourceWidth, sourceHeight));
+    return {
+      width: Math.max(1, Math.round(sourceWidth * scale)),
+      height: Math.max(1, Math.round(sourceHeight * scale)),
+      quality: attempt.quality,
+    };
+  });
+}
+
+function screenshotFromLoadedImage(image, sourceWidth, sourceHeight) {
+  var attempts = screenshotAttempts(sourceWidth, sourceHeight);
+  for (var i = 0; i < attempts.length; i += 1) {
+    var attempt = attempts[i];
+    var canvas = document.createElement('canvas');
+    canvas.width = attempt.width;
+    canvas.height = attempt.height;
+    var context = canvas.getContext && canvas.getContext('2d');
+    if (!context) return null;
+    context.drawImage(image, 0, 0, attempt.width, attempt.height);
+    var dataUrl = canvas.toDataURL('image/jpeg', attempt.quality);
+    var match = dataUrl.match(/^data:(image\/jpeg);base64,([A-Za-z0-9+/]+={0,2})$/);
+    if (!match) continue;
+    var byteSize = bugReportBase64ByteSize(match[2]);
+    if (byteSize > 0 && byteSize <= BUG_REPORT_SCREENSHOT_MAX_BYTES) {
+      return {
+        filename: bugReportScreenshotFilename(),
+        contentType: match[1],
+        base64Content: match[2],
+        width: attempt.width,
+        height: attempt.height,
+        byteSize: byteSize,
+      };
+    }
+  }
+  return null;
+}
+
+function screenshotStyles() {
+  if (!document.styleSheets) return '';
+  var chunks = [];
+  for (var i = 0; i < document.styleSheets.length; i += 1) {
+    var sheet = document.styleSheets[i];
+    var rules;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      rules = null;
+    }
+    if (!rules) continue;
+    for (var j = 0; j < rules.length; j += 1) {
+      var cssText = rules[j] && rules[j].cssText;
+      if (!cssText || /^@font-face\b/i.test(cssText) || /^@import\b/i.test(cssText)) continue;
+      chunks.push(cssText);
+    }
+  }
+  return chunks.join('\n');
+}
+
+function removeScreenshotExternalResources(clone) {
+  if (!clone || typeof clone.querySelectorAll !== 'function') return;
+  clone.querySelectorAll('script,link[rel="stylesheet"],style').forEach(function (node) {
+    if (node.parentNode) node.parentNode.removeChild(node);
+  });
+}
+
+function screenshotViewportCss(width, height) {
+  var scrollX = Math.max(0, Math.round(window.scrollX || window.pageXOffset || 0));
+  var scrollY = Math.max(0, Math.round(window.scrollY || window.pageYOffset || 0));
+  var doc = document.documentElement;
+  var body = document.body;
+  var pageWidth = Math.max(width, doc?.scrollWidth || 0, body?.scrollWidth || 0);
+  var pageHeight = Math.max(height, doc?.scrollHeight || 0, body?.scrollHeight || 0);
+  return [
+    `html{width:${pageWidth}px!important;min-height:${pageHeight}px!important;overflow:hidden!important;}`,
+    `body{width:${pageWidth}px!important;min-height:${pageHeight}px!important;margin:0!important;transform:translate(${-scrollX}px,${-scrollY}px);transform-origin:top left;}`,
+  ].join('\n');
+}
+
+function screenshotSvgMarkup(width, height) {
+  if (
+    !document.documentElement ||
+    typeof document.documentElement.cloneNode !== 'function' ||
+    typeof window.XMLSerializer !== 'function'
+  ) {
+    return null;
+  }
+  var clone = document.documentElement.cloneNode(true);
+  clone.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+  removeScreenshotExternalResources(clone);
+  var head = clone.querySelector && clone.querySelector('head');
+  if (!head) return null;
+  var style = document.createElement('style');
+  style.textContent = [screenshotStyles(), screenshotViewportCss(width, height)].join('\n');
+  head.appendChild(style);
+
+  var htmlMarkup = new window.XMLSerializer().serializeToString(clone);
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
+    `<foreignObject x="0" y="0" width="${width}" height="${height}">`,
+    htmlMarkup,
+    '</foreignObject>',
+    '</svg>',
+  ].join('');
+}
+
+function loadScreenshotImage(svgMarkup, width, height) {
+  return new Promise(function (resolve) {
+    var ImageCtor = window.Image;
+    if (typeof ImageCtor !== 'function') {
+      resolve(null);
+      return;
+    }
+    var image = new ImageCtor();
+    image.onload = function () {
+      try {
+        resolve(screenshotFromLoadedImage(image, width, height));
+      } catch {
+        resolve(null);
+      }
+    };
+    image.onerror = function () {
+      resolve(null);
+    };
+    image.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgMarkup);
+  });
+}
+
+function nextScreenshotFrame() {
+  return new Promise(function (resolve) {
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(function () {
+        resolve();
+      });
+      return;
+    }
+    window.setTimeout(resolve, 0);
+  });
+}
+
+function captureCurrentPageScreenshot() {
+  var width = Math.max(
+    1,
+    Math.round(window.innerWidth || document.documentElement?.clientWidth || 1),
+  );
+  var height = Math.max(
+    1,
+    Math.round(window.innerHeight || document.documentElement?.clientHeight || 1),
+  );
+  var svgMarkup = screenshotSvgMarkup(width, height);
+  return svgMarkup ? loadScreenshotImage(svgMarkup, width, height) : Promise.resolve(null);
+}
+
+function captureBugReportScreenshot(hiddenElement) {
+  if (
+    !document ||
+    !document.createElement ||
+    !document.documentElement ||
+    typeof window.XMLSerializer !== 'function'
+  ) {
+    return Promise.resolve(null);
+  }
+
+  return hideDuringScreenshot(hiddenElement, function () {
+    return nextScreenshotFrame()
+      .then(captureCurrentPageScreenshot)
+      .catch(function () {
+        return null;
+      });
+  });
+}
+
+function buildBugReportBrowserMetadata() {
+  var metadata = {
+    url: currentBrowserUrl(),
+    replaySnapshotId: maskedReplaySnapshotId(),
+  };
+  var userAgent = userAgentTelemetry();
+  if (userAgent) metadata.userAgent = userAgent;
+  var viewport = viewportTelemetry();
+  if (viewport) metadata.viewport = viewport;
+  var timezone = browserTimezone();
+  if (timezone) metadata.timezone = timezone;
+  return metadata;
+}
+
+function assignBugReportToken(payload, key, value) {
+  var token = bugReportToken(value);
+  if (token) payload[key] = token;
+}
+
+function buildBugReportPayload(details, associatedEventId) {
+  var routeConversationId = conversationIdFromPath(currentRoutePath());
+  var payload = {
+    kind: bugReportKind(details && details.kind),
+    browser: buildBugReportBrowserMetadata(),
+  };
+  assignBugReportToken(
+    payload,
+    'conversationId',
+    (details && details.conversationId) || routeConversationId,
+  );
+  assignBugReportToken(payload, 'userMessageId', details && details.userMessageId);
+  assignBugReportToken(payload, 'assistantMessageId', details && details.assistantMessageId);
+  assignBugReportToken(payload, 'langsmithRunId', details && details.langsmithRunId);
+  var langsmithRunUrl = bugReportUrl(details && details.langsmithRunUrl);
+  if (langsmithRunUrl) payload.langsmithRunUrl = langsmithRunUrl;
+  var langsmithTraceUrl = bugReportUrl(details && details.langsmithTraceUrl);
+  if (langsmithTraceUrl) payload.langsmithTraceUrl = langsmithTraceUrl;
+  var observed = bugReportText(details && details.observed);
+  if (observed) payload.observed = observed;
+  var expected = bugReportText(details && details.expected);
+  if (expected) payload.expected = expected;
+  var eventId =
+    sentryEventId(associatedEventId) || sentryEventId(details && details.associatedEventId);
+  if (eventId) payload.associatedEventId = eventId;
+  var screenshot = bugReportScreenshot(details && details.screenshot);
+  if (screenshot) payload.screenshot = screenshot;
+  return payload;
+}
+
+function postBugReportPayload(payload) {
+  var fetchFn = window.fetch;
+  if (typeof fetchFn !== 'function') return;
+  try {
+    return fetchFn.call(window, '/api/bug-reports', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-csrf-token': bugReportCsrfToken(),
+      },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function submitBugReport(details) {
+  var kind = bugReportKind(details && details.kind);
+  var feedbackResult = reportBrowserFeedback({
+    feedbackKind: BUG_REPORT_FEEDBACK_KIND[kind],
+    associatedEventId: details && details.associatedEventId,
+  });
+  var feedbackPromise =
+    feedbackResult && typeof feedbackResult.then === 'function'
+      ? feedbackResult
+      : Promise.resolve(feedbackResult);
+  var screenshotPromise =
+    details && details.includeScreenshot
+      ? captureBugReportScreenshot(details.captureElement)
+      : Promise.resolve(null);
+
+  return Promise.all([
+    feedbackPromise.catch(function () {
+      return null;
+    }),
+    screenshotPromise,
+  ]).then(function (results) {
+    var screenshot = results[1] || (details && details.screenshot);
+    return postBugReportPayload(
+      buildBugReportPayload({ ...(details || {}), kind: kind, screenshot: screenshot }, results[0]),
+    );
+  });
+}
+
+function closestBugReportButton(target) {
+  var node = target;
+  while (node) {
+    if (node.getAttribute && node.getAttribute('data-squire-report-bug') !== null) {
+      return node;
+    }
+    node = node.parentNode || null;
+  }
+  return null;
+}
+
+function bugReportButtonDetails(button) {
+  var transcript =
+    button && typeof button.closest === 'function' ? button.closest('.squire-transcript') : null;
+  return {
+    kind: button && button.dataset ? button.dataset.bugReportDefaultKind : 'other',
+    conversationId:
+      (transcript && transcript.dataset && transcript.dataset.conversationId) ||
+      conversationIdFromPath(currentRoutePath()),
+    userMessageId: button && button.dataset ? button.dataset.userMessageId : null,
+    assistantMessageId: button && button.dataset ? button.dataset.assistantMessageId : null,
+    langsmithRunId: button && button.dataset ? button.dataset.langsmithRunId : null,
+    langsmithRunUrl: button && button.dataset ? button.dataset.langsmithRunUrl : null,
+    langsmithTraceUrl: button && button.dataset ? button.dataset.langsmithTraceUrl : null,
+  };
+}
+
+function appendBugReportOption(select, value, label, selected) {
+  var option = document.createElement('option');
+  option.value = value;
+  option.textContent = label;
+  if (selected) option.selected = true;
+  select.appendChild(option);
+}
+
+function appendBugReportField(form, labelText, field) {
+  var label = document.createElement('label');
+  label.className = 'squire-bug-report__field';
+  var span = document.createElement('span');
+  span.textContent = labelText;
+  label.appendChild(span);
+  label.appendChild(field);
+  form.appendChild(label);
+}
+
+function appendBugReportCheckbox(form, input, labelText, hintText) {
+  var label = document.createElement('label');
+  label.className = 'squire-bug-report__checkbox';
+  label.appendChild(input);
+  var text = document.createElement('span');
+  text.textContent = labelText;
+  label.appendChild(text);
+  form.appendChild(label);
+  if (hintText) {
+    var hint = document.createElement('p');
+    hint.className = 'squire-bug-report__hint';
+    hint.textContent = hintText;
+    form.appendChild(hint);
+  }
+}
+
+function setBugReportStatus(status, message) {
+  if (!status) return;
+  status.textContent = message || '';
+}
+
+function bugReportResponseError(body) {
+  if (body && typeof body.error === 'string' && body.error.trim()) return body.error.trim();
+  if (body && typeof body.message === 'string' && body.message.trim()) return body.message.trim();
+  return 'Could not create bug.';
+}
+
+function readBugReportResponse(response) {
+  var bodyPromise =
+    response && typeof response.json === 'function'
+      ? response.json().catch(function () {
+          return {};
+        })
+      : Promise.resolve({});
+  return bodyPromise.then(function (body) {
+    if (!response || !response.ok) throw new Error(bugReportResponseError(body));
+    return body;
+  });
+}
+
+function setBugReportControlsDisabled(controls, disabled) {
+  var fields = controls.fields || [];
+  for (var i = 0; i < fields.length; i += 1) {
+    if (fields[i]) fields[i].disabled = disabled;
+  }
+}
+
+function setBugReportSubmittingState(dialog, form, controls, submitting) {
+  if (submitting) {
+    form.dataset.submitting = 'true';
+    delete form.dataset.submitted;
+    dialog.setAttribute('aria-busy', 'true');
+    setBugReportControlsDisabled(controls, true);
+    controls.cancel.disabled = true;
+    controls.submit.disabled = true;
+    controls.submit.textContent = 'Creating...';
+    return;
+  }
+
+  delete form.dataset.submitting;
+  dialog.removeAttribute('aria-busy');
+  setBugReportControlsDisabled(controls, false);
+  controls.cancel.disabled = false;
+  controls.submit.disabled = false;
+  controls.submit.textContent = 'Create bug';
+}
+
+function setBugReportCreatedState(dialog, form, controls, status, identifier) {
+  delete form.dataset.submitting;
+  form.dataset.submitted = 'true';
+  dialog.removeAttribute('aria-busy');
+  setBugReportControlsDisabled(controls, true);
+  controls.cancel.disabled = false;
+  controls.cancel.textContent = 'Close';
+  controls.submit.disabled = true;
+  controls.submit.textContent = 'Created';
+  setBugReportStatus(status, identifier ? 'Created ' + identifier + '.' : 'Bug created.');
+}
+
+function closeBugReportDialog(dialog) {
+  if (!dialog) return;
+  if (typeof dialog.close === 'function') dialog.close();
+  if (typeof dialog.remove === 'function') dialog.remove();
+}
+
+function openBugReportDialog(button) {
+  if (!document.createElement || !document.body) return;
+  var baseDetails = bugReportButtonDetails(button);
+  var dialog = document.createElement('dialog');
+  dialog.className = 'squire-bug-report';
+  var form = document.createElement('form');
+  form.method = 'dialog';
+  form.className = 'squire-bug-report__form';
+  var title = document.createElement('h2');
+  title.className = 'squire-bug-report__title';
+  title.textContent = 'Report bug';
+  form.appendChild(title);
+
+  var kind = document.createElement('select');
+  kind.name = 'kind';
+  appendBugReportOption(kind, 'bad_answer', 'Bad answer', baseDetails.kind === 'bad_answer');
+  appendBugReportOption(
+    kind,
+    'broken_stream',
+    'Broken stream',
+    baseDetails.kind === 'broken_stream',
+  );
+  appendBugReportOption(kind, 'visual_issue', 'Visual issue', baseDetails.kind === 'visual_issue');
+  appendBugReportOption(kind, 'wrong_source', 'Wrong source', baseDetails.kind === 'wrong_source');
+  appendBugReportOption(kind, 'other', 'Other', baseDetails.kind === 'other');
+  appendBugReportField(form, 'Type', kind);
+
+  var observed = document.createElement('textarea');
+  observed.name = 'observed';
+  observed.rows = 3;
+  appendBugReportField(form, 'Observed', observed);
+
+  var expected = document.createElement('textarea');
+  expected.name = 'expected';
+  expected.rows = 3;
+  appendBugReportField(form, 'Expected', expected);
+
+  var includeScreenshot = document.createElement('input');
+  includeScreenshot.type = 'checkbox';
+  includeScreenshot.name = 'includeScreenshot';
+  appendBugReportCheckbox(
+    form,
+    includeScreenshot,
+    'Attach screenshot',
+    'Captures the current conversation view. Visible conversation text may be included.',
+  );
+
+  var status = document.createElement('p');
+  status.className = 'squire-bug-report__status';
+  status.setAttribute('role', 'status');
+  form.appendChild(status);
+
+  var actions = document.createElement('div');
+  actions.className = 'squire-bug-report__actions';
+  var cancel = document.createElement('button');
+  cancel.type = 'button';
+  cancel.className = 'squire-button squire-button--ghost';
+  cancel.textContent = 'Cancel';
+  var submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.className = 'squire-button squire-button--primary';
+  submit.textContent = 'Create bug';
+  actions.appendChild(cancel);
+  actions.appendChild(submit);
+  form.appendChild(actions);
+  dialog.appendChild(form);
+  var controls = {
+    cancel: cancel,
+    submit: submit,
+    fields: [kind, observed, expected, includeScreenshot],
+  };
+
+  cancel.addEventListener('click', function () {
+    closeBugReportDialog(dialog);
+  });
+  form.addEventListener('submit', function (event) {
+    event.preventDefault();
+    setBugReportSubmittingState(dialog, form, controls, true);
+    setBugReportStatus(status, 'Creating bug...');
+    var response = submitBugReport({
+      ...baseDetails,
+      kind: kind.value,
+      observed: observed.value,
+      expected: expected.value,
+      includeScreenshot: includeScreenshot.checked,
+      captureElement: dialog,
+    });
+    if (!response || typeof response.then !== 'function') {
+      setBugReportSubmittingState(dialog, form, controls, false);
+      setBugReportStatus(status, 'Could not create bug.');
+      return;
+    }
+    response
+      .then(readBugReportResponse)
+      .then(function (body) {
+        var identifier = body && body.issue && body.issue.identifier;
+        if (button && identifier) button.textContent = 'Reported ' + identifier;
+        setBugReportCreatedState(dialog, form, controls, status, identifier);
+      })
+      .catch(function (error) {
+        setBugReportSubmittingState(dialog, form, controls, false);
+        setBugReportStatus(
+          status,
+          error instanceof Error && error.message ? error.message : 'Could not create bug.',
+        );
+      });
+  });
+
+  document.body.appendChild(dialog);
+  if (typeof dialog.showModal === 'function') {
+    dialog.showModal();
+  } else {
+    dialog.setAttribute('open', '');
+  }
+  if (typeof observed.focus === 'function') observed.focus();
 }
 
 if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
@@ -402,6 +1040,15 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
   });
   document.addEventListener('squire:browser-feedback', function (event) {
     reportBrowserFeedback(event && event.detail);
+  });
+  document.addEventListener('squire:bug-report', function (event) {
+    submitBugReport(event && event.detail);
+  });
+  document.addEventListener('click', function (event) {
+    var button = closestBugReportButton(event && event.target);
+    if (!button) return;
+    event.preventDefault();
+    openBugReportDialog(button);
   });
 }
 

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -388,7 +388,9 @@ function bugReportCsrfToken() {
 }
 
 function currentBrowserUrl() {
-  if (window.location && typeof window.location.href === 'string') return window.location.href;
+  if (window.location && typeof window.location.href === 'string') {
+    return window.location.href.split('#')[0].split('?')[0] || currentRoutePath();
+  }
   return currentRoutePath();
 }
 
@@ -713,7 +715,6 @@ function postBugReportPayload(payload) {
         'x-csrf-token': bugReportCsrfToken(),
       },
       body: JSON.stringify(payload),
-      keepalive: true,
     });
   } catch {
     return null;
@@ -888,8 +889,10 @@ function openBugReportDialog(button) {
   form.method = 'dialog';
   form.className = 'squire-bug-report__form';
   var title = document.createElement('h2');
+  title.id = 'squire-bug-report-title';
   title.className = 'squire-bug-report__title';
   title.textContent = 'Report bug';
+  dialog.setAttribute('aria-labelledby', title.id);
   form.appendChild(title);
 
   var kind = document.createElement('select');

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -762,16 +762,17 @@ function closestBugReportButton(target) {
 function bugReportButtonDetails(button) {
   var transcript =
     button && typeof button.closest === 'function' ? button.closest('.squire-transcript') : null;
+  var dataset = button.dataset || null;
   return {
-    kind: button && button.dataset ? button.dataset.bugReportDefaultKind : 'other',
+    kind: dataset ? dataset.bugReportDefaultKind : 'other',
     conversationId:
       (transcript && transcript.dataset && transcript.dataset.conversationId) ||
       conversationIdFromPath(currentRoutePath()),
-    userMessageId: button && button.dataset ? button.dataset.userMessageId : null,
-    assistantMessageId: button && button.dataset ? button.dataset.assistantMessageId : null,
-    langsmithRunId: button && button.dataset ? button.dataset.langsmithRunId : null,
-    langsmithRunUrl: button && button.dataset ? button.dataset.langsmithRunUrl : null,
-    langsmithTraceUrl: button && button.dataset ? button.dataset.langsmithTraceUrl : null,
+    userMessageId: dataset ? dataset.userMessageId : null,
+    assistantMessageId: dataset ? dataset.assistantMessageId : null,
+    langsmithRunId: dataset ? dataset.langsmithRunId : null,
+    langsmithRunUrl: dataset ? dataset.langsmithRunUrl : null,
+    langsmithTraceUrl: dataset ? dataset.langsmithTraceUrl : null,
   };
 }
 

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -890,6 +890,112 @@ html {
   max-width: 320px;
 }
 
+.squire-bug-report {
+  width: min(92vw, 460px);
+  padding: var(--space-lg);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--parchment);
+}
+
+.squire-bug-report::backdrop {
+  background: rgb(10 10 9 / 0.72);
+}
+
+.squire-bug-report__form {
+  display: grid;
+  gap: var(--space-md);
+}
+
+.squire-bug-report__form[data-submitting='true'] {
+  cursor: wait;
+}
+
+.squire-bug-report__form[data-submitting='true'] .squire-button--primary {
+  opacity: 0.72;
+}
+
+.squire-bug-report__form[data-submitted='true'] .squire-bug-report__status {
+  color: var(--sage);
+}
+
+.squire-bug-report__title {
+  margin: 0;
+  font-family: 'Fraunces', 'Georgia', serif;
+  font-size: 24px;
+  font-weight: 550;
+  line-height: 1.2;
+  color: var(--parchment);
+}
+
+.squire-bug-report__field {
+  display: grid;
+  gap: var(--space-xs);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--sepia);
+}
+
+.squire-bug-report__field select,
+.squire-bug-report__field textarea {
+  width: 100%;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--ink);
+  color: var(--parchment);
+  font: inherit;
+  line-height: 1.45;
+}
+
+.squire-bug-report__field select {
+  min-height: 44px;
+  padding: 0 var(--space-sm);
+}
+
+.squire-bug-report__field textarea {
+  resize: vertical;
+  min-height: 96px;
+  padding: var(--space-sm);
+}
+
+.squire-bug-report__checkbox {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--parchment);
+}
+
+.squire-bug-report__checkbox input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--wax);
+}
+
+.squire-bug-report__hint {
+  margin: calc(-1 * var(--space-xs)) 0 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--sepia);
+}
+
+.squire-bug-report__status {
+  min-height: 20px;
+  margin: 0;
+  font-size: 13px;
+  color: var(--sepia);
+}
+
+.squire-bug-report__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+}
+
 .squire-google-mark {
   width: 18px;
   height: 18px;
@@ -1385,6 +1491,31 @@ template#squire-banner-fixtures {
   background: transparent;
   border-radius: 0;
   box-shadow: none;
+}
+
+.squire-answer__actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--space-sm);
+}
+
+.squire-answer__report {
+  min-height: 32px;
+  padding: 6px 10px;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--sepia);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.3;
+  cursor: pointer;
+}
+
+.squire-answer__report:hover {
+  border-color: var(--wax);
+  color: var(--wax);
 }
 
 .squire-markdown {

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -893,8 +893,8 @@ html {
 .squire-bug-report {
   width: min(92vw, 460px);
   padding: var(--space-lg);
-  border: 1px solid var(--rule);
-  border-radius: 4px;
+  border: 0;
+  border-radius: 8px;
   background: var(--surface);
   color: var(--parchment);
 }

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -31,6 +31,7 @@ const {
           recordException: (error: unknown) => void;
           setStatus: (status: unknown) => void;
           end: () => void;
+          spanContext: () => { spanId: string };
         }) => unknown)
       | undefined;
     if (!callback) throw new Error(`No span callback for ${name}`);
@@ -44,6 +45,7 @@ const {
       recordException: vi.fn(),
       setStatus: vi.fn(),
       end: vi.fn(),
+      spanContext: () => ({ spanId: 'abcd0123456789ab' }),
     };
     mockStartedSpans.push({ name, span });
     return callback(span);
@@ -748,7 +750,7 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
       ]),
     );
 
-    await runLangGraphAgentLoopWithTrajectory('How does loot work?', {
+    const result = await runLangGraphAgentLoopWithTrajectory('How does loot work?', {
       emit: async () => undefined,
       toolSurface: 'redesigned',
       requestId: 'req-langgraph',
@@ -756,6 +758,9 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
       userMessageId: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
       userId: '7ba7b810-9dad-11d1-80b4-00c04fd430c8',
       game: 'frosthaven',
+    });
+    expect(result.observability).toEqual({
+      langsmithRunId: '00000000-0000-0000-abcd-0123456789ab',
     });
 
     const attributes = spanAttributes('squire.agent.langgraph.run');

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -39,6 +39,7 @@ const {
       recordException: (error: unknown) => void;
       setStatus: (status: unknown) => void;
       end: () => void;
+      spanContext: () => { spanId: string };
     } = {
       attributes,
       setAttributes: (nextAttributes: Record<string, unknown>) => {
@@ -50,6 +51,7 @@ const {
       recordException: vi.fn(),
       setStatus: vi.fn(),
       end: vi.fn(),
+      spanContext: () => ({ spanId: 'abcd0123456789ab' }),
     };
     mockStartedSpans.push({ name, span });
     return callback(span);

--- a/test/auth-google.test.ts
+++ b/test/auth-google.test.ts
@@ -37,6 +37,7 @@ vi.mock('../src/service.ts', () => ({
   initialize: vi.fn(),
   isReady: vi.fn(() => true),
   ask: vi.fn(),
+  askWithResult: vi.fn(),
 }));
 
 vi.mock('../src/tools.ts', () => ({

--- a/test/auth-restart.test.ts
+++ b/test/auth-restart.test.ts
@@ -30,6 +30,7 @@ vi.mock('../src/service.ts', () => ({
   initialize: vi.fn(),
   isReady: vi.fn(() => true),
   ask: vi.fn(),
+  askWithResult: vi.fn(),
 }));
 
 vi.mock('../src/tools.ts', () => ({

--- a/test/chat-observability.test.ts
+++ b/test/chat-observability.test.ts
@@ -95,9 +95,11 @@ describe('chat observability lifecycle wrapper', () => {
           surface: 'chat_sse',
           status: 'ok',
           duration_ms: 42,
-          langsmith_thread_id: 'conv-1',
         }),
       }),
+    );
+    expect(mockCaptureTelemetryLog.mock.calls[0]?.[2].attributes).not.toHaveProperty(
+      'langsmith_thread_id',
     );
   });
 

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -53,6 +53,12 @@ vi.mock('../src/service.ts', () => ({
   })),
   isReady: vi.fn(() => true),
   ask: mockAsk,
+  askWithResult: vi.fn(async (...args: unknown[]) => {
+    const result = await mockAsk(...args);
+    return typeof result === 'object' && result !== null && 'answer' in result
+      ? result
+      : { answer: result };
+  }),
   startBootstrapLifecycle: vi.fn(),
 }));
 
@@ -498,7 +504,16 @@ describe('conversation history summaries', () => {
 
 describe('conversation web backend', () => {
   it('creates a conversation on first message and reload restores ordered history', async () => {
-    mockAsk.mockResolvedValueOnce('Loot tokens in your hex are picked up.');
+    mockAsk.mockResolvedValueOnce({
+      answer: 'Loot tokens in your hex are picked up.',
+      observability: {
+        langsmithRunId: '00000000-0000-0000-abcd-0123456789ab',
+        langsmithRunUrl:
+          'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true',
+        langsmithTraceUrl:
+          'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true',
+      },
+    });
     const auth = await createAuthContext();
 
     const createRes = await requestWithAuth(auth, 'http://localhost:3000/chat', {
@@ -528,16 +543,37 @@ describe('conversation web backend', () => {
     expect(page).toContain('action="/auth/logout"');
     expect(page).toContain('How does looting work?');
     expect(page).toContain('Loot tokens in your hex are picked up.');
+    expect(page).toContain('data-langsmith-run-id="00000000-0000-0000-abcd-0123456789ab"');
+    expect(page).toContain(
+      'data-langsmith-run-url="https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true"',
+    );
+    expect(page).toContain(
+      'data-langsmith-trace-url="https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true"',
+    );
 
     const { db } = getDb('server');
     const messages = await db.execute(sql`
-      select role, content
+      select role, content, langsmith_run_id, langsmith_run_url, langsmith_trace_url
       from messages
       order by created_at asc, id asc
     `);
     expect(messages.rows).toEqual([
-      { role: 'user', content: 'How does looting work?' },
-      { role: 'assistant', content: 'Loot tokens in your hex are picked up.' },
+      {
+        role: 'user',
+        content: 'How does looting work?',
+        langsmith_run_id: null,
+        langsmith_run_url: null,
+        langsmith_trace_url: null,
+      },
+      {
+        role: 'assistant',
+        content: 'Loot tokens in your hex are picked up.',
+        langsmith_run_id: '00000000-0000-0000-abcd-0123456789ab',
+        langsmith_run_url:
+          'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true',
+        langsmith_trace_url:
+          'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true',
+      },
     ]);
   });
 

--- a/test/diagnostic-bundle.test.ts
+++ b/test/diagnostic-bundle.test.ts
@@ -88,6 +88,7 @@ describe('diagnostic bundle', () => {
       user: { id: conversation.userId, hash: 'user-hash-1', email: 'person@example.com' },
       sentryIssueUrl: 'https://sentry.io/organizations/maz/issues/123/?query=secret',
       sentryEventUrl: 'https://sentry.io/organizations/maz/issues/123/events/abc/?project=1',
+      sentryEventId: 'abcdefabcdefabcdefabcdefabcdefab',
       sentryReplayUrl: 'https://sentry.io/replays/xyz/?query=secret',
       sentryTraceUrl: 'https://sentry.io/organizations/maz/traces/trace-1/?token=secret',
       sentryLogsUrl:
@@ -100,6 +101,7 @@ describe('diagnostic bundle', () => {
         userAgent: 'SquireTest/1.0',
         viewport: { width: 390, height: 844 },
         replaySnapshotId: 'masked-replay-snapshot-1',
+        timezone: 'America/New_York',
       },
       conversation,
       messages: [userMessage, assistantMessage],
@@ -128,6 +130,10 @@ describe('diagnostic bundle', () => {
       status: 'available',
       value: 'https://sentry.io/organizations/maz/issues/123/events/abc/',
     });
+    expect(bundle.sentry.eventId).toEqual({
+      status: 'available',
+      value: 'abcdefabcdefabcdefabcdefabcdefab',
+    });
     expect(bundle.sentry.traceUrl).toEqual({
       status: 'available',
       value: 'https://sentry.io/organizations/maz/traces/trace-1/',
@@ -144,6 +150,10 @@ describe('diagnostic bundle', () => {
     expect(bundle.langsmith.traceUrl).toEqual({
       status: 'available',
       value: 'https://smith.langchain.com/o/org/projects/p/project/r/run-1',
+    });
+    expect(bundle.browser.timezone).toEqual({
+      status: 'available',
+      value: 'America/New_York',
     });
     expect(bundle.stream.status).toEqual({ status: 'available', value: 'error' });
     expect(bundle.stream.workLogRows).toEqual({
@@ -185,7 +195,7 @@ describe('diagnostic bundle', () => {
 
     expect(bundle.sentry.logsUrl).toEqual({
       status: 'available',
-      value: 'https://sentry.io/organizations/maz/logs/?field=message',
+      value: 'https://sentry.io/organizations/maz/logs/?field=message&project=4511564194643969',
     });
     expect(JSON.stringify(bundle)).not.toContain('raw prompt');
     expect(JSON.stringify(bundle)).not.toContain('Alice');
@@ -203,27 +213,106 @@ describe('diagnostic bundle', () => {
     });
   });
 
+  it('derives Sentry searches and only real LangSmith run links from safe ids and server config', () => {
+    const bundle = buildDiagnosticBundle({
+      now,
+      env: {
+        SQUIRE_ENV: 'production',
+        SENTRY_ORG_SLUG: 'acme',
+        SENTRY_PROJECT_ID: '12345',
+        SENTRY_RELEASE: '5f2b5f152df6c3b277d2234a82717ef8cd060a52',
+        LANGSMITH_WORKSPACE_ID: '44be4d80-ba50-4833-ae22-6e176be2dbf2',
+        LANGSMITH_PROJECT_ID: 'd2a644ae-c64f-49ab-8b4a-fdf09e00f65a',
+      },
+      conversationUrl: `https://squire.maz.org/chat/${conversation.id}`,
+      requestId: 'req-safe-1',
+      langsmithRunId: 'run-1',
+      conversation,
+      messages: [userMessage, assistantMessage],
+      streamEvents,
+    });
+
+    expect(bundle.sentry.issueUrl).toEqual({
+      status: 'available',
+      value:
+        'https://acme.sentry.io/issues/?project=12345&environment=production&query=request_id%3Areq-safe-1+conversation_id%3A11111111-1111-4111-8111-111111111111+user_message_id%3A33333333-3333-4333-8333-333333333333+assistant_message_id%3A55555555-5555-4555-8555-555555555555&referrer=squire-bug-report',
+    });
+    expect(bundle.sentry.logsUrl).toEqual({
+      status: 'available',
+      value:
+        'https://acme.sentry.io/explore/logs/?project=12345&environment=production&query=request_id%3Areq-safe-1+conversation_id%3A11111111-1111-4111-8111-111111111111+user_message_id%3A33333333-3333-4333-8333-333333333333+assistant_message_id%3A55555555-5555-4555-8555-555555555555&referrer=squire-bug-report',
+    });
+    expect(bundle.sentry.traceUrl).toEqual({
+      status: 'available',
+      value:
+        'https://acme.sentry.io/explore/traces/?project=12345&environment=production&query=squire.request_id%3Areq-safe-1+squire.conversation_id%3A11111111-1111-4111-8111-111111111111+squire.user_message_id%3A33333333-3333-4333-8333-333333333333+squire.assistant_message_id%3A55555555-5555-4555-8555-555555555555&referrer=squire-bug-report',
+    });
+    expect(bundle.langsmith.traceUrl).toEqual({
+      status: 'available',
+      value:
+        'https://smith.langchain.com/o/44be4d80-ba50-4833-ae22-6e176be2dbf2/projects/p/d2a644ae-c64f-49ab-8b4a-fdf09e00f65a/r/run-1',
+    });
+    expect(bundle.langsmith.threadUrl).toEqual({
+      status: 'unavailable',
+      reason: 'LangSmith thread URL was not provided',
+    });
+    expect(bundle.langsmith.threadId).toEqual({
+      status: 'unavailable',
+      reason: 'LangSmith thread id was not provided',
+    });
+    expect(bundle.langsmith.runUrl).toEqual({
+      status: 'available',
+      value:
+        'https://smith.langchain.com/o/44be4d80-ba50-4833-ae22-6e176be2dbf2/projects/p/d2a644ae-c64f-49ab-8b4a-fdf09e00f65a/r/run-1',
+    });
+  });
+
+  it('keeps an explicit LangSmith thread id without deriving a thread URL', () => {
+    const bundle = buildDiagnosticBundle({
+      now,
+      env: {
+        LANGSMITH_WORKSPACE_ID: '44be4d80-ba50-4833-ae22-6e176be2dbf2',
+        LANGSMITH_PROJECT_ID: 'd2a644ae-c64f-49ab-8b4a-fdf09e00f65a',
+      },
+      langsmithThreadId: 'thread-1',
+      conversation,
+      messages: [userMessage, assistantMessage],
+    });
+
+    expect(bundle.langsmith.threadId).toEqual({
+      status: 'available',
+      value: 'thread-1',
+    });
+    expect(bundle.langsmith.threadUrl).toEqual({
+      status: 'unavailable',
+      reason: 'LangSmith thread URL was not provided',
+    });
+  });
+
   it('marks missing Sentry, LangSmith, replay, and message data with unavailable reasons', () => {
     const bundle = buildDiagnosticBundle({
       now,
       env: { SQUIRE_ENV: 'test' },
-      conversationUrl: `https://squire.maz.org/chat/${conversation.id}`,
+      route: '/chat',
     });
 
     expect(bundle.sentry.issueUrl.status).toBe('unavailable');
     expect(bundle.sentry.eventUrl.status).toBe('unavailable');
+    expect(bundle.sentry.eventId.status).toBe('unavailable');
     expect(bundle.sentry.replayUrl.status).toBe('unavailable');
     expect(bundle.sentry.traceUrl.status).toBe('unavailable');
     expect(bundle.sentry.logsUrl.status).toBe('unavailable');
     expect(bundle.sentry.traceId.status).toBe('unavailable');
     expect(bundle.langsmith.traceUrl.status).toBe('unavailable');
     expect(bundle.browser.replaySnapshotId.status).toBe('unavailable');
+    expect(bundle.browser.timezone.status).toBe('unavailable');
     expect(bundle.stream.workLogRows.status).toBe('unavailable');
     expect(bundle.unavailable).toEqual(
       expect.arrayContaining([
-        { path: 'sentry.issueUrl', reason: 'Sentry issue URL was not provided' },
-        { path: 'sentry.traceUrl', reason: 'Sentry trace URL was not provided' },
-        { path: 'sentry.logsUrl', reason: 'Sentry logs query URL was not provided' },
+        { path: 'sentry.issueUrl', reason: 'Sentry issue URL was not provided or derivable' },
+        { path: 'sentry.eventId', reason: 'Sentry event ID was not provided' },
+        { path: 'sentry.traceUrl', reason: 'Sentry trace URL was not provided or derivable' },
+        { path: 'sentry.logsUrl', reason: 'Sentry logs query URL was not provided or derivable' },
         { path: 'sentry.traceId', reason: 'Sentry trace ID was not provided' },
         { path: 'langsmith.traceUrl', reason: 'LangSmith trace URL was not provided' },
         { path: 'stream.workLogRows', reason: 'stream events were not loaded' },
@@ -287,10 +376,18 @@ describe('diagnostic bundle', () => {
   });
 
   it('collects conversation evidence by message id through an ownership-aware data source', async () => {
+    const assistantWithLangSmith: ConversationMessage = {
+      ...assistantMessage,
+      langsmithRunId: '00000000-0000-0000-abcd-0123456789ab',
+      langsmithRunUrl:
+        'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true',
+      langsmithTraceUrl:
+        'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true',
+    };
     const dataSource: DiagnosticBundleDataSource = {
       findOwnedConversation: vi.fn(async () => conversation),
       findMessageById: vi.fn(async () => userMessage),
-      listMessagesByConversationId: vi.fn(async () => [userMessage, assistantMessage]),
+      listMessagesByConversationId: vi.fn(async () => [userMessage, assistantWithLangSmith]),
       listStreamEventsByUserMessageId: vi.fn(async () => streamEvents),
     };
 
@@ -312,6 +409,20 @@ describe('diagnostic bundle', () => {
     expect(bundle.conversation.assistantMessageId).toEqual({
       status: 'available',
       value: assistantMessage.id,
+    });
+    expect(bundle.langsmith.runId).toEqual({
+      status: 'available',
+      value: '00000000-0000-0000-abcd-0123456789ab',
+    });
+    expect(bundle.langsmith.runUrl).toEqual({
+      status: 'available',
+      value:
+        'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab',
+    });
+    expect(bundle.langsmith.traceUrl).toEqual({
+      status: 'available',
+      value:
+        'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab',
     });
   });
 });

--- a/test/linear-bug-intake.test.ts
+++ b/test/linear-bug-intake.test.ts
@@ -279,6 +279,7 @@ describe('linear bug intake', () => {
       observed: 'Wrong answer.',
       expected: 'Correct answer.',
       linearApiKey: '',
+      env: {},
       fetch: async () => {
         throw new Error('fetch should not be called');
       },

--- a/test/linear-bug-intake.test.ts
+++ b/test/linear-bug-intake.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDiagnosticBundle } from '../src/diagnostic-bundle.ts';
+import { buildLinearBugReportDraft, submitLinearBugReport } from '../src/linear-bug-intake.ts';
+import type {
+  LinearIssueCreateInput,
+  LinearIssueRef,
+  LinearTargets,
+  LinearUploadFile,
+  SquireLinearClient,
+} from '../src/linear-client.ts';
+
+class FakeLinearClient implements SquireLinearClient {
+  readonly operations: string[] = [];
+  readonly comments: Array<{ issueId: string; body: string }> = [];
+  readonly targets: LinearTargets = {
+    teamId: 'team-id',
+    projectId: 'project-id',
+    labelIds: ['bug-label-id'],
+    labelName: 'Bug',
+    assigneeId: 'me-id',
+    stateId: 'todo-id',
+  };
+
+  createdInput?: LinearIssueCreateInput;
+  uploadInput?: { filename: string; contentType: string; size: number };
+  existingIssue?: LinearIssueRef;
+  failComments = false;
+
+  async resolveTargets(): Promise<LinearTargets> {
+    this.operations.push('resolveTargets');
+    return this.targets;
+  }
+
+  async findIssueByMarker(_teamKey: string, marker: string): Promise<LinearIssueRef | undefined> {
+    this.operations.push('findIssueByMarker');
+    expect(marker).toBe('squire-bug:production:conv-1:msg-user-1');
+    return this.existingIssue;
+  }
+
+  async createIssue(input: LinearIssueCreateInput): Promise<LinearIssueRef> {
+    this.operations.push('createIssue');
+    this.createdInput = input;
+    return {
+      id: 'created-id',
+      identifier: 'SQR-124',
+      url: 'https://linear.app/squire/issue/SQR-124/example',
+    };
+  }
+
+  async updateIssue(): Promise<LinearIssueRef> {
+    throw new Error('updateIssue should not be called');
+  }
+
+  async createComment(issueId: string, body: string): Promise<void> {
+    this.operations.push('createComment');
+    if (this.failComments) throw new Error('Invalid scope: comments:create required');
+    this.comments.push({ issueId, body });
+  }
+
+  async requestFileUpload(input: {
+    filename: string;
+    contentType: string;
+    size: number;
+  }): Promise<LinearUploadFile> {
+    this.operations.push('requestFileUpload');
+    this.uploadInput = input;
+    return {
+      uploadUrl: 'https://upload.linear.test/screenshot',
+      assetUrl: 'https://uploads.linear.test/squire-bug-test.jpg',
+      headers: [{ key: 'x-upload-token', value: 'upload-token' }],
+    };
+  }
+}
+
+function bundle() {
+  return buildDiagnosticBundle({
+    now: new Date('2026-06-17T12:00:00.000Z'),
+    env: {
+      SQUIRE_ENV: 'production',
+      SENTRY_RELEASE: 'abcdef1234567890',
+    },
+    route: '/chat/conv-1',
+    requestId: 'req-1',
+    conversationUrl: 'https://squire.maz.org/chat/conv-1?token=secret',
+    browserUrl: 'https://squire.maz.org/chat/conv-1?email=person@example.com',
+    conversationId: 'conv-1',
+    userMessageId: 'msg-user-1',
+    assistantMessageId: 'msg-assistant-1',
+    user: { id: 'user-1', email: 'person@example.com' },
+    sentryEventUrl: 'https://sentry.io/organizations/maz/issues/123/events/abc/?token=secret',
+    langsmithTraceUrl: 'https://smith.langchain.com/o/org/projects/p/project/r/run-1?secret=1',
+    browser: {
+      url: 'https://squire.maz.org/chat/conv-1?email=person@example.com',
+      userAgent: 'SquireTest/1.0 person@example.com',
+      viewport: { width: 390, height: 844 },
+      replaySnapshotId: 'replay-1',
+    },
+  });
+}
+
+describe('linear bug intake', () => {
+  it('builds the SQR-298 dedupe marker and safe Linear body from one diagnostic contract', () => {
+    const draft = buildLinearBugReportDraft({
+      bundle: bundle(),
+      kind: 'wrong_source',
+      observed: 'The answer cited the wrong source. Bearer sk_test_secret_secret',
+      expected: 'Use the consulted source that actually covers the turn.',
+    });
+
+    expect(draft.marker).toBe('squire-bug:production:conv-1:msg-user-1');
+    expect(draft.title).toBe('[User submitted bug] Wrong source');
+    expect(draft.priority).toBe(2);
+    expect(draft.labelName).toBe('Bug');
+    expect(draft.description.startsWith('## User Report')).toBe(true);
+    expect(draft.description).toContain('Type: Wrong source');
+    expect(draft.description).toContain('## Diagnostic Evidence');
+    expect(draft.description).toContain('<!-- squire-bug:production:conv-1:msg-user-1 -->');
+    expect(draft.diagnosticCommentBody).toContain('## Redacted Diagnostic JSON');
+    expect(draft.diagnosticCommentBody).toContain('"schemaVersion": 1');
+
+    const serialized = JSON.stringify(draft);
+    expect(serialized).not.toContain('token=secret');
+    expect(serialized).not.toContain('person@example.com');
+    expect(serialized).not.toContain('sk_test');
+  });
+
+  it('returns an existing Linear issue when the dedupe marker is already present', async () => {
+    const linearClient = new FakeLinearClient();
+    linearClient.existingIssue = {
+      id: 'issue-id',
+      identifier: 'SQR-123',
+      url: 'https://linear.app/squire/issue/SQR-123/example',
+    };
+
+    const result = await submitLinearBugReport({
+      bundle: bundle(),
+      kind: 'bad_answer',
+      observed: 'Wrong table answer.',
+      expected: 'Correct table answer.',
+      linearApiKey: 'lin-test',
+      linearClient,
+    });
+
+    expect(result.status).toBe('existing');
+    if (result.status !== 'existing') throw new Error('expected existing issue');
+    expect(result.issue?.identifier).toBe('SQR-123');
+    expect(linearClient.operations).toEqual(['resolveTargets', 'findIssueByMarker']);
+  });
+
+  it('creates a Linear issue in Squire Bugs and adds the redacted diagnostic payload', async () => {
+    const linearClient = new FakeLinearClient();
+
+    const result = await submitLinearBugReport({
+      bundle: bundle(),
+      kind: 'visual_issue',
+      observed: 'The report button overlaps the answer content.',
+      expected: 'The action should stay below the answer.',
+      linearApiKey: 'lin-test',
+      linearClient,
+    });
+
+    expect(result.status).toBe('created');
+    if (result.status !== 'created') throw new Error('expected created issue');
+    expect(result.issue?.identifier).toBe('SQR-124');
+    expect(linearClient.createdInput).toMatchObject({
+      teamId: 'team-id',
+      projectId: 'project-id',
+      assigneeId: 'me-id',
+      stateId: 'todo-id',
+      labelIds: ['bug-label-id'],
+      priority: 3,
+    });
+    expect(linearClient.comments).toHaveLength(1);
+    expect(linearClient.comments[0]).toMatchObject({ issueId: 'created-id' });
+    expect(linearClient.comments[0]?.body).toContain('Redacted Diagnostic JSON');
+    expect(linearClient.operations).toEqual([
+      'resolveTargets',
+      'findIssueByMarker',
+      'createIssue',
+      'createComment',
+    ]);
+  });
+
+  it('uploads an opt-in screenshot attachment after creating the Linear issue', async () => {
+    const linearClient = new FakeLinearClient();
+    const uploadedBodies: unknown[] = [];
+    const fetch: typeof globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      if (url === 'https://upload.linear.test/screenshot') {
+        uploadedBodies.push(init?.body);
+        return new Response(null, { status: 200 });
+      }
+
+      throw new Error(`Unexpected request: ${url}`);
+    };
+
+    const result = await submitLinearBugReport({
+      bundle: bundle(),
+      kind: 'visual_issue',
+      observed: 'The answer actions overlap the transcript.',
+      expected: 'The actions should stay below the answer.',
+      linearApiKey: 'lin-test',
+      attachments: [
+        {
+          filename: 'squire-bug-test.jpg',
+          contentType: 'image/jpeg',
+          base64Content: 'aGVsbG8=',
+          title: 'Conversation UI screenshot',
+          subtitle: 'Opt-in screenshot.',
+        },
+      ],
+      fetch,
+      linearClient,
+    });
+
+    expect(result.status).toBe('created');
+    expect(uploadedBodies).toHaveLength(1);
+    expect(linearClient.uploadInput).toMatchObject({
+      filename: 'squire-bug-test.jpg',
+      contentType: 'image/jpeg',
+      size: 5,
+    });
+    expect(linearClient.comments[1]?.body).toContain(
+      'https://uploads.linear.test/squire-bug-test.jpg',
+    );
+    expect(linearClient.operations).toEqual([
+      'resolveTargets',
+      'findIssueByMarker',
+      'createIssue',
+      'createComment',
+      'requestFileUpload',
+      'createComment',
+    ]);
+  });
+
+  it('still creates the Linear issue when optional comments require extra Linear scope', async () => {
+    const linearClient = new FakeLinearClient();
+    linearClient.failComments = true;
+
+    const result = await submitLinearBugReport({
+      bundle: bundle(),
+      kind: 'visual_issue',
+      observed: 'The answer actions overlap the transcript.',
+      expected: 'The actions should stay below the answer.',
+      linearApiKey: 'lin-test',
+      attachments: [
+        {
+          filename: 'squire-bug-test.jpg',
+          contentType: 'image/jpeg',
+          base64Content: 'aGVsbG8=',
+        },
+      ],
+      fetch: async () => {
+        throw new Error('attachment upload should be skipped when comments are unavailable');
+      },
+      linearClient,
+    });
+
+    expect(result.status).toBe('created');
+    if (result.status !== 'created') throw new Error('expected created issue');
+    expect(result.issue.identifier).toBe('SQR-124');
+    expect(result.warnings?.join('\n')).toContain('comments:create required');
+    expect(result.warnings?.join('\n')).toContain(
+      'skipped because Linear comments are unavailable',
+    );
+    expect(linearClient.operations).toEqual([
+      'resolveTargets',
+      'findIssueByMarker',
+      'createIssue',
+      'createComment',
+    ]);
+  });
+
+  it('is disabled without a Linear API key', async () => {
+    const result = await submitLinearBugReport({
+      bundle: bundle(),
+      kind: 'bad_answer',
+      observed: 'Wrong answer.',
+      expected: 'Correct answer.',
+      linearApiKey: '',
+      fetch: async () => {
+        throw new Error('fetch should not be called');
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'disabled',
+      reason: 'LINEAR_API_KEY is not configured',
+    });
+  });
+});

--- a/test/linear-bug-report-template.test.ts
+++ b/test/linear-bug-report-template.test.ts
@@ -70,6 +70,7 @@ function fullBundle() {
     user: { id: conversation.userId, email: 'person@example.com' },
     sentryIssueUrl: 'https://sentry.io/organizations/maz/issues/123/?query=secret',
     sentryEventUrl: 'https://sentry.io/organizations/maz/issues/123/events/abc/?project=1',
+    sentryEventId: 'abcdefabcdefabcdefabcdefabcdefab',
     sentryReplayUrl: 'https://sentry.io/replays/xyz/?query=secret',
     sentryTraceUrl: 'https://sentry.io/organizations/maz/traces/trace-1/?token=secret',
     sentryLogsUrl:
@@ -78,6 +79,7 @@ function fullBundle() {
     langsmithTraceUrl: 'https://smith.langchain.com/o/org/projects/p/project/r/run-1?secret=1',
     langsmithThreadUrl: 'https://smith.langchain.com/o/org/projects/p/project/threads/thread-1',
     langsmithRunId: 'run-1',
+    langsmithRunUrl: 'https://smith.langchain.com/o/org/projects/p/project/r/run-1?secret=1',
     conversation,
     messages: [userMessage, assistantMessage],
     streamEvents,
@@ -99,7 +101,17 @@ describe('linear bug report template', () => {
       ],
     });
 
-    expect(body).toContain('## Evidence');
+    expect(body.startsWith('## User Report')).toBe(true);
+    expect(body).toContain('Type: App/runtime bug');
+    expect(body).toContain('Observed:\nThe stream failed after the first tool result.');
+    expect(body).toContain(
+      'Expected:\nThe assistant should finish or show the normal SSE error state.',
+    );
+    expect(body).toContain('## Triage Notes');
+    expect(body).toContain(
+      'Likely failing area:\nSSE transport or conversation-service error handling.',
+    );
+    expect(body).toContain('## Diagnostic Evidence');
     expect(body).toContain(`Conversation: https://squire.maz.org/chat/${conversation.id}`);
     expect(body).toContain(
       `Turn: userMessageId=${userMessage.id}, assistantMessageId=${assistantMessage.id}`,
@@ -108,6 +120,7 @@ describe('linear bug report template', () => {
     expect(body).toContain('Sentry:');
     expect(body).toContain('- Issue: https://sentry.io/organizations/maz/issues/123/');
     expect(body).toContain('- Event: https://sentry.io/organizations/maz/issues/123/events/abc/');
+    expect(body).toContain('- Event ID: abcdefabcdefabcdefabcdefabcdefab');
     expect(body).toContain('- Replay: https://sentry.io/replays/xyz/');
     expect(body).toContain('- Trace: https://sentry.io/organizations/maz/traces/trace-1/');
     expect(body).toContain(
@@ -118,17 +131,17 @@ describe('linear bug report template', () => {
     expect(body).toContain('- Environment: production');
     expect(body).toContain('LangSmith:');
     expect(body).toContain('- Trace: https://smith.langchain.com/o/org/projects/p/project/r/run-1');
-    expect(body).toContain('- Thread: 11111111-1111-4111-8111-111111111111');
+    expect(body).toContain('- Thread: Unavailable: LangSmith thread id was not provided');
     expect(body).toContain(
       '- Thread URL: https://smith.langchain.com/o/org/projects/p/project/threads/thread-1',
     );
     expect(body).toContain('- Run ID: run-1');
-    expect(body).toContain('## Observed Behavior');
-    expect(body).toContain('## Expected Behavior');
-    expect(body).toContain('## Why This Is Likely Failing');
-    expect(body).toContain('## First Files To Inspect');
+    expect(body).toContain(
+      '- Run URL: https://smith.langchain.com/o/org/projects/p/project/r/run-1',
+    );
     expect(body).toContain('## Repro Steps');
     expect(body).toContain('## Acceptance Criteria');
+    expect(body.indexOf('## User Report')).toBeLessThan(body.indexOf('## Diagnostic Evidence'));
     expect(body.indexOf('Sentry:')).toBeLessThan(body.indexOf('LangSmith:'));
   });
 
@@ -144,8 +157,9 @@ describe('linear bug report template', () => {
       acceptanceCriteria: ['The corrected answer is backed by the cited rule source.'],
     });
 
+    expect(body).toContain('Type: Answer-quality bug');
     expect(body).toContain(
-      'Debug lane: Answer-quality bug. Start in LangSmith, then use Sentry only if there was an app/runtime error.',
+      'Suggested diagnostic starting point: Start in LangSmith for the answer trace. Use Sentry only if the app also reported an error, failed stream, replay, or log event.',
     );
     expect(body.indexOf('LangSmith:')).toBeLessThan(body.indexOf('Sentry:'));
   });
@@ -155,17 +169,20 @@ describe('linear bug report template', () => {
       bundle: buildDiagnosticBundle({
         now,
         env: { SQUIRE_ENV: 'test' },
-        conversationUrl: `https://squire.maz.org/chat/${conversation.id}`,
+        route: '/chat',
       }),
       kind: 'app_runtime',
     });
 
     expect(body).toContain('Request: Unavailable: request id was not provided');
-    expect(body).toContain('- Issue: Unavailable: Sentry issue URL was not provided');
+    expect(body).toContain('- Issue: Unavailable: Sentry issue URL was not provided or derivable');
     expect(body).toContain('- Event: Unavailable: Sentry event URL was not provided');
+    expect(body).toContain('- Event ID: Unavailable: Sentry event ID was not provided');
     expect(body).toContain('- Replay: Unavailable: Sentry replay URL was not provided');
-    expect(body).toContain('- Trace: Unavailable: Sentry trace URL was not provided');
-    expect(body).toContain('- Logs: Unavailable: Sentry logs query URL was not provided');
+    expect(body).toContain('- Trace: Unavailable: Sentry trace URL was not provided or derivable');
+    expect(body).toContain(
+      '- Logs: Unavailable: Sentry logs query URL was not provided or derivable',
+    );
     expect(body).toContain('- Trace ID: Unavailable: Sentry trace ID was not provided');
     expect(body).toContain('- Release: Unavailable: SENTRY_RELEASE is not configured');
     expect(body).toContain('- Trace: Unavailable: LangSmith trace URL was not provided');

--- a/test/mcp-transport.test.ts
+++ b/test/mcp-transport.test.ts
@@ -34,6 +34,7 @@ vi.mock('../src/service.ts', () => ({
   initialize: vi.fn(),
   isReady: vi.fn(() => true),
   ask: vi.fn(),
+  askWithResult: vi.fn(),
 }));
 
 vi.mock('../src/db.ts', () => ({

--- a/test/security-alert-linear-sync.test.ts
+++ b/test/security-alert-linear-sync.test.ts
@@ -4,6 +4,14 @@ import {
   collectRoutableAlerts,
   syncSecurityAlertsToLinear,
 } from '../scripts/sync-security-alerts-to-linear.ts';
+import type {
+  LinearIssueCreateInput,
+  LinearIssueRef,
+  LinearIssueUpdateInput,
+  LinearTargets,
+  LinearUploadFile,
+  SquireLinearClient,
+} from '../src/linear-client.ts';
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -11,6 +19,66 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
     headers: { 'content-type': 'application/json', ...init.headers },
     ...init,
   });
+}
+
+class FakeSecurityLinearClient implements SquireLinearClient {
+  readonly operations: string[] = [];
+  readonly targets: LinearTargets = {
+    teamId: 'team-id',
+    projectId: 'project-id',
+    labelIds: ['security-label-id'],
+    labelName: 'Security',
+  };
+
+  createInputs: LinearIssueCreateInput[] = [];
+  updateInputs: Array<{ id: string; input: LinearIssueUpdateInput }> = [];
+
+  async resolveTargets(): Promise<LinearTargets> {
+    this.operations.push('resolveTargets');
+    return this.targets;
+  }
+
+  async findIssueByMarker(_teamKey: string, marker: string): Promise<LinearIssueRef | undefined> {
+    this.operations.push('findIssueByMarker');
+    if (marker !== 'github-security:maz-org/squire:code-scanning:21') return undefined;
+    return {
+      id: 'existing-id',
+      identifier: 'SQR-999',
+      url: 'https://linear.app/existing',
+    };
+  }
+
+  async createIssue(input: LinearIssueCreateInput): Promise<LinearIssueRef> {
+    this.operations.push('createIssue');
+    this.createInputs.push(input);
+    return {
+      id: 'new-id',
+      identifier: 'SQR-998',
+      url: 'https://linear.app/new',
+    };
+  }
+
+  async updateIssue(id: string, input: LinearIssueUpdateInput): Promise<LinearIssueRef> {
+    this.operations.push('updateIssue');
+    this.updateInputs.push({ id, input });
+    return {
+      id: 'existing-id',
+      identifier: 'SQR-999',
+      url: 'https://linear.app/existing',
+    };
+  }
+
+  async createComment(_issueId: string, _body: string): Promise<void> {
+    throw new Error('createComment should not be called');
+  }
+
+  async requestFileUpload(_input: {
+    filename: string;
+    contentType: string;
+    size: number;
+  }): Promise<LinearUploadFile> {
+    throw new Error('requestFileUpload should not be called');
+  }
 }
 
 describe('security alert Linear sync', () => {
@@ -261,119 +329,40 @@ describe('security alert Linear sync', () => {
   });
 
   it('creates new Linear issues and updates existing ones by alert marker', async () => {
-    const operations: string[] = [];
-    const fetch: typeof globalThis.fetch = async (input, init) => {
+    const linearClient = new FakeSecurityLinearClient();
+    const fetch: typeof globalThis.fetch = async (input) => {
       const url = String(input);
 
-      if (!url.includes('api.linear.app')) {
-        if (url.includes('/dependabot/alerts')) {
-          return jsonResponse([
-            {
-              number: 11,
-              state: 'open',
-              html_url: 'https://github.com/maz-org/squire/security/dependabot/11',
-              dependency: { package: { name: 'vite', ecosystem: 'npm' } },
-              security_advisory: {
-                ghsa_id: 'GHSA-1111',
-                severity: 'high',
-                summary: 'vite dev server exposure',
-              },
-            },
-          ]);
-        }
-        if (url.includes('/code-scanning/alerts')) {
-          return jsonResponse([
-            {
-              number: 21,
-              state: 'open',
-              html_url: 'https://github.com/maz-org/squire/security/code-scanning/21',
-              rule: {
-                id: 'js/xss',
-                description: 'Unsanitized user input',
-                security_severity_level: 'critical',
-              },
-            },
-          ]);
-        }
-        return jsonResponse([]);
-      }
-
-      const body = JSON.parse(String(init?.body)) as {
-        operationName: string;
-        query: string;
-        variables?: Record<string, unknown>;
-      };
-      operations.push(body.operationName);
-
-      if (body.operationName === 'ResolveLinearTargets') {
-        expect(body.query).toContain('accessibleTeams');
-        expect(body.query).toContain('team: { null: true }');
-        return jsonResponse({
-          data: {
-            teams: { nodes: [{ id: 'team-id', key: 'SQR', name: 'Squire' }] },
-            projects: { nodes: [{ id: 'project-id', name: 'Squire · Security Alert Automation' }] },
-            issueLabels: { nodes: [{ id: 'security-label-id', name: 'Security', team: null }] },
-          },
-        });
-      }
-
-      if (body.operationName === 'FindIssueByAlertMarker') {
-        const marker = body.variables?.marker;
-        return jsonResponse({
-          data: {
-            issues: {
-              nodes:
-                marker === 'github-security:maz-org/squire:code-scanning:21'
-                  ? [
-                      {
-                        id: 'existing-id',
-                        identifier: 'SQR-999',
-                        url: 'https://linear.app/existing',
-                      },
-                    ]
-                  : [],
+      if (url.includes('/dependabot/alerts')) {
+        return jsonResponse([
+          {
+            number: 11,
+            state: 'open',
+            html_url: 'https://github.com/maz-org/squire/security/dependabot/11',
+            dependency: { package: { name: 'vite', ecosystem: 'npm' } },
+            security_advisory: {
+              ghsa_id: 'GHSA-1111',
+              severity: 'high',
+              summary: 'vite dev server exposure',
             },
           },
-        });
+        ]);
       }
-
-      if (body.operationName === 'CreateSecurityAlertIssue') {
-        expect(body.variables?.input).toMatchObject({
-          teamId: 'team-id',
-          projectId: 'project-id',
-          labelIds: ['security-label-id'],
-          priority: 2,
-        });
-        return jsonResponse({
-          data: {
-            issueCreate: {
-              success: true,
-              issue: { id: 'new-id', identifier: 'SQR-998', url: 'https://linear.app/new' },
+      if (url.includes('/code-scanning/alerts')) {
+        return jsonResponse([
+          {
+            number: 21,
+            state: 'open',
+            html_url: 'https://github.com/maz-org/squire/security/code-scanning/21',
+            rule: {
+              id: 'js/xss',
+              description: 'Unsanitized user input',
+              security_severity_level: 'critical',
             },
           },
-        });
+        ]);
       }
-
-      if (body.operationName === 'UpdateSecurityAlertIssue') {
-        expect(body.variables?.id).toBe('existing-id');
-        expect(body.variables?.input).toMatchObject({
-          labelIds: ['security-label-id'],
-        });
-        return jsonResponse({
-          data: {
-            issueUpdate: {
-              success: true,
-              issue: {
-                id: 'existing-id',
-                identifier: 'SQR-999',
-                url: 'https://linear.app/existing',
-              },
-            },
-          },
-        });
-      }
-
-      throw new Error(`Unexpected Linear operation: ${body.operationName}`);
+      return jsonResponse([]);
     };
 
     const result = await syncSecurityAlertsToLinear({
@@ -384,45 +373,37 @@ describe('security alert Linear sync', () => {
       linearProjectName: 'Squire · Security Alert Automation',
       dryRun: false,
       fetch,
+      linearClient,
       log: () => undefined,
     });
 
     expect(result).toMatchObject({ created: 1, updated: 1, dryRun: 0, alerts: 2 });
-    expect(operations).toEqual([
-      'ResolveLinearTargets',
-      'FindIssueByAlertMarker',
-      'CreateSecurityAlertIssue',
-      'FindIssueByAlertMarker',
-      'UpdateSecurityAlertIssue',
+    expect(linearClient.createInputs[0]).toMatchObject({
+      teamId: 'team-id',
+      projectId: 'project-id',
+      labelIds: ['security-label-id'],
+      priority: 2,
+    });
+    expect(linearClient.updateInputs[0]).toMatchObject({
+      id: 'existing-id',
+      input: { labelIds: ['security-label-id'] },
+    });
+    expect(linearClient.operations).toEqual([
+      'resolveTargets',
+      'findIssueByMarker',
+      'createIssue',
+      'findIssueByMarker',
+      'updateIssue',
     ]);
   });
 
   it('validates Linear configuration on live runs even when there are no alerts', async () => {
-    const operations: string[] = [];
+    const linearClient = new FakeSecurityLinearClient();
     const logs: string[] = [];
-    const fetch: typeof globalThis.fetch = async (input, init) => {
+    const fetch: typeof globalThis.fetch = async (input) => {
       const url = String(input);
-
-      if (!url.includes('api.linear.app')) {
-        return jsonResponse([]);
-      }
-
-      const body = JSON.parse(String(init?.body)) as {
-        operationName: string;
-      };
-      operations.push(body.operationName);
-
-      if (body.operationName === 'ResolveLinearTargets') {
-        return jsonResponse({
-          data: {
-            teams: { nodes: [{ id: 'team-id', key: 'SQR', name: 'Squire' }] },
-            projects: { nodes: [{ id: 'project-id', name: 'Squire · Security Alert Automation' }] },
-            issueLabels: { nodes: [{ id: 'security-label-id', name: 'Security', team: null }] },
-          },
-        });
-      }
-
-      throw new Error(`Unexpected Linear operation: ${body.operationName}`);
+      if (url.includes('api.linear.app')) throw new Error('test should use fake Linear client');
+      return jsonResponse([]);
     };
 
     const result = await syncSecurityAlertsToLinear({
@@ -434,11 +415,12 @@ describe('security alert Linear sync', () => {
       linearLabelName: 'Security',
       dryRun: false,
       fetch,
+      linearClient,
       log: (message) => logs.push(message),
     });
 
     expect(result).toMatchObject({ created: 0, updated: 0, dryRun: 0, alerts: 0 });
-    expect(operations).toEqual(['ResolveLinearTargets']);
+    expect(linearClient.operations).toEqual(['resolveTargets']);
     expect(logs.join('\n')).toContain('Validated Linear target');
     expect(logs.join('\n')).toContain('No high or critical GitHub security alerts found.');
   });

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -86,6 +86,7 @@ const {
   mockCollectDiagnosticBundle,
   mockSubmitLinearBugReport,
   mockFindSessionById,
+  mockFindOwnedConversation,
 } = vi.hoisted(() => {
   const requestSpan = {
     setAttributes: vi.fn(),
@@ -127,6 +128,7 @@ const {
     mockCollectDiagnosticBundle: vi.fn(),
     mockSubmitLinearBugReport: vi.fn(),
     mockFindSessionById: vi.fn(),
+    mockFindOwnedConversation: vi.fn(),
   };
 });
 
@@ -202,6 +204,10 @@ vi.mock('../src/db/repositories/session-repository.ts', () => ({
   deleteExpired: vi.fn(),
 }));
 
+vi.mock('../src/db/repositories/conversation-repository.ts', () => ({
+  findOwnedById: mockFindOwnedConversation,
+}));
+
 vi.mock('@opentelemetry/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@opentelemetry/api')>();
   return {
@@ -245,6 +251,7 @@ import {
   API_ASK_RATE_LIMIT_POLICY,
   API_CARD_SEARCH_RATE_LIMIT_POLICY,
   API_RULE_SEARCH_RATE_LIMIT_POLICY,
+  BUG_REPORT_RATE_LIMIT_POLICY,
   hashRateLimitIdentity,
   resetRateLimiterForTesting,
   setRateLimiterForTesting,
@@ -335,6 +342,7 @@ function resetRouteMocks() {
   mockCollectDiagnosticBundle.mockReset();
   mockSubmitLinearBugReport.mockReset();
   mockFindSessionById.mockReset();
+  mockFindOwnedConversation.mockReset();
 }
 
 function findTelemetryLog(message: string) {
@@ -749,14 +757,15 @@ describe('POST /api/bug-reports', () => {
   }
 
   it('collects safe diagnostics and creates a Linear issue for an authenticated turn report', async () => {
+    const now = new Date();
     const session = {
       id: 'session-1',
       userId: 'user-1',
-      expiresAt: new Date(Date.now() + 60_000),
-      createdAt: new Date(),
+      expiresAt: new Date(now.getTime() + 60_000),
+      createdAt: now,
       ipAddress: null,
       userAgent: null,
-      lastSeenAt: new Date(),
+      lastSeenAt: now,
       user: {
         id: 'user-1',
         googleSub: 'google-sub-1',
@@ -766,8 +775,16 @@ describe('POST /api/bug-reports', () => {
         createdAt: new Date(),
       },
     };
+    const conversation = {
+      id: 'conv-1',
+      userId: 'user-1',
+      creationIdempotencyKey: null,
+      createdAt: now,
+      lastMessageAt: now,
+    };
     const diagnosticBundle = { schemaVersion: 1, report: {} };
     mockFindSessionById.mockResolvedValueOnce(session);
+    mockFindOwnedConversation.mockResolvedValueOnce(conversation);
     mockCollectDiagnosticBundle.mockResolvedValueOnce(diagnosticBundle);
     mockSubmitLinearBugReport.mockResolvedValueOnce({
       status: 'created',
@@ -796,7 +813,7 @@ describe('POST /api/bug-reports', () => {
         observed: 'The assistant got the rule wrong.',
         expected: 'The assistant should answer from the cited rule.',
         browser: {
-          url: 'https://squire.maz.org/chat/conv-1?token=secret',
+          url: 'https://squire.maz.org/chat/conv-1',
           userAgent: 'SquireTest/1.0',
           viewport: { width: 390, height: 844 },
           replaySnapshotId: 'replay-1',
@@ -830,9 +847,10 @@ describe('POST /api/bug-reports', () => {
         userMessageId: 'msg-user-1',
         assistantMessageId: 'msg-assistant-1',
         sentryEventId: 'abcdefabcdefabcdefabcdefabcdefab',
-        browserUrl: 'https://squire.maz.org/chat/conv-1?token=secret',
-        conversationUrl: 'https://squire.maz.org/chat/conv-1?token=secret',
+        browserUrl: 'https://squire.maz.org/chat/conv-1',
+        conversationUrl: 'https://squire.maz.org/chat/conv-1',
         user: { id: 'user-1' },
+        conversation,
         browser: expect.objectContaining({
           userAgent: 'SquireTest/1.0',
           viewport: { width: 390, height: 844 },
@@ -860,6 +878,94 @@ describe('POST /api/bug-reports', () => {
     expect(JSON.stringify(mockSubmitLinearBugReport.mock.calls)).not.toContain(
       'person@example.com',
     );
+    expect(mockFindOwnedConversation).toHaveBeenCalledWith('user-1', 'conv-1');
+  });
+
+  it('rejects bug reports for conversations not owned by the session user', async () => {
+    const now = new Date();
+    const session = {
+      id: 'session-1',
+      userId: 'user-1',
+      expiresAt: new Date(now.getTime() + 60_000),
+      createdAt: now,
+      ipAddress: null,
+      userAgent: null,
+      lastSeenAt: now,
+      user: {
+        id: 'user-1',
+        googleSub: 'google-sub-1',
+        email: 'person@example.com',
+        name: 'Test User',
+        avatarUrl: null,
+        createdAt: now,
+      },
+    };
+    mockFindSessionById.mockResolvedValueOnce(session);
+    mockFindOwnedConversation.mockResolvedValueOnce(null);
+
+    const res = await app.request('/api/bug-reports', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: await signedSessionCookie(session.id),
+        'x-csrf-token': createCsrfToken(session.id),
+      },
+      body: JSON.stringify({
+        kind: 'bad_answer',
+        conversationId: 'foreign-conv',
+        userMessageId: 'foreign-msg',
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(mockCollectDiagnosticBundle).not.toHaveBeenCalled();
+    expect(mockSubmitLinearBugReport).not.toHaveBeenCalled();
+  });
+
+  it('rate limits authenticated bug reports before parsing the JSON body', async () => {
+    const now = new Date();
+    const session = {
+      id: 'session-1',
+      userId: 'user-1',
+      expiresAt: new Date(now.getTime() + 60_000),
+      createdAt: now,
+      ipAddress: null,
+      userAgent: null,
+      lastSeenAt: now,
+      user: {
+        id: 'user-1',
+        googleSub: 'google-sub-1',
+        email: 'person@example.com',
+        name: 'Test User',
+        avatarUrl: null,
+        createdAt: now,
+      },
+    };
+    const { calls } = installOneRequestLimiter();
+    mockFindSessionById.mockResolvedValue(session);
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Cookie: await signedSessionCookie(session.id),
+      'x-csrf-token': createCsrfToken(session.id),
+    };
+    await app.request('/api/bug-reports', {
+      method: 'POST',
+      headers,
+      body: '{not valid json',
+    });
+    const rejected = await app.request('/api/bug-reports', {
+      method: 'POST',
+      headers,
+      body: '{not valid json',
+    });
+
+    expect(rejected.status).toBe(429);
+    expect(calls).toEqual([
+      { policy: BUG_REPORT_RATE_LIMIT_POLICY, identity: 'user:user-1' },
+      { policy: BUG_REPORT_RATE_LIMIT_POLICY, identity: 'user:user-1' },
+    ]);
+    expect(mockCollectDiagnosticBundle).not.toHaveBeenCalled();
   });
 });
 

--- a/test/server-api.test.ts
+++ b/test/server-api.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { generateSignedCookie } from 'hono/cookie';
 
 import { parseSSE } from './helpers/server-oauth-helpers.ts';
 import { LlmBudgetExceededError } from '../src/llm-budget.ts';
@@ -82,6 +83,9 @@ const {
   mockSentryTraceSampleRateFromEnv,
   mockRequestSpan,
   mockStartActiveSpan,
+  mockCollectDiagnosticBundle,
+  mockSubmitLinearBugReport,
+  mockFindSessionById,
 } = vi.hoisted(() => {
   const requestSpan = {
     setAttributes: vi.fn(),
@@ -120,6 +124,9 @@ const {
       if (!callback) throw new TypeError('startActiveSpan callback missing');
       return callback(requestSpan);
     }),
+    mockCollectDiagnosticBundle: vi.fn(),
+    mockSubmitLinearBugReport: vi.fn(),
+    mockFindSessionById: vi.fn(),
   };
 });
 
@@ -130,6 +137,12 @@ vi.mock('../src/service.ts', () => ({
   isReady: mockIsReady,
   refreshInitializationIfReady: mockRefreshInitializationIfReady,
   ask: mockAsk,
+  askWithResult: vi.fn(async (...args: unknown[]) => {
+    const result = await mockAsk(...args);
+    return typeof result === 'object' && result !== null && 'answer' in result
+      ? result
+      : { answer: result };
+  }),
   ensureAskBudgetAvailable: mockEnsureAskBudgetAvailable,
 }));
 vi.mock('../src/db.ts', () => ({
@@ -159,6 +172,34 @@ vi.mock('../src/telemetry.ts', () => ({
   captureTelemetryMessage: mockCaptureTelemetryMessage,
   addTelemetryBreadcrumb: mockAddTelemetryBreadcrumb,
   flushTelemetry: mockFlushTelemetry,
+}));
+
+vi.mock('../src/diagnostic-bundle.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/diagnostic-bundle.ts')>(
+    '../src/diagnostic-bundle.ts',
+  );
+  return {
+    ...actual,
+    collectDiagnosticBundle: mockCollectDiagnosticBundle,
+  };
+});
+
+vi.mock('../src/linear-bug-intake.ts', async () => {
+  const actual = await vi.importActual<typeof import('../src/linear-bug-intake.ts')>(
+    '../src/linear-bug-intake.ts',
+  );
+  return {
+    ...actual,
+    submitLinearBugReport: mockSubmitLinearBugReport,
+  };
+});
+
+vi.mock('../src/db/repositories/session-repository.ts', () => ({
+  SESSION_LIFETIME_MS: 30 * 24 * 60 * 60 * 1000,
+  findById: mockFindSessionById,
+  create: vi.fn(),
+  destroy: vi.fn(),
+  deleteExpired: vi.fn(),
 }));
 
 vi.mock('@opentelemetry/api', async (importOriginal) => {
@@ -198,6 +239,8 @@ vi.mock('../src/auth.ts', () => ({
 
 import { app } from '../src/server.ts';
 import { verifyAccessToken } from '../src/auth.ts';
+import { createCsrfToken } from '../src/auth/csrf.ts';
+import { SESSION_COOKIE_NAME, getSessionSecret } from '../src/auth/session-middleware.ts';
 import {
   API_ASK_RATE_LIMIT_POLICY,
   API_CARD_SEARCH_RATE_LIMIT_POLICY,
@@ -214,7 +257,10 @@ const mockVerifyAccessToken = vi.mocked(verifyAccessToken);
 const ORIGINAL_ORIGIN_SHARED_SECRET = process.env.ORIGIN_SHARED_SECRET;
 const ORIGINAL_SQUIRE_ENV = process.env.SQUIRE_ENV;
 const ORIGINAL_SENTRY_RELEASE = process.env.SENTRY_RELEASE;
+const ORIGINAL_SESSION_SECRET = process.env.SESSION_SECRET;
+const ORIGINAL_LINEAR_API_KEY = process.env.LINEAR_API_KEY;
 const USER_HASH_PATTERN = /^[A-Za-z0-9_-]{32}$/;
+process.env.SESSION_SECRET = 'test-session-secret-must-be-at-least-32-characters-long';
 
 /** Stub bearer header — the mocked `verifyAccessToken` accepts anything. */
 async function auth(): Promise<Record<string, string>> {
@@ -260,6 +306,7 @@ function installUnavailableLimiter(error = new Error('redis unavailable')) {
 }
 
 function resetRouteMocks() {
+  process.env.SESSION_SECRET = 'test-session-secret-must-be-at-least-32-characters-long';
   vi.clearAllMocks();
   mockStartActiveSpan.mockReset();
   mockStartActiveSpan.mockImplementation((_: string, ...args: unknown[]) => {
@@ -285,6 +332,9 @@ function resetRouteMocks() {
   mockCaptureTelemetryFeedback.mockReset();
   mockCaptureTelemetryLog.mockReset();
   mockCaptureTelemetryMessage.mockReset();
+  mockCollectDiagnosticBundle.mockReset();
+  mockSubmitLinearBugReport.mockReset();
+  mockFindSessionById.mockReset();
 }
 
 function findTelemetryLog(message: string) {
@@ -307,6 +357,16 @@ function latestRequestSpanAttributes(): Record<string, unknown> {
 
 afterEach(() => {
   resetRateLimiterForTesting();
+  if (ORIGINAL_SESSION_SECRET === undefined) {
+    delete process.env.SESSION_SECRET;
+  } else {
+    process.env.SESSION_SECRET = ORIGINAL_SESSION_SECRET;
+  }
+  if (ORIGINAL_LINEAR_API_KEY === undefined) {
+    delete process.env.LINEAR_API_KEY;
+  } else {
+    process.env.LINEAR_API_KEY = ORIGINAL_LINEAR_API_KEY;
+  }
 });
 
 describe('POST /api/browser-telemetry', () => {
@@ -665,6 +725,141 @@ describe('POST /api/browser-telemetry', () => {
     expect(browserTelemetryLogCalls()).toEqual([]);
     expect(mockCaptureTelemetryMessage).not.toHaveBeenCalled();
     expect(mockCaptureTelemetryFeedback).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/bug-reports', () => {
+  beforeEach(() => {
+    resetRouteMocks();
+    process.env.LINEAR_API_KEY = 'lin-test';
+  });
+
+  async function signedSessionCookie(sessionId: string): Promise<string> {
+    const signedCookie = await generateSignedCookie(
+      SESSION_COOKIE_NAME,
+      sessionId,
+      getSessionSecret(),
+      {
+        path: '/',
+        httpOnly: true,
+        sameSite: 'Lax',
+      },
+    );
+    return signedCookie.split(';')[0] ?? signedCookie;
+  }
+
+  it('collects safe diagnostics and creates a Linear issue for an authenticated turn report', async () => {
+    const session = {
+      id: 'session-1',
+      userId: 'user-1',
+      expiresAt: new Date(Date.now() + 60_000),
+      createdAt: new Date(),
+      ipAddress: null,
+      userAgent: null,
+      lastSeenAt: new Date(),
+      user: {
+        id: 'user-1',
+        googleSub: 'google-sub-1',
+        email: 'person@example.com',
+        name: 'Test User',
+        avatarUrl: null,
+        createdAt: new Date(),
+      },
+    };
+    const diagnosticBundle = { schemaVersion: 1, report: {} };
+    mockFindSessionById.mockResolvedValueOnce(session);
+    mockCollectDiagnosticBundle.mockResolvedValueOnce(diagnosticBundle);
+    mockSubmitLinearBugReport.mockResolvedValueOnce({
+      status: 'created',
+      marker: 'squire-bug:production:conv-1:msg-user-1',
+      issue: {
+        id: 'issue-id',
+        identifier: 'SQR-123',
+        url: 'https://linear.app/squire/issue/SQR-123/example',
+      },
+    });
+
+    const res = await app.request('/api/bug-reports', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: await signedSessionCookie(session.id),
+        'x-csrf-token': createCsrfToken(session.id),
+        'x-request-id': 'req-bug-1',
+      },
+      body: JSON.stringify({
+        kind: 'bad_answer',
+        conversationId: 'conv-1',
+        userMessageId: 'msg-user-1',
+        assistantMessageId: 'msg-assistant-1',
+        associatedEventId: 'abcdefabcdefabcdefabcdefabcdefab',
+        observed: 'The assistant got the rule wrong.',
+        expected: 'The assistant should answer from the cited rule.',
+        browser: {
+          url: 'https://squire.maz.org/chat/conv-1?token=secret',
+          userAgent: 'SquireTest/1.0',
+          viewport: { width: 390, height: 844 },
+          replaySnapshotId: 'replay-1',
+          timezone: 'America/New_York',
+        },
+        screenshot: {
+          filename: 'squire-bug-test.jpg',
+          contentType: 'image/jpeg',
+          base64Content: 'aGVsbG8=',
+          width: 390,
+          height: 844,
+          byteSize: 5,
+        },
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toEqual({
+      status: 'created',
+      issue: {
+        identifier: 'SQR-123',
+        url: 'https://linear.app/squire/issue/SQR-123/example',
+      },
+      marker: 'squire-bug:production:conv-1:msg-user-1',
+    });
+    expect(mockCollectDiagnosticBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route: '/api/bug-reports',
+        requestId: 'req-bug-1',
+        conversationId: 'conv-1',
+        userMessageId: 'msg-user-1',
+        assistantMessageId: 'msg-assistant-1',
+        sentryEventId: 'abcdefabcdefabcdefabcdefabcdefab',
+        browserUrl: 'https://squire.maz.org/chat/conv-1?token=secret',
+        conversationUrl: 'https://squire.maz.org/chat/conv-1?token=secret',
+        user: { id: 'user-1' },
+        browser: expect.objectContaining({
+          userAgent: 'SquireTest/1.0',
+          viewport: { width: 390, height: 844 },
+          replaySnapshotId: 'replay-1',
+        }),
+      }),
+    );
+    expect(mockSubmitLinearBugReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bundle: diagnosticBundle,
+        kind: 'bad_answer',
+        observed: 'The assistant got the rule wrong.',
+        expected: 'The assistant should answer from the cited rule.',
+        attachments: [
+          expect.objectContaining({
+            filename: 'squire-bug-test.jpg',
+            contentType: 'image/jpeg',
+            base64Content: 'aGVsbG8=',
+            title: 'Conversation UI screenshot',
+          }),
+        ],
+        linearApiKey: 'lin-test',
+      }),
+    );
+    expect(JSON.stringify(mockSubmitLinearBugReport.mock.calls)).not.toContain(
+      'person@example.com',
+    );
   });
 });
 

--- a/test/server-oauth.test.ts
+++ b/test/server-oauth.test.ts
@@ -67,6 +67,7 @@ vi.mock('../src/service.ts', () => ({
   isReady: mockIsReady,
   refreshInitializationIfReady: mockRefreshInitializationIfReady,
   ask: mockAsk,
+  askWithResult: vi.fn(),
 }));
 
 vi.mock('../src/tools.ts', () => ({

--- a/test/server-pending-stream-urls.test.ts
+++ b/test/server-pending-stream-urls.test.ts
@@ -6,6 +6,7 @@ vi.mock('../src/service.ts', () => ({
   initialize: vi.fn(),
   isReady: vi.fn(),
   ask: vi.fn(),
+  askWithResult: vi.fn(),
   ensureBootstrapStatus: vi.fn(),
   getBootstrapStatus: vi.fn(),
   startBootstrapLifecycle: vi.fn(),

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -34,6 +34,7 @@ vi.mock('../src/service.ts', () => ({
   initialize: vi.fn(),
   isReady: vi.fn(),
   ask: vi.fn(),
+  askWithResult: vi.fn(),
 }));
 vi.mock('../src/db.ts', () => ({
   getDb: () => ({ db: { execute: vi.fn() }, close: async () => {} }),
@@ -673,6 +674,11 @@ describe('renderConversationTurnAppendFragment (SQR-108 / ADR 0012 E-3)', () => 
     expect(body).toContain('data-answer-work-status');
     expect(body).toContain('data-answer-work-rows');
     expect(body).toMatch(
+      /<button[^>]*type="button"[^>]*class="squire-answer__report"[^>]*data-squire-report-bug/,
+    );
+    expect(body).toContain('data-user-message-id="msg-456"');
+    expect(body).toContain('data-bug-report-default-kind="broken_stream"');
+    expect(body).toMatch(
       /<div[^>]*class="squire-answer__artifacts"[^>]*data-testid="answer-artifacts"[^>]*aria-live="polite"><\/div>/,
     );
     expect(body).toMatch(/class="squire-answer__skeleton"[^>]*aria-hidden="true"/);
@@ -736,7 +742,17 @@ describe('renderConversationTranscript (SQR-108 / ADR 0012)', () => {
     const body = String(
       actualLayout.renderConversationTranscript({
         conversationId: 'conv-123',
-        messages: messages.slice(0, 2),
+        messages: [
+          messages[0]!,
+          {
+            ...messages[1]!,
+            langsmithRunId: '00000000-0000-0000-abcd-0123456789ab',
+            langsmithRunUrl:
+              'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true',
+            langsmithTraceUrl:
+              'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true',
+          },
+        ],
       }),
     );
 
@@ -748,6 +764,17 @@ describe('renderConversationTranscript (SQR-108 / ADR 0012)', () => {
     expect(body).toMatch(
       /<article[^>]*class="squire-turn squire-answer"[^>]*data-testid="answer-turn"[^>]*data-message-id="m2"[^>]*data-response-to-message-id="m1"[^>]*aria-labelledby="squire-answer-label-m2"/,
     );
+    expect(body).toMatch(
+      /<button[^>]*type="button"[^>]*class="squire-answer__report"[^>]*data-squire-report-bug[^>]*data-user-message-id="m1"[^>]*data-assistant-message-id="m2"/,
+    );
+    expect(body).toContain('data-langsmith-run-id="00000000-0000-0000-abcd-0123456789ab"');
+    expect(body).toContain(
+      'data-langsmith-run-url="https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true"',
+    );
+    expect(body).toContain(
+      'data-langsmith-trace-url="https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true"',
+    );
+    expect(body).toContain('data-bug-report-default-kind="bad_answer"');
     expect(body).toContain('<h2 class="sr-only" id="squire-answer-label-m2">Squire answer</h2>');
     expect(body).toMatch(
       /<div[^>]*class="squire-answer__content squire-markdown"[^>]*data-testid="answer-content"/,

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -614,6 +614,7 @@ function bootBugReportHarness(pathname = '/chat/conv-1') {
     url: string;
     method?: string;
     headers?: Record<string, string>;
+    keepalive?: boolean;
     body: unknown;
   }> = [];
   const csrfMeta = {
@@ -643,7 +644,7 @@ function bootBugReportHarness(pathname = '/chat/conv-1') {
     },
   };
   const window = {
-    location: { pathname, href: `https://squire.maz.org${pathname}?token=secret` },
+    location: { pathname, href: `https://squire.maz.org${pathname}` },
     crypto: { randomUUID: () => 'bug-report-snapshot-1' },
     EventSource: function () {},
     addEventListener: () => {},
@@ -661,14 +662,21 @@ function bootBugReportHarness(pathname = '/chat/conv-1') {
     scrollTo: () => {},
     fetch(
       url: string,
-      init?: { method?: string; headers?: Record<string, string>; body?: unknown },
+      init?: {
+        method?: string;
+        headers?: Record<string, string>;
+        body?: unknown;
+        keepalive?: boolean;
+      },
     ) {
-      fetches.push({
+      const record: (typeof fetches)[number] = {
         url,
         method: init?.method,
         headers: init?.headers,
         body: typeof init?.body === 'string' ? JSON.parse(init.body) : init?.body,
-      });
+      };
+      if (init && 'keepalive' in init) record.keepalive = Boolean(init.keepalive);
+      fetches.push(record);
       return Promise.resolve({
         ok: true,
         json: () =>
@@ -1108,7 +1116,7 @@ describe('squire.js bug reports', () => {
           byteSize: 5,
         },
         browser: {
-          url: 'https://squire.maz.org/chat/conv-1?token=secret',
+          url: 'https://squire.maz.org/chat/conv-1',
           userAgent: 'SquireTest/1.0',
           viewport: { width: 390, height: 844 },
           replaySnapshotId: 'bug-report-snapshot-1',
@@ -1116,6 +1124,7 @@ describe('squire.js bug reports', () => {
         },
       }),
     });
+    expect(fetches[0]?.keepalive).toBeUndefined();
   });
 
   it('does not ask Chrome for tab/window sharing when attaching a screenshot', async () => {
@@ -1160,6 +1169,8 @@ describe('squire.js bug reports', () => {
     const cancel = dialog.querySelector('button[type="button"]');
     const status = dialog.querySelector('.squire-bug-report__status');
     if (!form || !submit || !cancel || !status) throw new Error('expected bug report controls');
+
+    expect(dialog.getAttribute('aria-labelledby')).toBe('squire-bug-report-title');
 
     form.dispatch('submit', { preventDefault() {} });
     await flushMicrotasks();

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -51,15 +51,24 @@ class FakeElement {
   innerHTML = '';
   hidden = false;
   open = false;
+  disabled = false;
+  method = '';
+  name = '';
+  rows = 0;
+  selected = false;
+  type = '';
+  value = '';
   dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
   parentNode: FakeElement | null = null;
   readonly children: FakeElement[] = [];
   readonly attributes = new Map<string, string>();
   readonly classList = new FakeClassList(this);
+  readonly listeners = new Map<string, Array<(event?: unknown) => void>>();
   readonly tagName: string;
 
   constructor(tagName: string) {
-    this.tagName = tagName;
+    this.tagName = tagName.toLowerCase();
   }
 
   appendChild(child: FakeElement) {
@@ -78,6 +87,31 @@ class FakeElement {
       child.parentNode = this;
       this.children.push(child);
     }
+  }
+
+  addEventListener(event: string, callback: (event?: unknown) => void) {
+    this.listeners.set(event, [...(this.listeners.get(event) ?? []), callback]);
+  }
+
+  dispatch(event: string, payload?: unknown) {
+    for (const callback of this.listeners.get(event) ?? []) callback(payload);
+  }
+
+  focus() {}
+
+  showModal() {
+    this.open = true;
+  }
+
+  close() {
+    this.open = false;
+  }
+
+  remove() {
+    if (!this.parentNode) return;
+    const index = this.parentNode.children.indexOf(this);
+    if (index !== -1) this.parentNode.children.splice(index, 1);
+    this.parentNode = null;
   }
 
   setAttribute(name: string, value: string) {
@@ -107,6 +141,30 @@ class FakeElement {
   querySelector(selector: string): FakeElement | null {
     if (selector === 'p') {
       return this.find((node) => node.tagName === 'p');
+    }
+
+    if (selector === 'form') {
+      return this.find((node) => node.tagName === 'form');
+    }
+
+    if (selector === 'button[type="submit"]') {
+      return this.find((node) => node.tagName === 'button' && node.type === 'submit');
+    }
+
+    if (selector === 'button[type="button"]') {
+      return this.find((node) => node.tagName === 'button' && node.type === 'button');
+    }
+
+    if (selector === 'select') {
+      return this.find((node) => node.tagName === 'select');
+    }
+
+    if (selector === 'textarea[name="observed"]') {
+      return this.find((node) => node.tagName === 'textarea' && node.name === 'observed');
+    }
+
+    if (selector === 'textarea[name="expected"]') {
+      return this.find((node) => node.tagName === 'textarea' && node.name === 'expected');
     }
 
     if (selector.startsWith('.')) {
@@ -505,6 +563,9 @@ function bootBrowserTelemetryHarness(
     },
     documentElement: { scrollHeight: 0 },
   };
+  const navigator = {
+    userAgent: 'SquireTest/1.0',
+  };
   const window = {
     location: { pathname },
     crypto: {
@@ -517,7 +578,7 @@ function bootBrowserTelemetryHarness(
     scrollY: 0,
     innerHeight: 844,
     innerWidth: 390,
-    navigator: { userAgent: 'SquireTest/1.0' },
+    navigator,
     scrollTo: () => {},
     fetch(url: string, init?: { body?: unknown }) {
       telemetryPayloads.push({
@@ -544,6 +605,189 @@ function bootBrowserTelemetryHarness(
     },
     telemetryPayloads,
   };
+}
+
+function bootBugReportHarness(pathname = '/chat/conv-1') {
+  const docListeners = new Map<string, Array<(event?: unknown) => void>>();
+  let displayMediaCalls = 0;
+  const fetches: Array<{
+    url: string;
+    method?: string;
+    headers?: Record<string, string>;
+    body: unknown;
+  }> = [];
+  const csrfMeta = {
+    getAttribute(name: string) {
+      return name === 'content' ? 'csrf-test-token' : null;
+    },
+  };
+  const document = {
+    addEventListener(event: string, callback: (event?: unknown) => void) {
+      docListeners.set(event, [...(docListeners.get(event) ?? []), callback]);
+    },
+    querySelector(selector: string) {
+      return selector === 'meta[name="csrf-token"]' ? csrfMeta : null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    documentElement: { scrollHeight: 0 },
+  };
+  const navigator = {
+    userAgent: 'SquireTest/1.0',
+    mediaDevices: {
+      getDisplayMedia() {
+        displayMediaCalls += 1;
+        throw new Error('getDisplayMedia should not be used for bug report screenshots');
+      },
+    },
+  };
+  const window = {
+    location: { pathname, href: `https://squire.maz.org${pathname}?token=secret` },
+    crypto: { randomUUID: () => 'bug-report-snapshot-1' },
+    EventSource: function () {},
+    addEventListener: () => {},
+    scrollY: 0,
+    innerHeight: 844,
+    innerWidth: 390,
+    navigator,
+    Intl: {
+      DateTimeFormat: function () {
+        return {
+          resolvedOptions: () => ({ timeZone: 'America/New_York' }),
+        };
+      },
+    },
+    scrollTo: () => {},
+    fetch(
+      url: string,
+      init?: { method?: string; headers?: Record<string, string>; body?: unknown },
+    ) {
+      fetches.push({
+        url,
+        method: init?.method,
+        headers: init?.headers,
+        body: typeof init?.body === 'string' ? JSON.parse(init.body) : init?.body,
+      });
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status: 'created',
+            issue: { identifier: 'SQR-123', url: 'https://linear.app/squire/issue/SQR-123' },
+          }),
+      });
+    },
+  };
+  const context = vm.createContext({ document, window, navigator });
+
+  vm.runInContext(scriptSource, context);
+
+  return {
+    emitDocument(event: string, payload: unknown) {
+      for (const callback of docListeners.get(event) ?? []) callback(payload);
+    },
+    fetches,
+    getDisplayMediaCalls() {
+      return displayMediaCalls;
+    },
+  };
+}
+
+function bootBugReportDialogHarness(pathname = '/chat/conv-1') {
+  const docListeners = new Map<string, Array<(event?: unknown) => void>>();
+  const bugReports: Array<Record<string, unknown>> = [];
+  let resolveBugReport:
+    | ((response: { ok: boolean; json: () => Promise<Record<string, unknown>> }) => void)
+    | undefined;
+  const body = new FakeElement('body');
+  const csrfMeta = {
+    getAttribute(name: string) {
+      return name === 'content' ? 'csrf-test-token' : null;
+    },
+  };
+  const document = {
+    body,
+    documentElement: new FakeElement('html'),
+    createElement(tagName: string) {
+      return new FakeElement(tagName);
+    },
+    addEventListener(event: string, callback: (event?: unknown) => void) {
+      docListeners.set(event, [...(docListeners.get(event) ?? []), callback]);
+    },
+    querySelector(selector: string) {
+      return selector === 'meta[name="csrf-token"]' ? csrfMeta : null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    styleSheets: [],
+  };
+  const window = {
+    location: { pathname, href: `https://squire.maz.org${pathname}` },
+    crypto: { randomUUID: () => 'bug-report-dialog-snapshot' },
+    EventSource: function () {},
+    addEventListener: () => {},
+    scrollY: 0,
+    innerHeight: 844,
+    innerWidth: 390,
+    navigator: { userAgent: 'SquireTest/1.0' },
+    Intl: {
+      DateTimeFormat: function () {
+        return {
+          resolvedOptions: () => ({ timeZone: 'America/New_York' }),
+        };
+      },
+    },
+    scrollTo: () => {},
+    fetch(url: string, init?: { body?: unknown }) {
+      if (url === '/api/browser-telemetry') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ eventId: '0123456789abcdef0123456789abcdef' }),
+        });
+      }
+      if (url === '/api/bug-reports') {
+        if (typeof init?.body === 'string') bugReports.push(JSON.parse(init.body));
+        return new Promise((resolve) => {
+          resolveBugReport = resolve;
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    },
+  };
+  const context = vm.createContext({ document, window });
+  vm.runInContext(scriptSource, context);
+
+  return {
+    clickReportButton(button: FakeElement) {
+      for (const callback of docListeners.get('click') ?? []) {
+        callback({
+          target: button,
+          preventDefault() {},
+        });
+      }
+    },
+    resolveBugReport(identifier = 'SQR-321') {
+      if (!resolveBugReport) throw new Error('bug report request was not started');
+      resolveBugReport({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status: 'created',
+            issue: { identifier, url: `https://linear.app/squire/issue/${identifier}` },
+          }),
+      });
+    },
+    bugReports,
+    body,
+  };
+}
+
+async function flushMicrotasks(count = 12) {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
 }
 
 function workRowMessage(row: FakeElement): string | undefined {
@@ -809,6 +1053,144 @@ describe('squire.js browser telemetry', () => {
     });
     expect(telemetryPayloads[1].body).not.toHaveProperty('maskedReplay');
     expect(JSON.stringify(telemetryPayloads)).not.toContain('raw transcript');
+  });
+});
+
+describe('squire.js bug reports', () => {
+  it('submits an in-chat bug report with CSRF and safe browser metadata', async () => {
+    const { emitDocument, fetches } = bootBugReportHarness('/chat/conv-1');
+
+    emitDocument('squire:bug-report', {
+      detail: {
+        kind: 'bad_answer',
+        conversationId: 'conv-1',
+        userMessageId: 'msg-user-1',
+        assistantMessageId: 'msg-assistant-1',
+        observed: 'The answer used the wrong rule.',
+        expected: 'It should use the rule covering this turn.',
+        associatedEventId: '0123456789abcdef0123456789abcdef',
+        screenshot: {
+          filename: 'squire-bug-test.jpg',
+          contentType: 'image/jpeg',
+          base64Content: 'aGVsbG8=',
+          width: 390,
+          height: 844,
+          byteSize: 5,
+        },
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetches).toHaveLength(1);
+    expect(fetches[0]).toEqual({
+      url: '/api/bug-reports',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-csrf-token': 'csrf-test-token',
+      },
+      body: expect.objectContaining({
+        kind: 'bad_answer',
+        conversationId: 'conv-1',
+        userMessageId: 'msg-user-1',
+        assistantMessageId: 'msg-assistant-1',
+        observed: 'The answer used the wrong rule.',
+        expected: 'It should use the rule covering this turn.',
+        associatedEventId: '0123456789abcdef0123456789abcdef',
+        screenshot: {
+          filename: 'squire-bug-test.jpg',
+          contentType: 'image/jpeg',
+          base64Content: 'aGVsbG8=',
+          width: 390,
+          height: 844,
+          byteSize: 5,
+        },
+        browser: {
+          url: 'https://squire.maz.org/chat/conv-1?token=secret',
+          userAgent: 'SquireTest/1.0',
+          viewport: { width: 390, height: 844 },
+          replaySnapshotId: 'bug-report-snapshot-1',
+          timezone: 'America/New_York',
+        },
+      }),
+    });
+  });
+
+  it('does not ask Chrome for tab/window sharing when attaching a screenshot', async () => {
+    const { emitDocument, fetches, getDisplayMediaCalls } = bootBugReportHarness('/chat/conv-1');
+
+    emitDocument('squire:bug-report', {
+      detail: {
+        kind: 'visual_issue',
+        conversationId: 'conv-1',
+        userMessageId: 'msg-user-1',
+        includeScreenshot: true,
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getDisplayMediaCalls()).toBe(0);
+    expect(fetches).toHaveLength(1);
+    expect(fetches[0]?.body).not.toHaveProperty('screenshot');
+  });
+
+  it('shows submitting and created states instead of closing the bug dialog immediately', async () => {
+    const harness = bootBugReportDialogHarness('/chat/conv-1');
+    const button = new FakeElement('button');
+    button.setAttribute('data-squire-report-bug', '');
+    button.dataset.bugReportDefaultKind = 'bad_answer';
+    button.dataset.userMessageId = 'msg-user-1';
+    button.dataset.assistantMessageId = 'msg-assistant-1';
+    button.dataset.langsmithRunId = '00000000-0000-0000-abcd-0123456789ab';
+    button.dataset.langsmithRunUrl =
+      'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true';
+    button.dataset.langsmithTraceUrl =
+      'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true';
+
+    harness.clickReportButton(button);
+
+    const dialog = harness.body.querySelector('.squire-bug-report');
+    if (!dialog) throw new Error('expected bug report dialog');
+    const form = dialog.querySelector('form');
+    const submit = dialog.querySelector('button[type="submit"]');
+    const cancel = dialog.querySelector('button[type="button"]');
+    const status = dialog.querySelector('.squire-bug-report__status');
+    if (!form || !submit || !cancel || !status) throw new Error('expected bug report controls');
+
+    form.dispatch('submit', { preventDefault() {} });
+    await flushMicrotasks();
+
+    expect(form.dataset.submitting).toBe('true');
+    expect(dialog.getAttribute('aria-busy')).toBe('true');
+    expect(submit.disabled).toBe(true);
+    expect(cancel.disabled).toBe(true);
+    expect(submit.textContent).toBe('Creating...');
+    expect(status.textContent).toBe('Creating bug...');
+    expect(harness.bugReports[0]).toMatchObject({
+      langsmithRunId: '00000000-0000-0000-abcd-0123456789ab',
+      langsmithRunUrl:
+        'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true',
+      langsmithTraceUrl:
+        'https://smith.langchain.com/o/org/projects/p/project/r/00000000-0000-0000-abcd-0123456789ab?poll=true',
+    });
+
+    harness.resolveBugReport('SQR-321');
+    await flushMicrotasks();
+
+    expect(harness.body.querySelector('.squire-bug-report')).toBe(dialog);
+    expect(form.dataset.submitting).toBeUndefined();
+    expect(form.dataset.submitted).toBe('true');
+    expect(dialog.getAttribute('aria-busy')).toBeNull();
+    expect(submit.disabled).toBe(true);
+    expect(cancel.disabled).toBe(false);
+    expect(cancel.textContent).toBe('Close');
+    expect(submit.textContent).toBe('Created');
+    expect(status.textContent).toContain('Created SQR-321');
+    expect(button.textContent).toBe('Reported SQR-321');
   });
 });
 


### PR DESCRIPTION
## Summary

- add authenticated `/api/bug-reports` intake that builds a redacted diagnostic bundle, dedupes by marker, creates Linear issues, and attaches an opt-in screenshot when provided
- persist LangSmith run/trace links on assistant messages and pass those safe IDs from the conversation page into bug reports
- update bug-reporting docs, `.env.example`, and the Squire bug-report skill so agents file consistent evidence-backed bugs
- move Linear admin calls to the Linear SDK wrapper and centralize Sentry admin request handling for observability scripts

## Validation

- `npm run check`
- `git diff --check`
- manual local bug-report submit flow created a Linear issue; final UI keeps the dialog open with creating/created state

Fixes SQR-298
Fixes SQR-299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-chat and answer “Report bug” workflow with a form dialog, optional screenshot capture, and one-click Linear issue creation/deduping.
  * Introduced an authenticated bug-report API with CSRF protection and per-user rate limiting.
  * Enhanced diagnostic/observability data with Sentry event IDs, browser timezone, and LangSmith run/trace correlation links.

* **Documentation**
  * Updated observability, diagnostic bundle, and Linear bug-reporting guides to match the new evidence and tracing conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->