### PR TITLE
feat(campaigns): build active and retired party roster

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1567,6 +1567,7 @@ async function renderCampaignDashboardPage(
       characterId: string;
       message: string;
       action: 'level' | 'retire' | 'remove';
+      levelValue?: string;
     };
     inviteError?: string;
     renameError?: string;
@@ -1807,6 +1808,7 @@ async function renderCharacterActionErrorPage(
   characterId: string,
   action: 'level' | 'retire' | 'remove',
   fallbackName: string,
+  details: { levelValue?: string } = {},
   error?: unknown,
 ): Promise<Response> {
   if (error instanceof CampaignService.CampaignNotFoundError) return c.notFound();
@@ -1820,6 +1822,7 @@ async function renderCharacterActionErrorPage(
         characterId,
         action,
         message: characterActionFailureMessage(action, name),
+        levelValue: details.levelValue,
       },
     },
     422,
@@ -1845,16 +1848,29 @@ app.post('/campaigns/:id/characters/:characterId/level', async (c) => {
   const form = await c.req.formData();
   const expectedVersion = formInt(form, 'expectedVersion');
   const level = formInt(form, 'level');
+  const levelValue = formString(form, 'level') ?? '';
   let name = '';
   try {
     name = await requirePartyCharacterName(identity, campaignId, characterId);
     if (expectedVersion === null || level === null || level < 1 || level > 20) {
-      return await renderCharacterActionErrorPage(c, campaignId, characterId, 'level', name);
+      return await renderCharacterActionErrorPage(c, campaignId, characterId, 'level', name, {
+        levelValue,
+      });
     }
     await CharacterService.updateCharacter(identity, characterId, { expectedVersion, level });
     return c.redirect(campaignPartyViewPath(campaignId), 303);
   } catch (error) {
-    return renderCharacterActionErrorPage(c, campaignId, characterId, 'level', name, error);
+    return renderCharacterActionErrorPage(
+      c,
+      campaignId,
+      characterId,
+      'level',
+      name,
+      {
+        levelValue,
+      },
+      error,
+    );
   }
 });
 
@@ -1886,7 +1902,7 @@ app.post('/campaigns/:id/characters/:characterId/retire', async (c) => {
     });
     return c.redirect(campaignPartyViewPath(campaignId), 303);
   } catch (error) {
-    return renderCharacterActionErrorPage(c, campaignId, characterId, 'retire', name, error);
+    return renderCharacterActionErrorPage(c, campaignId, characterId, 'retire', name, {}, error);
   }
 });
 
@@ -1909,7 +1925,7 @@ app.post('/campaigns/:id/characters/:characterId/remove', async (c) => {
     });
     return c.redirect(campaignPartyViewPath(campaignId), 303);
   } catch (error) {
-    return renderCharacterActionErrorPage(c, campaignId, characterId, 'remove', name, error);
+    return renderCharacterActionErrorPage(c, campaignId, characterId, 'remove', name, {}, error);
   }
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1563,6 +1563,11 @@ async function renderCampaignDashboardPage(
   campaignId: string,
   opts: {
     characterError?: string;
+    characterActionError?: {
+      characterId: string;
+      message: string;
+      action: 'level' | 'retire' | 'remove';
+    };
     inviteError?: string;
     renameError?: string;
     modulesError?: string;
@@ -1596,7 +1601,10 @@ async function renderCampaignDashboardPage(
           name: character.name,
           className: character.className,
           level: character.level,
+          status: character.status,
+          version: character.version,
           placeholder: character.placeholderForEmail !== null,
+          own: character.ownerUserId === identity.userId,
         }))
       : undefined;
   const characterCreateForm =
@@ -1629,6 +1637,7 @@ async function renderCampaignDashboardPage(
       journalFragment,
       partyCharacters,
       characterCreateForm,
+      opts.characterActionError,
       // Invite-member affordance (SQR-319): form is owner-only; the error
       // banner still renders for a non-owner who tampers the route.
       { csrfToken, canInvite: isOwner, errorMessage: opts.inviteError },
@@ -1780,6 +1789,127 @@ app.post('/campaigns/:id/characters', async (c) => {
       );
     }
     throw error;
+  }
+});
+
+function characterActionFailureMessage(
+  action: 'level' | 'retire' | 'remove',
+  name: string,
+): string {
+  if (action === 'level') return `Could not update ${name}.`;
+  if (action === 'retire') return `Could not retire ${name}.`;
+  return `Could not remove ${name}.`;
+}
+
+async function renderCharacterActionErrorPage(
+  c: Context,
+  campaignId: string,
+  characterId: string,
+  action: 'level' | 'retire' | 'remove',
+  fallbackName: string,
+  error?: unknown,
+): Promise<Response> {
+  if (error instanceof CampaignService.CampaignNotFoundError) return c.notFound();
+  const name = fallbackName || 'character';
+  return renderCampaignDashboardPage(
+    c,
+    campaignId,
+    {
+      view: 'party',
+      characterActionError: {
+        characterId,
+        action,
+        message: characterActionFailureMessage(action, name),
+      },
+    },
+    422,
+  );
+}
+
+async function requirePartyCharacterName(
+  identity: CallerIdentity,
+  campaignId: string,
+  characterId: string,
+): Promise<string> {
+  const detail = await CharacterService.getCharacterDetail(identity, characterId);
+  if (detail.character.campaignId !== campaignId) throw new CampaignService.CampaignNotFoundError();
+  return detail.character.name;
+}
+
+app.post('/campaigns/:id/characters/:characterId/level', async (c) => {
+  const session = c.get('session')!;
+  const campaignId = campaignRouteId(c, 'id');
+  const characterId = campaignRouteId(c, 'characterId');
+  if (!campaignId || !characterId) return c.notFound();
+  const identity = identityFromSessionUser(session.userId);
+  const form = await c.req.formData();
+  const expectedVersion = formInt(form, 'expectedVersion');
+  const level = formInt(form, 'level');
+  let name = '';
+  try {
+    name = await requirePartyCharacterName(identity, campaignId, characterId);
+    if (expectedVersion === null || level === null || level < 1 || level > 20) {
+      return await renderCharacterActionErrorPage(c, campaignId, characterId, 'level', name);
+    }
+    await CharacterService.updateCharacter(identity, characterId, { expectedVersion, level });
+    return c.redirect(campaignPartyViewPath(campaignId), 303);
+  } catch (error) {
+    return renderCharacterActionErrorPage(c, campaignId, characterId, 'level', name, error);
+  }
+});
+
+async function confirmPartyCharacterProposal(
+  identity: CallerIdentity,
+  campaignId: string,
+  mutation: PendingMutations.StagedMutation,
+): Promise<void> {
+  const proposal = await PendingMutations.propose(identity, campaignId, mutation);
+  await PendingMutations.confirm(identity, proposal.id);
+}
+
+app.post('/campaigns/:id/characters/:characterId/retire', async (c) => {
+  const session = c.get('session')!;
+  const campaignId = campaignRouteId(c, 'id');
+  const characterId = campaignRouteId(c, 'characterId');
+  if (!campaignId || !characterId) return c.notFound();
+  const identity = identityFromSessionUser(session.userId);
+  const form = await c.req.formData();
+  let name = '';
+  try {
+    name = await requirePartyCharacterName(identity, campaignId, characterId);
+    if (formString(form, 'confirm') !== 'retire') {
+      return await renderCharacterActionErrorPage(c, campaignId, characterId, 'retire', name);
+    }
+    await confirmPartyCharacterProposal(identity, campaignId, {
+      type: 'character.retire',
+      characterId,
+    });
+    return c.redirect(campaignPartyViewPath(campaignId), 303);
+  } catch (error) {
+    return renderCharacterActionErrorPage(c, campaignId, characterId, 'retire', name, error);
+  }
+});
+
+app.post('/campaigns/:id/characters/:characterId/remove', async (c) => {
+  const session = c.get('session')!;
+  const campaignId = campaignRouteId(c, 'id');
+  const characterId = campaignRouteId(c, 'characterId');
+  if (!campaignId || !characterId) return c.notFound();
+  const identity = identityFromSessionUser(session.userId);
+  const form = await c.req.formData();
+  let name = '';
+  try {
+    name = await requirePartyCharacterName(identity, campaignId, characterId);
+    if (formString(form, 'confirm') !== 'remove') {
+      return await renderCharacterActionErrorPage(c, campaignId, characterId, 'remove', name);
+    }
+    await confirmPartyCharacterProposal(identity, campaignId, {
+      type: 'character.delete',
+      characterId,
+    });
+    return c.redirect(campaignPartyViewPath(campaignId), 303);
+  } catch (error) {
+    return renderCharacterActionErrorPage(c, campaignId, characterId, 'remove', name, error);
   }
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1572,6 +1572,11 @@ async function renderCampaignDashboardPage(
     inviteError?: string;
     renameError?: string;
     modulesError?: string;
+    characterFormValues?: {
+      nameValue?: string;
+      classNameValue?: string;
+      levelValue?: string;
+    };
     view?: CampaignDashboardView;
   } = {},
   status: 200 | 422 = 200,
@@ -1614,6 +1619,7 @@ async function renderCampaignDashboardPage(
           csrfToken,
           classOptions: await knownClassNames(detail.campaign.game),
           errorMessage: opts.characterError,
+          ...opts.characterFormValues,
         }
       : undefined;
   // Per-user, never-cached: set on every path through the shared renderer
@@ -1734,8 +1740,14 @@ app.post('/campaigns/:id/characters', async (c) => {
   const classNameInput =
     typeof form.get('className') === 'string' ? (form.get('className') as string).trim() : '';
   const levelRaw = form.get('level');
+  const levelValue = typeof levelRaw === 'string' ? levelRaw : '1';
   const levelNum = typeof levelRaw === 'string' ? Number.parseInt(levelRaw, 10) : Number.NaN;
   const level = Number.isFinite(levelNum) ? Math.min(20, Math.max(1, levelNum)) : 1;
+  const characterFormValues = {
+    nameValue: name,
+    classNameValue: classNameInput,
+    levelValue,
+  };
 
   try {
     // getCampaignDetail gates membership: a non-member gets the 404 below.
@@ -1744,7 +1756,7 @@ app.post('/campaigns/:id/characters', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { characterError: 'Character name is required.', view: 'party' },
+        { characterError: 'Character name is required.', characterFormValues, view: 'party' },
         422,
       );
     }
@@ -1755,7 +1767,7 @@ app.post('/campaigns/:id/characters', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { characterError: 'Class is required.', view: 'party' },
+        { characterError: 'Class is required.', characterFormValues, view: 'party' },
         422,
       );
     }
@@ -1769,7 +1781,7 @@ app.post('/campaigns/:id/characters', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { characterError: message, view: 'party' },
+        { characterError: message, characterFormValues, view: 'party' },
         422,
       );
     }
@@ -1785,7 +1797,7 @@ app.post('/campaigns/:id/characters', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { characterError: error.message, view: 'party' },
+        { characterError: error.message, characterFormValues, view: 'party' },
         422,
       );
     }

--- a/src/web-ui/campaign-pages.ts
+++ b/src/web-ui/campaign-pages.ts
@@ -196,6 +196,9 @@ export interface CharacterCreateForm {
   classOptions: string[];
   /** Inline error rendered above the form after a failed create attempt. */
   errorMessage?: string;
+  nameValue?: string;
+  classNameValue?: string;
+  levelValue?: string;
 }
 
 export interface CharacterActionError {
@@ -231,13 +234,28 @@ function renderCharacterCreateForm(
         <input type="hidden" name="_csrf" value="${data.csrfToken}" />
         <label class="squire-character-create__field">
           <span class="squire-character-create__field-label">NAME</span>
-          <input name="name" type="text" required maxlength="100" autocomplete="off" />
+          <input
+            name="name"
+            type="text"
+            required
+            maxlength="100"
+            autocomplete="off"
+            value="${data.nameValue ?? ''}"
+          />
         </label>
         <label class="squire-character-create__field">
           <span class="squire-character-create__field-label">CLASS</span>
           ${data.classOptions.length > 0
             ? html`<select name="className" required>
-                ${data.classOptions.map((cls) => html`<option value="${cls}">${cls}</option>`)}
+                ${data.classOptions.map(
+                  (cls) =>
+                    html`<option
+                      value="${cls}"
+                      ${data.classNameValue === cls ? raw('selected') : raw('')}
+                    >
+                      ${cls}
+                    </option>`,
+                )}
               </select>`
             : html`<input
                 name="className"
@@ -245,11 +263,12 @@ function renderCharacterCreateForm(
                 required
                 maxlength="100"
                 autocomplete="off"
+                value="${data.classNameValue ?? ''}"
               />`}
         </label>
         <label class="squire-character-create__field">
           <span class="squire-character-create__field-label">LEVEL</span>
-          <input name="level" type="number" min="1" max="20" value="1" />
+          <input name="level" type="number" min="1" max="20" value="${data.levelValue ?? '1'}" />
         </label>
         <button type="submit" class="squire-character-create__submit">ADD CHARACTER</button>
       </form>

--- a/src/web-ui/campaign-pages.ts
+++ b/src/web-ui/campaign-pages.ts
@@ -202,6 +202,7 @@ export interface CharacterActionError {
   characterId: string;
   message: string;
   action: 'level' | 'retire' | 'remove';
+  levelValue?: string;
 }
 
 /** The dashboard Characters section: existing sheet links + the create form. */
@@ -315,6 +316,8 @@ function renderCharacterLevelAction(
   actionError?: CharacterActionError,
 ): HtmlEscapedString {
   const open = actionError?.characterId === character.id && actionError.action === 'level';
+  const value =
+    open && actionError.levelValue !== undefined ? actionError.levelValue : character.level;
   return html`<details
     class="squire-party-row__action squire-party-row__action--level"
     ${open ? raw('open') : raw('')}
@@ -323,9 +326,10 @@ function renderCharacterLevelAction(
     <form method="post" action="/campaigns/${campaignId}/characters/${character.id}/level">
       <input type="hidden" name="_csrf" value="${csrfToken}" />
       <input type="hidden" name="expectedVersion" value="${character.version}" />
+      ${open ? renderCharacterActionError(character, actionError) : html``}
       <label>
         <span>Level</span>
-        <input name="level" type="number" min="1" max="20" value="${character.level}" />
+        <input name="level" type="number" min="1" max="20" value="${value}" />
       </label>
       <button type="submit">Save</button>
     </form>
@@ -351,6 +355,7 @@ function renderCharacterConfirmAction(input: {
     <summary aria-label="${input.label} ${input.character.name}">${input.label}</summary>
     <div class="squire-party-row__confirm">
       <p>${input.label} ${input.character.name}?</p>
+      ${open ? renderCharacterActionError(input.character, input.actionError) : html``}
       <form
         method="post"
         action="/campaigns/${input.campaignId}/characters/${input.character.id}/${input.action}"
@@ -358,6 +363,7 @@ function renderCharacterConfirmAction(input: {
         <input type="hidden" name="_csrf" value="${input.csrfToken}" />
         <input type="hidden" name="confirm" value="${input.confirmValue}" />
         <button type="submit">Confirm ${input.label.toLowerCase()}</button>
+        <a class="squire-party-row__cancel" href="/campaigns/${input.campaignId}/party"> Cancel </a>
       </form>
     </div>
   </details>` as HtmlEscapedString;
@@ -398,19 +404,18 @@ function renderPartyCharacterRow(input: {
             label: 'Retire',
             confirmValue: 'retire',
             actionError: input.actionError,
-          })}
-          ${renderCharacterConfirmAction({
-            campaignId: input.campaignId,
-            csrfToken: input.csrfToken,
-            character,
-            action: 'remove',
-            label: 'Remove',
-            confirmValue: 'remove',
-            actionError: input.actionError,
           })}`
         : html``}
+      ${renderCharacterConfirmAction({
+        campaignId: input.campaignId,
+        csrfToken: input.csrfToken,
+        character,
+        action: 'remove',
+        label: 'Remove',
+        confirmValue: 'remove',
+        actionError: input.actionError,
+      })}
     </div>
-    ${renderCharacterActionError(character, input.actionError)}
   </li>` as HtmlEscapedString;
 }
 

--- a/src/web-ui/campaign-pages.ts
+++ b/src/web-ui/campaign-pages.ts
@@ -12,7 +12,7 @@ import { html, raw } from 'hono/html';
 import type { HtmlEscapedString } from 'hono/utils/html';
 
 import type { CampaignDetail, PendingInvite } from '../campaign/campaign-service.ts';
-import type { Campaign } from '../db/repositories/types.ts';
+import type { Campaign, CharacterStatus } from '../db/repositories/types.ts';
 import { allOptionalModuleOptions, gameDefinitionFor, isGameId, moduleLabel } from '../game.ts';
 import { renderDashboardProgressEmpty } from './campaign-dashboard.ts';
 
@@ -179,7 +179,10 @@ export interface DashboardCharacterRow {
   name: string;
   className: string;
   level: number;
+  status: CharacterStatus;
+  version: number;
   placeholder: boolean;
+  own: boolean;
 }
 
 /** The "New character" create form on the dashboard (SQR-318). */
@@ -195,17 +198,23 @@ export interface CharacterCreateForm {
   errorMessage?: string;
 }
 
+export interface CharacterActionError {
+  characterId: string;
+  message: string;
+  action: 'level' | 'retire' | 'remove';
+}
+
 /** The dashboard Characters section: existing sheet links + the create form. */
 function renderCharacterCreateForm(
   campaignId: string,
   data: CharacterCreateForm,
 ): HtmlEscapedString {
   return html`<details
-    class="squire-section-reveal squire-character-create-reveal"
+    class="squire-party-section__add squire-character-create-reveal"
     ${data.errorMessage ? raw('open') : raw('')}
   >
-    <summary class="squire-section-reveal__summary">Add character</summary>
-    <div class="squire-section-reveal__body">
+    <summary class="squire-party-section__add-summary">Add character</summary>
+    <div class="squire-party-section__add-body">
       ${data.errorMessage
         ? html`<div class="squire-banner squire-banner--error" role="alert">
             <span class="squire-banner__label">COULD NOT SAVE</span>
@@ -285,27 +294,178 @@ function renderInviteMemberForm(campaignId: string, data: InviteMemberForm): Htm
     : html``}` as HtmlEscapedString;
 }
 
-function renderDashboardCharacters(characters?: DashboardCharacterRow[]): HtmlEscapedString {
-  if (!characters || characters.length === 0) {
-    return html`<p class="squire-campaign-dashboard__empty">
-      No characters yet — add your first below.
-    </p>` as HtmlEscapedString;
-  }
-  return html`<ul class="squire-campaign-dashboard__characters">
-    ${characters.map(
-      (character) =>
-        html`<li class="squire-campaign-dashboard__character">
-          <a class="squire-campaign-dashboard__character-link" href="/characters/${character.id}">
-            <span class="squire-campaign-dashboard__character-name">${character.name}</span>
-            <span class="squire-campaign-dashboard__character-class">${character.className}</span>
-            <span class="squire-campaign-dashboard__character-level">Level ${character.level}</span>
-            ${character.placeholder
-              ? html`<span class="squire-campaign-dashboard__character-note">Unclaimed</span>`
-              : html``}
-          </a>
-        </li>`,
-    )}
-  </ul>` as HtmlEscapedString;
+function compactCharacterClass(character: DashboardCharacterRow): string {
+  return `${character.className} ${character.level}`;
+}
+
+function renderCharacterActionError(
+  character: DashboardCharacterRow,
+  actionError?: CharacterActionError,
+): HtmlEscapedString {
+  if (!actionError || actionError.characterId !== character.id) return html`` as HtmlEscapedString;
+  return html`<div class="squire-party-row__error" role="alert">
+    ${actionError.message}
+  </div>` as HtmlEscapedString;
+}
+
+function renderCharacterLevelAction(
+  campaignId: string,
+  csrfToken: string,
+  character: DashboardCharacterRow,
+  actionError?: CharacterActionError,
+): HtmlEscapedString {
+  const open = actionError?.characterId === character.id && actionError.action === 'level';
+  return html`<details
+    class="squire-party-row__action squire-party-row__action--level"
+    ${open ? raw('open') : raw('')}
+  >
+    <summary aria-label="Level ${character.name}">Level</summary>
+    <form method="post" action="/campaigns/${campaignId}/characters/${character.id}/level">
+      <input type="hidden" name="_csrf" value="${csrfToken}" />
+      <input type="hidden" name="expectedVersion" value="${character.version}" />
+      <label>
+        <span>Level</span>
+        <input name="level" type="number" min="1" max="20" value="${character.level}" />
+      </label>
+      <button type="submit">Save</button>
+    </form>
+  </details>` as HtmlEscapedString;
+}
+
+function renderCharacterConfirmAction(input: {
+  campaignId: string;
+  csrfToken: string;
+  character: DashboardCharacterRow;
+  action: 'retire' | 'remove';
+  label: string;
+  confirmValue: string;
+  actionError?: CharacterActionError;
+}): HtmlEscapedString {
+  const open =
+    input.actionError?.characterId === input.character.id &&
+    input.actionError.action === input.action;
+  return html`<details
+    class="squire-party-row__action squire-party-row__action--${input.action}"
+    ${open ? raw('open') : raw('')}
+  >
+    <summary aria-label="${input.label} ${input.character.name}">${input.label}</summary>
+    <div class="squire-party-row__confirm">
+      <p>${input.label} ${input.character.name}?</p>
+      <form
+        method="post"
+        action="/campaigns/${input.campaignId}/characters/${input.character.id}/${input.action}"
+      >
+        <input type="hidden" name="_csrf" value="${input.csrfToken}" />
+        <input type="hidden" name="confirm" value="${input.confirmValue}" />
+        <button type="submit">Confirm ${input.label.toLowerCase()}</button>
+      </form>
+    </div>
+  </details>` as HtmlEscapedString;
+}
+
+function renderPartyCharacterRow(input: {
+  campaignId: string;
+  csrfToken: string;
+  character: DashboardCharacterRow;
+  actionError?: CharacterActionError;
+}): HtmlEscapedString {
+  const { character } = input;
+  const inactive = character.status !== 'active';
+  return html`<li
+    class="squire-party-row ${inactive ? 'squire-party-row--retired' : 'squire-party-row--active'}"
+  >
+    <div class="squire-party-row__identity">
+      <span class="squire-party-row__name">${character.name}</span>
+      ${character.placeholder
+        ? html`<span class="squire-party-row__note">Unclaimed</span>`
+        : html``}
+    </div>
+    <span class="squire-party-row__class">${compactCharacterClass(character)}</span>
+    <div class="squire-party-row__actions">
+      <a class="squire-party-row__link" href="/characters/${character.id}">Open sheet</a>
+      ${character.status === 'active'
+        ? html`${renderCharacterLevelAction(
+            input.campaignId,
+            input.csrfToken,
+            character,
+            input.actionError,
+          )}
+          ${renderCharacterConfirmAction({
+            campaignId: input.campaignId,
+            csrfToken: input.csrfToken,
+            character,
+            action: 'retire',
+            label: 'Retire',
+            confirmValue: 'retire',
+            actionError: input.actionError,
+          })}
+          ${renderCharacterConfirmAction({
+            campaignId: input.campaignId,
+            csrfToken: input.csrfToken,
+            character,
+            action: 'remove',
+            label: 'Remove',
+            confirmValue: 'remove',
+            actionError: input.actionError,
+          })}`
+        : html``}
+    </div>
+    ${renderCharacterActionError(character, input.actionError)}
+  </li>` as HtmlEscapedString;
+}
+
+function renderPartyCharacterSection(input: {
+  campaignId: string;
+  csrfToken: string;
+  title: string;
+  characters: DashboardCharacterRow[];
+  empty: string;
+  actionError?: CharacterActionError;
+}): HtmlEscapedString {
+  return html`<section class="squire-party-roster__group" aria-label="${input.title}">
+    <h3 class="squire-party-roster__group-title">${input.title}</h3>
+    ${input.characters.length === 0
+      ? html`<p class="squire-party-roster__empty">${input.empty}</p>`
+      : html`<ul class="squire-party-roster__rows">
+          ${input.characters.map((character) =>
+            renderPartyCharacterRow({
+              campaignId: input.campaignId,
+              csrfToken: input.csrfToken,
+              character,
+              actionError: input.actionError,
+            }),
+          )}
+        </ul>`}
+  </section>` as HtmlEscapedString;
+}
+
+function renderPartyRoster(input: {
+  campaignId: string;
+  csrfToken: string;
+  characters?: DashboardCharacterRow[];
+  actionError?: CharacterActionError;
+}): HtmlEscapedString {
+  const characters = input.characters ?? [];
+  const active = characters.filter((character) => character.status === 'active');
+  const retired = characters.filter((character) => character.status === 'retired');
+  return html`<div class="squire-party-roster">
+    ${renderPartyCharacterSection({
+      campaignId: input.campaignId,
+      csrfToken: input.csrfToken,
+      title: 'Active characters',
+      characters: active,
+      empty: 'No active characters yet.',
+      actionError: input.actionError,
+    })}
+    ${renderPartyCharacterSection({
+      campaignId: input.campaignId,
+      csrfToken: input.csrfToken,
+      title: 'Retired characters',
+      characters: retired,
+      empty: 'No retired characters yet.',
+      actionError: input.actionError,
+    })}
+  </div>` as HtmlEscapedString;
 }
 
 function renderPendingInvites(pendingInvites: CampaignDetail['members']): HtmlEscapedString {
@@ -597,6 +757,7 @@ export function renderCampaignDashboardContent(
   journalFragment?: HtmlEscapedString,
   characters?: DashboardCharacterRow[],
   characterCreate?: CharacterCreateForm,
+  characterActionError?: CharacterActionError,
   inviteForm?: InviteMemberForm,
   renameForm?: CampaignRenameForm,
   modulesForm?: CampaignModulesForm,
@@ -615,9 +776,25 @@ export function renderCampaignDashboardContent(
         : html``}
       ${activeView === 'party'
         ? html`<section class="squire-campaign-dashboard__party" aria-label="Party">
-            <h2 class="squire-campaign-dashboard__section-title">Party</h2>
-            ${renderDashboardCharacters(characters)}
-            ${characterCreate ? renderCharacterCreateForm(campaign.id, characterCreate) : html``}
+            <header class="squire-party-section__header">
+              <div>
+                <h2 class="squire-campaign-dashboard__section-title">Party</h2>
+                <p class="squire-party-section__lede">
+                  Manage active and retired player characters for this campaign.
+                </p>
+              </div>
+              <div class="squire-party-section__action">
+                ${characterCreate
+                  ? renderCharacterCreateForm(campaign.id, characterCreate)
+                  : html``}
+              </div>
+            </header>
+            ${renderPartyRoster({
+              campaignId: campaign.id,
+              csrfToken: characterCreate?.csrfToken ?? '',
+              characters,
+              actionError: characterActionError,
+            })}
           </section>`
         : html``}
       ${activeView === 'players'

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -1302,6 +1302,25 @@ document.addEventListener('keydown', function (event) {
   trapHistoryDrawerFocus(event);
 });
 
+document.addEventListener('submit', function (event) {
+  var form = event.target;
+  if (
+    !form ||
+    !form.matches ||
+    !form.matches('.squire-character-create, .squire-party-row__action form')
+  ) {
+    return;
+  }
+  if (form.dataset.submitting === 'true') {
+    event.preventDefault();
+    return;
+  }
+  form.dataset.submitting = 'true';
+  form.setAttribute('aria-busy', 'true');
+  var submitButton = form.querySelector('button[type="submit"]');
+  if (submitButton) submitButton.setAttribute('disabled', 'true');
+});
+
 document.addEventListener('submit', function (e) {
   var form = e.target;
   if (!form || !form.matches || !form.matches('.squire-input-dock')) return;

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -3020,7 +3020,7 @@ template#squire-banner-fixtures {
   margin-top: var(--space-sm);
   padding: var(--space-md);
   border: 1px solid var(--rule);
-  border-radius: 6px;
+  border-radius: 8px;
   background: var(--surface-2);
   box-shadow: 0 16px 40px rgb(0 0 0 / 0.35);
 }
@@ -3053,7 +3053,7 @@ template#squire-banner-fixtures {
   margin: 0;
   padding: 0;
   border: 1px solid var(--rule);
-  border-radius: 6px;
+  border-radius: 8px;
   overflow: visible;
 }
 
@@ -3116,7 +3116,8 @@ template#squire-banner-fixtures {
 .squire-party-row__link,
 .squire-party-row__action > summary,
 .squire-party-row__confirm button,
-.squire-party-row__action--level button {
+.squire-party-row__action--level button,
+.squire-party-row__cancel {
   min-height: 44px;
   display: inline-flex;
   align-items: center;
@@ -3176,7 +3177,7 @@ template#squire-banner-fixtures {
   width: min(280px, calc(100vw - var(--space-xl)));
   padding: var(--space-sm);
   border: 1px solid var(--rule);
-  border-radius: 6px;
+  border-radius: 8px;
   background: var(--surface-2);
   box-shadow: 0 12px 32px rgb(0 0 0 / 0.35);
 }
@@ -3210,6 +3211,8 @@ template#squire-banner-fixtures {
 }
 
 .squire-party-row__confirm form {
+  display: grid;
+  gap: var(--space-xs);
   margin: 0;
 }
 
@@ -3218,6 +3221,10 @@ template#squire-banner-fixtures {
   width: 100%;
   background: var(--wax);
   border-color: var(--wax);
+}
+
+.squire-party-row__cancel {
+  width: 100%;
 }
 
 .squire-party-row__action--remove .squire-party-row__confirm button {

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -2992,10 +2992,8 @@ template#squire-banner-fixtures {
   color: var(--parchment);
   cursor: pointer;
   font-family: 'Geist', system-ui, sans-serif;
-  font-size: 11px;
+  font-size: 14px;
   font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
   white-space: nowrap;
 }
 

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -2458,8 +2458,6 @@ template#squire-banner-fixtures {
   font-weight: 500;
   font-size: 18px;
   color: var(--parchment);
-  border-bottom: 1px solid var(--rule);
-  padding-bottom: var(--space-xs);
   margin: var(--space-lg) 0 var(--space-sm);
 }
 
@@ -2641,6 +2639,16 @@ template#squire-banner-fixtures {
   padding: 0 var(--space-md);
   min-height: 44px;
   cursor: pointer;
+}
+
+.squire-character-create[data-submitting='true'],
+.squire-party-row__action form[data-submitting='true'] {
+  opacity: 0.75;
+}
+
+.squire-character-create[data-submitting='true'] button[type='submit'],
+.squire-party-row__action form[data-submitting='true'] button[type='submit'] {
+  cursor: wait;
 }
 
 .squire-character-create__submit:hover {
@@ -2939,6 +2947,326 @@ template#squire-banner-fixtures {
   min-height: 44px;
   padding: 0 var(--space-sm);
   font-family: 'Geist', system-ui, sans-serif;
+}
+
+/* ─── Campaign Party roster (SQR-360) ────────────────────────────────────── */
+
+.squire-party-section__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  margin-bottom: var(--space-lg);
+}
+
+.squire-party-section__header .squire-campaign-dashboard__section-title {
+  margin: 0;
+}
+
+.squire-party-section__lede {
+  margin: var(--space-2xs) 0 0;
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 14px;
+  color: var(--sepia);
+}
+
+.squire-party-section__action {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.squire-party-section__add {
+  position: relative;
+}
+
+.squire-party-section__add-summary {
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 var(--space-md);
+  border: 1px solid var(--wax);
+  border-radius: 4px;
+  background: var(--wax);
+  color: var(--parchment);
+  cursor: pointer;
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.squire-party-section__add-summary::-webkit-details-marker {
+  display: none;
+}
+
+.squire-party-section__add-summary:hover {
+  background: var(--wax-dim);
+}
+
+.squire-party-section__add-summary:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+}
+
+.squire-party-section__add-body {
+  position: absolute;
+  right: 0;
+  z-index: 10;
+  width: min(520px, calc(100vw - var(--space-xl)));
+  margin-top: var(--space-sm);
+  padding: var(--space-md);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--surface-2);
+  box-shadow: 0 16px 40px rgb(0 0 0 / 0.35);
+}
+
+.squire-party-roster {
+  display: grid;
+  gap: var(--space-xl);
+}
+
+.squire-party-roster__group-title {
+  margin: 0 0 var(--space-sm);
+  font-family: 'Fraunces', 'Georgia', serif;
+  font-weight: 500;
+  font-size: 20px;
+  color: var(--parchment);
+}
+
+.squire-party-roster__empty {
+  margin: 0;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 14px;
+  color: var(--sepia);
+}
+
+.squire-party-roster__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  overflow: visible;
+}
+
+.squire-party-row {
+  display: grid;
+  grid-template-columns: minmax(16rem, 1.6fr) minmax(9rem, 0.8fr) max-content;
+  gap: var(--space-md);
+  align-items: center;
+  min-height: 64px;
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--rule);
+}
+
+.squire-party-row:last-child {
+  border-bottom: none;
+}
+
+.squire-party-row:has(.squire-party-row__action[open]) {
+  padding-bottom: calc(var(--space-sm) + 140px);
+}
+
+.squire-party-row--retired {
+  color: var(--sepia-dim);
+}
+
+.squire-party-row__identity {
+  display: grid;
+  gap: var(--space-2xs);
+}
+
+.squire-party-row__name {
+  font-family: 'Fraunces', 'Georgia', serif;
+  font-size: 20px;
+  color: var(--parchment);
+}
+
+.squire-party-row--retired .squire-party-row__name {
+  color: var(--parchment-dim);
+}
+
+.squire-party-row__note,
+.squire-party-row__class {
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 13px;
+  color: var(--sepia);
+}
+
+.squire-party-row__class {
+  color: var(--parchment-dim);
+}
+
+.squire-party-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.squire-party-row__link,
+.squire-party-row__action > summary,
+.squire-party-row__confirm button,
+.squire-party-row__action--level button {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--space-sm);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--parchment);
+  cursor: pointer;
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.squire-party-row__action > summary {
+  list-style: none;
+}
+
+.squire-party-row__action > summary::-webkit-details-marker {
+  display: none;
+}
+
+.squire-party-row__action--remove > summary {
+  color: var(--error);
+}
+
+.squire-party-row__link:hover,
+.squire-party-row__action > summary:hover {
+  border-color: var(--sepia);
+}
+
+.squire-party-row__link:focus-visible,
+.squire-party-row__action > summary:focus-visible,
+.squire-party-row__confirm button:focus-visible,
+.squire-party-row__action--level button:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+}
+
+.squire-party-row__action {
+  position: relative;
+}
+
+.squire-party-row__action--level form,
+.squire-party-row__confirm {
+  position: absolute;
+  right: 0;
+  top: calc(100% + var(--space-xs));
+  z-index: 8;
+  display: grid;
+  gap: var(--space-sm);
+  width: min(280px, calc(100vw - var(--space-xl)));
+  padding: var(--space-sm);
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--surface-2);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.35);
+}
+
+.squire-party-row__action--level label {
+  display: grid;
+  gap: var(--space-xs);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--sepia);
+}
+
+.squire-party-row__action--level input {
+  min-height: 44px;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--parchment);
+  padding: 0 var(--space-sm);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 14px;
+}
+
+.squire-party-row__confirm p {
+  margin: 0;
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 13px;
+  color: var(--parchment-dim);
+}
+
+.squire-party-row__confirm form {
+  margin: 0;
+}
+
+.squire-party-row__confirm button,
+.squire-party-row__action--level button {
+  width: 100%;
+  background: var(--wax);
+  border-color: var(--wax);
+}
+
+.squire-party-row__action--remove .squire-party-row__confirm button {
+  color: var(--parchment);
+  background: color-mix(in srgb, var(--error) 65%, var(--wax));
+  border-color: color-mix(in srgb, var(--error) 70%, var(--rule));
+}
+
+.squire-party-row__error {
+  grid-column: 1 / -1;
+  padding-top: var(--space-xs);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 13px;
+  color: var(--error);
+}
+
+@media (max-width: 820px) {
+  .squire-party-section__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .squire-party-section__action {
+    justify-content: stretch;
+  }
+
+  .squire-party-section__add-summary {
+    width: 100%;
+  }
+
+  .squire-party-section__add-body {
+    position: static;
+    width: auto;
+  }
+
+  .squire-party-row {
+    grid-template-columns: 1fr;
+    gap: var(--space-xs);
+  }
+
+  .squire-party-row__actions {
+    justify-content: flex-start;
+  }
+
+  .squire-party-row__action--level form,
+  .squire-party-row__confirm {
+    right: auto;
+    left: 0;
+  }
 }
 
 /* ─── Phase 4: scenario-progression dashboard (SQR-276) ────────────────── */

--- a/test/campaign-character-create.test.ts
+++ b/test/campaign-character-create.test.ts
@@ -39,9 +39,14 @@ const OUTSIDER_EMAIL = 'outsider@example.com';
 // auth state), so seed once and clean up in afterAll.
 const MAT_SOURCE_IDS = ['test-create-drifter', 'test-create-banner-spear'];
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function expectSelectOption(body: string, value: string, selected = false) {
+  const escapedValue = escapeRegExp(value);
   const optionPattern = new RegExp(
-    `<option\\s+value="${value}"[\\s\\S]*?${selected ? 'selected' : ''}[\\s\\S]*?>\\s*${value}\\s*</option>`,
+    `<option\\s+value="${escapedValue}"[\\s\\S]*?${selected ? 'selected' : ''}[\\s\\S]*?>\\s*${escapedValue}\\s*</option>`,
   );
   expect(body).toMatch(optionPattern);
 }

--- a/test/campaign-character-create.test.ts
+++ b/test/campaign-character-create.test.ts
@@ -20,6 +20,7 @@ import { SESSION_COOKIE_NAME, getSessionSecret } from '../src/auth/session-middl
 import * as SessionRepository from '../src/db/repositories/session-repository.ts';
 import { SESSION_LIFETIME_MS } from '../src/db/repositories/session-repository.ts';
 import * as CampaignService from '../src/campaign/campaign-service.ts';
+import * as CharacterService from '../src/campaign/character-service.ts';
 import { identityFromSessionUser } from '../src/campaign/identity.ts';
 import { users } from '../src/db/schema/core.ts';
 import { cardCharacterMats } from '../src/db/schema/cards.ts';
@@ -140,18 +141,235 @@ describe('create-character UI (SQR-318)', () => {
     expect(res.status).toBe(200);
     const body = await res.text();
     const revealTag = body.match(
-      /<details[^>]*class="squire-section-reveal squire-character-create-reveal"[^>]*>/,
+      /<details[^>]*class="squire-party-section__add squire-character-create-reveal"[^>]*>/,
     )?.[0];
     expect(revealTag).toBeDefined();
     expect(revealTag).not.toContain('open');
-    expect(body).toContain('squire-section-reveal__summary">Add character</summary>');
+    expect(body).toContain('squire-party-section__add-summary">Add character</summary>');
     expect(body).toContain('squire-character-create');
     expect(body).toContain('action="/campaigns/' + campaign.id + '/characters"');
     // Class select offers the seeded real class names.
     expect(body).toContain('<option value="Banner Spear">Banner Spear</option>');
     expect(body).toContain('<option value="Drifter">Drifter</option>');
     // Empty roster shows the create call-to-action, never fake values.
-    expect(body).toContain('No characters yet');
+    expect(body).toContain('No active characters yet');
+  });
+
+  it('renders the SQR-360 party roster with active and retired character sections', async () => {
+    const { owner, campaign } = await setupFixture();
+    const active = await CharacterService.createCharacter(
+      identityFromSessionUser(owner.userId),
+      campaign.id,
+      {
+        name: 'Manual Bruiser',
+        className: 'Drifter',
+        level: 3,
+      },
+    );
+    const retired = await CharacterService.createCharacter(
+      identityFromSessionUser(owner.userId),
+      campaign.id,
+      {
+        name: 'Old Bones',
+        className: 'Banner Spear',
+        level: 5,
+      },
+    );
+    const proposal = await import('../src/campaign/pending-mutations.ts').then((mod) =>
+      mod.propose(identityFromSessionUser(owner.userId), campaign.id, {
+        type: 'character.retire',
+        characterId: retired.id,
+      }),
+    );
+    await import('../src/campaign/pending-mutations.ts').then((mod) =>
+      mod.confirm(identityFromSessionUser(owner.userId), proposal.id),
+    );
+
+    const res = await app.request(`/campaigns/${campaign.id}/party`, {
+      headers: { Cookie: owner.cookie },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.text();
+
+    expect(body).toContain('squire-party-roster');
+    expect(body).toContain('Active characters');
+    expect(body).toContain('Retired characters');
+    expect(body).toContain('Manual Bruiser');
+    expect(body.replace(/\s+/g, ' ')).toContain('Drifter 3');
+    expect(body).toContain('Old Bones');
+    expect(body.replace(/\s+/g, ' ')).toContain('Banner Spear 5');
+    expect(body).toContain(`href="/characters/${active.id}"`);
+    expect(body).toContain(`href="/characters/${retired.id}"`);
+    expect(body).toContain('Open sheet');
+    expect(body).toContain('Level');
+    expect(body).toContain('Retire');
+    expect(body).toContain('Remove');
+    expect(body).toContain('aria-label="Retire Manual Bruiser"');
+    expect(body).toContain('aria-label="Remove Manual Bruiser"');
+    expect(body).not.toContain('Invite by email');
+    expect(body).not.toContain('Pending invites');
+  });
+
+  it('keeps Add character in the party section action and opens it on validation failure', async () => {
+    const { owner, campaign } = await setupFixture();
+    const res = await createCharacter(owner, campaign.id, {
+      name: '  ',
+      className: 'Drifter',
+      level: '1',
+    });
+    expect(res.status).toBe(422);
+    const body = await res.text();
+
+    expect(body).toContain('squire-party-section__action');
+    expect(body).toContain('squire-party-section__add-summary">Add character</summary>');
+    const revealTag = body.match(
+      /<details[^>]*class="squire-party-section__add squire-character-create-reveal"[^>]*>/,
+    )?.[0];
+    expect(revealTag).toContain('open');
+    expect(body).toContain('Character name is required.');
+  });
+
+  it('updates level from the party row and reports stale-row failures inline', async () => {
+    const { owner, campaign } = await setupFixture();
+    const character = await CharacterService.createCharacter(
+      identityFromSessionUser(owner.userId),
+      campaign.id,
+      {
+        name: 'Leveler',
+        className: 'Drifter',
+        level: 2,
+      },
+    );
+
+    const form = new FormData();
+    form.set('_csrf', createCsrfToken(owner.sessionId));
+    form.set('expectedVersion', String(character.version));
+    form.set('level', '4');
+    let res = await app.request(`/campaigns/${campaign.id}/characters/${character.id}/level`, {
+      method: 'POST',
+      headers: { Cookie: owner.cookie },
+      body: form,
+    });
+    expect(res.status).toBe(303);
+
+    const page = await app.request(`/campaigns/${campaign.id}/party`, {
+      headers: { Cookie: owner.cookie },
+    });
+    let body = await page.text();
+    expect(body.replace(/\s+/g, ' ')).toContain('Drifter 4');
+
+    const stale = new FormData();
+    stale.set('_csrf', createCsrfToken(owner.sessionId));
+    stale.set('expectedVersion', String(character.version));
+    stale.set('level', '5');
+    res = await app.request(`/campaigns/${campaign.id}/characters/${character.id}/level`, {
+      method: 'POST',
+      headers: { Cookie: owner.cookie },
+      body: stale,
+    });
+    expect(res.status).toBe(422);
+    body = await res.text();
+    expect(body).toContain('Leveler');
+    expect(body).toContain('Could not update Leveler.');
+  });
+
+  it('retires and removes characters from explicit party row confirmations', async () => {
+    const { owner, campaign } = await setupFixture();
+    const retiree = await CharacterService.createCharacter(
+      identityFromSessionUser(owner.userId),
+      campaign.id,
+      { name: 'Retire Me', className: 'Drifter', level: 3 },
+    );
+    const doomed = await CharacterService.createCharacter(
+      identityFromSessionUser(owner.userId),
+      campaign.id,
+      { name: 'Remove Me', className: 'Banner Spear', level: 2 },
+    );
+
+    const retire = new FormData();
+    retire.set('_csrf', createCsrfToken(owner.sessionId));
+    retire.set('confirm', 'retire');
+    let res = await app.request(`/campaigns/${campaign.id}/characters/${retiree.id}/retire`, {
+      method: 'POST',
+      headers: { Cookie: owner.cookie },
+      body: retire,
+    });
+    expect(res.status).toBe(303);
+
+    let page = await app.request(`/campaigns/${campaign.id}/party`, {
+      headers: { Cookie: owner.cookie },
+    });
+    let body = await page.text();
+    expect(body).toContain('Retired characters');
+    expect(body).toContain('Retire Me');
+
+    const remove = new FormData();
+    remove.set('_csrf', createCsrfToken(owner.sessionId));
+    remove.set('confirm', 'remove');
+    res = await app.request(`/campaigns/${campaign.id}/characters/${doomed.id}/remove`, {
+      method: 'POST',
+      headers: { Cookie: owner.cookie },
+      body: remove,
+    });
+    expect(res.status).toBe(303);
+
+    page = await app.request(`/campaigns/${campaign.id}/party`, {
+      headers: { Cookie: owner.cookie },
+    });
+    body = await page.text();
+    expect(body).not.toContain('Remove Me');
+  });
+
+  it('rejects party row actions when the character belongs to another campaign', async () => {
+    const { owner, campaign } = await setupFixture();
+    const other = await CampaignService.createCampaign(identityFromSessionUser(owner.userId), {
+      name: 'Other Roster Campaign',
+      game: 'frosthaven',
+      modules: [],
+    });
+    const character = await CharacterService.createCharacter(
+      identityFromSessionUser(owner.userId),
+      campaign.id,
+      { name: 'Wrong Campaign Hero', className: 'Drifter', level: 2 },
+    );
+
+    const level = new FormData();
+    level.set('_csrf', createCsrfToken(owner.sessionId));
+    level.set('expectedVersion', String(character.version));
+    level.set('level', '4');
+    let res = await app.request(`/campaigns/${other.id}/characters/${character.id}/level`, {
+      method: 'POST',
+      headers: { Cookie: owner.cookie },
+      body: level,
+    });
+    expect(res.status).toBe(404);
+
+    const retire = new FormData();
+    retire.set('_csrf', createCsrfToken(owner.sessionId));
+    retire.set('confirm', 'retire');
+    res = await app.request(`/campaigns/${other.id}/characters/${character.id}/retire`, {
+      method: 'POST',
+      headers: { Cookie: owner.cookie },
+      body: retire,
+    });
+    expect(res.status).toBe(404);
+
+    const remove = new FormData();
+    remove.set('_csrf', createCsrfToken(owner.sessionId));
+    remove.set('confirm', 'remove');
+    res = await app.request(`/campaigns/${other.id}/characters/${character.id}/remove`, {
+      method: 'POST',
+      headers: { Cookie: owner.cookie },
+      body: remove,
+    });
+    expect(res.status).toBe(404);
+
+    const detail = await CharacterService.getCharacterDetail(
+      identityFromSessionUser(owner.userId),
+      character.id,
+    );
+    expect(detail.character.level).toBe(2);
+    expect(detail.character.status).toBe('active');
   });
 
   it('creates a character and shows it in the roster', async () => {
@@ -169,11 +387,10 @@ describe('create-character UI (SQR-318)', () => {
     });
     const body = await dash.text();
     expect(body).toContain('Vesper');
-    expect(body).toContain('squire-campaign-dashboard__character-name');
-    expect(body).toContain('squire-campaign-dashboard__character-class');
-    expect(body).toContain('squire-campaign-dashboard__character-level');
+    expect(body).toContain('squire-party-row__name');
+    expect(body).toContain('squire-party-row__class');
     expect(body.replace(/\s+/g, ' ')).toContain('Drifter');
-    expect(body.replace(/\s+/g, ' ')).toContain('Level 3');
+    expect(body.replace(/\s+/g, ' ')).toContain('Drifter 3');
     expect(body).toContain('/characters/'); // sheet link
   });
 
@@ -190,7 +407,7 @@ describe('create-character UI (SQR-318)', () => {
     });
     const body = (await dash.text()).replace(/\s+/g, ' ');
     expect(body).toContain('Banner Spear');
-    expect(body).toContain('Level 1');
+    expect(body).toContain('Banner Spear 1');
   });
 
   it('rejects an unknown/codename class with an inline error and no create', async () => {
@@ -211,7 +428,7 @@ describe('create-character UI (SQR-318)', () => {
     expect(body).toContain('COULD NOT SAVE');
     expect(body).toContain('not a class in this game');
     const revealTag = body.match(
-      /<details[^>]*class="squire-section-reveal squire-character-create-reveal"[^>]*>/,
+      /<details[^>]*class="squire-party-section__add squire-character-create-reveal"[^>]*>/,
     )?.[0];
     expect(revealTag).toContain('open');
 
@@ -219,7 +436,7 @@ describe('create-character UI (SQR-318)', () => {
     const dash = await app.request(`/campaigns/${campaign.id}/party`, {
       headers: { Cookie: owner.cookie },
     });
-    expect(await dash.text()).toContain('No characters yet');
+    expect(await dash.text()).toContain('No active characters yet');
   });
 
   it('requires a name', async () => {

--- a/test/campaign-character-create.test.ts
+++ b/test/campaign-character-create.test.ts
@@ -39,6 +39,13 @@ const OUTSIDER_EMAIL = 'outsider@example.com';
 // auth state), so seed once and clean up in afterAll.
 const MAT_SOURCE_IDS = ['test-create-drifter', 'test-create-banner-spear'];
 
+function expectSelectOption(body: string, value: string, selected = false) {
+  const optionPattern = new RegExp(
+    `<option\\s+value="${value}"[\\s\\S]*?${selected ? 'selected' : ''}[\\s\\S]*?>\\s*${value}\\s*</option>`,
+  );
+  expect(body).toMatch(optionPattern);
+}
+
 async function createTestUser(email: string): Promise<TestUser> {
   const { db } = getDb('server');
   const [user] = await db
@@ -149,8 +156,8 @@ describe('create-character UI (SQR-318)', () => {
     expect(body).toContain('squire-character-create');
     expect(body).toContain('action="/campaigns/' + campaign.id + '/characters"');
     // Class select offers the seeded real class names.
-    expect(body).toContain('<option value="Banner Spear">Banner Spear</option>');
-    expect(body).toContain('<option value="Drifter">Drifter</option>');
+    expectSelectOption(body, 'Banner Spear');
+    expectSelectOption(body, 'Drifter');
     // Empty roster shows the create call-to-action, never fake values.
     expect(body).toContain('No active characters yet');
   });
@@ -218,7 +225,7 @@ describe('create-character UI (SQR-318)', () => {
     const res = await createCharacter(owner, campaign.id, {
       name: '  ',
       className: 'Drifter',
-      level: '1',
+      level: '4',
     });
     expect(res.status).toBe(422);
     const body = await res.text();
@@ -230,6 +237,8 @@ describe('create-character UI (SQR-318)', () => {
     )?.[0];
     expect(revealTag).toContain('open');
     expect(body).toContain('Character name is required.');
+    expectSelectOption(body, 'Drifter', true);
+    expect(body).toContain('value="4"');
   });
 
   it('updates level from the party row and reports stale-row failures inline', async () => {

--- a/test/campaign-character-create.test.ts
+++ b/test/campaign-character-create.test.ts
@@ -206,6 +206,9 @@ describe('create-character UI (SQR-318)', () => {
     expect(body).toContain('Remove');
     expect(body).toContain('aria-label="Retire Manual Bruiser"');
     expect(body).toContain('aria-label="Remove Manual Bruiser"');
+    expect(body).toContain('aria-label="Remove Old Bones"');
+    expect(body).toContain(`href="/campaigns/${campaign.id}/party"`);
+    expect(body).toContain('Cancel');
     expect(body).not.toContain('Invite by email');
     expect(body).not.toContain('Pending invites');
   });
@@ -271,6 +274,7 @@ describe('create-character UI (SQR-318)', () => {
     body = await res.text();
     expect(body).toContain('Leveler');
     expect(body).toContain('Could not update Leveler.');
+    expect(body).toContain('value="5"');
   });
 
   it('retires and removes characters from explicit party row confirmations', async () => {
@@ -318,6 +322,46 @@ describe('create-character UI (SQR-318)', () => {
     });
     body = await page.text();
     expect(body).not.toContain('Remove Me');
+  });
+
+  it('removes retired characters from explicit party row confirmations', async () => {
+    const { owner, campaign } = await setupFixture();
+    const retired = await CharacterService.createCharacter(
+      identityFromSessionUser(owner.userId),
+      campaign.id,
+      { name: 'Remove Retired', className: 'Banner Spear', level: 2 },
+    );
+    const proposal = await import('../src/campaign/pending-mutations.ts').then((mod) =>
+      mod.propose(identityFromSessionUser(owner.userId), campaign.id, {
+        type: 'character.retire',
+        characterId: retired.id,
+      }),
+    );
+    await import('../src/campaign/pending-mutations.ts').then((mod) =>
+      mod.confirm(identityFromSessionUser(owner.userId), proposal.id),
+    );
+
+    let page = await app.request(`/campaigns/${campaign.id}/party`, {
+      headers: { Cookie: owner.cookie },
+    });
+    let body = await page.text();
+    expect(body).toContain('aria-label="Remove Remove Retired"');
+
+    const remove = new FormData();
+    remove.set('_csrf', createCsrfToken(owner.sessionId));
+    remove.set('confirm', 'remove');
+    const res = await app.request(`/campaigns/${campaign.id}/characters/${retired.id}/remove`, {
+      method: 'POST',
+      headers: { Cookie: owner.cookie },
+      body: remove,
+    });
+    expect(res.status).toBe(303);
+
+    page = await app.request(`/campaigns/${campaign.id}/party`, {
+      headers: { Cookie: owner.cookie },
+    });
+    body = await page.text();
+    expect(body).not.toContain('Remove Retired');
   });
 
   it('rejects party row actions when the character belongs to another campaign', async () => {

--- a/test/campaign-dashboard.test.ts
+++ b/test/campaign-dashboard.test.ts
@@ -217,7 +217,10 @@ describe('dashboard rendering', () => {
     expect(body).toContain('squire-campaign-dashboard squire-campaign-dashboard--party');
     expect(body).toContain('class="squire-campaign-dashboard__party"');
     expect(body).toContain('aria-label="Party"');
-    expect(body).toContain('squire-section-reveal__summary">Add character</summary>');
+    expect(body).toContain('squire-party-section__action');
+    expect(body).toContain('squire-party-section__add-summary">Add character</summary>');
+    expect(body).toContain('Active characters');
+    expect(body).toContain('Retired characters');
     expect(body).not.toContain('aria-label="Scenario progression"');
     expect(body).not.toContain('squire-dashboard-grid');
   });

--- a/test/character-sheet.test.ts
+++ b/test/character-sheet.test.ts
@@ -406,9 +406,9 @@ describe('dashboard reachability', () => {
     const body = await res.text();
     expect(body).toContain(`href="/characters/${character.id}"`);
     expect(body).toContain('squire-campaign-dashboard__party');
-    expect(body).toContain('squire-campaign-dashboard__character-name');
-    expect(body).toContain('squire-campaign-dashboard__character-class');
-    expect(body).toContain('squire-campaign-dashboard__character-level');
+    expect(body).toContain('squire-party-row__name');
+    expect(body).toContain('squire-party-row__class');
+    expect(body.replace(/\s+/g, ' ')).toContain('Drifter 3');
     expect(body).not.toContain('squire-campaign-dashboard__member-role');
     expect(body).not.toContain('OWNER');
     expect(body).not.toContain('>Characters</h2>');

--- a/test/web-ui-htmx.regression-1.test.ts
+++ b/test/web-ui-htmx.regression-1.test.ts
@@ -44,6 +44,14 @@ describe('squire.js HTMX first-turn submit regression', () => {
     expect(squireJs).toContain('delete form.dataset.submitting');
   });
 
+  it('marks Party character forms submitting without touching chat submit text', () => {
+    expect(squireJs).toContain(
+      "form.matches('.squire-character-create, .squire-party-row__action form')",
+    );
+    expect(squireJs).toContain("form.dataset.submitting = 'true';");
+    expect(squireJs).toContain("form.setAttribute('aria-busy', 'true');");
+  });
+
   it('keeps lookup work separate from answer prose and collapses it after completion', () => {
     expect(squireJs).toContain('function answerWorkElements(answerEl) {');
     expect(squireJs).toContain('function renderAnswerWorkRow(');


### PR DESCRIPTION
## Summary

- Rebuilds the campaign Party view around active and retired character rosters.
- Adds visible row actions for open sheet, level, retire, and remove, with explicit confirmation for destructive actions.
- Keeps Party scoped to character state only and removes the extra section-header divider lines.
- Adds server-side campaign/character route binding for row actions so a character cannot be acted on through another campaign URL.

## Validation

- `npm test -- test/campaign-character-create.test.ts`
- `npm run check`
- Browser QA on `http://localhost:4450/campaigns/20f9999c-0fe3-4d8a-8ca1-56c5ef1bb775/party` for add, level, retire, remove, desktop layout, mobile layout, and clean console after reload.

Fixes SQR-360


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded the campaign party dashboard to an action-capable roster with separate **“Active characters”** and **“Retired characters”** sections
  * Added per-character actions (**Level**, **Retire**, **Remove**) with confirmation, ownership-aware display, and optimistic concurrency (version/expectedVersion)

* **UI/UX Improvements**
  * Improved inline, character-specific error handling after failed actions (including preserving previously entered form values)
  * Added “submitting” busy-state styling and disabled submit buttons for character/party-row actions

* **Tests**
  * Updated party/dashboard/character-sheet assertions to the new roster markup and expanded retire/remove coverage
  * Added regression coverage for the new busy-state submit handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->