### PR TITLE
fix(campaign): show open scenario count in dashboard header

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -128,6 +128,7 @@ import {
 import { renderAssistantContentHtml } from './web-ui/assistant-content.ts';
 import {
   renderCampaignDashboardContent,
+  renderCampaignDashboardThreadsSwap,
   renderCampaignListContent,
   type CampaignStripState,
 } from './web-ui/campaign-pages.ts';
@@ -1531,6 +1532,7 @@ async function renderCampaignDashboardPage(
   // Modules editor only for games that have optional modules to toggle.
   const gameId = normalizeGameId(detail.campaign.game);
   const gameDef = gameId ? gameDefinitionFor(gameId) : null;
+  const dashboardThreads = await dashboardThreadsFragment(detail.campaign, csrfToken);
   // Per-user, never-cached: set on every path through the shared renderer
   // (GET and the create-error re-render) so neither leaks across sessions.
   c.header('Cache-Control', 'no-store');
@@ -1548,7 +1550,7 @@ async function renderCampaignDashboardPage(
     campaignStripProminent: true,
     mainContent: renderCampaignDashboardContent(
       detail,
-      await dashboardThreadsFragment(detail.campaign, csrfToken),
+      dashboardThreads?.html,
       renderCampaignJournal(await listJournal(identity, campaignId)),
       // Sheet links (SQR-277): member-visible projection only.
       (await CharacterRepository.listMemberVisibleByCampaign(campaignId)).map((character) => ({
@@ -1582,6 +1584,7 @@ async function renderCampaignDashboardPage(
             errorMessage: opts.modulesError,
           }
         : undefined,
+      { openScenarioCount: dashboardThreads?.openScenarioCount },
     ),
   });
   return c.html(body, status);
@@ -1830,7 +1833,7 @@ async function dashboardThreadsFragment(
   campaign: Campaign,
   csrfToken: string,
   announcement?: string,
-): Promise<HtmlEscapedString | undefined> {
+): Promise<{ html: HtmlEscapedString; openScenarioCount: number } | undefined> {
   const graphs = await loadModuleGraphs(campaign.game, campaign.modules);
   if (graphs.length === 0) return undefined;
   const roster = await CharacterRepository.listActiveRosterByCampaign(campaign.id);
@@ -1841,7 +1844,13 @@ async function dashboardThreadsFragment(
     new Set(campaign.skippedScenarios),
     roster,
   );
-  return renderDashboardThreads({ campaign, graphs, availability, csrfToken, announcement });
+  const openScenarioCount = [...availability.statuses.values()].filter(
+    (status) => status === 'open',
+  ).length;
+  return {
+    html: renderDashboardThreads({ campaign, graphs, availability, csrfToken, announcement }),
+    openScenarioCount,
+  };
 }
 
 /**
@@ -1930,7 +1939,15 @@ app.post('/campaigns/:id/scenarios/toggle', async (c) => {
   );
   c.header('Cache-Control', 'no-store');
   c.header('Vary', 'Cookie');
-  if (isHtmxRequest(c) && fragment) return c.html(fragment);
+  if (isHtmxRequest(c) && fragment) {
+    return c.html(
+      renderCampaignDashboardThreadsSwap({
+        campaign: detail.campaign,
+        headerStats: { openScenarioCount: fragment.openScenarioCount },
+        threadsFragment: fragment.html,
+      }),
+    );
+  }
   return c.redirect(`/campaigns/${campaignId}`, 303);
 });
 

--- a/src/web-ui/campaign-pages.ts
+++ b/src/web-ui/campaign-pages.ts
@@ -298,6 +298,49 @@ export interface CampaignModulesForm {
   errorMessage?: string;
 }
 
+export interface CampaignDashboardHeaderStats {
+  openScenarioCount?: number;
+}
+
+function campaignDashboardHeaderStatsLine(
+  campaign: Campaign,
+  headerStats?: CampaignDashboardHeaderStats,
+): string {
+  return [
+    gameLabel(campaign.game),
+    `PROSPERITY ${campaign.prosperity}`,
+    typeof headerStats?.openScenarioCount === 'number'
+      ? `OPEN ${headerStats.openScenarioCount}`
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+}
+
+export function renderCampaignDashboardHeaderStats(
+  campaign: Campaign,
+  headerStats?: CampaignDashboardHeaderStats,
+  options: { outOfBand?: boolean } = {},
+): HtmlEscapedString {
+  return html`<p
+    class="squire-campaign-dashboard__stats"
+    id="squire-campaign-dashboard-stats"
+    ${options.outOfBand ? html`hx-swap-oob="true"` : html``}
+  >
+    ${campaignDashboardHeaderStatsLine(campaign, headerStats)}
+  </p>` as HtmlEscapedString;
+}
+
+export function renderCampaignDashboardThreadsSwap(input: {
+  campaign: Campaign;
+  headerStats: CampaignDashboardHeaderStats;
+  threadsFragment: HtmlEscapedString;
+}): HtmlEscapedString {
+  return html`${renderCampaignDashboardHeaderStats(input.campaign, input.headerStats, {
+    outOfBand: true,
+  })}${input.threadsFragment}` as HtmlEscapedString;
+}
+
 /**
  * A quiet modules disclosure. Toggling changes which scenario set the dashboard
  * shows; removal is non-destructive (a removed module's played/skipped keys
@@ -396,6 +439,7 @@ export function renderCampaignDashboardContent(
   inviteForm?: InviteMemberForm,
   renameForm?: CampaignRenameForm,
   modulesForm?: CampaignModulesForm,
+  headerStats?: CampaignDashboardHeaderStats,
 ): HtmlEscapedString {
   const { campaign } = detail;
   const activeMembers = detail.members.filter((member) => member.status === 'active');
@@ -404,10 +448,7 @@ export function renderCampaignDashboardContent(
   return html`<section class="squire-campaign-dashboard" data-campaign-id="${campaign.id}">
     <header class="squire-campaign-dashboard__header">
       <h1 class="squire-campaign-dashboard__name">${campaign.name}</h1>
-      <p class="squire-campaign-dashboard__stats">
-        ${gameLabel(campaign.game)} · PROSPERITY ${campaign.prosperity} · PLAYED
-        ${campaign.playedScenarios.length} · DRAWN ${campaign.drawnScenarios.length}
-      </p>
+      ${renderCampaignDashboardHeaderStats(campaign, headerStats)}
       ${renameForm ? renderCampaignRenameForm(campaign, renameForm) : html``}
       ${modulesForm ? renderCampaignModulesForm(campaign, modulesForm) : html``}
     </header>

--- a/test/campaign-dashboard.test.ts
+++ b/test/campaign-dashboard.test.ts
@@ -66,6 +66,14 @@ const scenario = (key: string, overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+function dashboardHeaderStats(body: string): string {
+  const match = body.match(
+    /<p\b[^>]*class="squire-campaign-dashboard__stats"[^>]*>\s*([\s\S]*?)\s*<\/p>/,
+  );
+  if (!match) throw new Error('Dashboard header stats not found');
+  return match[1]!.replace(/\s+/g, ' ').trim();
+}
+
 async function setupFixture() {
   const { db } = getDb('server');
   await seedUnlockGraphModule(db, {
@@ -172,6 +180,11 @@ describe('dashboard rendering', () => {
     expect(body).toContain('aria-live="polite"');
     expect(body).toContain('squire-dashboard-stats');
 
+    const headerStats = dashboardHeaderStats(body);
+    expect(headerStats).toBe('FH · PROSPERITY 1 · OPEN 1');
+    expect(headerStats).not.toContain('PLAYED');
+    expect(headerStats).not.toContain('DRAWN');
+
     // No hazard banner yet: 2/3 close each other but neither is reachable
     // (locked culprits still project warnings — both unplayed, so the
     // banner SHOULD render inside Main Thread).
@@ -192,6 +205,8 @@ describe('toggle route', () => {
     expect(playedBody).toContain('PLAYED ✓');
     // 2 and 3 opened by playing 1.
     expect(playedBody.match(/--open/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(playedBody).toContain('hx-swap-oob="true"');
+    expect(dashboardHeaderStats(playedBody)).toBe('FH · PROSPERITY 1 · OPEN 2');
 
     // Manual cycle: via-event → drew-it → played.
     const drew = await toggle(owner, campaign.id, 'fh:4');


### PR DESCRIPTION
## Summary

Fixes the campaign dashboard header so it shows the currently selectable/open scenario count instead of stored `PLAYED` and `DRAWN` counts.

- Replaces the header stats line with `GAME · PROSPERITY n · OPEN n` when scenario availability data exists.
- Uses the same derived availability result as the scenario dashboard, so the header reflects real selectable scenarios.
- Updates the HTMX scenario-toggle response with an out-of-band header stats swap so the count changes without a full page reload.

## Pre-Landing Review

Pre-Landing Review: No issues found.

Scope Check: CLEAN
Intent: SQR-323 dashboard header should show selectable scenario count and drop `DRAWN`/duplicated `PLAYED`.
Delivered: Header uses derived `OPEN` count and updates after scenario toggles.

## Test Coverage

Regression coverage added in `test/campaign-dashboard.test.ts`:
- Initial dashboard render asserts `FH · PROSPERITY 1 · OPEN 1`.
- Header no longer includes `PLAYED` or `DRAWN`.
- HTMX toggle response includes an out-of-band header update and moves the count to `OPEN 2` in the fixture.

## Eval Results

No prompt-related files changed. Evals skipped.

## Plan Completion

No plan file detected.

## Verification Results

- `npm run check` passed.
- Manual local smoke passed on a prepared SQR-323 campaign fixture: initial header showed `FH · PROSPERITY 1 · OPEN 2`, and clicking scenario `1` updated it to `OPEN 3`.

## Test plan

- [x] `npm run check` passed: 155 test files, 1850 tests.

Fixes SQR-323


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaign dashboard header statistics now update dynamically when scenario statuses change.
  * Dashboard utilizes HTMX-based updates for real-time stat synchronization without full page refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->