### PR TITLE
feat(campaigns): split dashboard into Scenarios and Party paths

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,7 +1,7 @@
 # Design System — Squire
 
-**Version:** 0.9
-**Date:** 2026-06-12
+**Version:** 0.11
+**Date:** 2026-06-19
 **Status:** Approved via `/design-consultation`. Covers all eight phases of the
 Squire initiative, not just Phase 1. Implementation in `src/web-ui/` follows
 this document. v0.8 (2026-06-05) preserves the split home + scrolling-chat IA,
@@ -584,6 +584,15 @@ rail remains conversation history (ADR 0020). The **header context strip is
 the persistent bridge**: it shows the active campaign/character and tapping it
 opens the campaign dashboard from anywhere.
 
+Within `/campaigns/:id`, the dashboard itself is a two-view segmented surface:
+**Scenarios** is the default route view, and **Party** is the secondary view.
+The view state is encoded in the URL (`/campaigns/:id` for Scenarios,
+`/campaigns/:id/party` for Party) so no-JS users, agents, and shared links
+can reach either view. This supersedes the G2 assumption that party management
+and scenario progression should stack on one full-viewport surface; the route
+and context-strip parts of G2 still stand. See
+[ADR 0023](docs/adr/0023-campaign-dashboard-path-segmented-views.md).
+
 ### Context strip
 
 Small-caps Geist line in the header, present on chat and Phase 4 routes alike.
@@ -613,6 +622,12 @@ gets a glyph:
 
 ### Progression dashboard (`/campaigns/:id`)
 
+- **Segmented dashboard views**: Scenarios first, Party second. The segment
+  control is quiet ledger navigation, not a marketing tab bar: Geist small-caps,
+  44px tap targets, hairline rule, no pill badges. Scenarios renders the
+  flowchart, scenario stats, and journal. Party renders the member roster,
+  invite affordance, character links, and create-character form. The default
+  page must not put party management above the scenario flow.
 - **Stats line** under the header: `PLAYED 16 · OPEN 7 · LOCKED 58 ·
 BLOCKED 2` — Geist small caps with `tabular-nums`.
 - **Thread sections**: Fraunces heading + one-line `--sepia` note + hairline
@@ -701,12 +716,22 @@ holds at label sizes for the status vocabulary above.
 | 2026-06-12 | **G4: State transparency = per-answer work-log rows + route-level inspect/correct** (rejected dedicated chat panel, rejected routes-only)                                                                                                                                                                                                                                                               | The work log is already the trust surface; per-answer provenance ("used: Drifter L4 · gold 23") lands exactly where doubt arises, and the campaign/character routes carry the full "what Squire knows" view without new chat chrome. From plan-design-review D4 / SQR-258.                                                                                                                                                                                                                                      |
 | 2026-06-12 | **G5: Phase 4 component vocabulary** — sepia small-caps status labels (PLAYED sage / OPEN parchment / LOCKED sepia-dim / BLOCKED amber / VIA EVENT sepia / DREW IT amber), Fraunces thread headings + sepia notes, tabular-nums stats line, adjacent `.squire-banner` amber hazard warnings, confirmation block = surface panel + work-log rows + wax confirm (distinct from the Phase 5 verdict block) | Reuses the existing token and banner vocabulary instead of inventing new chrome; statuses as typography (not chips) keeps the printed-index feel and answered the variant-A "badges too loud" feedback. See §Phase 4 Components.                                                                                                                                                                                                                                                                                |
 | 2026-06-12 | **G6: Phase 4 a11y + responsive bundle** — 44px scenario-row/accordion targets, keyboard row-focus with Enter-to-toggle (hazard rows always confirm), `aria-live="polite"` recalc announcements, desktop multi-column thread grid (640px column is for prose, not data surfaces)                                                                                                                        | The dashboard is an interactive data surface, not a transcript; recalculation is the moment screen-reader users most need narrated, and the reading-column rule was never meant to constrain tabular layouts. From plan-design-review Pass 6.                                                                                                                                                                                                                                                                   |
+| 2026-06-19 | **G7: Campaign dashboard internal IA = Scenarios / Party segmented views** — narrows G2. `/campaigns/:id` defaults to Scenarios; `/campaigns/:id/party` opens Party. No-JS and agent links use the same URLs.                                                                                                                                                                                           | Real dashboard use is usually "find the next scenario" or "mark one played." Party management is secondary and should not push the scenario flow below the fold. A path segment reads as a named dashboard section instead of presentation state, which makes reports, logs, and agent links clearer. See [ADR 0023](docs/adr/0023-campaign-dashboard-path-segmented-views.md).                                                                                                                                 |
 
 <!-- markdownlint-enable MD060 -->
 
 ---
 
 ## Changelog
+
+- **2026-06-19 (v0.11):** SQR-322 now uses path-backed dashboard segments:
+  `/campaigns/:id` for Scenarios and `/campaigns/:id/party` for Party. ADR 0023
+  supersedes the earlier query-param route decision in ADR 0022.
+
+- **2026-06-18 (v0.10):** SQR-322 narrows the Phase 4 dashboard IA: the route
+  and context-strip bridge from G2 remain, but `/campaigns/:id` now defaults to
+  a Scenarios view with Party available via URL-backed segmented navigation.
+  Decision recorded as G7 and [ADR 0022](docs/adr/0022-campaign-dashboard-segmented-views.md).
 
 - **2026-06-12 (v0.9):** Phase 4 component section added (campaign &
   character surfaces): IA routes + context-strip bridge, scenario status

--- a/docs/adr/0022-campaign-dashboard-segmented-views.md
+++ b/docs/adr/0022-campaign-dashboard-segmented-views.md
@@ -1,0 +1,78 @@
+---
+type: ADR
+id: '0022'
+title: 'Campaign dashboard segmented views'
+status: superseded
+superseded_by: '0023'
+date: 2026-06-18
+---
+
+## Context
+
+DESIGN.md G2 chose dedicated campaign routes plus the header context-strip
+bridge. That remains right: `/campaigns/:id` is a full dashboard route, and chat
+stays the home conversation surface. The part that no longer fits lived use is
+the dashboard's internal order.
+
+The default dashboard rendered party roster, invites, characters, character
+creation, scenario progression, and journal in one vertical stack. In real
+table use, the common task is to find the next scenario, inspect what opened, or
+mark a scenario played. Party management is secondary. Stacking Party and
+Characters above the scenario flow makes the primary task start below the fold,
+especially on a phone.
+
+SQR-322 re-opens only the internal dashboard IA, not the route-level IA.
+
+## Decision
+
+**`/campaigns/:id` uses URL-backed segmented views: Scenarios is the default,
+and Party is available at `?view=party`.**
+
+Scenarios renders the scenario flowchart, scenario stats, and journal. Party
+renders member roster, invite controls, character links, and character creation.
+The segment links are normal anchors, so JavaScript is not required and links
+from agents or bug reports can target either view.
+
+## Options considered
+
+- **Option A — keep one dense stack.** Minimum code and matches the first Phase
+  4 mockup. Rejected because the party and character controls push the primary
+  scenario task below the fold.
+- **Option B — client-side tabs only.** Fast-feeling interaction, but no-JS
+  users and agent links cannot target the Party view without client state.
+  Rejected.
+- **Option C — URL-backed segmented views** (chosen). Slightly more server
+  routing and tests, but it preserves no-JS access, keeps links precise, and
+  makes Scenarios the first screen without hiding Party permanently.
+- **Option D — split Party into a separate route.** Cleanest separation, but it
+  makes basic campaign maintenance feel farther away than one gesture and adds
+  another Phase 4 route before there is enough surface area to justify it.
+  Rejected.
+
+## Consequences
+
+Easier:
+
+- The default dashboard opens on the scenario flow, matching the most common
+  at-table task.
+- Party management remains reachable by one link without JavaScript.
+- Bug reports and agent replies can link to the exact view.
+- Character and invite validation errors can re-render directly on Party.
+
+Harder:
+
+- Tests that previously assumed Party content existed on the default dashboard
+  must request `?view=party`.
+- POST redirects for Party forms should return to `?view=party` so successful
+  writes do not drop the user back on Scenarios.
+- Future dashboard sections need an explicit home: Scenarios, Party, or a new
+  segment.
+
+Re-evaluate if Party becomes the dominant dashboard task or if the dashboard
+adds enough campaign-management sections that Party needs its own route.
+
+## Advice
+
+This decision comes from SQR-322 and Brian's dashboard bug log from
+2026-06-14. It narrows DESIGN.md G2; it does not supersede ADR 0020 or the
+route/context-strip part of G2.

--- a/docs/adr/0023-campaign-dashboard-path-segmented-views.md
+++ b/docs/adr/0023-campaign-dashboard-path-segmented-views.md
@@ -1,0 +1,70 @@
+---
+type: ADR
+id: '0023'
+title: 'Campaign dashboard path-segmented views'
+status: active
+date: 2026-06-19
+---
+
+## Context
+
+ADR 0022 split the campaign dashboard into Scenarios and Party, but encoded the
+secondary Party view with `?view=party`. That solved no-JS reachability, but it
+made Party feel like state on the Scenarios page instead of a named dashboard
+section.
+
+The user-facing contract should be simple enough to read aloud, paste into a
+bug report, and recognize in server logs. `/campaigns/:id/party` is clearer
+than a query-param tab state and matches the rest of the Phase 4 route style.
+
+## Decision
+
+**The campaign dashboard uses path-backed segmented views: `/campaigns/:id`
+opens Scenarios, and `/campaigns/:id/party` opens Party.**
+
+Scenarios renders the scenario flowchart, scenario stats, and journal. Party
+renders member roster, invite controls, character links, and character creation.
+The segment links are normal anchors, so JavaScript is not required and links
+from agents or bug reports can target either view.
+
+## Options considered
+
+- **Option A — query-param tab state.** Works without JavaScript and keeps one
+  route handler, but `?view=party` reads as presentation state rather than an
+  addressable campaign section. Superseded.
+- **Option B — path-backed Party view** (chosen). Slightly more routing, but it
+  gives Party a stable readable URL and keeps the Scenarios default clean.
+- **Option C — keep one dense stack.** Still rejected for the same reason as
+  ADR 0022: party and character controls push the primary scenario task below
+  the fold.
+- **Option D — client-side tabs only.** Still rejected because no-JS users and
+  agent links cannot target Party without client state.
+
+## Consequences
+
+Easier:
+
+- User reports, Sentry tags, and agent-generated links can refer to a readable
+  Party URL.
+- The default campaign URL remains the scenario workflow.
+- Party form redirects can return to a canonical path instead of preserving tab
+  query state.
+
+Harder:
+
+- Tests that previously assumed Party content existed on the default dashboard
+  must request `/campaigns/:id/party`.
+- Route changes need to preserve the member/404 indistinguishability contract on
+  both dashboard paths.
+- Future dashboard sections need an explicit path if they become first-class
+  sections.
+
+Re-evaluate if Party becomes the dominant dashboard task or if the dashboard
+adds enough campaign-management sections that `/campaigns/:id/manage` would be
+clearer than additional sibling paths.
+
+## Advice
+
+Brian explicitly chose path routing over query-param routing on 2026-06-19 while
+reviewing SQR-322. This supersedes ADR 0022 and still narrows DESIGN.md G2
+without changing ADR 0020 or the route/context-strip part of G2.

--- a/src/server.ts
+++ b/src/server.ts
@@ -131,6 +131,7 @@ import {
   renderCampaignDashboardThreadsSwap,
   renderCampaignListContent,
   type CampaignStripState,
+  type CampaignDashboardView,
 } from './web-ui/campaign-pages.ts';
 import { renderDashboardThreads } from './web-ui/campaign-dashboard.ts';
 import { renderCampaignJournal } from './web-ui/campaign-journal.ts';
@@ -1506,10 +1507,11 @@ app.post('/campaigns/:id/leave-web', async (c) => {
 });
 
 /**
- * Render the `/campaigns/:id` dashboard page. Shared by the GET route and the
- * create-character / invite POST error paths so a failed write re-renders in
- * place with an inline banner (SQR-318, SQR-319). Throws `CampaignNotFoundError`
- * for non-members — callers map it to the indistinguishable 404 (ADR 0021).
+ * Render the campaign dashboard page. Shared by the Scenarios/Party GET routes
+ * and the create-character / invite POST error paths so a failed write
+ * re-renders in place with an inline banner (SQR-318, SQR-319). Throws
+ * `CampaignNotFoundError` for non-members — callers map it to the
+ * indistinguishable 404 (ADR 0021).
  */
 async function renderCampaignDashboardPage(
   c: Context,
@@ -1519,6 +1521,7 @@ async function renderCampaignDashboardPage(
     inviteError?: string;
     renameError?: string;
     modulesError?: string;
+    view?: CampaignDashboardView;
   } = {},
   status: 200 | 422 = 200,
 ): Promise<Response> {
@@ -1533,6 +1536,7 @@ async function renderCampaignDashboardPage(
   const gameId = normalizeGameId(detail.campaign.game);
   const gameDef = gameId ? gameDefinitionFor(gameId) : null;
   const dashboardThreads = await dashboardThreadsFragment(detail.campaign, csrfToken);
+  const dashboardView = opts.view ?? 'scenarios';
   // Per-user, never-cached: set on every path through the shared renderer
   // (GET and the create-error re-render) so neither leaks across sessions.
   c.header('Cache-Control', 'no-store');
@@ -1585,9 +1589,14 @@ async function renderCampaignDashboardPage(
           }
         : undefined,
       { openScenarioCount: dashboardThreads?.openScenarioCount },
+      dashboardView,
     ),
   });
   return c.html(body, status);
+}
+
+function campaignPartyViewPath(campaignId: string): string {
+  return `/campaigns/${campaignId}/party`;
 }
 
 app.get('/campaigns/:id', async (c) => {
@@ -1595,6 +1604,18 @@ app.get('/campaigns/:id', async (c) => {
   if (!campaignId) return c.notFound();
   try {
     return await renderCampaignDashboardPage(c, campaignId);
+  } catch (error) {
+    // Non-member and absent are the same 404 page (ADR 0021).
+    if (error instanceof CampaignService.CampaignNotFoundError) return c.notFound();
+    throw error;
+  }
+});
+
+app.get('/campaigns/:id/party', async (c) => {
+  const campaignId = campaignRouteId(c, 'id');
+  if (!campaignId) return c.notFound();
+  try {
+    return await renderCampaignDashboardPage(c, campaignId, { view: 'party' });
   } catch (error) {
     // Non-member and absent are the same 404 page (ADR 0021).
     if (error instanceof CampaignService.CampaignNotFoundError) return c.notFound();
@@ -1623,7 +1644,7 @@ app.post('/campaigns/:id/characters', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { characterError: 'Character name is required.' },
+        { characterError: 'Character name is required.', view: 'party' },
         422,
       );
     }
@@ -1634,7 +1655,7 @@ app.post('/campaigns/:id/characters', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { characterError: 'Class is required.' },
+        { characterError: 'Class is required.', view: 'party' },
         422,
       );
     }
@@ -1645,21 +1666,26 @@ app.post('/campaigns/:id/characters', async (c) => {
       const message = check.suggestion
         ? `Unknown class "${classNameInput}". Did you mean ${check.suggestion}?`
         : `"${classNameInput}" is not a class in this game.`;
-      return await renderCampaignDashboardPage(c, campaignId, { characterError: message }, 422);
+      return await renderCampaignDashboardPage(
+        c,
+        campaignId,
+        { characterError: message, view: 'party' },
+        422,
+      );
     }
     await CharacterService.createCharacter(identity, campaignId, {
       name,
       className: check.canonical,
       level,
     });
-    return c.redirect(`/campaigns/${campaignId}`, 303);
+    return c.redirect(campaignPartyViewPath(campaignId), 303);
   } catch (error) {
     if (error instanceof CampaignService.CampaignNotFoundError) return c.notFound();
     if (error instanceof CampaignService.CampaignForbiddenError) {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { characterError: error.message },
+        { characterError: error.message, view: 'party' },
         422,
       );
     }
@@ -1685,7 +1711,7 @@ app.post('/campaigns/:id/invites', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { inviteError: 'Only the owner can invite members' },
+        { inviteError: 'Only the owner can invite members', view: 'party' },
         422,
       );
     }
@@ -1693,13 +1719,13 @@ app.post('/campaigns/:id/invites', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { inviteError: 'Enter a valid email address.' },
+        { inviteError: 'Enter a valid email address.', view: 'party' },
         422,
       );
     }
     // inviteMember re-checks the owner gate and enforces the allowlist + dedupe.
     await CampaignService.inviteMember(identity, campaignId, email);
-    return c.redirect(`/campaigns/${campaignId}`, 303);
+    return c.redirect(campaignPartyViewPath(campaignId), 303);
   } catch (error) {
     if (error instanceof CampaignService.CampaignNotFoundError) return c.notFound();
     if (
@@ -1707,7 +1733,12 @@ app.post('/campaigns/:id/invites', async (c) => {
       error instanceof CampaignService.NotAllowlistedError ||
       error instanceof CampaignService.AlreadyInvitedError
     ) {
-      return await renderCampaignDashboardPage(c, campaignId, { inviteError: error.message }, 422);
+      return await renderCampaignDashboardPage(
+        c,
+        campaignId,
+        { inviteError: error.message, view: 'party' },
+        422,
+      );
     }
     throw error;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1537,6 +1537,28 @@ async function renderCampaignDashboardPage(
   const gameDef = gameId ? gameDefinitionFor(gameId) : null;
   const dashboardThreads = await dashboardThreadsFragment(detail.campaign, csrfToken);
   const dashboardView = opts.view ?? 'scenarios';
+  const journalFragment =
+    dashboardView === 'scenarios'
+      ? renderCampaignJournal(await listJournal(identity, campaignId))
+      : undefined;
+  const partyCharacters =
+    dashboardView === 'party'
+      ? (await CharacterRepository.listMemberVisibleByCampaign(campaignId)).map((character) => ({
+          id: character.id,
+          name: character.name,
+          className: character.className,
+          level: character.level,
+          placeholder: character.placeholderForEmail !== null,
+        }))
+      : undefined;
+  const characterCreateForm =
+    dashboardView === 'party'
+      ? {
+          csrfToken,
+          classOptions: await knownClassNames(detail.campaign.game),
+          errorMessage: opts.characterError,
+        }
+      : undefined;
   // Per-user, never-cached: set on every path through the shared renderer
   // (GET and the create-error re-render) so neither leaks across sessions.
   c.header('Cache-Control', 'no-store');
@@ -1555,22 +1577,9 @@ async function renderCampaignDashboardPage(
     mainContent: renderCampaignDashboardContent(
       detail,
       dashboardThreads?.html,
-      renderCampaignJournal(await listJournal(identity, campaignId)),
-      // Sheet links (SQR-277): member-visible projection only.
-      (await CharacterRepository.listMemberVisibleByCampaign(campaignId)).map((character) => ({
-        id: character.id,
-        name: character.name,
-        className: character.className,
-        level: character.level,
-        placeholder: character.placeholderForEmail !== null,
-      })),
-      // Create-character form (SQR-318): a select of the game's real class
-      // names structurally prevents an invalid class.
-      {
-        csrfToken,
-        classOptions: await knownClassNames(detail.campaign.game),
-        errorMessage: opts.characterError,
-      },
+      journalFragment,
+      partyCharacters,
+      characterCreateForm,
       // Invite-member affordance (SQR-319): form is owner-only; the error
       // banner still renders for a non-owner who tampers the route.
       { csrfToken, canInvite: isOwner, errorMessage: opts.inviteError },

--- a/src/web-ui/campaign-pages.ts
+++ b/src/web-ui/campaign-pages.ts
@@ -302,6 +302,8 @@ export interface CampaignDashboardHeaderStats {
   openScenarioCount?: number;
 }
 
+export type CampaignDashboardView = 'scenarios' | 'party';
+
 function campaignDashboardHeaderStatsLine(
   campaign: Campaign,
   headerStats?: CampaignDashboardHeaderStats,
@@ -339,6 +341,33 @@ export function renderCampaignDashboardThreadsSwap(input: {
   return html`${renderCampaignDashboardHeaderStats(input.campaign, input.headerStats, {
     outOfBand: true,
   })}${input.threadsFragment}` as HtmlEscapedString;
+}
+
+function renderCampaignDashboardViewNav(
+  campaignId: string,
+  activeView: CampaignDashboardView,
+): HtmlEscapedString {
+  return html`<nav
+    class="squire-campaign-dashboard__view-nav"
+    aria-label="Campaign dashboard sections"
+  >
+    <a
+      class="squire-campaign-dashboard__view-link ${activeView === 'scenarios'
+        ? 'squire-campaign-dashboard__view-link--active'
+        : ''}"
+      href="/campaigns/${campaignId}"
+      ${activeView === 'scenarios' ? html`aria-current="page"` : html``}
+      >Scenarios</a
+    >
+    <a
+      class="squire-campaign-dashboard__view-link ${activeView === 'party'
+        ? 'squire-campaign-dashboard__view-link--active'
+        : ''}"
+      href="/campaigns/${campaignId}/party"
+      ${activeView === 'party' ? html`aria-current="page"` : html``}
+      >Party</a
+    >
+  </nav>` as HtmlEscapedString;
 }
 
 /**
@@ -440,6 +469,7 @@ export function renderCampaignDashboardContent(
   renameForm?: CampaignRenameForm,
   modulesForm?: CampaignModulesForm,
   headerStats?: CampaignDashboardHeaderStats,
+  activeView: CampaignDashboardView = 'scenarios',
 ): HtmlEscapedString {
   const { campaign } = detail;
   const activeMembers = detail.members.filter((member) => member.status === 'active');
@@ -452,64 +482,66 @@ export function renderCampaignDashboardContent(
       ${renameForm ? renderCampaignRenameForm(campaign, renameForm) : html``}
       ${modulesForm ? renderCampaignModulesForm(campaign, modulesForm) : html``}
     </header>
-    <section class="squire-campaign-dashboard__roster" aria-label="Party roster">
-      <h2 class="squire-campaign-dashboard__section-title">Party</h2>
-      <ul class="squire-campaign-dashboard__members">
-        ${activeMembers.map(
-          (member) =>
-            html`<li class="squire-campaign-dashboard__member">
-              ${member.name ?? member.email}
-              <span class="squire-campaign-dashboard__member-role"
-                >${member.role.toUpperCase()}</span
-              >
-            </li>`,
-        )}
-        ${pendingInvites.map(
-          (member) =>
-            html`<li
-              class="squire-campaign-dashboard__member squire-campaign-dashboard__member--invited"
-            >
-              ${member.email}
-              <span class="squire-campaign-dashboard__member-role">INVITED</span>
-            </li>`,
-        )}
-      </ul>
-      ${inviteForm ? renderInviteMemberForm(campaign.id, inviteForm) : html``}
-    </section>
-    <section class="squire-campaign-dashboard__characters" aria-label="Characters">
-      <h2 class="squire-campaign-dashboard__section-title">Characters</h2>
-      ${characters && characters.length > 0
-        ? html`<ul class="squire-campaign-dashboard__members">
-            ${characters.map(
-              (character) =>
-                html`<li class="squire-campaign-dashboard__member">
-                  <a
-                    class="squire-campaign-dashboard__character-link"
-                    href="/characters/${character.id}"
-                    >${character.name}</a
+    ${renderCampaignDashboardViewNav(campaign.id, activeView)}
+    ${activeView === 'scenarios'
+      ? html`${threadsFragment ??
+        html`<section
+          class="squire-campaign-dashboard__threads"
+          id="squire-dashboard-threads"
+          aria-label="Scenario progression"
+        >
+          <p class="squire-campaign-dashboard__placeholder">
+            No scenario data for this campaign's modules yet.
+          </p>
+        </section>`}
+        ${journalFragment ?? html``}`
+      : html`<section class="squire-campaign-dashboard__roster" aria-label="Party roster">
+            <h2 class="squire-campaign-dashboard__section-title">Party</h2>
+            <ul class="squire-campaign-dashboard__members">
+              ${activeMembers.map(
+                (member) =>
+                  html`<li class="squire-campaign-dashboard__member">
+                    ${member.name ?? member.email}
+                    <span class="squire-campaign-dashboard__member-role"
+                      >${member.role.toUpperCase()}</span
+                    >
+                  </li>`,
+              )}
+              ${pendingInvites.map(
+                (member) =>
+                  html`<li
+                    class="squire-campaign-dashboard__member squire-campaign-dashboard__member--invited"
                   >
-                  <span class="squire-campaign-dashboard__member-role"
-                    >${character.className.toUpperCase()} ·
-                    L${character.level}${character.placeholder ? ' · UNCLAIMED' : ''}</span
-                  >
-                </li>`,
-            )}
-          </ul>`
-        : html`<p class="squire-campaign-dashboard__empty">
-            No characters yet — add your first below.
-          </p>`}
-      ${characterCreate ? renderCharacterCreateForm(campaign.id, characterCreate) : html``}
-    </section>
-    ${threadsFragment ??
-    html`<section
-      class="squire-campaign-dashboard__threads"
-      id="squire-dashboard-threads"
-      aria-label="Scenario progression"
-    >
-      <p class="squire-campaign-dashboard__placeholder">
-        No scenario data for this campaign's modules yet.
-      </p>
-    </section>`}
-    ${journalFragment ?? html``}
+                    ${member.email}
+                    <span class="squire-campaign-dashboard__member-role">INVITED</span>
+                  </li>`,
+              )}
+            </ul>
+            ${inviteForm ? renderInviteMemberForm(campaign.id, inviteForm) : html``}
+          </section>
+          <section class="squire-campaign-dashboard__characters" aria-label="Characters">
+            <h2 class="squire-campaign-dashboard__section-title">Characters</h2>
+            ${characters && characters.length > 0
+              ? html`<ul class="squire-campaign-dashboard__members">
+                  ${characters.map(
+                    (character) =>
+                      html`<li class="squire-campaign-dashboard__member">
+                        <a
+                          class="squire-campaign-dashboard__character-link"
+                          href="/characters/${character.id}"
+                          >${character.name}</a
+                        >
+                        <span class="squire-campaign-dashboard__member-role"
+                          >${character.className.toUpperCase()} ·
+                          L${character.level}${character.placeholder ? ' · UNCLAIMED' : ''}</span
+                        >
+                      </li>`,
+                  )}
+                </ul>`
+              : html`<p class="squire-campaign-dashboard__empty">
+                  No characters yet — add your first below.
+                </p>`}
+            ${characterCreate ? renderCharacterCreateForm(campaign.id, characterCreate) : html``}
+          </section>`}
   </section>` as HtmlEscapedString;
 }

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -2302,7 +2302,7 @@ template#squire-banner-fixtures {
 .squire-campaign-dashboard__view-nav {
   display: flex;
   gap: var(--space-lg);
-  align-items: end;
+  align-items: flex-end;
   margin: var(--space-lg) 0 var(--space-md);
   border-bottom: 1px solid var(--rule);
 }

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -2299,6 +2299,39 @@ template#squire-banner-fixtures {
   margin: var(--space-lg) 0 var(--space-sm);
 }
 
+.squire-campaign-dashboard__view-nav {
+  display: flex;
+  gap: var(--space-lg);
+  align-items: end;
+  margin: var(--space-lg) 0 var(--space-md);
+  border-bottom: 1px solid var(--rule);
+}
+
+.squire-campaign-dashboard__view-link {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  padding: 0 0 var(--space-xs);
+  margin-bottom: -1px;
+  border-bottom: 1px solid transparent;
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  color: var(--sepia);
+  text-decoration: none;
+}
+
+.squire-campaign-dashboard__view-link:hover {
+  color: var(--parchment-dim);
+}
+
+.squire-campaign-dashboard__view-link--active,
+.squire-campaign-dashboard__view-link[aria-current='page'] {
+  color: var(--parchment);
+  border-bottom-color: var(--wax);
+}
+
 .squire-campaign-dashboard__member {
   display: flex;
   justify-content: space-between;

--- a/test/campaign-character-create.test.ts
+++ b/test/campaign-character-create.test.ts
@@ -1,11 +1,11 @@
 /**
  * Create-a-character web UI tests (SQR-318).
  *
- * The dashboard Characters section always renders a "New character" form
- * (a class select sourced from the game's real class names). Posting it
- * creates the character on the active campaign under the caller's identity;
- * an unknown/codename class is rejected with an inline banner; a non-member
- * gets the indistinguishable 404.
+ * The dashboard Party view renders a "New character" form (a class select
+ * sourced from the game's real class names). Posting it creates the character
+ * on the active campaign under the caller's identity; an unknown/codename
+ * class is rejected with an inline banner; a non-member gets the
+ * indistinguishable 404.
  */
 import { generateSignedCookie } from 'hono/cookie';
 import { inArray } from 'drizzle-orm';
@@ -134,7 +134,7 @@ afterAll(async () => {
 describe('create-character UI (SQR-318)', () => {
   it('renders a New character form with a class select of real class names', async () => {
     const { owner, campaign } = await setupFixture();
-    const res = await app.request(`/campaigns/${campaign.id}`, {
+    const res = await app.request(`/campaigns/${campaign.id}/party`, {
       headers: { Cookie: owner.cookie },
     });
     expect(res.status).toBe(200);
@@ -156,9 +156,9 @@ describe('create-character UI (SQR-318)', () => {
       level: '3',
     });
     expect(created.status).toBe(303);
-    expect(created.headers.get('location')).toBe(`/campaigns/${campaign.id}`);
+    expect(created.headers.get('location')).toBe(`/campaigns/${campaign.id}/party`);
 
-    const dash = await app.request(`/campaigns/${campaign.id}`, {
+    const dash = await app.request(`/campaigns/${campaign.id}/party`, {
       headers: { Cookie: owner.cookie },
     });
     const body = await dash.text();
@@ -176,7 +176,7 @@ describe('create-character UI (SQR-318)', () => {
       level: '1',
     });
     expect(created.status).toBe(303);
-    const dash = await app.request(`/campaigns/${campaign.id}`, {
+    const dash = await app.request(`/campaigns/${campaign.id}/party`, {
       headers: { Cookie: owner.cookie },
     });
     expect((await dash.text()).replace(/\s+/g, ' ')).toContain('BANNER SPEAR · L1');
@@ -195,7 +195,7 @@ describe('create-character UI (SQR-318)', () => {
     expect(body).toContain('not a class in this game');
 
     // Nothing was created — the roster is still empty.
-    const dash = await app.request(`/campaigns/${campaign.id}`, {
+    const dash = await app.request(`/campaigns/${campaign.id}/party`, {
       headers: { Cookie: owner.cookie },
     });
     expect(await dash.text()).toContain('No characters yet');

--- a/test/campaign-dashboard.test.ts
+++ b/test/campaign-dashboard.test.ts
@@ -163,6 +163,40 @@ afterAll(async () => {
 });
 
 describe('dashboard rendering', () => {
+  it('defaults to the Scenarios view and keeps Party management one link away', async () => {
+    const { owner, campaign } = await setupFixture();
+    const res = await app.request(`/campaigns/${campaign.id}`, {
+      headers: { Cookie: owner.cookie },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+
+    expect(body).toContain('squire-campaign-dashboard__view-nav');
+    expect(body).toMatch(new RegExp(`href="/campaigns/${campaign.id}"[^>]*aria-current="page"`));
+    expect(body).toContain(`href="/campaigns/${campaign.id}/party"`);
+    expect(body).toContain('aria-label="Scenario progression"');
+    expect(body).not.toContain('aria-label="Party roster"');
+    expect(body).not.toContain('squire-character-create');
+  });
+
+  it('renders the deep-linked Party view without the scenario flow', async () => {
+    const { owner, campaign } = await setupFixture();
+    const res = await app.request(`/campaigns/${campaign.id}/party`, {
+      headers: { Cookie: owner.cookie },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+
+    expect(body).toMatch(
+      new RegExp(`href="/campaigns/${campaign.id}/party"[^>]*aria-current="page"`),
+    );
+    expect(body).toContain(`href="/campaigns/${campaign.id}"`);
+    expect(body).toContain('aria-label="Party roster"');
+    expect(body).toContain('aria-label="Characters"');
+    expect(body).not.toContain('aria-label="Scenario progression"');
+    expect(body).not.toContain('squire-dashboard-grid');
+  });
+
   it('renders threads, statuses, stats, and adjacent hazard banners', async () => {
     const { owner, campaign } = await setupFixture();
     const res = await app.request(`/campaigns/${campaign.id}`, {

--- a/test/campaign-invite-member.test.ts
+++ b/test/campaign-invite-member.test.ts
@@ -1,7 +1,7 @@
 /**
  * Invite-a-member web UI tests (SQR-319).
  *
- * The dashboard Party section carries an owner-only "Invite member" form.
+ * The dashboard Party view carries an owner-only "Invite member" form.
  * Posting it creates a pending invite (shown distinctly in the roster);
  * non-owners never see the form and the route rejects them; invalid /
  * not-allowlisted / duplicate emails surface inline; a non-member gets the
@@ -108,13 +108,17 @@ describe('invite-member UI (SQR-319)', () => {
     const member = await addActiveMember(owner, campaign.id, MEMBER_EMAIL);
 
     const ownerView = await (
-      await app.request(`/campaigns/${campaign.id}`, { headers: { Cookie: owner.cookie } })
+      await app.request(`/campaigns/${campaign.id}/party`, {
+        headers: { Cookie: owner.cookie },
+      })
     ).text();
     expect(ownerView).toContain('squire-invite-member');
     expect(ownerView).toContain('INVITE BY EMAIL');
 
     const memberView = await (
-      await app.request(`/campaigns/${campaign.id}`, { headers: { Cookie: member.cookie } })
+      await app.request(`/campaigns/${campaign.id}/party`, {
+        headers: { Cookie: member.cookie },
+      })
     ).text();
     expect(memberView).not.toContain('squire-invite-member');
   });
@@ -123,10 +127,12 @@ describe('invite-member UI (SQR-319)', () => {
     const { owner, campaign } = await setupFixture();
     const res = await invite(owner, campaign.id, INVITEE_EMAIL);
     expect(res.status).toBe(303);
-    expect(res.headers.get('location')).toBe(`/campaigns/${campaign.id}`);
+    expect(res.headers.get('location')).toBe(`/campaigns/${campaign.id}/party`);
 
     const dash = await (
-      await app.request(`/campaigns/${campaign.id}`, { headers: { Cookie: owner.cookie } })
+      await app.request(`/campaigns/${campaign.id}/party`, {
+        headers: { Cookie: owner.cookie },
+      })
     ).text();
     expect(dash).toContain(INVITEE_EMAIL);
     expect(dash).toContain('INVITED');

--- a/test/character-sheet.test.ts
+++ b/test/character-sheet.test.ts
@@ -291,9 +291,9 @@ describe('items section', () => {
 });
 
 describe('dashboard reachability', () => {
-  it('links each character from the campaign dashboard', async () => {
+  it('links each character from the campaign party view', async () => {
     const { owner, campaign, character } = await setupSheetFixture();
-    const res = await app.request(`/campaigns/${campaign.id}`, {
+    const res = await app.request(`/campaigns/${campaign.id}/party`, {
       headers: { Cookie: owner.cookie },
     });
     const body = await res.text();


### PR DESCRIPTION
## Summary
- Default campaign dashboards now open the Scenarios view at `/campaigns/:id`.
- Party management now has the path route `/campaigns/:id/party`, and the dashboard nav uses normal anchors for both views.
- Character creation and invite success/error paths return to the Party view.
- DESIGN.md and ADR 0023 record the path-backed route decision; ADR 0022 is preserved as the superseded query-param decision.

Fixes SQR-322

## Test plan
- [x] `npm run check` static phases passed: typecheck, eslint, stylelint, markdownlint, Prettier. The combined Vitest phase was interrupted after several silent minutes to isolate the slow runner.
- [x] `npm run test:unit -- --reporter=verbose` — 115 files, 1266 tests passed in 229.66s.
- [x] `npm run test:db -- --reporter=verbose` — 40 files, 586 tests passed in 464.75s.
- [x] `git diff --check`
- [x] Browser smoke on local dev: verified `/campaigns/:id` and `/campaigns/:id/party` on desktop and mobile widths, with no console errors and no horizontal overflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Campaign dashboard now has two views—**Scenarios** (default) and **Party**—using clean, shareable URLs.
  * View switching uses standard links (no JavaScript required).
  * Scenarios shows progression/threads; Party shows roster, pending invites, and character management.
  * After creating characters or sending invites, users are routed to the **Party** view.
* **UI Enhancements**
  * Added view navigation styling and active-state indication (including accessible current-page marking).
* **Documentation**
  * Updated the information-architecture and ADR guidance to reflect path-based segmentation.
* **Tests**
  * Adjusted and added dashboard/invite/create reachability tests for the new routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->