### PR TITLE
SQR-364: Make campaign context switchable in chat

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -586,9 +586,10 @@ campaign workspace.
 Dedicated routes sharing the ledger shell — `/campaigns` (list/create/join),
 `/campaigns/:id` (progression dashboard + shared state + roster + journal),
 `/characters/:id` (character sheet). Chat stays the home surface; the desktop
-rail remains conversation history (ADR 0020). The **header context strip is
-the persistent bridge**: it shows the active campaign/character and tapping it
-opens the campaign dashboard from anywhere.
+rail remains conversation history (ADR 0020). Chat renders campaign context in
+the ask area, directly above the input, so players can verify or change the
+campaign immediately before asking. Campaign surfaces use header wayfinding
+and the campaign strip as the bridge back into campaign management.
 
 Within `/campaigns/:id`, the campaign surface is a four-section workspace:
 **Progress**, **Party**, **Players**, and **Settings**. The campaign root
@@ -605,14 +606,21 @@ historical guidance for the current implementation, not the target for new
 campaign workspace work. See
 [docs/plans/campaign-workspace-redesign-design-plan.md](docs/plans/campaign-workspace-redesign-design-plan.md).
 
-### Context strip
+### Campaign context
 
-Small-caps Geist line in the header, present on chat and Phase 4 routes alike.
-States: `GH2E · TRAVEL CAMPAIGN · DRIFTER L4` (campaign + active character),
+Small-caps Geist line in the header on Phase 4 routes. States:
+`GH2E · TRAVEL CAMPAIGN · DRIFTER L4` (campaign + active character),
 campaign-only, and `NO CAMPAIGN · SET UP` (links to `/campaigns`) when none.
 **On campaign surfaces the campaign name is more prominent than the Squire
 brand** — the user's campaign outranks our wordmark there. Never shows fake
 state: no campaign means the set-up affordance, not placeholder content.
+
+On chat routes, do not put campaign selection in the header. Render a compact
+campaign context panel above the ask widget with the active campaign, an
+`Open campaign` link, and a `Change` control. When chat is in no-campaign mode,
+the same panel owns the game picker. This keeps the active campaign useful for
+LLM context while making the next question's binding explicit at the moment of
+use.
 
 On campaign workspace routes, the header carries campaign wayfinding: a
 breadcrumb back to `Campaigns`, the current campaign name as the dominant page

--- a/src/chat-campaign-context-contract.ts
+++ b/src/chat-campaign-context-contract.ts
@@ -1,0 +1,1 @@
+export const NO_CAMPAIGN_CONTEXT = '__none';

--- a/src/server.ts
+++ b/src/server.ts
@@ -1335,7 +1335,7 @@ app.get('/', requirePageSession(), async (c) => {
     return c.html(
       await renderHomePage(session, createCsrfToken(session.id), {
         conversationHistory,
-        campaignStrip: await campaignStripFor(c, session.userId),
+        chatCampaignContext: await chatCampaignContextFor(c, session.userId),
       }),
     );
   } catch (err) {
@@ -1401,6 +1401,30 @@ app.get('/profile', requirePageSession(), async (c) => {
 // ─── Campaign pages + context strip (SQR-275, SQR-11) ───────────────────────
 
 const ACTIVE_CAMPAIGN_COOKIE = 'squire_active_campaign';
+const NO_CAMPAIGN_CONTEXT = '__none';
+
+function campaignStripFrom(campaign: Campaign): CampaignStripState {
+  return { campaignId: campaign.id, campaignName: campaign.name, game: campaign.game };
+}
+
+async function campaignSelectionFor(
+  c: Context,
+  userId: string,
+  preferCampaignId?: string,
+): Promise<{ campaigns: Campaign[]; active: Campaign | null }> {
+  const campaigns = await CampaignService.listMyCampaigns(identityFromSessionUser(userId));
+  const cookieSelection = await getSignedCookie(c, getSessionSecret(), ACTIVE_CAMPAIGN_COOKIE);
+  const preferred = preferCampaignId
+    ? campaigns.find((campaign) => campaign.id === preferCampaignId)
+    : undefined;
+  if (preferred) return { campaigns, active: preferred };
+  if (cookieSelection === NO_CAMPAIGN_CONTEXT) return { campaigns, active: null };
+  const cookieCampaign =
+    typeof cookieSelection === 'string'
+      ? campaigns.find((campaign) => campaign.id === cookieSelection)
+      : undefined;
+  return { campaigns, active: cookieCampaign ?? campaigns[0] ?? null };
+}
 
 /**
  * The active campaign for the header strip: the explicit selection (signed
@@ -1413,15 +1437,32 @@ async function campaignStripFor(
   userId: string,
   preferCampaignId?: string,
 ): Promise<CampaignStripState | null> {
-  const mine = await CampaignService.listMyCampaigns(identityFromSessionUser(userId));
-  const cookieSelection = await getSignedCookie(c, getSessionSecret(), ACTIVE_CAMPAIGN_COOKIE);
-  const active =
-    (preferCampaignId && mine.find((campaign) => campaign.id === preferCampaignId)) ||
-    (typeof cookieSelection === 'string' &&
-      mine.find((campaign) => campaign.id === cookieSelection)) ||
-    mine[0];
-  if (!active) return null;
-  return { campaignId: active.id, campaignName: active.name, game: active.game };
+  const { active } = await campaignSelectionFor(c, userId, preferCampaignId);
+  return active ? campaignStripFrom(active) : null;
+}
+
+function requestReturnTo(c: Context): string {
+  const url = new URL(c.req.url);
+  return `${url.pathname}${url.search}`;
+}
+
+function safeReturnTo(value: FormDataEntryValue | null): string {
+  if (typeof value !== 'string' || !value.startsWith('/') || value.startsWith('//')) return '/';
+  try {
+    const parsed = new URL(value, 'https://squire.local');
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return '/';
+  }
+}
+
+async function chatCampaignContextFor(c: Context, userId: string) {
+  const { campaigns, active } = await campaignSelectionFor(c, userId);
+  return {
+    activeCampaign: active ? campaignStripFrom(active) : null,
+    campaigns: campaigns.map(campaignStripFrom),
+    returnTo: requestReturnTo(c),
+  };
 }
 
 async function renderCampaignListPage(c: Context, errorMessage?: string): Promise<Response> {
@@ -3154,6 +3195,40 @@ function renderChatErrorFragment(message: string) {
   </div>`;
 }
 
+app.post('/chat/campaign-context', async (c) => {
+  const session = c.get('session')!;
+  const form = await c.req.formData();
+  const campaignIdValue = form.get('campaignId');
+  const returnTo = safeReturnTo(form.get('returnTo'));
+
+  if (campaignIdValue === NO_CAMPAIGN_CONTEXT) {
+    await setSignedCookie(c, ACTIVE_CAMPAIGN_COOKIE, NO_CAMPAIGN_CONTEXT, getSessionSecret(), {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    });
+    return c.redirect(returnTo, 303);
+  }
+
+  if (
+    typeof campaignIdValue !== 'string' ||
+    !z.string().uuid().safeParse(campaignIdValue).success
+  ) {
+    return c.notFound();
+  }
+  try {
+    await CampaignService.requireActiveMember(campaignIdValue, session.userId);
+  } catch {
+    return c.notFound();
+  }
+  await setSignedCookie(c, ACTIVE_CAMPAIGN_COOKIE, campaignIdValue, getSessionSecret(), {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'Lax',
+  });
+  return c.redirect(returnTo, 303);
+});
+
 function buildStreamUrl(conversationId: string, messageId: string): string {
   return `/chat/${conversationId}/messages/${messageId}/stream`;
 }
@@ -3303,7 +3378,7 @@ app.get('/chat/:conversationId', async (c) => {
       messages: loaded.messages,
       pendingStreamUrls,
       conversationHistory,
-      campaignStrip: await campaignStripFor(c, session.userId),
+      chatCampaignContext: await chatCampaignContextFor(c, session.userId),
     }),
   );
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -156,6 +156,7 @@ import {
 } from './db/repositories/campaign-member-repository.ts';
 import { getAppCss, getHtmxJs, getSquireJs } from './web-ui/assets.ts';
 import { getSquireLogoPng } from './web-ui/logo.ts';
+import { NO_CAMPAIGN_CONTEXT } from './chat-campaign-context-contract.ts';
 import {
   appendMessage,
   createPendingConversation,
@@ -1401,7 +1402,15 @@ app.get('/profile', requirePageSession(), async (c) => {
 // ─── Campaign pages + context strip (SQR-275, SQR-11) ───────────────────────
 
 const ACTIVE_CAMPAIGN_COOKIE = 'squire_active_campaign';
-const NO_CAMPAIGN_CONTEXT = '__none';
+
+function activeCampaignCookieOptions() {
+  return {
+    path: '/',
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'Lax' as const,
+  };
+}
 
 function campaignStripFrom(campaign: Campaign): CampaignStripState {
   return { campaignId: campaign.id, campaignName: campaign.name, game: campaign.game };
@@ -1533,11 +1542,13 @@ app.post('/campaigns', async (c) => {
       game,
       modules,
     });
-    await setSignedCookie(c, ACTIVE_CAMPAIGN_COOKIE, campaign.id, getSessionSecret(), {
-      path: '/',
-      httpOnly: true,
-      sameSite: 'Lax',
-    });
+    await setSignedCookie(
+      c,
+      ACTIVE_CAMPAIGN_COOKIE,
+      campaign.id,
+      getSessionSecret(),
+      activeCampaignCookieOptions(),
+    );
     return c.redirect(`/campaigns/${campaign.id}`, 303);
   } catch (error) {
     if (error instanceof Error && 'code' in error) {
@@ -1557,11 +1568,13 @@ app.post('/campaigns/:id/activate', async (c) => {
   } catch {
     return c.notFound();
   }
-  await setSignedCookie(c, ACTIVE_CAMPAIGN_COOKIE, campaignId, getSessionSecret(), {
-    path: '/',
-    httpOnly: true,
-    sameSite: 'Lax',
-  });
+  await setSignedCookie(
+    c,
+    ACTIVE_CAMPAIGN_COOKIE,
+    campaignId,
+    getSessionSecret(),
+    activeCampaignCookieOptions(),
+  );
   return c.redirect('/campaigns', 303);
 });
 
@@ -3202,11 +3215,13 @@ app.post('/chat/campaign-context', async (c) => {
   const returnTo = safeReturnTo(form.get('returnTo'));
 
   if (campaignIdValue === NO_CAMPAIGN_CONTEXT) {
-    await setSignedCookie(c, ACTIVE_CAMPAIGN_COOKIE, NO_CAMPAIGN_CONTEXT, getSessionSecret(), {
-      path: '/',
-      httpOnly: true,
-      sameSite: 'Lax',
-    });
+    await setSignedCookie(
+      c,
+      ACTIVE_CAMPAIGN_COOKIE,
+      NO_CAMPAIGN_CONTEXT,
+      getSessionSecret(),
+      activeCampaignCookieOptions(),
+    );
     return c.redirect(returnTo, 303);
   }
 
@@ -3221,11 +3236,13 @@ app.post('/chat/campaign-context', async (c) => {
   } catch {
     return c.notFound();
   }
-  await setSignedCookie(c, ACTIVE_CAMPAIGN_COOKIE, campaignIdValue, getSessionSecret(), {
-    path: '/',
-    httpOnly: true,
-    sameSite: 'Lax',
-  });
+  await setSignedCookie(
+    c,
+    ACTIVE_CAMPAIGN_COOKIE,
+    campaignIdValue,
+    getSessionSecret(),
+    activeCampaignCookieOptions(),
+  );
   return c.redirect(returnTo, 303);
 });
 

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -58,6 +58,12 @@ export interface LayoutShellOptions {
   campaignStrip?: CampaignStripState | null;
   campaignStripProminent?: boolean;
   /**
+   * Chat-specific campaign context. Unlike `campaignStrip`, this renders in
+   * the ask surface rather than the header, so users verify context immediately
+   * before asking and can change it without leaving chat.
+   */
+  chatCampaignContext?: ChatCampaignContextView;
+  /**
    * Slot content rendered inside `main.squire-surface`. Must be an
    * already-escaped `HtmlEscapedString` produced by hono/html's `html`
    * tagged template (or `raw()` if the caller has manually escaped). The
@@ -111,6 +117,12 @@ export interface LayoutShellOptions {
    * two nested polite regions.
    */
   transcriptOwnsLiveRegion?: boolean;
+}
+
+export interface ChatCampaignContextView {
+  activeCampaign: CampaignStripState | null;
+  campaigns: CampaignStripState[];
+  returnTo: string;
 }
 
 const EMPTY_CONVERSATION_HISTORY: ConversationHistoryViewModel = {
@@ -206,6 +218,68 @@ function renderActiveGamePicker(): HtmlEscapedString {
         </label>`,
     )}
   </fieldset>` as HtmlEscapedString;
+}
+
+function chatGameLabel(game: string): string {
+  return SUPPORTED_GAMES.find((definition) => definition.id === game)?.label ?? game;
+}
+
+function renderChatCampaignContext(
+  context: ChatCampaignContextView,
+  csrfToken: string,
+): HtmlEscapedString {
+  const active = context.activeCampaign;
+  return html`<section class="squire-chat-context" aria-label="Chat campaign context">
+    <div class="squire-chat-context__current">
+      <span class="squire-chat-context__label">Current campaign</span>
+      <strong class="squire-chat-context__name"
+        >${active ? active.campaignName : 'No campaign selected'}</strong
+      >
+      <span class="squire-chat-context__meta">
+        ${active
+          ? `${chatGameLabel(active.game)} context for your next question`
+          : 'Game-only rules lookup'}
+      </span>
+    </div>
+    ${active
+      ? html`<a class="squire-chat-context__campaign-link" href="/campaigns/${active.campaignId}">
+          Open campaign
+        </a>`
+      : renderActiveGamePicker()}
+    ${context.campaigns.length > 0
+      ? html`<details class="squire-chat-context__switcher">
+          <summary>Change</summary>
+          <div class="squire-chat-context__menu">
+            ${context.campaigns.map(
+              (campaign) =>
+                html`<form method="post" action="/chat/campaign-context">
+                  <input type="hidden" name="${CSRF_FORM_FIELD_NAME}" value="${csrfToken}" />
+                  <input type="hidden" name="campaignId" value="${campaign.campaignId}" />
+                  <input type="hidden" name="returnTo" value="${context.returnTo}" />
+                  <button
+                    type="submit"
+                    ${active?.campaignId === campaign.campaignId
+                      ? html`aria-current="true"`
+                      : html``}
+                  >
+                    ${campaign.campaignName}
+                    <span>${chatGameLabel(campaign.game)}</span>
+                  </button>
+                </form>`,
+            )}
+            <form method="post" action="/chat/campaign-context">
+              <input type="hidden" name="${CSRF_FORM_FIELD_NAME}" value="${csrfToken}" />
+              <input type="hidden" name="campaignId" value="__none" />
+              <input type="hidden" name="returnTo" value="${context.returnTo}" />
+              <button type="submit" ${active === null ? html`aria-current="true"` : html``}>
+                No campaign
+                <span>Use the game picker</span>
+              </button>
+            </form>
+          </div>
+        </details>`
+      : html`<a class="squire-chat-context__setup" href="/campaigns">Set up campaign</a>`}
+  </section>` as HtmlEscapedString;
 }
 
 function statusLabel(status: ConversationHistoryStatus): string {
@@ -1120,14 +1194,19 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
   const chatFormAction = options.chatFormAction ?? '/chat';
   const chatFormHxTarget = options.chatFormHxTarget ?? '#squire-surface';
   const chatFormHxSwap = options.chatFormHxSwap ?? 'innerHTML';
+  const activeChatCampaign =
+    options.chatCampaignContext !== undefined
+      ? options.chatCampaignContext.activeCampaign
+      : options.campaignStrip;
   const headerContext = options.headerContext ?? 'HAVEN · RULES';
   const columnClassName = options.columnClassName ?? 'squire-column';
   const historyQuery = conversationHistory?.query ?? '';
   const chatFormHiddenFields = [
     ...(csrfToken ? [{ name: CSRF_FORM_FIELD_NAME, value: csrfToken }] : []),
-    // E8: an active campaign supplies the game dimension; the per-session
-    // selector (and its hidden field) exist only for no-campaign sessions.
-    ...(options.campaignStrip ? [] : [{ name: 'game', value: DEFAULT_GAME_ID }]),
+    // E8/SQR-364: a campaign context supplies the game dimension; no-campaign
+    // chat keeps the game picker and game hidden field available.
+    ...(activeChatCampaign ? [] : [{ name: 'game', value: DEFAULT_GAME_ID }]),
+    ...(activeChatCampaign ? [{ name: 'campaignId', value: activeChatCampaign.campaignId }] : []),
     ...(historyQuery ? [{ name: 'historyQuery', value: historyQuery }] : []),
     ...(options.chatFormHiddenFields ?? []),
   ];
@@ -1166,9 +1245,7 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
                       })
                     : html``}
                   ${showChatChrome
-                    ? options.campaignStrip
-                      ? html``
-                      : renderActiveGamePicker()
+                    ? html``
                     : html`<span class="squire-context">${headerContext}</span>`}
                   <div class="squire-header__account">
                     ${renderAccountMenu(options.session, authenticatedCsrfToken)}
@@ -1187,27 +1264,30 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
           </main>
           ${!authenticated || !showChatChrome
             ? html``
-            : html`<form
-                class="squire-input-dock"
-                method="post"
-                action="${chatFormAction}"
-                hx-post="${chatFormAction}"
-                hx-target="${chatFormHxTarget}"
-                hx-swap="${chatFormHxSwap}"
-              >
-                ${chatFormHiddenFields.map(
-                  (field) =>
-                    html`<input type="hidden" name="${field.name}" value="${field.value}" />`,
-                )}
-                <input
-                  id="squire-input"
-                  name="question"
-                  type="text"
-                  autocomplete="off"
-                  placeholder="Ask a question..."
-                />
-                <button type="submit" class="squire-input-dock__submit" aria-label="Ask"></button>
-              </form>`}
+            : html`${options.chatCampaignContext
+                  ? renderChatCampaignContext(options.chatCampaignContext, authenticatedCsrfToken)
+                  : html``}
+                <form
+                  class="squire-input-dock"
+                  method="post"
+                  action="${chatFormAction}"
+                  hx-post="${chatFormAction}"
+                  hx-target="${chatFormHxTarget}"
+                  hx-swap="${chatFormHxSwap}"
+                >
+                  ${chatFormHiddenFields.map(
+                    (field) =>
+                      html`<input type="hidden" name="${field.name}" value="${field.value}" />`,
+                  )}
+                  <input
+                    id="squire-input"
+                    name="question"
+                    type="text"
+                    autocomplete="off"
+                    placeholder="Ask a question..."
+                  />
+                  <button type="submit" class="squire-input-dock__submit" aria-label="Ask"></button>
+                </form>`}
         </div>
       </div>` as HtmlEscapedString,
   });
@@ -1406,6 +1486,7 @@ export async function renderHomePage(
   options: {
     conversationHistory?: ConversationHistoryViewModel;
     campaignStrip?: CampaignStripState | null;
+    chatCampaignContext?: ChatCampaignContextView;
   } = {},
 ): Promise<HtmlEscapedString> {
   return layoutShell({
@@ -1413,15 +1494,9 @@ export async function renderHomePage(
     csrfToken,
     conversationHistory: options.conversationHistory,
     campaignStrip: options.campaignStrip,
+    chatCampaignContext: options.chatCampaignContext,
     chatFormAction: '/chat',
-    chatFormHiddenFields: [
-      { name: 'idempotencyKey', value: '' },
-      // Per-message campaign binding (E6/SQR-19): chat turns bind to the
-      // active campaign shown in the strip.
-      ...(options.campaignStrip
-        ? [{ name: 'campaignId', value: options.campaignStrip.campaignId }]
-        : []),
-    ],
+    chatFormHiddenFields: [{ name: 'idempotencyKey', value: '' }],
     mainContent: renderHomeLanding(),
   });
 }
@@ -1433,6 +1508,7 @@ export async function renderConversationPage(options: {
   messages: ConversationMessage[];
   conversationHistory?: ConversationHistoryViewModel;
   campaignStrip?: CampaignStripState | null;
+  chatCampaignContext?: ChatCampaignContextView;
   /**
    * Map of user-message id → SSE stream URL for any user message
    * without an assistant reply. The common case is a single entry (one
@@ -1460,12 +1536,11 @@ export async function renderConversationPage(options: {
     mainContent: transcript,
     conversationHistory: options.conversationHistory,
     campaignStrip: options.campaignStrip,
+    chatCampaignContext: options.chatCampaignContext,
     chatFormAction: `/chat/${options.conversationId}/messages`,
     chatFormHxTarget: '.squire-transcript',
     chatFormHxSwap: 'beforeend',
-    chatFormHiddenFields: options.campaignStrip
-      ? [{ name: 'campaignId', value: options.campaignStrip.campaignId }]
-      : [],
+    chatFormHiddenFields: [],
     transcriptOwnsLiveRegion: true,
   });
 }

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -24,6 +24,7 @@ import { renderCampaignStrip, type CampaignStripState } from './campaign-pages.t
 import { aggregateSourceLabels, type ToolSourceLabel } from './consulted-footer.ts';
 import { CSRF_FORM_FIELD_NAME, CSRF_HEADER_NAME, CSRF_META_NAME } from './csrf.ts';
 import { FONT_PRECONNECTS, GOOGLE_FONTS_HREF } from './fonts.ts';
+import { NO_CAMPAIGN_CONTEXT } from '../chat-campaign-context-contract.ts';
 import {
   SUPPORTED_MARKDOWN_FEATURES,
   SUPPORTED_MARKDOWN_SPECIMEN,
@@ -269,7 +270,7 @@ function renderChatCampaignContext(
             )}
             <form method="post" action="/chat/campaign-context">
               <input type="hidden" name="${CSRF_FORM_FIELD_NAME}" value="${csrfToken}" />
-              <input type="hidden" name="campaignId" value="__none" />
+              <input type="hidden" name="campaignId" value="${NO_CAMPAIGN_CONTEXT}" />
               <input type="hidden" name="returnTo" value="${context.returnTo}" />
               <button type="submit" ${active === null ? html`aria-current="true"` : html``}>
                 No campaign

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -713,6 +713,128 @@ html {
   outline-offset: 3px;
 }
 
+.squire-chat-context {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: var(--space-sm);
+  align-items: center;
+  margin: 0 0 var(--space-sm);
+  padding: var(--space-sm);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--surface);
+}
+
+.squire-chat-context__current {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.squire-chat-context__label,
+.squire-chat-context__meta {
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--sepia);
+}
+
+.squire-chat-context__label {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.squire-chat-context__name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--parchment);
+  font-family: 'Fraunces', 'Georgia', serif;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.squire-chat-context__campaign-link,
+.squire-chat-context__setup,
+.squire-chat-context__switcher summary {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--sepia);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.squire-chat-context__campaign-link:hover,
+.squire-chat-context__setup:hover,
+.squire-chat-context__switcher summary:hover {
+  color: var(--parchment);
+}
+
+.squire-chat-context__switcher {
+  position: relative;
+}
+
+.squire-chat-context__switcher summary {
+  list-style: none;
+}
+
+.squire-chat-context__switcher summary::-webkit-details-marker {
+  display: none;
+}
+
+.squire-chat-context__menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + var(--space-xs));
+  right: 0;
+  min-width: min(18rem, calc(100vw - 2rem));
+  display: grid;
+  gap: 2px;
+  padding: var(--space-xs);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--surface-2);
+}
+
+.squire-chat-context__menu button {
+  width: 100%;
+  min-height: 44px;
+  display: grid;
+  gap: 2px;
+  justify-items: start;
+  padding: var(--space-xs) var(--space-sm);
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--parchment);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.squire-chat-context__menu button span {
+  color: var(--sepia);
+  font-size: 11px;
+}
+
+.squire-chat-context__menu button:hover,
+.squire-chat-context__menu button:focus-visible,
+.squire-chat-context__menu button[aria-current='true'] {
+  border-color: var(--rule);
+  background: var(--surface);
+}
+
 /* 2. Main surface — flexes to fill. NOT a chat column — content modes
    (streaming answer, card comparison, character sheet) drop in as siblings
    of any error banner that the fallback path injects. The 640px max-width
@@ -1203,6 +1325,23 @@ template#squire-banner-fixtures {
 
   .squire-game-picker__option {
     padding-inline: 8px;
+  }
+
+  .squire-chat-context {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .squire-chat-context__campaign-link,
+  .squire-chat-context__setup,
+  .squire-chat-context__switcher summary {
+    justify-content: flex-start;
+  }
+
+  .squire-chat-context__menu {
+    position: static;
+    min-width: 0;
+    margin-top: var(--space-xs);
   }
 
   .squire-user {

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -788,6 +788,11 @@ html {
   list-style: none;
 }
 
+.squire-chat-context__switcher summary:focus-visible {
+  outline: 2px solid var(--wax);
+  outline-offset: 3px;
+}
+
 .squire-chat-context__switcher summary::-webkit-details-marker {
   display: none;
 }
@@ -829,10 +834,14 @@ html {
 }
 
 .squire-chat-context__menu button:hover,
-.squire-chat-context__menu button:focus-visible,
-.squire-chat-context__menu button[aria-current='true'] {
+.squire-chat-context__menu button:focus-visible {
   border-color: var(--rule);
   background: var(--surface);
+}
+
+.squire-chat-context__menu button[aria-current='true'] {
+  border-color: var(--wax);
+  background: color-mix(in srgb, var(--wax) 20%, var(--surface));
 }
 
 /* 2. Main surface — flexes to fill. NOT a chat column — content modes

--- a/test/campaign-pages.test.ts
+++ b/test/campaign-pages.test.ts
@@ -1,10 +1,10 @@
 /**
- * Campaign route shell + context strip tests (SQR-275).
+ * Campaign route shell + chat context tests (SQR-275, SQR-364).
  *
- * The strip is the persistent bridge (DESIGN.md §Phase 4): campaign name
- * on chat and campaign surfaces, NO CAMPAIGN · SET UP when none, and the
- * chat form binds turns to the strip's campaign (E6). Non-member campaign
- * pages are the indistinguishable 404.
+ * Campaign pages still use the header strip/wayfinding bridge. Chat renders
+ * campaign context in the ask area so the next turn's binding is visible and
+ * changeable immediately before asking. Non-member campaign pages are the
+ * indistinguishable 404.
  */
 import { generateSignedCookie } from 'hono/cookie';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
@@ -68,7 +68,7 @@ afterAll(async () => {
   await shutdownServerPool();
 });
 
-describe('context strip states', () => {
+describe('chat context states', () => {
   it('shows NO CAMPAIGN · SET UP for users without campaigns', async () => {
     const owner = await createTestUser(OWNER_EMAIL);
     const res = await pageRequest(owner, '/campaigns');
@@ -88,10 +88,15 @@ describe('context strip states', () => {
     const res = await pageRequest(owner, '/');
     expect(res.status).toBe(200);
     const body = await res.text();
-    expect(body).toContain('GH2 · TRAVEL CAMPAIGN');
-    expect(body).toContain(`/campaigns/${campaign.id}`);
+    const header = body.match(/<header class="squire-header">[\s\S]*?<\/header>/)?.[0] ?? '';
+    const context = body.match(/<section class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+    expect(header).not.toContain('TRAVEL CAMPAIGN');
+    expect(context).toContain('Current campaign');
+    expect(context).toContain('Travel Campaign');
+    expect(context).toContain(`/campaigns/${campaign.id}`);
     // E6: the chat form carries the binding as a hidden field.
     expect(body).toContain(`name="campaignId" value="${campaign.id}"`);
+    expect(body).not.toContain('class="squire-game-picker"');
   });
 });
 
@@ -199,9 +204,69 @@ describe('campaign picker (SQR-11)', () => {
       headers: { Cookie: `${owner.cookie}; ${cookie.split(';')[0]}` },
     });
     const body = await home.text();
-    expect(body).toContain('GH2 · SECOND CAMPAIGN');
+    const context = body.match(/<section class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+    expect(context).toContain('Second Campaign');
     // E8: an active campaign hides the per-session game selector.
     expect(body).not.toContain('squire-game-picker');
+  });
+
+  it('switches active campaign from the chat context panel and returns to chat', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    const identity = identityFromSessionUser(owner.userId);
+    await CampaignService.createCampaign(identity, {
+      name: 'First Campaign',
+      game: 'frosthaven',
+    });
+    const second = await CampaignService.createCampaign(identity, {
+      name: 'Second Campaign',
+      game: 'gloomhaven-2e',
+    });
+
+    const switchRes = await formPost(owner, '/chat/campaign-context', {
+      campaignId: second.id,
+      returnTo: '/',
+    });
+    expect(switchRes.status).toBe(303);
+    expect(switchRes.headers.get('location')).toBe('/');
+    const cookie = switchRes.headers.get('set-cookie') ?? '';
+    expect(cookie).toContain('squire_active_campaign');
+
+    const home = await app.request('/', {
+      headers: { Cookie: `${owner.cookie}; ${cookie.split(';')[0]}` },
+    });
+    const body = await home.text();
+    const context = body.match(/<section class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+    expect(context).toContain('Second Campaign');
+    expect(body).toContain(`name="campaignId" value="${second.id}"`);
+  });
+
+  it('can switch chat to no-campaign mode and exposes the game picker in the ask area', async () => {
+    const owner = await createTestUser(OWNER_EMAIL);
+    await CampaignService.createCampaign(identityFromSessionUser(owner.userId), {
+      name: 'Travel Campaign',
+      game: 'frosthaven',
+    });
+
+    const switchRes = await formPost(owner, '/chat/campaign-context', {
+      campaignId: '__none',
+      returnTo: '/',
+    });
+    expect(switchRes.status).toBe(303);
+    const cookie = switchRes.headers.get('set-cookie') ?? '';
+    expect(cookie).toContain('squire_active_campaign');
+
+    const home = await app.request('/', {
+      headers: { Cookie: `${owner.cookie}; ${cookie.split(';')[0]}` },
+    });
+    const body = await home.text();
+    const header = body.match(/<header class="squire-header">[\s\S]*?<\/header>/)?.[0] ?? '';
+    const context = body.match(/<section class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+    const askForm = body.match(/<form[^>]*class="squire-input-dock"[\s\S]*?<\/form>/)?.[0];
+    expect(header).not.toContain('Travel Campaign');
+    expect(context).toContain('No campaign selected');
+    expect(context).toContain('class="squire-game-picker"');
+    expect(askForm).toContain(`name="game" value="frosthaven"`);
+    expect(askForm).not.toContain('name="campaignId"');
   });
 
   it('lists pending invites distinctly and accepts via form post', async () => {

--- a/test/e2e/sqr-11-campaign-picker.spec.ts
+++ b/test/e2e/sqr-11-campaign-picker.spec.ts
@@ -1,8 +1,8 @@
 /**
- * Campaign picker E2E (SQR-11): list/create happy path, active-campaign
- * switching reflected by the context strip, and the navigation bridge
- * (chat → strip → dashboard). Failure path: campaign creation blocked by
- * the allowlist is covered at the integration layer
+ * Campaign picker E2E (SQR-11/SQR-364): list/create happy path, campaign
+ * activation reflected in campaign wayfinding, and the chat context bridge
+ * to the campaign dashboard. Failure path: campaign creation blocked by the
+ * allowlist is covered at the integration layer
  * (test/campaign-pages.test.ts) because the E2E server pins the dev user
  * onto the allowlist for the happy path.
  */
@@ -17,7 +17,7 @@ async function loginAsDevUser(page: Page): Promise<void> {
   await expect(page).toHaveURL('/');
 }
 
-test.describe('campaign picker and context strip', () => {
+test.describe('campaign picker and chat context', () => {
   test.beforeEach(async ({ page }) => {
     await resetE2eDb();
     await page.context().clearCookies();
@@ -28,11 +28,13 @@ test.describe('campaign picker and context strip', () => {
     await teardownE2eDb();
   });
 
-  test('creates a campaign, switches activation, and bridges via the strip', async ({ page }) => {
+  test('creates a campaign, switches activation, and bridges via chat context', async ({
+    page,
+  }) => {
     await loginAsDevUser(page);
 
-    // Chat home shows the set-up affordance or an existing campaign strip.
-    await expect(page.locator('.squire-campaign-strip')).toBeVisible();
+    // Chat home shows the set-up affordance or an existing campaign context.
+    await expect(page.locator('.squire-chat-context')).toBeVisible();
 
     await page.goto('/campaigns');
     const name = `E2E Campaign ${Date.now()}`;
@@ -47,16 +49,17 @@ test.describe('campaign picker and context strip', () => {
       name.toUpperCase(),
     );
 
-    // The picker lists it as ACTIVE; the strip bridges from chat home.
+    // The picker lists it as ACTIVE; the chat context bridges to the dashboard.
     await page.goto('/campaigns');
     const row = page.locator('.squire-campaigns__row', { hasText: name });
     await expect(row.locator('.squire-campaigns__active')).toHaveText('ACTIVE');
 
     await page.goto('/');
-    await expect(page.locator('.squire-campaign-strip')).toContainText(name.toUpperCase());
+    await expect(page.locator('.squire-header')).not.toContainText(name);
+    await expect(page.locator('.squire-chat-context')).toContainText(name);
     // E8: an active campaign hides the per-session game selector.
     await expect(page.locator('.squire-game-picker')).toHaveCount(0);
-    await page.locator('.squire-campaign-strip').click();
+    await page.getByRole('link', { name: 'Open campaign' }).click();
     await expect(page).toHaveURL(/\/campaigns\/[0-9a-f-]{36}/);
   });
 });

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -98,6 +98,12 @@ const testSession: Session = {
 
 const testCsrfToken = 'test-csrf-token';
 
+const noCampaignChatContext = {
+  activeCampaign: null,
+  campaigns: [],
+  returnTo: '/',
+};
+
 function testConversationHistory() {
   return {
     rows: [
@@ -256,7 +262,6 @@ describe('GET / — companion-first layout shell (SQR-65)', () => {
     expect(body).toContain('class="squire-header"');
     expect(body).toContain('class="squire-header__brand"');
     expect(body).toMatch(/<a[^>]*class="squire-header__brand"[^>]*href="\/"[^>]*>/);
-    expect(body).toContain('class="squire-game-picker"');
     expect(body).toContain('class="squire-account-menu"');
     expect(body).toContain('class="squire-account-menu__avatar"');
     expect(body).toContain('Open account menu for Test User');
@@ -270,17 +275,27 @@ describe('GET / — companion-first layout shell (SQR-65)', () => {
     expect(body).toMatch(/>\s*Log out\s*</);
   });
 
-  it('renders an active-game selector in the header and submits the current game with chat forms', async () => {
-    const body = String(await actualLayout.renderHomePage(testSession, testCsrfToken));
+  it('renders a no-campaign game selector in the chat context and submits the current game with chat forms', async () => {
+    const body = String(
+      await actualLayout.renderHomePage(testSession, testCsrfToken, {
+        chatCampaignContext: noCampaignChatContext,
+      }),
+    );
+    const header = body.match(/<header class="squire-header">[\s\S]*?<\/header>/)?.[0] ?? '';
+    const context = body.match(/<section class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
 
-    expect(body).toContain('class="squire-game-picker"');
-    expect(body).toContain('aria-label="Active game"');
-    expect(body).toMatch(
+    expect(header).not.toContain('squire-game-picker');
+    expect(context).toContain('No campaign selected');
+    expect(context).toContain('class="squire-game-picker"');
+    expect(context).toContain('aria-label="Active game"');
+    expect(context).toMatch(
       /<input[^>]*type="radio"[^>]*name="activeGame"[^>]*value="frosthaven"[^>]*checked/,
     );
-    expect(body).toMatch(/<input[^>]*type="radio"[^>]*name="activeGame"[^>]*value="gloomhaven-2e"/);
-    expect(body).toContain('Frosthaven');
-    expect(body).toContain('Gloomhaven 2e');
+    expect(context).toMatch(
+      /<input[^>]*type="radio"[^>]*name="activeGame"[^>]*value="gloomhaven-2e"/,
+    );
+    expect(context).toContain('Frosthaven');
+    expect(context).toContain('Gloomhaven 2e');
     expect(body).toMatch(/<input[^>]*type="hidden"[^>]*name="game"[^>]*value="frosthaven"/);
   });
 


### PR DESCRIPTION
## Summary
- Move chat campaign context out of the global header and into the ask surface.
- Add a signed-cookie campaign context switcher with an explicit no-campaign mode.
- Bind chat submissions to the selected campaign and update docs/tests for the new surface.

## Validation
- npm run check
- npm run e2e:browser -- test/e2e/sqr-24-chat-game-selection.spec.ts
- npm run e2e:browser -- test/e2e/sqr-11-campaign-picker.spec.ts

Fixes SQR-364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Current campaign” context panel above the chat input to show active campaign state and keep the transcript/rail consistent.
  * Added a “Change” control in the chat panel to switch campaigns (including a no-campaign mode) and update the chat accordingly.
  * When no campaign is active, the game picker appears in the chat panel; it hides when a campaign is active, with an “Open campaign” link to the campaign dashboard.
* **Documentation**
  * Updated Phase 4 campaign/character UI information architecture in DESIGN.md.
* **Style**
  * Refreshed chat context styling for desktop and mobile layouts.
* **Tests**
  * Updated unit and end-to-end coverage to match the new chat context flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->