### PR TITLE
Build campaign Players section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.25] - 2026-06-21
+
+### Added
+
+- Built the campaign Players section with separate joined-player and pending-invite rosters, owner-only invite creation, member removal, invite cancellation, row-level confirmations, and empty states.
+- Added Players-section tests covering owner/member visibility, preserved invite errors, cancel-invite flow, remove-member flow, and browser pending states.
+
 ## [0.1.24] - 2026-06-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squire",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squire",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.105.0",
         "@aws-sdk/client-s3": "^3.1073.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squire",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Frosthaven AI assistant with RAG over rulebooks",
   "type": "module",
   "engines": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1570,6 +1570,14 @@ async function renderCampaignDashboardPage(
       levelValue?: string;
     };
     inviteError?: string;
+    inviteFormValues?: {
+      emailValue?: string;
+    };
+    playerActionError?: {
+      memberId: string;
+      action: 'remove' | 'cancel';
+      message: string;
+    };
     renameError?: string;
     modulesError?: string;
     characterFormValues?: {
@@ -1647,7 +1655,13 @@ async function renderCampaignDashboardPage(
       opts.characterActionError,
       // Invite-member affordance (SQR-319): form is owner-only; the error
       // banner still renders for a non-owner who tampers the route.
-      { csrfToken, canInvite: isOwner, errorMessage: opts.inviteError },
+      {
+        csrfToken,
+        canInvite: isOwner,
+        errorMessage: opts.inviteError,
+        ...opts.inviteFormValues,
+      },
+      opts.playerActionError,
       // Rename affordance (SQR-320): any active member; the name is shared
       // state. expectedVersion drives optimistic concurrency.
       { csrfToken, version: detail.campaign.version, errorMessage: opts.renameError },
@@ -1941,6 +1955,120 @@ app.post('/campaigns/:id/characters/:characterId/remove', async (c) => {
   }
 });
 
+function playerActionFailureMessage(
+  action: 'remove' | 'cancel',
+  member: CampaignService.RosterMember | null,
+  error?: unknown,
+): string {
+  if (error instanceof CampaignService.CampaignForbiddenError) return error.message;
+  if (action === 'cancel') return 'Could not cancel this invitation.';
+  return `Could not remove ${member?.email ?? 'this player'}.`;
+}
+
+async function renderPlayerActionErrorPage(
+  c: Context,
+  campaignId: string,
+  memberId: string,
+  action: 'remove' | 'cancel',
+  member: CampaignService.RosterMember | null,
+  message?: string,
+  error?: unknown,
+): Promise<Response> {
+  if (error instanceof CampaignService.CampaignNotFoundError) return c.notFound();
+  return renderCampaignDashboardPage(
+    c,
+    campaignId,
+    {
+      view: 'players',
+      playerActionError: {
+        memberId,
+        action,
+        message: message ?? playerActionFailureMessage(action, member, error),
+      },
+    },
+    422,
+  );
+}
+
+async function requireCampaignRosterMember(
+  identity: CallerIdentity,
+  campaignId: string,
+  memberId: string,
+): Promise<CampaignService.RosterMember> {
+  const detail = await CampaignService.getCampaignDetail(identity, campaignId);
+  const member = detail.members.find((row) => row.memberId === memberId);
+  if (!member) throw new CampaignService.CampaignNotFoundError();
+  return member;
+}
+
+async function confirmCampaignMemberRemoval(
+  identity: CallerIdentity,
+  campaignId: string,
+  memberId: string,
+): Promise<void> {
+  const proposal = await PendingMutations.propose(identity, campaignId, {
+    type: 'member.remove',
+    memberId,
+  });
+  await PendingMutations.confirm(identity, proposal.id);
+}
+
+app.post('/campaigns/:id/members/:memberId/remove', async (c) => {
+  const session = c.get('session')!;
+  const campaignId = campaignRouteId(c, 'id');
+  const memberId = campaignRouteId(c, 'memberId');
+  if (!campaignId || !memberId) return c.notFound();
+  const identity = identityFromSessionUser(session.userId);
+  const form = await c.req.formData();
+  let member: CampaignService.RosterMember | null = null;
+  try {
+    member = await requireCampaignRosterMember(identity, campaignId, memberId);
+    if (member.status !== 'active') throw new CampaignService.CampaignNotFoundError();
+    if (formString(form, 'confirm') !== 'remove') {
+      return await renderPlayerActionErrorPage(
+        c,
+        campaignId,
+        memberId,
+        'remove',
+        member,
+        'Confirm remove to remove this player from the campaign.',
+      );
+    }
+    await confirmCampaignMemberRemoval(identity, campaignId, memberId);
+    return c.redirect(campaignPlayersViewPath(campaignId), 303);
+  } catch (error) {
+    return renderPlayerActionErrorPage(c, campaignId, memberId, 'remove', member, undefined, error);
+  }
+});
+
+app.post('/campaigns/:id/invites/:memberId/cancel', async (c) => {
+  const session = c.get('session')!;
+  const campaignId = campaignRouteId(c, 'id');
+  const memberId = campaignRouteId(c, 'memberId');
+  if (!campaignId || !memberId) return c.notFound();
+  const identity = identityFromSessionUser(session.userId);
+  const form = await c.req.formData();
+  let member: CampaignService.RosterMember | null = null;
+  try {
+    member = await requireCampaignRosterMember(identity, campaignId, memberId);
+    if (member.status !== 'invited') throw new CampaignService.CampaignNotFoundError();
+    if (formString(form, 'confirm') !== 'cancel') {
+      return await renderPlayerActionErrorPage(
+        c,
+        campaignId,
+        memberId,
+        'cancel',
+        member,
+        'Confirm cancel to remove the pending invite.',
+      );
+    }
+    await confirmCampaignMemberRemoval(identity, campaignId, memberId);
+    return c.redirect(campaignPlayersViewPath(campaignId), 303);
+  } catch (error) {
+    return renderPlayerActionErrorPage(c, campaignId, memberId, 'cancel', member, undefined, error);
+  }
+});
+
 /** Invite a member from the dashboard Players section (owner-only, SQR-319). */
 app.post('/campaigns/:id/invites', async (c) => {
   const session = c.get('session')!;
@@ -1959,7 +2087,11 @@ app.post('/campaigns/:id/invites', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { inviteError: 'Only the owner can invite members', view: 'players' },
+        {
+          inviteError: 'Only the owner can invite members',
+          inviteFormValues: { emailValue: email },
+          view: 'players',
+        },
         422,
       );
     }
@@ -1967,7 +2099,11 @@ app.post('/campaigns/:id/invites', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { inviteError: 'Enter a valid email address.', view: 'players' },
+        {
+          inviteError: 'Enter a valid email address.',
+          inviteFormValues: { emailValue: email },
+          view: 'players',
+        },
         422,
       );
     }
@@ -1984,7 +2120,7 @@ app.post('/campaigns/:id/invites', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { inviteError: error.message, view: 'players' },
+        { inviteError: error.message, inviteFormValues: { emailValue: email }, view: 'players' },
         422,
       );
     }

--- a/src/web-ui/campaign-pages.ts
+++ b/src/web-ui/campaign-pages.ts
@@ -283,10 +283,12 @@ export interface InviteMemberForm {
   canInvite: boolean;
   /** Inline error rendered after a failed invite attempt. */
   errorMessage?: string;
+  /** Preserve the submitted address when validation or authorization fails. */
+  emailValue?: string;
 }
 
 /**
- * The Party-section invite affordance. The error banner renders independently
+ * The Players-section invite affordance. The error banner renders independently
  * of the form so a non-owner who tampers the route still sees the rejection,
  * while only the owner ever sees the form inputs.
  */
@@ -307,11 +309,224 @@ function renderInviteMemberForm(campaignId: string, data: InviteMemberForm): Htm
         <input type="hidden" name="_csrf" value="${data.csrfToken}" />
         <label class="squire-invite-member__field">
           <span class="squire-invite-member__field-label">INVITE BY EMAIL</span>
-          <input name="email" type="email" required maxlength="320" autocomplete="off" />
+          <input
+            name="email"
+            type="email"
+            required
+            maxlength="320"
+            autocomplete="off"
+            value="${data.emailValue ?? ''}"
+          />
         </label>
         <button type="submit" class="squire-invite-member__submit">INVITE</button>
       </form>`
     : html``}` as HtmlEscapedString;
+}
+
+type CampaignPlayerRow = CampaignDetail['members'][number];
+
+export interface CampaignPlayerActionError {
+  memberId: string;
+  action: 'remove' | 'cancel';
+  message: string;
+}
+
+function playerDisplayName(member: CampaignPlayerRow): string {
+  return member.name?.trim() || member.email;
+}
+
+function playerRoleLabel(member: CampaignPlayerRow): string {
+  return member.role === 'owner' ? 'Owner' : 'Member';
+}
+
+function renderPlayerActionError(
+  member: CampaignPlayerRow,
+  actionError?: CampaignPlayerActionError,
+): HtmlEscapedString {
+  if (!actionError || actionError.memberId !== member.memberId) return html`` as HtmlEscapedString;
+  return html`<div class="squire-player-row__error" role="alert">
+    ${actionError.message}
+  </div>` as HtmlEscapedString;
+}
+
+function renderPlayerConfirmAction(input: {
+  campaignId: string;
+  csrfToken: string;
+  member: CampaignPlayerRow;
+  action: 'remove' | 'cancel';
+  label: string;
+  confirmValue: string;
+  prompt: string;
+  actionError?: CampaignPlayerActionError;
+}): HtmlEscapedString {
+  const open =
+    input.actionError?.memberId === input.member.memberId &&
+    input.actionError.action === input.action;
+  const actionPath =
+    input.action === 'cancel'
+      ? `/campaigns/${input.campaignId}/invites/${input.member.memberId}/cancel`
+      : `/campaigns/${input.campaignId}/members/${input.member.memberId}/remove`;
+  return html`<details
+    class="squire-player-row__action squire-player-row__action--${input.action}"
+    ${open ? raw('open') : raw('')}
+  >
+    <summary aria-label="${input.label} ${playerDisplayName(input.member)}">${input.label}</summary>
+    <div class="squire-player-row__confirm">
+      <p>${input.prompt}</p>
+      ${open ? renderPlayerActionError(input.member, input.actionError) : html``}
+      <form method="post" action="${actionPath}">
+        <input type="hidden" name="_csrf" value="${input.csrfToken}" />
+        <input type="hidden" name="confirm" value="${input.confirmValue}" />
+        <button type="submit">Confirm ${input.label.toLowerCase()}</button>
+        <a class="squire-player-row__cancel" href="/campaigns/${input.campaignId}/players">
+          Cancel
+        </a>
+      </form>
+    </div>
+  </details>` as HtmlEscapedString;
+}
+
+function renderJoinedPlayerRow(input: {
+  campaignId: string;
+  csrfToken: string;
+  member: CampaignPlayerRow;
+  canManage: boolean;
+  isSelf: boolean;
+  actionError?: CampaignPlayerActionError;
+}): HtmlEscapedString {
+  const { member } = input;
+  const displayName = playerDisplayName(member);
+  return html`<li class="squire-player-row squire-player-row--joined">
+    <div class="squire-player-row__identity">
+      <span class="squire-player-row__name">${displayName}</span>
+      ${displayName !== member.email
+        ? html`<span class="squire-player-row__email">${member.email}</span>`
+        : html``}
+    </div>
+    <span class="squire-player-row__status">${playerRoleLabel(member)}</span>
+    <div class="squire-player-row__actions">
+      ${input.canManage && !input.isSelf
+        ? renderPlayerConfirmAction({
+            campaignId: input.campaignId,
+            csrfToken: input.csrfToken,
+            member,
+            action: 'remove',
+            label: 'Remove',
+            confirmValue: 'remove',
+            prompt: `Remove ${member.email}?`,
+            actionError: input.actionError,
+          })
+        : html``}
+    </div>
+  </li>` as HtmlEscapedString;
+}
+
+function renderPendingInviteRow(input: {
+  campaignId: string;
+  csrfToken: string;
+  member: CampaignPlayerRow;
+  canManage: boolean;
+  actionError?: CampaignPlayerActionError;
+}): HtmlEscapedString {
+  const { member } = input;
+  return html`<li class="squire-player-row squire-player-row--pending">
+    <div class="squire-player-row__identity">
+      <span class="squire-player-row__name">${member.email}</span>
+    </div>
+    <span class="squire-player-row__status">Invited</span>
+    <div class="squire-player-row__actions">
+      ${input.canManage
+        ? renderPlayerConfirmAction({
+            campaignId: input.campaignId,
+            csrfToken: input.csrfToken,
+            member,
+            action: 'cancel',
+            label: 'Cancel',
+            confirmValue: 'cancel',
+            prompt: `Cancel invite for ${member.email}?`,
+            actionError: input.actionError,
+          })
+        : html``}
+    </div>
+  </li>` as HtmlEscapedString;
+}
+
+function renderPlayerRosterSection(input: {
+  title: string;
+  empty: string;
+  rows: CampaignPlayerRow[];
+  rowRenderer: (member: CampaignPlayerRow) => HtmlEscapedString;
+}): HtmlEscapedString {
+  return html`<section class="squire-player-roster__group" aria-label="${input.title}">
+    <h3 class="squire-player-roster__group-title">${input.title}</h3>
+    ${input.rows.length === 0
+      ? html`<p class="squire-player-roster__empty">${input.empty}</p>`
+      : html`<ul class="squire-player-roster__rows">
+          ${input.rows.map((member) => input.rowRenderer(member))}
+        </ul>`}
+  </section>` as HtmlEscapedString;
+}
+
+function renderPlayersSection(input: {
+  detail: CampaignDetail;
+  inviteForm?: InviteMemberForm;
+  actionError?: CampaignPlayerActionError;
+}): HtmlEscapedString {
+  const { campaign, self } = input.detail;
+  const joinedPlayers = input.detail.members.filter((member) => member.status === 'active');
+  const pendingInvites = input.detail.members.filter((member) => member.status === 'invited');
+  const csrfToken = input.inviteForm?.csrfToken ?? '';
+  const canManage = input.inviteForm?.canInvite === true;
+  return html`<section class="squire-campaign-dashboard__players" aria-label="Players">
+    <header class="squire-player-section__header">
+      <div>
+        <h2 class="squire-campaign-dashboard__section-title">Players</h2>
+        <p class="squire-player-section__lede">Manage campaign members and pending invitations.</p>
+      </div>
+      <div class="squire-player-section__action">
+        ${input.inviteForm?.canInvite
+          ? html`<details class="squire-player-section__invite">
+              <summary class="squire-player-section__invite-summary">Invite player</summary>
+              <div class="squire-player-section__invite-body">
+                ${renderInviteMemberForm(campaign.id, input.inviteForm)}
+              </div>
+            </details>`
+          : html``}
+      </div>
+    </header>
+    ${!input.inviteForm?.canInvite && input.inviteForm?.errorMessage
+      ? renderInviteMemberForm(campaign.id, input.inviteForm)
+      : html``}
+    <div class="squire-player-roster">
+      ${renderPlayerRosterSection({
+        title: 'Joined players',
+        empty: 'No joined players yet.',
+        rows: joinedPlayers,
+        rowRenderer: (member) =>
+          renderJoinedPlayerRow({
+            campaignId: campaign.id,
+            csrfToken,
+            member,
+            canManage,
+            isSelf: member.memberId === self.memberId,
+            actionError: input.actionError,
+          }),
+      })}
+      ${renderPlayerRosterSection({
+        title: 'Pending invites',
+        empty: 'No pending invites.',
+        rows: pendingInvites,
+        rowRenderer: (member) =>
+          renderPendingInviteRow({
+            campaignId: campaign.id,
+            csrfToken,
+            member,
+            canManage,
+            actionError: input.actionError,
+          }),
+      })}
+    </div>
+  </section>` as HtmlEscapedString;
 }
 
 function compactCharacterClass(character: DashboardCharacterRow): string {
@@ -490,25 +705,6 @@ function renderPartyRoster(input: {
       actionError: input.actionError,
     })}
   </div>` as HtmlEscapedString;
-}
-
-function renderPendingInvites(pendingInvites: CampaignDetail['members']): HtmlEscapedString {
-  if (pendingInvites.length === 0) return html`` as HtmlEscapedString;
-  return html`<section
-    class="squire-campaign-dashboard__pending-invites"
-    aria-label="Pending invites"
-  >
-    <h3 class="squire-campaign-dashboard__subsection-title">Pending invites</h3>
-    <ul class="squire-campaign-dashboard__invite-list">
-      ${pendingInvites.map(
-        (member) =>
-          html`<li class="squire-campaign-dashboard__invite-row">
-            <span>${member.email}</span>
-            <span class="squire-campaign-dashboard__invite-status">Invited</span>
-          </li>`,
-      )}
-    </ul>
-  </section>` as HtmlEscapedString;
 }
 
 /** The dashboard "Rename campaign" affordance (SQR-320). */
@@ -783,14 +979,13 @@ export function renderCampaignDashboardContent(
   characterCreate?: CharacterCreateForm,
   characterActionError?: CharacterActionError,
   inviteForm?: InviteMemberForm,
+  playerActionError?: CampaignPlayerActionError,
   renameForm?: CampaignRenameForm,
   modulesForm?: CampaignModulesForm,
   headerStats?: CampaignDashboardHeaderStats,
   activeView: CampaignDashboardView = 'progress',
 ): HtmlEscapedString {
   const { campaign } = detail;
-  // Pending invites are real state — shown distinctly, never as fake rows.
-  const pendingInvites = detail.members.filter((member) => member.status === 'invited');
   return html`<section class="squire-campaign-workspace" data-campaign-id="${campaign.id}">
     ${renderCampaignWorkspaceHeader(campaign, headerStats)}
     ${renderCampaignWorkspaceNav(campaign.id, activeView)}
@@ -822,22 +1017,7 @@ export function renderCampaignDashboardContent(
           </section>`
         : html``}
       ${activeView === 'players'
-        ? html`<section class="squire-campaign-dashboard__players" aria-label="Players">
-            <h2 class="squire-campaign-dashboard__section-title">Players</h2>
-            <ul class="squire-campaign-dashboard__members">
-              ${detail.members.map(
-                (member) =>
-                  html`<li class="squire-campaign-dashboard__member">
-                    <span>${member.email}</span>
-                    <span class="squire-campaign-dashboard__member-role"
-                      >${member.status === 'active' ? member.role : member.status}</span
-                    >
-                  </li>`,
-              )}
-            </ul>
-            ${renderPendingInvites(pendingInvites)}
-            ${inviteForm ? renderInviteMemberForm(campaign.id, inviteForm) : html``}
-          </section>`
+        ? renderPlayersSection({ detail, inviteForm, actionError: playerActionError })
         : html``}
       ${activeView === 'settings'
         ? html`<section class="squire-campaign-dashboard__settings" aria-label="Settings">

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -1307,7 +1307,9 @@ document.addEventListener('submit', function (event) {
   if (
     !form ||
     !form.matches ||
-    !form.matches('.squire-character-create, .squire-party-row__action form')
+    !form.matches(
+      '.squire-character-create, .squire-invite-member, .squire-party-row__action form, .squire-player-row__action form',
+    )
   ) {
     return;
   }

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -2642,12 +2642,16 @@ template#squire-banner-fixtures {
 }
 
 .squire-character-create[data-submitting='true'],
-.squire-party-row__action form[data-submitting='true'] {
+.squire-invite-member[data-submitting='true'],
+.squire-party-row__action form[data-submitting='true'],
+.squire-player-row__action form[data-submitting='true'] {
   opacity: 0.75;
 }
 
 .squire-character-create[data-submitting='true'] button[type='submit'],
-.squire-party-row__action form[data-submitting='true'] button[type='submit'] {
+.squire-invite-member[data-submitting='true'] button[type='submit'],
+.squire-party-row__action form[data-submitting='true'] button[type='submit'],
+.squire-player-row__action form[data-submitting='true'] button[type='submit'] {
   cursor: wait;
 }
 
@@ -2947,6 +2951,294 @@ template#squire-banner-fixtures {
   min-height: 44px;
   padding: 0 var(--space-sm);
   font-family: 'Geist', system-ui, sans-serif;
+}
+
+/* ─── Campaign Players roster (SQR-361) ──────────────────────────────────── */
+
+.squire-player-section__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  margin-bottom: var(--space-lg);
+}
+
+.squire-player-section__header .squire-campaign-dashboard__section-title {
+  margin: 0;
+}
+
+.squire-player-section__lede {
+  margin: var(--space-2xs) 0 0;
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 14px;
+  color: var(--sepia);
+}
+
+.squire-player-section__action {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.squire-player-section__invite {
+  position: relative;
+}
+
+.squire-player-section__invite-summary {
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 var(--space-md);
+  border: 1px solid var(--wax);
+  border-radius: 4px;
+  background: var(--wax);
+  color: var(--parchment);
+  cursor: pointer;
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.squire-player-section__invite-summary::-webkit-details-marker {
+  display: none;
+}
+
+.squire-player-section__invite-summary:hover {
+  background: var(--wax-dim);
+}
+
+.squire-player-section__invite-summary:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+}
+
+.squire-player-section__invite-body {
+  position: absolute;
+  right: 0;
+  z-index: 10;
+  width: min(520px, calc(100vw - var(--space-xl)));
+  margin-top: var(--space-sm);
+  padding: var(--space-md);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background: var(--surface-2);
+  box-shadow: 0 16px 40px rgb(0 0 0 / 0.35);
+}
+
+.squire-player-roster {
+  display: grid;
+  gap: var(--space-xl);
+}
+
+.squire-player-roster__group-title {
+  margin: 0 0 var(--space-sm);
+  font-family: 'Fraunces', 'Georgia', serif;
+  font-weight: 500;
+  font-size: 20px;
+  color: var(--parchment);
+}
+
+.squire-player-roster__empty {
+  margin: 0;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 14px;
+  color: var(--sepia);
+}
+
+.squire-player-roster__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  overflow: visible;
+}
+
+.squire-player-row {
+  display: grid;
+  grid-template-columns: minmax(16rem, 1.6fr) minmax(8rem, 0.6fr) max-content;
+  gap: var(--space-md);
+  align-items: center;
+  min-height: 64px;
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--rule);
+}
+
+.squire-player-row:last-child {
+  border-bottom: none;
+}
+
+.squire-player-row:has(.squire-player-row__action[open]) {
+  padding-bottom: calc(var(--space-sm) + 120px);
+}
+
+.squire-player-row__identity {
+  display: grid;
+  gap: var(--space-2xs);
+  min-width: 0;
+}
+
+.squire-player-row__name {
+  font-family: 'Fraunces', 'Georgia', serif;
+  font-size: 20px;
+  color: var(--parchment);
+  overflow-wrap: anywhere;
+}
+
+.squire-player-row__email,
+.squire-player-row__status {
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 13px;
+  color: var(--sepia);
+}
+
+.squire-player-row__status {
+  color: var(--parchment-dim);
+}
+
+.squire-player-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-xs);
+  min-height: 44px;
+}
+
+.squire-player-row__action > summary,
+.squire-player-row__confirm button,
+.squire-player-row__cancel {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--space-sm);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--parchment);
+  cursor: pointer;
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.squire-player-row__action > summary {
+  list-style: none;
+}
+
+.squire-player-row__action > summary::-webkit-details-marker {
+  display: none;
+}
+
+.squire-player-row__action--remove > summary,
+.squire-player-row__action--cancel > summary {
+  color: var(--error);
+}
+
+.squire-player-row__action > summary:hover {
+  border-color: var(--sepia);
+}
+
+.squire-player-row__action > summary:focus-visible,
+.squire-player-row__confirm button:focus-visible,
+.squire-player-row__cancel:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+}
+
+.squire-player-row__action {
+  position: relative;
+}
+
+.squire-player-row__confirm {
+  position: absolute;
+  right: 0;
+  top: calc(100% + var(--space-xs));
+  z-index: 8;
+  display: grid;
+  gap: var(--space-sm);
+  width: min(300px, calc(100vw - var(--space-xl)));
+  padding: var(--space-sm);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background: var(--surface-2);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.35);
+}
+
+.squire-player-row__confirm p {
+  margin: 0;
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 13px;
+  color: var(--parchment-dim);
+}
+
+.squire-player-row__confirm form {
+  display: grid;
+  gap: var(--space-xs);
+  margin: 0;
+}
+
+.squire-player-row__confirm button {
+  width: 100%;
+  background: color-mix(in srgb, var(--error) 65%, var(--wax));
+  border-color: color-mix(in srgb, var(--error) 70%, var(--rule));
+  color: var(--parchment);
+}
+
+.squire-player-row__cancel {
+  width: 100%;
+}
+
+.squire-player-row__error {
+  grid-column: 1 / -1;
+  padding-top: var(--space-xs);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 13px;
+  color: var(--error);
+}
+
+@media (max-width: 820px) {
+  .squire-player-section__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .squire-player-section__action {
+    justify-content: stretch;
+  }
+
+  .squire-player-section__invite-summary {
+    width: 100%;
+  }
+
+  .squire-player-section__invite-body {
+    position: static;
+    width: auto;
+  }
+
+  .squire-player-row {
+    grid-template-columns: 1fr;
+    gap: var(--space-xs);
+  }
+
+  .squire-player-row__actions {
+    justify-content: flex-start;
+  }
+
+  .squire-player-row__confirm {
+    right: auto;
+    left: 0;
+  }
 }
 
 /* ─── Campaign Party roster (SQR-360) ────────────────────────────────────── */

--- a/test/campaign-invite-member.test.ts
+++ b/test/campaign-invite-member.test.ts
@@ -87,6 +87,27 @@ async function invite(user: TestUser, campaignId: string, email: string): Promis
   });
 }
 
+async function memberAction(input: {
+  user: TestUser;
+  campaignId: string;
+  memberId: string;
+  pathAction: 'remove' | 'cancel';
+  confirm?: string;
+}): Promise<Response> {
+  const form = new FormData();
+  form.set('_csrf', createCsrfToken(input.user.sessionId));
+  if (input.confirm !== undefined) form.set('confirm', input.confirm);
+  const segment =
+    input.pathAction === 'cancel'
+      ? `/invites/${input.memberId}/cancel`
+      : `/members/${input.memberId}/remove`;
+  return app.request(`/campaigns/${input.campaignId}${segment}`, {
+    method: 'POST',
+    headers: { Cookie: input.user.cookie, 'HX-Request': 'true' },
+    body: form,
+  });
+}
+
 beforeAll(async () => {
   await setupTestDb();
 });
@@ -136,17 +157,65 @@ describe('invite-member UI (SQR-319)', () => {
     ).text();
     expect(dash).toContain(INVITEE_EMAIL);
     expect(dash).toContain('Pending invites');
-    expect(dash).toContain('squire-campaign-dashboard__invite-status');
+    expect(dash).toContain('squire-player-row__status');
     expect(dash).toContain('Invited');
   });
 
-  it('rejects an invalid email with an inline error', async () => {
+  it('separates joined players from pending invites and gates owner actions', async () => {
+    const { owner, campaign } = await setupFixture();
+    const member = await addActiveMember(owner, campaign.id, MEMBER_EMAIL);
+    await invite(owner, campaign.id, INVITEE_EMAIL);
+
+    const ownerView = await (
+      await app.request(`/campaigns/${campaign.id}/players`, {
+        headers: { Cookie: owner.cookie },
+      })
+    ).text();
+    expect(ownerView).toContain('Joined players');
+    expect(ownerView).toContain('Pending invites');
+    expect(ownerView).toContain(MEMBER_EMAIL);
+    expect(ownerView).toContain(INVITEE_EMAIL);
+    expect(ownerView).toContain('action="/campaigns/' + campaign.id + '/members/');
+    expect(ownerView).toContain('/remove"');
+    expect(ownerView).toContain('Remove member@example.com?');
+    expect(ownerView).toContain('action="/campaigns/' + campaign.id + '/invites/');
+    expect(ownerView).toContain('/cancel"');
+    expect(ownerView).toContain('Cancel invite for invitee@example.com?');
+    expect(ownerView).not.toContain('No pending invites.');
+
+    const memberView = await (
+      await app.request(`/campaigns/${campaign.id}/players`, {
+        headers: { Cookie: member.cookie },
+      })
+    ).text();
+    expect(memberView).toContain('Joined players');
+    expect(memberView).toContain('Pending invites');
+    expect(memberView).toContain(MEMBER_EMAIL);
+    expect(memberView).toContain(INVITEE_EMAIL);
+    expect(memberView).not.toContain('/remove"');
+    expect(memberView).not.toContain('/cancel"');
+  });
+
+  it('shows an explicit empty state when there are no pending invites', async () => {
+    const { owner, campaign } = await setupFixture();
+    const body = await (
+      await app.request(`/campaigns/${campaign.id}/players`, {
+        headers: { Cookie: owner.cookie },
+      })
+    ).text();
+    expect(body).toContain('Joined players');
+    expect(body).toContain('Pending invites');
+    expect(body).toContain('No pending invites.');
+  });
+
+  it('rejects an invalid email with an inline error and preserves the entered value', async () => {
     const { owner, campaign } = await setupFixture();
     const res = await invite(owner, campaign.id, 'not-an-email');
     expect(res.status).toBe(422);
     const body = await res.text();
     expect(body).toContain('COULD NOT SAVE');
     expect(body).toContain('Enter a valid email address.');
+    expect(body).toContain('value="not-an-email"');
   });
 
   it('rejects an email that is not on the allowlist', async () => {
@@ -187,5 +256,79 @@ describe('invite-member UI (SQR-319)', () => {
     const outsider = await createTestUser(OUTSIDER_EMAIL);
     const res = await invite(outsider, campaign.id, INVITEE_EMAIL);
     expect(res.status).toBe(404);
+  });
+
+  it('cancels pending invites with a destructive confirmation', async () => {
+    const { owner, campaign } = await setupFixture();
+    const inviteRow = await CampaignService.inviteMember(
+      identityFromSessionUser(owner.userId),
+      campaign.id,
+      INVITEE_EMAIL,
+    );
+
+    const missingConfirm = await memberAction({
+      user: owner,
+      campaignId: campaign.id,
+      memberId: inviteRow.memberId,
+      pathAction: 'cancel',
+    });
+    expect(missingConfirm.status).toBe(422);
+    const errorBody = await missingConfirm.text();
+    expect(errorBody).toContain('Cancel invite for invitee@example.com?');
+    expect(errorBody).toContain('Confirm cancel to remove the pending invite.');
+
+    const cancelled = await memberAction({
+      user: owner,
+      campaignId: campaign.id,
+      memberId: inviteRow.memberId,
+      pathAction: 'cancel',
+      confirm: 'cancel',
+    });
+    expect(cancelled.status).toBe(303);
+    expect(cancelled.headers.get('location')).toBe(`/campaigns/${campaign.id}/players`);
+
+    const players = await (
+      await app.request(`/campaigns/${campaign.id}/players`, {
+        headers: { Cookie: owner.cookie },
+      })
+    ).text();
+    expect(players).not.toContain(INVITEE_EMAIL);
+    expect(players).toContain('No pending invites.');
+  });
+
+  it('removes joined players with a destructive confirmation', async () => {
+    const { owner, campaign } = await setupFixture();
+    await addActiveMember(owner, campaign.id, MEMBER_EMAIL);
+    const memberId = (
+      await CampaignService.getCampaignDetail(identityFromSessionUser(owner.userId), campaign.id)
+    ).members.find((member) => member.email === MEMBER_EMAIL)!.memberId;
+
+    const missingConfirm = await memberAction({
+      user: owner,
+      campaignId: campaign.id,
+      memberId,
+      pathAction: 'remove',
+    });
+    expect(missingConfirm.status).toBe(422);
+    const errorBody = await missingConfirm.text();
+    expect(errorBody).toContain('Remove member@example.com?');
+    expect(errorBody).toContain('Confirm remove to remove this player from the campaign.');
+
+    const removed = await memberAction({
+      user: owner,
+      campaignId: campaign.id,
+      memberId,
+      pathAction: 'remove',
+      confirm: 'remove',
+    });
+    expect(removed.status).toBe(303);
+    expect(removed.headers.get('location')).toBe(`/campaigns/${campaign.id}/players`);
+
+    const ownerView = await (
+      await app.request(`/campaigns/${campaign.id}/players`, {
+        headers: { Cookie: owner.cookie },
+      })
+    ).text();
+    expect(ownerView).not.toContain(MEMBER_EMAIL);
   });
 });

--- a/test/web-ui-htmx.regression-1.test.ts
+++ b/test/web-ui-htmx.regression-1.test.ts
@@ -45,9 +45,10 @@ describe('squire.js HTMX first-turn submit regression', () => {
   });
 
   it('marks Party character forms submitting without touching chat submit text', () => {
-    expect(squireJs).toContain(
-      "form.matches('.squire-character-create, .squire-party-row__action form')",
-    );
+    expect(squireJs).toContain('.squire-character-create');
+    expect(squireJs).toContain('.squire-invite-member');
+    expect(squireJs).toContain('.squire-party-row__action form');
+    expect(squireJs).toContain('.squire-player-row__action form');
     expect(squireJs).toContain("form.dataset.submitting = 'true';");
     expect(squireJs).toContain("form.setAttribute('aria-busy', 'true');");
   });


### PR DESCRIPTION
## Summary

- Build `/campaigns/:id/players` as the campaign membership page with separate joined-player and pending-invite sections.
- Add owner-only invite creation, member removal, and invite cancellation with destructive confirmations and inline row/form errors.
- Preserve invite form values on failure and extend browser pending-state handling to Players forms.
- Bump release metadata to `0.1.25` and update the changelog.

## Tests

- `npm run check`
- Manual browser QA at `http://localhost:3000/campaigns/<id>/players` covering joined players, pending invites, invite creation success/failure, cancel invite, remove player, empty pending state, desktop layout, and mobile layout.

Fixes SQR-361


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added campaign Players section displaying joined players and pending invites separately
  * Owners can now invite members by email and remove joined players
  * Owners can cancel pending invites with confirmation prompts
  * Implemented empty state messaging for the Players section

* **Bug Fixes**
  * Form now preserves entered email when validation fails

* **Chores**
  * Version bumped to 0.1.25
  * Enhanced form submission UI feedback and styling
  * Added comprehensive Players section test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->