### PR TITLE
ci: skip provider e2e for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
 
   authenticated-api-agent-e2e:
     name: Authenticated API and agent E2E smoke
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -144,6 +144,7 @@ describe('deployment configuration', () => {
 
     expect(packageJson.scripts?.['e2e:api-agent']).toBe('node scripts/e2e-api-agent-smoke.ts');
     expect(workflow).toContain('name: Authenticated API and agent E2E smoke');
+    expect(workflow).toContain("if: github.actor != 'dependabot[bot]'");
     expect(workflow).not.toContain("github.event_name == 'schedule'");
     expect(workflow).toContain('ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}');
     expect(workflow).toContain('VOYAGE_API_KEY: ${{ secrets.VOYAGE_API_KEY }}');


### PR DESCRIPTION
## Summary

- Skip the authenticated API/agent e2e job when the PR actor is `dependabot[bot]`
- Keep regular CI, browser e2e, slow PDF extraction, dependency review, CodeQL, and the e2e job for normal PRs/main pushes
- Add a workflow configuration assertion for the Dependabot skip

## Why

Dependabot `pull_request` jobs do not receive normal repository Actions secrets. The provider-backed e2e job runs `npm run index`, which requires `VOYAGE_API_KEY`, so Dependabot PRs fail before the smoke test starts.

## Validation

- `npm test -- test/deployment-config.test.ts`
- `actionlint .github/workflows/ci.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to conditionally skip certain jobs for automated dependency updates.

* **Tests**
  * Added verification that CI workflow correctly handles automated dependency update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->