### PR TITLE
feat(campaigns): build campaign settings workspace

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -641,6 +641,18 @@ gets a glyph:
 
 ### Campaign workspace components (`/campaigns/:id` and section routes)
 
+- **Campaign typography scale**: workspace and list page titles use the
+  largest campaign heading step (`1.556rem` desktop, `1.375rem` mobile).
+  Route-level section headings such as Progress, Party, Players, Settings,
+  Invitations, and New campaign use the next step (`1.222rem` desktop,
+  `1.25rem` mobile). Nested groups, scenario threads, character names, player
+  names, and campaign-list item names use `1rem` desktop / `1.125rem` mobile;
+  minor date headings use `0.889rem` desktop / `1rem` mobile; ledes and
+  empty-state copy use Geist `0.778rem` desktop / `0.875rem` mobile. The rem
+  values differ because the app root is `18px` on desktop and `16px` on
+  mobile; the intended rendered ladder is 28/22/18/16/14. Do not visually
+  invert semantic heading order: an `h3` group title must not render larger
+  than its parent `h2`.
 - **Workspace header**: campaign name is the strongest first-viewport signal.
   It sits below a conventional breadcrumb: linked `Campaigns` followed by the
   unlinked current campaign name. The subtitle uses the full game system name

--- a/src/server.ts
+++ b/src/server.ts
@@ -1580,6 +1580,8 @@ async function renderCampaignDashboardPage(
     };
     renameError?: string;
     modulesError?: string;
+    renameNameValue?: string;
+    moduleValues?: readonly string[];
     characterFormValues?: {
       nameValue?: string;
       classNameValue?: string;
@@ -1664,15 +1666,21 @@ async function renderCampaignDashboardPage(
       opts.playerActionError,
       // Rename affordance (SQR-320): any active member; the name is shared
       // state. expectedVersion drives optimistic concurrency.
-      { csrfToken, version: detail.campaign.version, errorMessage: opts.renameError },
-      // Modules editor (SQR-321): only when the game has optional modules.
-      gameDef && gameDef.optionalModules.length > 0
+      {
+        csrfToken,
+        version: detail.campaign.version,
+        nameValue: opts.renameNameValue,
+        errorMessage: opts.renameError,
+      },
+      // Optional content settings (SQR-321/SQR-362): always rendered for
+      // supported games so Settings owns the default/no-optional-content state.
+      gameDef
         ? {
             csrfToken,
             version: detail.campaign.version,
             baseModule: gameDef.baseModule,
             optionalModules: gameDef.optionalModules,
-            current: detail.campaign.modules,
+            current: opts.moduleValues ?? detail.campaign.modules,
             errorMessage: opts.modulesError,
           }
         : undefined,
@@ -2135,7 +2143,8 @@ app.post('/campaigns/:id/rename', async (c) => {
   if (!campaignId) return c.notFound();
   const identity = identityFromSessionUser(session.userId);
   const form = await c.req.formData();
-  const name = typeof form.get('name') === 'string' ? (form.get('name') as string).trim() : '';
+  const rawName = typeof form.get('name') === 'string' ? (form.get('name') as string) : '';
+  const name = rawName.trim();
   // Strict parse via formInt (`/^\d+$/` → null) so a malformed token like
   // "7abc" can't slip past Number.parseInt's leniency into the version guard.
   const expectedVersion = formInt(form, 'expectedVersion');
@@ -2149,7 +2158,11 @@ app.post('/campaigns/:id/rename', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { renameError: 'Campaign name is required.', view: 'settings' },
+        {
+          renameError: 'Campaign name is required.',
+          renameNameValue: rawName,
+          view: 'settings',
+        },
         422,
       );
     }
@@ -2157,7 +2170,11 @@ app.post('/campaigns/:id/rename', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { renameError: 'Campaign name must be 200 characters or fewer.', view: 'settings' },
+        {
+          renameError: 'Campaign name must be 200 characters or fewer.',
+          renameNameValue: rawName,
+          view: 'settings',
+        },
         422,
       );
     }
@@ -2165,7 +2182,11 @@ app.post('/campaigns/:id/rename', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { renameError: 'Could not save — please refresh and try again.', view: 'settings' },
+        {
+          renameError: 'Could not save — please refresh and try again.',
+          renameNameValue: rawName,
+          view: 'settings',
+        },
         422,
       );
     }
@@ -2179,7 +2200,8 @@ app.post('/campaigns/:id/rename', async (c) => {
         c,
         campaignId,
         {
-          renameError: 'Updated elsewhere — showing the latest. Try the rename again.',
+          renameError: 'Updated elsewhere — review your change and try again.',
+          renameNameValue: rawName,
           view: 'settings',
         },
         422,
@@ -2189,7 +2211,7 @@ app.post('/campaigns/:id/rename', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { renameError: error.message, view: 'settings' },
+        { renameError: error.message, renameNameValue: rawName, view: 'settings' },
         422,
       );
     }
@@ -2217,7 +2239,11 @@ app.post('/campaigns/:id/modules', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { modulesError: 'Could not save — please refresh and try again.', view: 'settings' },
+        {
+          modulesError: 'Could not save — please refresh and try again.',
+          moduleValues: [...checked],
+          view: 'settings',
+        },
         422,
       );
     }
@@ -2237,7 +2263,11 @@ app.post('/campaigns/:id/modules', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { modulesError: 'Updated elsewhere — showing the latest. Try again.', view: 'settings' },
+        {
+          modulesError: 'Updated elsewhere — review your choices and try again.',
+          moduleValues: [...checked],
+          view: 'settings',
+        },
         422,
       );
     }
@@ -2248,7 +2278,7 @@ app.post('/campaigns/:id/modules', async (c) => {
       return await renderCampaignDashboardPage(
         c,
         campaignId,
-        { modulesError: error.message, view: 'settings' },
+        { modulesError: error.message, moduleValues: [...checked], view: 'settings' },
         422,
       );
     }

--- a/src/web-ui/campaign-dashboard.ts
+++ b/src/web-ui/campaign-dashboard.ts
@@ -36,10 +36,15 @@ const STATUS_LABEL: Record<ScenarioStatus, string> = {
 const ACTIONABLE: ReadonlySet<ScenarioStatus> = new Set(['open', 'via-event', 'drew-it']);
 
 const PROGRESS_LOADING_INDICATOR = '#squire-dashboard-progress-loading';
+const PROGRESS_SECTION_LEDE =
+  'Track unlocked, played, skipped, and blocked scenarios for this campaign.';
 
 function progressSectionHeader(options: { hasScenarioData: boolean }): HtmlEscapedString {
   return html`<header class="squire-progress-section__header">
-    <h2 class="squire-campaign-dashboard__section-title">Progress</h2>
+    <div>
+      <h2 class="squire-campaign-dashboard__section-title">Progress</h2>
+      <p class="squire-progress-section__lede">${PROGRESS_SECTION_LEDE}</p>
+    </div>
     ${options.hasScenarioData
       ? html`<a
           class="squire-button squire-button--primary squire-button--small"
@@ -243,7 +248,7 @@ export function renderDashboardProgressEmpty(): HtmlEscapedString {
   >
     ${progressSectionHeader({ hasScenarioData: false })}
     <p class="squire-campaign-dashboard__placeholder">
-      No scenario data for this campaign's modules yet.
+      No scenario progress is available for this campaign yet.
     </p>
   </section>` as HtmlEscapedString;
 }
@@ -322,7 +327,7 @@ export function renderDashboardThreads(input: DashboardThreadsInput): HtmlEscape
           .filter((warning): warning is NonNullable<typeof warning> => warning !== undefined);
         return html`<section class="squire-dashboard-thread">
           <header class="squire-dashboard-thread__header">
-            <h2 class="squire-dashboard-thread__title">${thread.label}</h2>
+            <h3 class="squire-dashboard-thread__title">${thread.label}</h3>
             <p class="squire-dashboard-thread__note">
               ${thread.note}
               <span class="squire-dashboard-thread__progress"

--- a/src/web-ui/campaign-pages.ts
+++ b/src/web-ui/campaign-pages.ts
@@ -712,6 +712,8 @@ export interface CampaignRenameForm {
   csrfToken: string;
   /** Optimistic-concurrency token; submitted as expectedVersion. */
   version: number;
+  /** Submitted value to preserve after a failed save. Defaults to the current campaign name. */
+  nameValue?: string;
   /** Inline error/notice after a failed rename (validation or version race). */
   errorMessage?: string;
 }
@@ -882,92 +884,122 @@ function renderCampaignWorkspaceHeader(
   </header>` as HtmlEscapedString;
 }
 
-/**
- * A quiet modules disclosure. Toggling changes which scenario set the dashboard
- * shows; removal is non-destructive (a removed module's played/skipped keys
- * persist and return if it is re-added). Any active member may edit — modules
- * are shared state. Only rendered for games that have optional modules.
- */
 function renderCampaignModulesForm(
   campaign: Campaign,
   data: CampaignModulesForm,
 ): HtmlEscapedString {
   const checked = new Set(data.current);
-  return html`<details class="squire-campaign-modules" ${data.errorMessage ? 'open' : ''}>
-    <summary class="squire-campaign-modules__toggle">Modules</summary>
-    ${data.errorMessage
-      ? html`<div class="squire-banner squire-banner--error" role="alert">
-          <span class="squire-banner__label">COULD NOT SAVE</span>
-          <p class="squire-banner__body">${data.errorMessage}</p>
-        </div>`
-      : html``}
-    <form
-      method="post"
-      action="/campaigns/${campaign.id}/modules"
-      class="squire-campaign-modules__form"
-      aria-label="Edit campaign modules"
-    >
-      <input type="hidden" name="_csrf" value="${data.csrfToken}" />
-      <input type="hidden" name="expectedVersion" value="${data.version}" />
-      <label class="squire-campaign-modules__option">
-        <input type="checkbox" checked disabled />
-        ${moduleLabel(data.baseModule)}
-        <span class="squire-campaign-modules__required">required</span>
-      </label>
-      ${data.optionalModules.map(
-        (module) =>
-          html`<label class="squire-campaign-modules__option">
-            <input
-              type="checkbox"
-              name="module"
-              value="${module}"
-              ${checked.has(module) ? 'checked' : ''}
-            />
-            ${moduleLabel(module)}
-          </label>`,
-      )}
-      <button type="submit" class="squire-campaign-modules__submit">SAVE MODULES</button>
-    </form>
-  </details>` as HtmlEscapedString;
+  return html`<section
+    class="squire-campaign-settings__group"
+    aria-labelledby="optional-content-title"
+  >
+    <div class="squire-campaign-settings__group-copy">
+      <h3 class="squire-campaign-settings__group-title" id="optional-content-title">
+        Optional content
+      </h3>
+      <p class="squire-campaign-settings__group-lede">
+        Choose the scenario packs that belong to this campaign.
+      </p>
+    </div>
+    <div class="squire-campaign-settings__group-body">
+      ${data.errorMessage
+        ? html`<div class="squire-banner squire-banner--error" role="alert">
+            <span class="squire-banner__label">COULD NOT SAVE</span>
+            <p class="squire-banner__body">${data.errorMessage}</p>
+          </div>`
+        : html``}
+      ${data.optionalModules.length === 0
+        ? html`<p class="squire-campaign-settings__empty">
+            No optional content is available for ${gameSystemLabel(campaign.game)}.
+          </p>`
+        : html`
+            <form
+              method="post"
+              action="/campaigns/${campaign.id}/modules"
+              class="squire-campaign-settings__form"
+              aria-label="Edit optional content"
+            >
+              <input type="hidden" name="_csrf" value="${data.csrfToken}" />
+              <input type="hidden" name="expectedVersion" value="${data.version}" />
+              <label class="squire-campaign-settings__option">
+                <input type="checkbox" checked disabled />
+                ${moduleLabel(data.baseModule)}
+                <span class="squire-campaign-settings__required">required</span>
+              </label>
+              ${data.optionalModules.map(
+                (module) =>
+                  html`<label class="squire-campaign-settings__option">
+                    <input
+                      type="checkbox"
+                      name="module"
+                      value="${module}"
+                      ${checked.has(module) ? 'checked' : ''}
+                    />
+                    ${moduleLabel(module)}
+                  </label>`,
+              )}
+              <button
+                type="submit"
+                class="squire-campaign-settings__submit"
+                aria-label="Save optional content"
+              >
+                Save optional content
+              </button>
+            </form>
+          `}
+    </div>
+  </section>` as HtmlEscapedString;
 }
 
-/**
- * A quiet rename disclosure under the campaign title. Any active member may
- * rename (campaign name is shared state, like the scenario toggles), so the
- * affordance is not owner-gated. The disclosure opens automatically when a
- * prior attempt failed so the error and form are visible.
- */
 function renderCampaignRenameForm(campaign: Campaign, data: CampaignRenameForm): HtmlEscapedString {
-  return html`<details class="squire-campaign-rename" ${data.errorMessage ? 'open' : ''}>
-    <summary class="squire-campaign-rename__toggle">Rename</summary>
-    ${data.errorMessage
-      ? html`<div class="squire-banner squire-banner--error" role="alert">
-          <span class="squire-banner__label">COULD NOT SAVE</span>
-          <p class="squire-banner__body">${data.errorMessage}</p>
-        </div>`
-      : html``}
-    <form
-      method="post"
-      action="/campaigns/${campaign.id}/rename"
-      class="squire-campaign-rename__form"
-      aria-label="Rename campaign"
-    >
-      <input type="hidden" name="_csrf" value="${data.csrfToken}" />
-      <input type="hidden" name="expectedVersion" value="${data.version}" />
-      <label class="squire-campaign-rename__field">
-        <span class="squire-campaign-rename__field-label">CAMPAIGN NAME</span>
-        <input
-          name="name"
-          type="text"
-          required
-          maxlength="200"
-          autocomplete="off"
-          value="${campaign.name}"
-        />
-      </label>
-      <button type="submit" class="squire-campaign-rename__submit">SAVE</button>
-    </form>
-  </details>` as HtmlEscapedString;
+  const nameValue = data.nameValue ?? campaign.name;
+  return html`<section
+    class="squire-campaign-settings__group"
+    aria-labelledby="campaign-name-title"
+  >
+    <div class="squire-campaign-settings__group-copy">
+      <h3 class="squire-campaign-settings__group-title" id="campaign-name-title">Campaign name</h3>
+      <p class="squire-campaign-settings__group-lede">
+        This name appears in the campaign workspace and player campaign lists.
+      </p>
+    </div>
+    <div class="squire-campaign-settings__group-body">
+      ${data.errorMessage
+        ? html`<div class="squire-banner squire-banner--error" role="alert">
+            <span class="squire-banner__label">COULD NOT SAVE</span>
+            <p class="squire-banner__body">${data.errorMessage}</p>
+          </div>`
+        : html``}
+      <form
+        method="post"
+        action="/campaigns/${campaign.id}/rename"
+        class="squire-campaign-settings__form squire-campaign-settings__form--name"
+        aria-label="Edit campaign name"
+      >
+        <input type="hidden" name="_csrf" value="${data.csrfToken}" />
+        <input type="hidden" name="expectedVersion" value="${data.version}" />
+        <div class="squire-campaign-settings__field squire-campaign-settings__field--with-action">
+          <label class="sr-only" for="squire-campaign-name-${campaign.id}">Campaign name</label>
+          <input
+            id="squire-campaign-name-${campaign.id}"
+            name="name"
+            type="text"
+            required
+            maxlength="200"
+            autocomplete="off"
+            value="${nameValue}"
+          />
+          <button
+            type="submit"
+            class="squire-campaign-settings__submit squire-campaign-settings__submit--field-action"
+            aria-label="Save campaign name"
+          >
+            Save
+          </button>
+        </div>
+      </form>
+    </div>
+  </section>` as HtmlEscapedString;
 }
 
 /** `/campaigns/:id` — dashboard: header, threads (SQR-276), roster. */
@@ -1021,7 +1053,14 @@ export function renderCampaignDashboardContent(
         : html``}
       ${activeView === 'settings'
         ? html`<section class="squire-campaign-dashboard__settings" aria-label="Settings">
-            <h2 class="squire-campaign-dashboard__section-title">Settings</h2>
+            <header class="squire-campaign-settings__header">
+              <div>
+                <h2 class="squire-campaign-dashboard__section-title">Settings</h2>
+                <p class="squire-campaign-settings__lede">
+                  Manage campaign setup and content choices.
+                </p>
+              </div>
+            </header>
             ${renameForm ? renderCampaignRenameForm(campaign, renameForm) : html``}
             ${modulesForm ? renderCampaignModulesForm(campaign, modulesForm) : html``}
           </section>`

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -2247,10 +2247,8 @@ template#squire-banner-fixtures {
   padding-top: var(--space-md);
 }
 
-.squire-campaign-workspace .squire-campaign-dashboard--party,
-.squire-campaign-workspace .squire-campaign-dashboard--players,
 .squire-campaign-workspace .squire-campaign-dashboard--settings {
-  max-width: 640px;
+  max-width: 820px;
 }
 
 .squire-campaign-workspace__header {
@@ -2391,7 +2389,11 @@ template#squire-banner-fixtures {
   }
 
   .squire-campaign-workspace .squire-campaign-dashboard__name {
-    font-size: 22px;
+    font-size: var(--squire-campaign-type-page, 1.375rem);
+  }
+
+  .squire-campaign-workspace .squire-campaign-dashboard__section-title {
+    font-size: var(--squire-campaign-type-section, 1.25rem);
   }
 }
 
@@ -2399,9 +2401,30 @@ template#squire-banner-fixtures {
 .squire-campaign-dashboard__name {
   font-family: 'Fraunces', 'Georgia', serif;
   font-weight: 500;
-  font-size: 28px;
+  font-size: var(--squire-campaign-type-page, 1.75rem);
+  line-height: 1.25;
   color: var(--parchment);
   margin: 0 0 var(--space-sm);
+}
+
+.squire-campaigns,
+.squire-campaign-workspace {
+  --squire-campaign-type-page: 1.556rem;
+  --squire-campaign-type-section: 1.222rem;
+  --squire-campaign-type-group: 1rem;
+  --squire-campaign-type-minor: 0.889rem;
+  --squire-campaign-type-body: 0.778rem;
+}
+
+@media (max-width: 640px) {
+  .squire-campaigns,
+  .squire-campaign-workspace {
+    --squire-campaign-type-page: 1.375rem;
+    --squire-campaign-type-section: 1.25rem;
+    --squire-campaign-type-group: 1.125rem;
+    --squire-campaign-type-minor: 1rem;
+    --squire-campaign-type-body: 0.875rem;
+  }
 }
 
 .squire-campaign-workspace .squire-campaign-dashboard__name {
@@ -2412,8 +2435,19 @@ template#squire-banner-fixtures {
   text-overflow: ellipsis;
 }
 
-.squire-campaigns__empty,
+.squire-campaigns__empty {
+  color: var(--sepia);
+}
+
 .squire-campaign-dashboard__placeholder {
+  margin: 0;
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--surface) 66%, transparent);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: var(--squire-campaign-type-body, 0.875rem);
+  line-height: 1.45;
   color: var(--sepia);
 }
 
@@ -2439,7 +2473,8 @@ template#squire-banner-fixtures {
 
 .squire-campaigns__name {
   font-family: 'Fraunces', 'Georgia', serif;
-  font-size: 18px;
+  font-size: var(--squire-campaign-type-group, 1.125rem);
+  line-height: 1.25;
   color: var(--parchment);
 }
 
@@ -2456,7 +2491,8 @@ template#squire-banner-fixtures {
 .squire-campaign-dashboard__section-title {
   font-family: 'Fraunces', 'Georgia', serif;
   font-weight: 500;
-  font-size: 18px;
+  font-size: var(--squire-campaign-type-section, 1.375rem);
+  line-height: 1.25;
   color: var(--parchment);
   margin: var(--space-lg) 0 var(--space-sm);
 }
@@ -2714,49 +2750,87 @@ template#squire-banner-fixtures {
   background: var(--wax-dim);
 }
 
-/* Rename campaign (SQR-320): a quiet disclosure under the title. */
-.squire-campaign-rename {
-  margin-top: var(--space-sm);
+/* Campaign settings (SQR-362): campaign setup belongs on one explicit page. */
+.squire-campaign-settings__header {
+  margin-bottom: var(--space-lg);
 }
 
-.squire-campaign-rename__toggle {
+.squire-campaign-settings__header .squire-campaign-dashboard__section-title {
+  margin: 0;
+}
+
+.squire-campaign-settings__lede,
+.squire-player-section__lede,
+.squire-party-section__lede,
+.squire-progress-section__lede {
+  margin: var(--space-2xs) 0 0;
   font-family: 'Geist', system-ui, sans-serif;
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--sepia-dim);
-  cursor: pointer;
-  min-height: 44px;
-  display: flex;
-  align-items: center;
-}
-
-.squire-campaign-rename__toggle:hover {
+  font-size: var(--squire-campaign-type-body, 0.875rem);
+  line-height: 1.45;
   color: var(--sepia);
 }
 
-.squire-campaign-rename__form {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-md);
-  align-items: end;
-  margin-top: var(--space-sm);
+.squire-campaign-settings__group {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.35fr) minmax(280px, 0.65fr);
+  gap: var(--space-lg);
+  padding: var(--space-lg) 0;
+  border-top: 1px solid var(--rule);
 }
 
-.squire-campaign-rename__field {
-  display: flex;
-  flex-direction: column;
+.squire-campaign-settings__group-copy {
+  display: grid;
+  align-content: start;
   gap: var(--space-xs);
 }
 
-.squire-campaign-rename__field-label {
+.squire-campaign-settings__group-body {
+  display: grid;
+  align-content: start;
+  gap: var(--space-sm);
+  min-width: 0;
+}
+
+.squire-campaign-settings__group-title {
+  margin: 0;
+  font-family: 'Fraunces', 'Georgia', serif;
+  font-weight: 500;
+  font-size: var(--squire-campaign-type-group, 1.125rem);
+  line-height: 1.25;
+  color: var(--parchment);
+}
+
+.squire-campaign-settings__group-lede,
+.squire-campaign-settings__empty {
+  margin: 0;
   font-family: 'Geist', system-ui, sans-serif;
-  font-size: 11px;
-  letter-spacing: 0.14em;
+  font-size: var(--squire-campaign-type-body, 0.875rem);
+  line-height: 1.45;
   color: var(--sepia);
 }
 
-.squire-campaign-rename__field input {
+.squire-campaign-settings__form {
+  display: grid;
+  gap: var(--space-sm);
+  align-items: start;
+}
+
+.squire-campaign-settings__form--name {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.squire-campaign-settings__field {
+  display: grid;
+  gap: var(--space-xs);
+  min-width: 0;
+}
+
+.squire-campaign-settings__field--with-action {
+  position: relative;
+}
+
+.squire-campaign-settings__field input {
+  width: min(100%, 34rem);
   background: var(--surface);
   border: 1px solid var(--rule);
   border-radius: 4px;
@@ -2764,56 +2838,15 @@ template#squire-banner-fixtures {
   min-height: 44px;
   padding: 0 var(--space-sm);
   font-family: 'Geist', system-ui, sans-serif;
-  min-width: 16rem;
+  font-size: 15px;
 }
 
-.squire-campaign-rename__submit {
-  font-family: 'Geist', system-ui, sans-serif;
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  color: var(--parchment);
-  background: var(--wax);
-  border: 1px solid var(--wax);
-  border-radius: 4px;
-  padding: 0 var(--space-md);
-  min-height: 44px;
-  cursor: pointer;
+.squire-campaign-settings__field--with-action input {
+  width: 100%;
+  padding-right: 5.5rem;
 }
 
-.squire-campaign-rename__submit:hover {
-  background: var(--wax-dim);
-}
-
-/* Modules editor (SQR-321): a quiet disclosure mirroring rename. */
-.squire-campaign-modules {
-  margin-top: var(--space-xs);
-}
-
-.squire-campaign-modules__toggle {
-  font-family: 'Geist', system-ui, sans-serif;
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--sepia-dim);
-  cursor: pointer;
-  min-height: 44px;
-  display: flex;
-  align-items: center;
-}
-
-.squire-campaign-modules__toggle:hover {
-  color: var(--sepia);
-}
-
-.squire-campaign-modules__form {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-  margin-top: var(--space-sm);
-  align-items: start;
-}
-
-.squire-campaign-modules__option {
+.squire-campaign-settings__option {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
@@ -2823,17 +2856,18 @@ template#squire-banner-fixtures {
   color: var(--parchment-dim);
 }
 
-.squire-campaign-modules__required {
+.squire-campaign-settings__required {
   font-size: 11px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--sepia-dim);
 }
 
-.squire-campaign-modules__submit {
+.squire-campaign-settings__submit {
+  justify-self: start;
   font-family: 'Geist', system-ui, sans-serif;
-  font-size: 11px;
-  letter-spacing: 0.14em;
+  font-size: 14px;
+  font-weight: 700;
   color: var(--parchment);
   background: var(--wax);
   border: 1px solid var(--wax);
@@ -2841,11 +2875,38 @@ template#squire-banner-fixtures {
   padding: 0 var(--space-md);
   min-height: 44px;
   cursor: pointer;
-  margin-top: var(--space-xs);
+  white-space: nowrap;
 }
 
-.squire-campaign-modules__submit:hover {
+.squire-campaign-settings__submit--field-action {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  min-height: 36px;
+  padding: 0 var(--space-sm);
+}
+
+.squire-campaign-settings__submit:hover {
   background: var(--wax-dim);
+}
+
+@media (max-width: 820px) {
+  .squire-campaign-settings__group {
+    grid-template-columns: 1fr;
+    gap: var(--space-md);
+  }
+
+  .squire-campaign-settings__form--name {
+    grid-template-columns: 1fr;
+  }
+
+  .squire-campaign-settings__submit {
+    width: 100%;
+  }
+
+  .squire-campaign-settings__submit--field-action {
+    width: auto;
+  }
 }
 
 /* Create-form optional-content checkboxes (SQR-321). */
@@ -2915,7 +2976,8 @@ template#squire-banner-fixtures {
 .squire-campaigns__section-title {
   font-family: 'Fraunces', 'Georgia', serif;
   font-weight: 500;
-  font-size: 18px;
+  font-size: var(--squire-campaign-type-section, 1.375rem);
+  line-height: 1.25;
   color: var(--parchment);
   border-bottom: 1px solid var(--rule);
   padding-bottom: var(--space-xs);
@@ -2965,13 +3027,6 @@ template#squire-banner-fixtures {
 
 .squire-player-section__header .squire-campaign-dashboard__section-title {
   margin: 0;
-}
-
-.squire-player-section__lede {
-  margin: var(--space-2xs) 0 0;
-  font-family: 'Geist', system-ui, sans-serif;
-  font-size: 14px;
-  color: var(--sepia);
 }
 
 .squire-player-section__action {
@@ -3036,7 +3091,8 @@ template#squire-banner-fixtures {
   margin: 0 0 var(--space-sm);
   font-family: 'Fraunces', 'Georgia', serif;
   font-weight: 500;
-  font-size: 20px;
+  font-size: var(--squire-campaign-type-group, 1.125rem);
+  line-height: 1.25;
   color: var(--parchment);
 }
 
@@ -3085,7 +3141,8 @@ template#squire-banner-fixtures {
 
 .squire-player-row__name {
   font-family: 'Fraunces', 'Georgia', serif;
-  font-size: 20px;
+  font-size: var(--squire-campaign-type-group, 1.125rem);
+  line-height: 1.25;
   color: var(--parchment);
   overflow-wrap: anywhere;
 }
@@ -3255,13 +3312,6 @@ template#squire-banner-fixtures {
   margin: 0;
 }
 
-.squire-party-section__lede {
-  margin: var(--space-2xs) 0 0;
-  font-family: 'Geist', system-ui, sans-serif;
-  font-size: 14px;
-  color: var(--sepia);
-}
-
 .squire-party-section__action {
   display: flex;
   justify-content: flex-end;
@@ -3324,7 +3374,8 @@ template#squire-banner-fixtures {
   margin: 0 0 var(--space-sm);
   font-family: 'Fraunces', 'Georgia', serif;
   font-weight: 500;
-  font-size: 20px;
+  font-size: var(--squire-campaign-type-group, 1.125rem);
+  line-height: 1.25;
   color: var(--parchment);
 }
 
@@ -3349,7 +3400,7 @@ template#squire-banner-fixtures {
 
 .squire-party-row {
   display: grid;
-  grid-template-columns: minmax(16rem, 1.6fr) minmax(9rem, 0.8fr) max-content;
+  grid-template-columns: minmax(14rem, 1.4fr) minmax(8rem, 0.65fr) minmax(28rem, 1fr);
   gap: var(--space-md);
   align-items: center;
   min-height: 64px;
@@ -3376,7 +3427,8 @@ template#squire-banner-fixtures {
 
 .squire-party-row__name {
   font-family: 'Fraunces', 'Georgia', serif;
-  font-size: 20px;
+  font-size: var(--squire-campaign-type-group, 1.125rem);
+  line-height: 1.25;
   color: var(--parchment);
 }
 
@@ -3570,10 +3622,10 @@ template#squire-banner-fixtures {
 
 .squire-progress-section__header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: var(--space-md);
-  margin-bottom: var(--space-md);
+  gap: var(--space-lg);
+  margin-bottom: var(--space-lg);
 }
 
 .squire-progress-section__header .squire-campaign-dashboard__section-title {
@@ -3668,7 +3720,7 @@ template#squire-banner-fixtures {
 .squire-dashboard-stats__value {
   margin: 0;
   font-family: 'Fraunces', 'Georgia', serif;
-  font-size: 28px;
+  font-size: var(--squire-campaign-type-page, 1.75rem);
   font-variant-numeric: tabular-nums;
   color: var(--parchment);
 }
@@ -3696,7 +3748,8 @@ template#squire-banner-fixtures {
 .squire-dashboard-thread__title {
   font-family: 'Fraunces', 'Georgia', serif;
   font-weight: 500;
-  font-size: 20px;
+  font-size: var(--squire-campaign-type-group, 1.125rem);
+  line-height: 1.25;
   color: var(--parchment);
   margin: 0;
 }
@@ -3917,7 +3970,8 @@ template#squire-banner-fixtures {
 .squire-campaign-journal__date {
   font-family: 'Fraunces', 'Georgia', serif;
   font-weight: 500;
-  font-size: 15px;
+  font-size: var(--squire-campaign-type-minor, 1rem);
+  line-height: 1.25;
   color: var(--parchment-dim);
   margin: var(--space-md) 0 var(--space-xs);
 }

--- a/test/campaign-dashboard-renderer.test.ts
+++ b/test/campaign-dashboard-renderer.test.ts
@@ -10,7 +10,12 @@ describe('campaign progress renderer states', () => {
     const body = String(renderDashboardProgressEmpty());
 
     expect(body).toContain('<h2 class="squire-campaign-dashboard__section-title">Progress</h2>');
-    expect(body).toContain("No scenario data for this campaign's modules yet.");
+    expect(body).toContain('class="squire-progress-section__lede"');
+    expect(body).toContain(
+      'Track unlocked, played, skipped, and blocked scenarios for this campaign.',
+    );
+    expect(body).toContain('class="squire-campaign-dashboard__placeholder"');
+    expect(body).toContain('No scenario progress is available for this campaign yet.');
     expect(body).not.toContain('Record progress');
   });
 
@@ -18,6 +23,9 @@ describe('campaign progress renderer states', () => {
     const body = String(renderDashboardProgressError('campaign-1'));
 
     expect(body).toContain('COULD NOT LOAD');
+    expect(body).toContain(
+      'Track unlocked, played, skipped, and blocked scenarios for this campaign.',
+    );
     expect(body).toContain('Progress is unavailable right now.');
     expect(body).toContain('href="/campaigns/campaign-1"');
     expect(body).toContain('Retry');

--- a/test/campaign-dashboard.test.ts
+++ b/test/campaign-dashboard.test.ts
@@ -197,6 +197,9 @@ describe('dashboard rendering', () => {
     expect(body).not.toContain('>More</');
     expect(body).toContain('aria-label="Scenario progression"');
     expect(body).toContain('<h2 class="squire-campaign-dashboard__section-title">Progress</h2>');
+    expect(body).toContain(
+      'Track unlocked, played, skipped, and blocked scenarios for this campaign.',
+    );
     expect(body).toContain('Record progress');
     expect(body).not.toContain('aria-label="Party roster"');
     expect(body).not.toContain('squire-character-create');

--- a/test/campaign-modules.test.ts
+++ b/test/campaign-modules.test.ts
@@ -125,7 +125,7 @@ describe('edit-modules UI (SQR-321)', () => {
     expect(await modulesOf(owner, fh)).toEqual(['fh']);
   });
 
-  it('Settings shows the modules editor for GH2e but not Frosthaven', async () => {
+  it('Settings shows the optional-content editor for GH2e but not Frosthaven', async () => {
     const owner = await createTestUser(OWNER_EMAIL);
     const gh2e = await createViaForm(owner, 'GH2', 'gloomhaven-2e', { solo: true });
     const fh = await createViaForm(owner, 'FH', 'frosthaven', { solo: false });
@@ -133,13 +133,38 @@ describe('edit-modules UI (SQR-321)', () => {
     const gh2eBody = await (
       await app.request(`/campaigns/${gh2e}/settings`, { headers: { Cookie: owner.cookie } })
     ).text();
-    expect(gh2eBody).toContain('squire-campaign-modules');
+    expect(gh2eBody).toContain('aria-label="Edit optional content"');
     expect(gh2eBody).toContain('value="solo2e"');
 
     const fhBody = await (
       await app.request(`/campaigns/${fh}/settings`, { headers: { Cookie: owner.cookie } })
     ).text();
-    expect(fhBody).not.toContain('squire-campaign-modules');
+    expect(fhBody).not.toContain('aria-label="Edit optional content"');
+  });
+
+  it('Settings presents optional content explicitly, including the no-optional-content state', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const gh2e = await createViaForm(owner, 'GH2', 'gloomhaven-2e', { solo: true });
+    const fh = await createViaForm(owner, 'FH', 'frosthaven', { solo: false });
+
+    const gh2eBody = await (
+      await app.request(`/campaigns/${gh2e}/settings`, { headers: { Cookie: owner.cookie } })
+    ).text();
+    expect(gh2eBody).toMatch(
+      /squire-campaign-settings__group-title"[^>]*>\s*Optional content\s*<\/h3>/,
+    );
+    expect(gh2eBody).toContain('aria-label="Save optional content"');
+    expect(gh2eBody).toContain('squire-campaign-settings__group-body');
+    expect(gh2eBody).not.toContain('squire-campaign-modules__toggle">Modules</summary>');
+
+    const fhBody = await (
+      await app.request(`/campaigns/${fh}/settings`, { headers: { Cookie: owner.cookie } })
+    ).text();
+    expect(fhBody).toMatch(
+      /squire-campaign-settings__group-title"[^>]*>\s*Optional content\s*<\/h3>/,
+    );
+    expect(fhBody).toContain('No optional content is available for Frosthaven.');
+    expect(fhBody).not.toContain('squire-campaign-modules__toggle">Modules</summary>');
   });
 
   it('removing then re-adding a module is non-destructive to played keys', async () => {
@@ -192,7 +217,24 @@ describe('edit-modules UI (SQR-321)', () => {
     await editModules(owner, id, [], stale); // bumps version
     const conflict = await editModules(owner, id, ['solo2e'], stale);
     expect(conflict.status).toBe(422);
-    expect(await conflict.text()).toContain('Updated elsewhere');
+    expect(await conflict.text()).toContain(
+      'Updated elsewhere — review your choices and try again.',
+    );
+  });
+
+  it('keeps edited optional-content choices visible after a failed save', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const id = await createViaForm(owner, 'Conflict', 'gloomhaven-2e', { solo: true });
+    const stale = (
+      await CampaignService.getCampaignDetail(identityFromSessionUser(owner.userId), id)
+    ).campaign.version;
+    await editModules(owner, id, [], stale); // latest state now has solo unchecked
+
+    const conflict = await editModules(owner, id, ['solo2e'], stale);
+    expect(conflict.status).toBe(422);
+    const body = await conflict.text();
+    expect(body).toContain('Updated elsewhere — review your choices and try again.');
+    expect(body).toMatch(/name="module"\s+value="solo2e"[\s\S]*checked/);
   });
 
   it('404s a non-member posting the modules route', async () => {

--- a/test/campaign-pages.test.ts
+++ b/test/campaign-pages.test.ts
@@ -112,7 +112,10 @@ describe('campaign routes', () => {
     expect(body).toContain('squire-campaign-strip--prominent');
     expect(body).toContain('Frosthaven · Prosperity 1');
     expect(body).toContain('<h2 class="squire-campaign-dashboard__section-title">Progress</h2>');
-    expect(body).toContain("No scenario data for this campaign's modules yet.");
+    expect(body).toContain(
+      'Track unlocked, played, skipped, and blocked scenarios for this campaign.',
+    );
+    expect(body).toContain('No scenario progress is available for this campaign yet.');
     expect(body).not.toContain('Record progress');
   });
 

--- a/test/campaign-rename.test.ts
+++ b/test/campaign-rename.test.ts
@@ -107,18 +107,37 @@ afterAll(async () => {
 });
 
 describe('rename-campaign UI (SQR-320)', () => {
-  it('renders the rename disclosure on the dashboard', async () => {
+  it('renders the campaign-name settings form', async () => {
     const { owner, campaign } = await setupFixture();
     const body = await (
       await app.request(`/campaigns/${campaign.id}/settings`, {
         headers: { Cookie: owner.cookie },
       })
     ).text();
-    expect(body).toContain('squire-campaign-rename');
     expect(body).toContain('action="/campaigns/' + campaign.id + '/rename"');
-    expect(body).toContain('CAMPAIGN NAME');
+    expect(body).toContain('Campaign name');
     // The current name pre-fills the input.
     expect(body).toContain('value="Original Name"');
+  });
+
+  it('renders campaign naming as an explicit Settings field, not a loose Rename control', async () => {
+    const { owner, campaign } = await setupFixture();
+    const body = await (
+      await app.request(`/campaigns/${campaign.id}/settings`, {
+        headers: { Cookie: owner.cookie },
+      })
+    ).text();
+
+    expect(body).toMatch(
+      /<label class="sr-only" for="squire-campaign-name-[^"]+">\s*Campaign name\s*<\/label>/,
+    );
+    expect(body).toContain('squire-campaign-settings__group-body');
+    expect(body).toContain('squire-campaign-settings__form--name');
+    expect(body).toContain('squire-campaign-settings__field--with-action');
+    expect(body).toContain('aria-label="Save campaign name"');
+    expect(body).toMatch(/>\s*Save\s*<\/button>/);
+    expect(body).not.toMatch(/>\s*Save campaign name\s*<\/button>/);
+    expect(body).not.toContain('squire-campaign-rename__toggle">Rename</summary>');
   });
 
   it('renames the campaign and updates the title + context strip', async () => {
@@ -164,6 +183,18 @@ describe('rename-campaign UI (SQR-320)', () => {
     expect(await res.text()).toContain('200 characters or fewer');
   });
 
+  it('keeps the edited campaign name visible after a failed save', async () => {
+    const { owner, campaign } = await setupFixture();
+    const edited = 'x'.repeat(201);
+    const res = await rename(owner, campaign.id, edited, campaign.version);
+
+    expect(res.status).toBe(422);
+    const body = await res.text();
+    expect(body).toContain('Campaign name must be 200 characters or fewer.');
+    expect(body).toContain(`value="${edited}"`);
+    expect(body).not.toContain('value="Original Name"');
+  });
+
   it('surfaces a version conflict (stale expectedVersion)', async () => {
     const { owner, campaign } = await setupFixture();
     // First rename succeeds and bumps the version.
@@ -171,7 +202,9 @@ describe('rename-campaign UI (SQR-320)', () => {
     // Second rename reuses the now-stale original version.
     const conflict = await rename(owner, campaign.id, 'Second', campaign.version);
     expect(conflict.status).toBe(422);
-    expect(await conflict.text()).toContain('Updated elsewhere');
+    const body = await conflict.text();
+    expect(body).toContain('Updated elsewhere — review your change and try again.');
+    expect(body).toContain('value="Second"');
   });
 
   it('rejects a malformed version token instead of parsing it leniently', async () => {


### PR DESCRIPTION
## Summary

- Builds the Campaign Settings section as an explicit workspace page for campaign naming and optional content.
- Preserves submitted rename/module values on failed saves and keeps inline errors in the Settings layout.
- Normalizes campaign typography hierarchy across Progress, Party, Players, Settings, and the campaign list.
- Adds a Progress lede and distinct empty-state treatment.

## Validation

- `npm run check`
- Manual browser verification for Settings, Party, and Progress at desktop and mobile widths

Fixes SQR-362


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Campaign rename and optional modules forms now preserve your input when validation or version conflicts occur, preventing loss of work during failed submissions.
  * Improved conflict error messages to clarify when campaign settings have been updated elsewhere.

* **UI/UX**
  * Campaign settings are now presented as always-visible sections instead of collapsible panels for easier discoverability.
  * Enhanced progress section labeling and empty-state messaging for better clarity.
  * Refined campaign dashboard typography and spacing for improved readability.

* **Documentation**
  * Updated design guidelines with campaign typography scale specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->