### PR TITLE
SQR-366: Rework chat shell and pin campaign context

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -588,8 +588,19 @@ Dedicated routes sharing the ledger shell — `/campaigns` (list/create/join),
 `/characters/:id` (character sheet). Chat stays the home surface; the desktop
 rail remains conversation history (ADR 0020). Chat renders campaign context in
 the ask area, directly above the input, so players can verify or change the
-campaign immediately before asking. Campaign surfaces use header wayfinding
-and the campaign strip as the bridge back into campaign management.
+campaign immediately before asking. Campaign surfaces put campaign wayfinding in
+page content, never in the shared app header.
+
+The authenticated shell has one primary page header. It carries the Squire
+brand, account menu, and ordinary `Chat` / `Campaigns` navigation. The
+header never carries active campaign state, campaign names, subtitles, or game
+metadata. The conversation history rail is secondary navigation under that
+header; do not put another Squire logo or wordmark in the rail. Desktop chat
+locks the app frame to the viewport and lets the history rail and transcript
+scroll internally, so the ask widget stays available even when conversation
+history is long. The header is not sticky; the chat shell preserves the
+first-viewport ask path without keeping another bar permanently over the
+content.
 
 Within `/campaigns/:id`, the campaign surface is a four-section workspace:
 **Progress**, **Party**, **Players**, and **Settings**. The campaign root
@@ -608,21 +619,21 @@ campaign workspace work. See
 
 ### Campaign context
 
-Small-caps Geist line in the header on Phase 4 routes. States:
-`GH2E · TRAVEL CAMPAIGN · DRIFTER L4` (campaign + active character),
-campaign-only, and `NO CAMPAIGN · SET UP` (links to `/campaigns`) when none.
-**On campaign surfaces the campaign name is more prominent than the Squire
-brand** — the user's campaign outranks our wordmark there. Never shows fake
-state: no campaign means the set-up affordance, not placeholder content.
+The old app-header campaign strip is retired. The app header stays stable across
+chat and campaign management: brand, primary navigation, account controls, and
+the mobile history affordance when chat history exists. Campaign names,
+subtitles, active-campaign markers, and game metadata belong in the page body or
+chat composer.
 
 On chat routes, do not put campaign selection in the header. Render a compact
-campaign context panel above the ask widget with the active campaign, an
-`Open campaign` link, and a `Change` control. When chat is in no-campaign mode,
-the same panel owns the game picker. This keeps the active campaign useful for
-LLM context while making the next question's binding explicit at the moment of
-use.
+campaign context panel above the ask widget with the active campaign name
+itself linking to the campaign workspace and a `Change` control. When chat is
+in no-campaign mode, the same panel owns the game picker. This keeps the active
+campaign useful for LLM context while making the next question's binding
+explicit at the moment of use. The primary Chat/Campaigns header navigation
+stays lightweight link text with active state, not a segmented control.
 
-On campaign workspace routes, the header carries campaign wayfinding: a
+On campaign workspace routes, the page content carries campaign wayfinding: a
 breadcrumb back to `Campaigns`, the current campaign name as the dominant page
 title, and full campaign system metadata such as `Gloomhaven 2nd Edition`.
 Campaign switching happens on the campaign list, not in the workspace header;

--- a/src/chat/conversation-service.ts
+++ b/src/chat/conversation-service.ts
@@ -524,6 +524,7 @@ async function createConversationTurn(input: {
     const existingOrCreated = await ConversationRepository.getOrCreateByIdempotencyKey(tx, {
       userId: input.userId,
       creationIdempotencyKey: input.idempotencyKey,
+      campaignId: input.campaignId ?? null,
     });
 
     if (!existingOrCreated.created) {
@@ -537,7 +538,7 @@ async function createConversationTurn(input: {
       conversationId: existingOrCreated.conversation.id,
       role: 'user',
       content: input.question,
-      game: input.game ?? null,
+      game: input.campaignId ? null : (input.game ?? null),
       campaignId: input.campaignId ?? null,
     });
     await ConversationRepository.touchLastMessageAt(
@@ -552,13 +553,14 @@ async function createConversationTurn(input: {
   });
 
   if (result.currentUserMessage) {
+    const conversationCampaignId = result.conversation.campaignId ?? null;
     recordChatLifecycleEvent('turn.accepted', {
       route: input.telemetry?.route,
       surface: input.telemetry?.surface ?? 'web_chat',
       requestId: input.requestId,
       conversationId: result.conversation.id,
       userMessageId: result.currentUserMessage.id,
-      game: result.currentUserMessage.game ?? input.game ?? null,
+      game: conversationCampaignId ? null : (result.currentUserMessage.game ?? input.game ?? null),
       status: 'accepted',
       retry: false,
     });
@@ -573,7 +575,7 @@ async function createConversationTurn(input: {
       requestId: input.requestId,
       conversationId: result.conversation.id,
       userMessageId: repairedMessage.id,
-      game: repairedMessage.game ?? input.game ?? null,
+      game: result.conversation.campaignId ? null : (repairedMessage.game ?? input.game ?? null),
       status: 'replayed',
       replay: true,
     });
@@ -611,14 +613,15 @@ export async function createPendingFollowUp(input: {
     input.conversationId,
   );
   if (!existingConversation) return null;
+  const conversationCampaignId = existingConversation.campaignId ?? null;
 
   const currentUserMessage = await getDb('server').db.transaction(async (tx) => {
     const userMessage = await MessageRepository.create(tx, {
       conversationId: input.conversationId,
       role: 'user',
       content: input.question,
-      game: input.game ?? null,
-      campaignId: input.campaignId ?? null,
+      game: conversationCampaignId ? null : (input.game ?? null),
+      campaignId: conversationCampaignId,
     });
     await ConversationRepository.touchLastMessageAt(
       tx,
@@ -634,7 +637,7 @@ export async function createPendingFollowUp(input: {
     requestId: input.requestId,
     conversationId: input.conversationId,
     userMessageId: currentUserMessage.id,
-    game: currentUserMessage.game ?? input.game ?? null,
+    game: conversationCampaignId ? null : (currentUserMessage.game ?? input.game ?? null),
     status: 'accepted',
     retry: false,
   });
@@ -719,12 +722,14 @@ export async function startConversation(input: {
 }): Promise<Conversation> {
   const result = await createConversationTurn(input);
   if (result.currentUserMessage) {
+    const conversationCampaignId = result.conversation.campaignId ?? null;
     await persistAssistantOutcome({
       conversationId: result.conversation.id,
       question: result.currentUserMessage.content,
       userId: input.userId,
       currentUserMessageId: result.currentUserMessage.id,
-      game: result.currentUserMessage.game ?? input.game,
+      game: conversationCampaignId ? undefined : (result.currentUserMessage.game ?? input.game),
+      campaignId: conversationCampaignId,
       requestId: input.requestId,
       telemetry: input.telemetry,
     });
@@ -747,13 +752,15 @@ export async function appendMessage(input: {
 }): Promise<Conversation | null> {
   const result = await createPendingFollowUp(input);
   if (!result?.currentUserMessage) return null;
+  const conversationCampaignId = result.conversation.campaignId ?? null;
 
   await persistAssistantOutcome({
     conversationId: input.conversationId,
     question: input.question,
     userId: input.userId,
     currentUserMessageId: result.currentUserMessage.id,
-    game: result.currentUserMessage.game ?? input.game,
+    game: conversationCampaignId ? undefined : (result.currentUserMessage.game ?? input.game),
+    campaignId: conversationCampaignId,
     requestId: input.requestId,
     telemetry: input.telemetry,
   });

--- a/src/db/migrations/20260622090000_conversation_campaign/migration.sql
+++ b/src/db/migrations/20260622090000_conversation_campaign/migration.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "conversations" ADD COLUMN "campaign_id" uuid;
+--> statement-breakpoint
+UPDATE "conversations" c
+SET "campaign_id" = first_campaign."campaign_id"
+FROM (
+  SELECT DISTINCT ON (m."conversation_id")
+    m."conversation_id",
+    m."campaign_id"
+  FROM "messages" m
+  WHERE m."role" = 'user'
+    AND m."campaign_id" IS NOT NULL
+  ORDER BY m."conversation_id", m."created_at" ASC, m."id" ASC
+) first_campaign
+WHERE c."id" = first_campaign."conversation_id"
+  AND c."campaign_id" IS NULL;
+--> statement-breakpoint
+CREATE INDEX "conversations_campaign_idx" ON "conversations" ("campaign_id");

--- a/src/db/repositories/conversation-repository.ts
+++ b/src/db/repositories/conversation-repository.ts
@@ -18,6 +18,7 @@ function toDomain(row: ConversationRow): Conversation {
     id: row.id,
     userId: row.userId,
     creationIdempotencyKey: row.creationIdempotencyKey,
+    campaignId: row.campaignId,
     createdAt: row.createdAt,
     lastMessageAt: row.lastMessageAt,
   };
@@ -190,6 +191,7 @@ export async function create(
     .values({
       userId: input.userId,
       creationIdempotencyKey: input.creationIdempotencyKey ?? null,
+      campaignId: input.campaignId ?? null,
     })
     .returning();
   return toDomain(row);
@@ -209,6 +211,7 @@ export async function getOrCreateByIdempotencyKey(
     .values({
       userId: input.userId,
       creationIdempotencyKey: key,
+      campaignId: input.campaignId ?? null,
     })
     .onConflictDoNothing({
       target: [conversations.userId, conversations.creationIdempotencyKey],

--- a/src/db/repositories/types.ts
+++ b/src/db/repositories/types.ts
@@ -250,6 +250,8 @@ export interface Conversation {
   id: string;
   userId: string;
   creationIdempotencyKey: string | null;
+  /** Campaign binding for the full conversation. Null = no-campaign/legacy. */
+  campaignId: string | null;
   createdAt: Date;
   lastMessageAt: Date;
 }
@@ -257,6 +259,7 @@ export interface Conversation {
 export interface CreateConversationInput {
   userId: string;
   creationIdempotencyKey?: string | null;
+  campaignId?: string | null;
 }
 
 export interface ConversationHistoryCursor {

--- a/src/db/schema/conversations.ts
+++ b/src/db/schema/conversations.ts
@@ -22,11 +22,16 @@ export const conversations = pgTable(
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
     creationIdempotencyKey: text('creation_idempotency_key'),
+    // Conversation-level campaign binding. Plain uuid, no FK: chat history
+    // should remain readable after a campaign is deleted, matching
+    // messages.campaignId.
+    campaignId: uuid('campaign_id'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     lastMessageAt: timestamp('last_message_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
     index('conversations_user_last_message_idx').on(t.userId, t.lastMessageAt),
+    index('conversations_campaign_idx').on(t.campaignId),
     uniqueIndex('conversations_user_creation_idempotency_idx').on(
       t.userId,
       t.creationIdempotencyKey,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1389,7 +1389,6 @@ app.get('/profile', requirePageSession(), async (c) => {
       csrfToken: createCsrfToken(session.id),
       showChatChrome: false,
       showRail: false,
-      campaignStrip: await campaignStripFor(c, session.userId),
       mainContent: renderProfileContent({
         name: user.name,
         email: user.email,
@@ -1399,7 +1398,7 @@ app.get('/profile', requirePageSession(), async (c) => {
   );
 });
 
-// ─── Campaign pages + context strip (SQR-275, SQR-11) ───────────────────────
+// ─── Campaign pages + chat campaign context (SQR-275, SQR-11) ────────────────
 
 const ACTIVE_CAMPAIGN_COOKIE = 'squire_active_campaign';
 
@@ -1436,10 +1435,9 @@ async function campaignSelectionFor(
 }
 
 /**
- * The active campaign for the header strip: the explicit selection (signed
- * cookie, validated against current membership) when present, else the most
- * recently updated membership. Null = signed-in user with no campaigns →
- * the NO CAMPAIGN affordance.
+ * The active campaign selection: the explicit signed cookie, validated against
+ * current membership, when present; otherwise the first campaign membership.
+ * Null means the user has chosen no-campaign chat mode or has no campaigns.
  */
 async function campaignStripFor(
   c: Context,
@@ -1474,6 +1472,41 @@ async function chatCampaignContextFor(c: Context, userId: string) {
   };
 }
 
+async function chatCampaignContextForConversation(
+  c: Context,
+  userId: string,
+  campaignId: string | null | undefined,
+) {
+  if (!campaignId) {
+    return {
+      activeCampaign: null,
+      campaigns: [],
+      returnTo: requestReturnTo(c),
+      fixed: true,
+    };
+  }
+
+  try {
+    const detail = await CampaignService.getCampaignDetail(
+      identityFromSessionUser(userId),
+      campaignId,
+    );
+    return {
+      activeCampaign: campaignStripFrom(detail.campaign),
+      campaigns: [],
+      returnTo: requestReturnTo(c),
+      fixed: true,
+    };
+  } catch {
+    return {
+      activeCampaign: null,
+      campaigns: [],
+      returnTo: requestReturnTo(c),
+      fixed: true,
+    };
+  }
+}
+
 async function renderCampaignListPage(c: Context, errorMessage?: string): Promise<Response> {
   const session = c.get('session')!;
   const identity = identityFromSessionUser(session.userId);
@@ -1499,7 +1532,7 @@ async function renderCampaignListPage(c: Context, errorMessage?: string): Promis
       csrfToken: createCsrfToken(session.id),
       showChatChrome: false,
       showRail: false,
-      campaignStrip: strip,
+      activeAppSection: 'campaigns',
       mainContent: renderCampaignListContent({
         rows,
         invites,
@@ -1702,12 +1735,7 @@ async function renderCampaignDashboardPage(
     showChatChrome: false,
     showRail: false,
     columnClassName: 'squire-column squire-column--wide',
-    campaignStrip: {
-      campaignId: detail.campaign.id,
-      campaignName: detail.campaign.name,
-      game: detail.campaign.game,
-    },
-    campaignStripProminent: true,
+    activeAppSection: 'campaigns',
     mainContent: renderCampaignDashboardContent(
       detail,
       dashboardThreads?.html,
@@ -2536,12 +2564,7 @@ async function renderCharacterSheetPage(
       showChatChrome: false,
       showRail: false,
       columnClassName: 'squire-column squire-column--wide',
-      campaignStrip: {
-        campaignId: campaignDetail.campaign.id,
-        campaignName: campaignDetail.campaign.name,
-        game,
-      },
-      campaignStripProminent: true,
+      activeAppSection: 'campaigns',
       mainContent: renderCharacterSheetContent({
         detail,
         campaign: {
@@ -3395,7 +3418,11 @@ app.get('/chat/:conversationId', async (c) => {
       messages: loaded.messages,
       pendingStreamUrls,
       conversationHistory,
-      chatCampaignContext: await chatCampaignContextFor(c, session.userId),
+      chatCampaignContext: await chatCampaignContextForConversation(
+        c,
+        session.userId,
+        loaded.conversation.campaignId,
+      ),
     }),
   );
 });
@@ -3486,6 +3513,12 @@ app.post('/chat', async (c) => {
           conversationId: loaded.conversation.id,
           messages: loaded.messages,
           pendingStreamUrls,
+          chatCampaignContext: await chatCampaignContextForConversation(
+            c,
+            session.userId,
+            loaded.conversation.campaignId,
+          ),
+          csrfToken: createCsrfToken(session.id),
         }),
       );
     }
@@ -3507,6 +3540,12 @@ app.post('/chat', async (c) => {
             buildStreamUrl(pending.conversation.id, pending.currentUserMessage.id),
           ],
         ]),
+        chatCampaignContext: await chatCampaignContextForConversation(
+          c,
+          session.userId,
+          pending.conversation.campaignId,
+        ),
+        csrfToken: createCsrfToken(session.id),
       }),
     );
   }
@@ -3529,12 +3568,7 @@ app.post('/chat', async (c) => {
 app.post('/chat/:conversationId/messages', async (c) => {
   const requestId = correlateRequest(c);
   const session = c.get('session')!;
-  const {
-    question,
-    game: rawGame,
-    campaignId: rawCampaignId,
-    historyQuery,
-  } = await readQuestionForm(c);
+  const { question, game: rawGame, historyQuery } = await readQuestionForm(c);
   if (!question) return badChatRequest(c, 'Question is required');
   let game: string | undefined;
   try {
@@ -3550,7 +3584,6 @@ app.post('/chat/:conversationId/messages', async (c) => {
       userId: session.userId,
       question,
       game,
-      campaignId: await chatCampaignBinding(session.userId, rawCampaignId),
       requestId,
       telemetry: { route: '/chat/:conversationId/messages', surface: 'web_chat' },
     });
@@ -3584,7 +3617,6 @@ app.post('/chat/:conversationId/messages', async (c) => {
     userId: session.userId,
     question,
     game,
-    campaignId: await chatCampaignBinding(session.userId, rawCampaignId),
     requestId,
     telemetry: { route: '/chat/:conversationId/messages', surface: 'web_chat' },
   });

--- a/src/web-ui/campaign-pages.ts
+++ b/src/web-ui/campaign-pages.ts
@@ -1,12 +1,11 @@
 /**
- * Phase 4 campaign surfaces (SQR-275): the route shells and the header
- * context strip that bridges them.
+ * Phase 4 campaign surfaces (SQR-275): the route shells and campaign page
+ * content that bridges into campaign management.
  *
  * DESIGN.md §Phase 4 Components is authoritative: dedicated routes under
- * the ledger shell; the strip shows the active campaign (campaign name
- * outranks the Squire brand on campaign surfaces) or `NO CAMPAIGN ·
- * SET UP`; it never shows fake state. The dashboard content itself
- * (threads, statuses) lands in SQR-276 — this module owns the shells.
+ * the ledger shell. The shared app header stays generic; campaign identity
+ * belongs in page content and chat composer context. The dashboard content
+ * itself (threads, statuses) lands in SQR-276 — this module owns the shells.
  */
 import { html, raw } from 'hono/html';
 import type { HtmlEscapedString } from 'hono/utils/html';
@@ -29,10 +28,7 @@ function gameLabel(game: string): string {
   return isGameId(game) ? gameDefinitionFor(game).sourcePrefix.toUpperCase() : game.toUpperCase();
 }
 
-/**
- * The persistent bridge: tap → campaign dashboard. `prominent` marks
- * campaign surfaces, where the campaign name outranks the brand.
- */
+/** Historical header-strip renderer retained for old fixtures and migrations. */
 export function renderCampaignStrip(
   strip: CampaignStripState | null,
   options: { prominent?: boolean } = {},

--- a/src/web-ui/layout.ts
+++ b/src/web-ui/layout.ts
@@ -20,7 +20,7 @@ import type { HtmlEscapedString } from 'hono/utils/html';
 
 import { getAppCssUrl, getHtmxJsUrl, getSquireJsUrl } from './assets.ts';
 import { renderAssistantContent } from './assistant-content.ts';
-import { renderCampaignStrip, type CampaignStripState } from './campaign-pages.ts';
+import type { CampaignStripState } from './campaign-pages.ts';
 import { aggregateSourceLabels, type ToolSourceLabel } from './consulted-footer.ts';
 import { CSRF_FORM_FIELD_NAME, CSRF_HEADER_NAME, CSRF_META_NAME } from './csrf.ts';
 import { FONT_PRECONNECTS, GOOGLE_FONTS_HREF } from './fonts.ts';
@@ -50,14 +50,11 @@ import type {
 
 export interface LayoutShellOptions {
   /**
-   * Header context strip (SQR-275): the persistent campaign bridge.
-   * Pass the active campaign (or null for the NO CAMPAIGN affordance);
-   * leave undefined to omit the strip entirely (unauthenticated chrome).
-   * `campaignStripProminent` marks campaign surfaces, where the campaign
-   * name outranks the brand.
+   * Active campaign context used for chat form binding when a caller has not
+   * supplied `chatCampaignContext`. The shared app header never renders this
+   * state; campaign identity belongs in page content or the chat composer.
    */
   campaignStrip?: CampaignStripState | null;
-  campaignStripProminent?: boolean;
   /**
    * Chat-specific campaign context. Unlike `campaignStrip`, this renders in
    * the ask surface rather than the header, so users verify context immediately
@@ -109,6 +106,7 @@ export interface LayoutShellOptions {
   showChatChrome?: boolean;
   conversationHistory?: ConversationHistoryViewModel;
   headerContext?: string;
+  activeAppSection?: AppNavSection;
   columnClassName?: string;
   /**
    * Set to true on pages whose `mainContent` contains its own live region
@@ -124,7 +122,10 @@ export interface ChatCampaignContextView {
   activeCampaign: CampaignStripState | null;
   campaigns: CampaignStripState[];
   returnTo: string;
+  fixed?: boolean;
 }
+
+export type AppNavSection = 'chat' | 'campaigns' | 'none';
 
 const EMPTY_CONVERSATION_HISTORY: ConversationHistoryViewModel = {
   rows: [],
@@ -221,6 +222,28 @@ function renderActiveGamePicker(): HtmlEscapedString {
   </fieldset>` as HtmlEscapedString;
 }
 
+function renderAppNav(activeSection: AppNavSection): HtmlEscapedString {
+  const chatClass = [
+    'squire-app-nav__link',
+    activeSection === 'chat' ? 'squire-app-nav__link--active' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const campaignsClass = [
+    'squire-app-nav__link',
+    activeSection === 'campaigns' ? 'squire-app-nav__link--active' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const chatCurrent = activeSection === 'chat' ? html` aria-current="page"` : html``;
+  const campaignsCurrent = activeSection === 'campaigns' ? html` aria-current="page"` : html``;
+
+  return html`<nav class="squire-app-nav" aria-label="Primary">
+    <a class="${chatClass}" href="/" ${chatCurrent}>Chat</a>
+    <a class="${campaignsClass}" href="/campaigns" ${campaignsCurrent}>Campaigns</a>
+  </nav>` as HtmlEscapedString;
+}
+
 function chatGameLabel(game: string): string {
   return SUPPORTED_GAMES.find((definition) => definition.id === game)?.label ?? game;
 }
@@ -228,59 +251,79 @@ function chatGameLabel(game: string): string {
 function renderChatCampaignContext(
   context: ChatCampaignContextView,
   csrfToken: string,
+  options: { oob?: boolean } = {},
 ): HtmlEscapedString {
   const active = context.activeCampaign;
-  return html`<section class="squire-chat-context" aria-label="Chat campaign context">
+  const fixed = context.fixed === true;
+  return html`<section
+    id="squire-chat-context"
+    class="squire-chat-context"
+    aria-label="Chat campaign context"
+    ${options.oob ? html`hx-swap-oob="true"` : html``}
+  >
     <div class="squire-chat-context__current">
-      <span class="squire-chat-context__label">Current campaign</span>
-      <strong class="squire-chat-context__name"
-        >${active ? active.campaignName : 'No campaign selected'}</strong
-      >
+      <span class="squire-chat-context__label">
+        ${fixed ? 'Conversation campaign' : 'Current campaign'}
+      </span>
+      ${active
+        ? html`<a class="squire-chat-context__name" href="/campaigns/${active.campaignId}">
+            ${active.campaignName}
+          </a>`
+        : html`<strong class="squire-chat-context__name">No campaign selected</strong>`}
       <span class="squire-chat-context__meta">
         ${active
-          ? `${chatGameLabel(active.game)} context for your next question`
-          : 'Game-only rules lookup'}
+          ? fixed
+            ? `${chatGameLabel(active.game)} context for this conversation`
+            : `${chatGameLabel(active.game)} context for your next question`
+          : fixed
+            ? 'Game-only rules lookup for this conversation'
+            : 'Game-only rules lookup'}
       </span>
     </div>
-    ${active
-      ? html`<a class="squire-chat-context__campaign-link" href="/campaigns/${active.campaignId}">
-          Open campaign
-        </a>`
-      : renderActiveGamePicker()}
-    ${context.campaigns.length > 0
-      ? html`<details class="squire-chat-context__switcher">
-          <summary>Change</summary>
-          <div class="squire-chat-context__menu">
-            ${context.campaigns.map(
-              (campaign) =>
-                html`<form method="post" action="/chat/campaign-context">
-                  <input type="hidden" name="${CSRF_FORM_FIELD_NAME}" value="${csrfToken}" />
-                  <input type="hidden" name="campaignId" value="${campaign.campaignId}" />
-                  <input type="hidden" name="returnTo" value="${context.returnTo}" />
-                  <button
-                    type="submit"
-                    ${active?.campaignId === campaign.campaignId
-                      ? html`aria-current="true"`
-                      : html``}
-                  >
-                    ${campaign.campaignName}
-                    <span>${chatGameLabel(campaign.game)}</span>
-                  </button>
-                </form>`,
-            )}
-            <form method="post" action="/chat/campaign-context">
-              <input type="hidden" name="${CSRF_FORM_FIELD_NAME}" value="${csrfToken}" />
-              <input type="hidden" name="campaignId" value="${NO_CAMPAIGN_CONTEXT}" />
-              <input type="hidden" name="returnTo" value="${context.returnTo}" />
-              <button type="submit" ${active === null ? html`aria-current="true"` : html``}>
-                No campaign
-                <span>Use the game picker</span>
-              </button>
-            </form>
-          </div>
-        </details>`
-      : html`<a class="squire-chat-context__setup" href="/campaigns">Set up campaign</a>`}
+    ${active ? html`` : renderActiveGamePicker()}
+    ${fixed
+      ? html``
+      : context.campaigns.length > 0
+        ? html`<details class="squire-chat-context__switcher">
+            <summary>Change</summary>
+            <div class="squire-chat-context__menu">
+              ${context.campaigns.map(
+                (campaign) =>
+                  html`<form method="post" action="/chat/campaign-context">
+                    <input type="hidden" name="${CSRF_FORM_FIELD_NAME}" value="${csrfToken}" />
+                    <input type="hidden" name="campaignId" value="${campaign.campaignId}" />
+                    <input type="hidden" name="returnTo" value="${context.returnTo}" />
+                    <button
+                      type="submit"
+                      ${active?.campaignId === campaign.campaignId
+                        ? html`aria-current="true"`
+                        : html``}
+                    >
+                      ${campaign.campaignName}
+                      <span>${chatGameLabel(campaign.game)}</span>
+                    </button>
+                  </form>`,
+              )}
+              <form method="post" action="/chat/campaign-context">
+                <input type="hidden" name="${CSRF_FORM_FIELD_NAME}" value="${csrfToken}" />
+                <input type="hidden" name="campaignId" value="${NO_CAMPAIGN_CONTEXT}" />
+                <input type="hidden" name="returnTo" value="${context.returnTo}" />
+                <button type="submit" ${active === null ? html`aria-current="true"` : html``}>
+                  No campaign
+                  <span>Use the game picker</span>
+                </button>
+              </form>
+            </div>
+          </details>`
+        : html`<a class="squire-chat-context__setup" href="/campaigns">Set up campaign</a>`}
   </section>` as HtmlEscapedString;
+}
+
+export function renderChatCampaignContextOob(
+  context: ChatCampaignContextView,
+  csrfToken: string,
+): HtmlEscapedString {
+  return renderChatCampaignContext(context, csrfToken, { oob: true });
 }
 
 function statusLabel(status: ConversationHistoryStatus): string {
@@ -333,16 +376,18 @@ function renderConversationHistorySearch(
   const query = history.query ?? '';
   return html`<form class="squire-history-search" method="get" role="search">
     <label class="sr-only" for="squire-history-search-${idSuffix}">Search history</label>
-    <input
-      id="squire-history-search-${idSuffix}"
-      class="squire-history-search__input"
-      type="search"
-      name="historyQuery"
-      value="${query}"
-      placeholder="Search history"
-      autocomplete="off"
-    />
-    <button class="squire-history-search__submit" type="submit">Search</button>
+    <div class="squire-history-search__field">
+      <input
+        id="squire-history-search-${idSuffix}"
+        class="squire-history-search__input"
+        type="search"
+        name="historyQuery"
+        value="${query}"
+        placeholder="Search history"
+        autocomplete="off"
+      />
+      <button class="squire-history-search__submit" type="submit">Search</button>
+    </div>
   </form>` as HtmlEscapedString;
 }
 
@@ -371,10 +416,7 @@ export function renderConversationHistoryShell(
   >
     <aside class="squire-rail" aria-label="Conversation history">
       <div class="squire-history-head">
-        <a class="squire-history-brand" href="/" aria-label="Go to Squire home">
-          <span class="squire-monogram squire-monogram--masthead" aria-hidden="true"></span>
-          <span class="squire-wordmark">Squire</span>
-        </a>
+        <span class="squire-history-title">Conversations</span>
         ${renderNewChatLink('squire-history-new-chat')}
       </div>
       ${renderConversationHistorySearch(history, 'rail')} ${renderConversationHistoryList(history)}
@@ -391,7 +433,9 @@ export function renderConversationHistoryShell(
       hidden
     >
       <div class="squire-history-drawer__header">
-        <span id="squire-history-drawer-title" class="squire-history-drawer__title"> History </span>
+        <span id="squire-history-drawer-title" class="squire-history-drawer__title">
+          Conversations
+        </span>
         <button
           type="button"
           class="squire-history-drawer__close"
@@ -413,8 +457,13 @@ export function renderConversationTranscriptWithHistoryOob(options: {
   conversationId: string;
   messages: ConversationMessage[];
   pendingStreamUrls?: Map<string, string>;
+  chatCampaignContext?: ChatCampaignContextView;
+  csrfToken?: string;
 }): HtmlEscapedString {
   return html`${renderConversationHistoryShell(options.conversationHistory, { oob: true })}
+  ${options.chatCampaignContext && options.csrfToken
+    ? renderChatCampaignContextOob(options.chatCampaignContext, options.csrfToken)
+    : html``}
   ${renderConversationTranscript({
     conversationId: options.conversationId,
     messages: options.messages,
@@ -1199,7 +1248,10 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
     options.chatCampaignContext !== undefined
       ? options.chatCampaignContext.activeCampaign
       : options.campaignStrip;
+  const chatCampaignIsFixed = options.chatCampaignContext?.fixed === true;
   const headerContext = options.headerContext ?? 'HAVEN · RULES';
+  const activeAppSection =
+    options.activeAppSection ?? (authenticated && showChatChrome ? 'chat' : 'none');
   const columnClassName = options.columnClassName ?? 'squire-column';
   const historyQuery = conversationHistory?.query ?? '';
   const chatFormHiddenFields = [
@@ -1207,7 +1259,9 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
     // E8/SQR-364: a campaign context supplies the game dimension; no-campaign
     // chat keeps the game picker and game hidden field available.
     ...(activeChatCampaign ? [] : [{ name: 'game', value: DEFAULT_GAME_ID }]),
-    ...(activeChatCampaign ? [{ name: 'campaignId', value: activeChatCampaign.campaignId }] : []),
+    ...(activeChatCampaign && !chatCampaignIsFixed
+      ? [{ name: 'campaignId', value: activeChatCampaign.campaignId }]
+      : []),
     ...(historyQuery ? [{ name: 'historyQuery', value: historyQuery }] : []),
     ...(options.chatFormHiddenFields ?? []),
   ];
@@ -1223,6 +1277,19 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
         <p class="squire-banner__body">${options.errorBanner.message}</p>
       </div>`
     : (options.mainContent ?? (html`` as HtmlEscapedString));
+  const headerContent =
+    authenticated && options.session
+      ? html`<a class="squire-header__brand" href="/" aria-label="Go to Squire home">
+            <span class="squire-monogram" aria-hidden="true"></span>
+            <span class="squire-wordmark">Squire</span>
+          </a>
+          ${renderAppNav(activeAppSection)} ${conversationHistory ? renderHistoryToggle() : html``}
+          <div class="squire-header__account">
+            ${renderAccountMenu(options.session, authenticatedCsrfToken)}
+          </div>`
+      : html`<span class="squire-monogram" aria-hidden="true"></span>
+          <span class="squire-wordmark">Squire</span>
+          <span class="squire-context">${headerContext}</span>`;
   return renderDocument({
     authenticated,
     csrfToken,
@@ -1230,31 +1297,10 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
     bodyContent: html`${!authenticated || !showChatChrome
         ? html``
         : html`<a href="#squire-input" class="sr-only-focusable">Skip to ask Squire</a>`}
+      <header class="squire-header">${headerContent}</header>
       <div class="squire-frame">
         ${conversationHistory ? renderConversationHistoryShell(conversationHistory) : html``}
         <div class="${columnClassName}">
-          <header class="squire-header">
-            ${authenticated && options.session
-              ? html`<a class="squire-header__brand" href="/" aria-label="Go to Squire home">
-                    <span class="squire-monogram" aria-hidden="true"></span>
-                    <span class="squire-wordmark">Squire</span>
-                  </a>
-                  ${conversationHistory ? renderHistoryToggle() : html``}
-                  ${options.campaignStrip !== undefined
-                    ? renderCampaignStrip(options.campaignStrip, {
-                        prominent: options.campaignStripProminent,
-                      })
-                    : html``}
-                  ${showChatChrome
-                    ? html``
-                    : html`<span class="squire-context">${headerContext}</span>`}
-                  <div class="squire-header__account">
-                    ${renderAccountMenu(options.session, authenticatedCsrfToken)}
-                  </div>`
-              : html`<span class="squire-monogram" aria-hidden="true"></span>
-                  <span class="squire-wordmark">Squire</span>
-                  <span class="squire-context">${headerContext}</span>`}
-          </header>
           <main
             id="squire-surface"
             class="squire-surface"
@@ -1265,7 +1311,8 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
           </main>
           ${!authenticated || !showChatChrome
             ? html``
-            : html`${options.chatCampaignContext
+            : html`<div class="squire-composer">
+                ${options.chatCampaignContext
                   ? renderChatCampaignContext(options.chatCampaignContext, authenticatedCsrfToken)
                   : html``}
                 <form
@@ -1280,15 +1327,16 @@ export async function layoutShell(options: LayoutShellOptions = {}): Promise<Htm
                     (field) =>
                       html`<input type="hidden" name="${field.name}" value="${field.value}" />`,
                   )}
-                  <input
+                  <textarea
                     id="squire-input"
                     name="question"
-                    type="text"
+                    rows="3"
                     autocomplete="off"
-                    placeholder="Ask a question..."
-                  />
+                    placeholder="Ask about a rule, card, item, monster, or scenario"
+                  ></textarea>
                   <button type="submit" class="squire-input-dock__submit" aria-label="Ask"></button>
-                </form>`}
+                </form>
+              </div>`}
         </div>
       </div>` as HtmlEscapedString,
   });
@@ -1599,6 +1647,7 @@ export async function renderMarkdownStyleguidePage(
     mainContent,
     showRail: false,
     showChatChrome: false,
+    activeAppSection: 'none',
     headerContext: 'INTERNAL · STYLEGUIDE',
     columnClassName: 'squire-column squire-column--wide',
   });

--- a/src/web-ui/squire.js
+++ b/src/web-ui/squire.js
@@ -1327,7 +1327,7 @@ document.addEventListener('submit', function (e) {
   var form = e.target;
   if (!form || !form.matches || !form.matches('.squire-input-dock')) return;
 
-  var questionInput = form.querySelector('input[name="question"]');
+  var questionInput = form.querySelector('[name="question"]');
   var submitButton = form.querySelector('button[type="submit"]');
   setHiddenGameInputs(activeGame);
   ensureIdempotencyKey(form);
@@ -1381,7 +1381,7 @@ function ensureIdempotencyKey(form) {
 
 function setFormPendingState(form, pending) {
   if (!form) return;
-  var questionInput = form.querySelector('input[name="question"]');
+  var questionInput = form.querySelector('[name="question"]');
   var submitButton = form.querySelector('button[type="submit"]');
 
   if (pending) {
@@ -3516,7 +3516,7 @@ document.addEventListener('htmx:afterSwap', function (event) {
   // the append-fragment swap touches `.squire-transcript`, not the form
   // — so we manage form state here regardless of the swap target id.
   var form = document.querySelector('.squire-input-dock');
-  var questionInput = form && form.querySelector('input[name="question"]');
+  var questionInput = form && form.querySelector('[name="question"]');
   if (questionInput) questionInput.value = '';
   consumeDashboardToastPayload(event.detail && event.detail.target);
   syncChatFormAction();

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -66,6 +66,11 @@
   --space-2xl: 48px;
   --space-3xl: 64px;
   --space-4xl: 96px;
+  --squire-rail-width: 280px;
+  --squire-content-column-width: 640px;
+  --squire-content-inline-padding-desktop: 24px;
+  --squire-header-nav-min-left: 10rem;
+  --squire-header-nav-baseline-offset: 5px;
 }
 
 /*
@@ -120,6 +125,7 @@ html {
   margin: 0;
   padding: 0;
   min-height: 100vh;
+  min-height: 100dvh;
 
   /* Body text floor — DESIGN.md §Typography "16px mobile / 18px desktop." */
   font-size: 16px;
@@ -129,6 +135,12 @@ html {
 .squire-body {
   /* Prevent horizontal scroll at 375px viewport (an SQR-65 acceptance
      criterion). The mobile regions are width-bounded by the column wrapper. */
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  height: 100dvh;
+  min-height: 100vh;
+  min-height: 100dvh;
   overflow-x: hidden;
 }
 
@@ -138,7 +150,7 @@ html {
 
 /* Skip-link: visually hidden until focused, then becomes a wax-outlined
    button at the top of the viewport so keyboard users land directly on the
-   real `<input id="squire-input">` inside `.squire-input-dock`. */
+   real `<textarea id="squire-input">` inside `.squire-input-dock`. */
 .sr-only-focusable {
   position: absolute;
   width: 1px;
@@ -187,7 +199,9 @@ html {
 .squire-frame {
   display: flex;
   flex-direction: row;
-  min-height: 100vh;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
 }
 
 .squire-history-shell {
@@ -196,30 +210,27 @@ html {
 
 .squire-rail {
   display: none; /* Hidden on mobile + tablet — desktop only. */
-  width: 280px;
+  width: var(--squire-rail-width);
   flex-shrink: 0;
   background: var(--surface);
   border-right: 1px solid var(--rule);
   padding: 20px 16px;
 }
 
-.squire-history-head,
-.squire-history-brand {
-  display: flex;
-  align-items: center;
-}
-
 .squire-history-head {
+  display: flex;
   flex-direction: column;
   align-items: stretch;
   gap: 16px;
   margin-bottom: 20px;
 }
 
-.squire-history-brand {
-  gap: 12px;
+.squire-history-title {
   color: var(--parchment);
-  text-decoration: none;
+  font-family: 'Fraunces', 'Georgia', serif;
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 1.2;
 }
 
 .squire-history-new-chat {
@@ -244,18 +255,21 @@ html {
 }
 
 .squire-history-search {
-  display: flex;
-  gap: 6px;
+  display: block;
   margin-bottom: 14px;
+}
+
+.squire-history-search__field {
+  position: relative;
 }
 
 .squire-history-search__input {
   min-width: 0;
   width: 100%;
-  height: 36px;
+  height: 44px;
   border: 1px solid var(--rule);
   border-radius: 6px;
-  padding: 0 10px;
+  padding: 0 5.75rem 0 10px;
   color: var(--parchment);
   background: var(--surface);
   font-family: 'Geist', system-ui, sans-serif;
@@ -273,12 +287,15 @@ html {
 }
 
 .squire-history-search__submit {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
   min-height: 36px;
-  border: 1px solid var(--rule);
+  border: 1px solid var(--wax);
   border-radius: 6px;
   padding: 0 10px;
   color: var(--parchment);
-  background: var(--surface-2);
+  background: var(--wax);
   font-family: 'Geist', system-ui, sans-serif;
   font-size: 12px;
   font-weight: 600;
@@ -286,8 +303,9 @@ html {
 
 .squire-history-search__submit:hover,
 .squire-history-search__submit:focus-visible {
-  color: var(--wax);
-  border-color: var(--wax);
+  color: var(--parchment);
+  border-color: var(--wax-dim);
+  background: var(--wax-dim);
 }
 
 .squire-history-list {
@@ -453,34 +471,33 @@ html {
    while the body was bounded — visually asymmetric. CodeRabbit caught it
    on PR #198. */
 .squire-column {
+  position: relative;
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
-  min-height: 100vh;
+  min-height: 0;
   width: 100%;
-  max-width: 640px;
+  max-width: var(--squire-content-column-width);
   margin: 0 auto;
 }
 
-/* SQR-297: once a surface contains a transcript, the transcript scrolls
-   inside the viewport space above the input dock. Keeping the dock in normal
-   flex flow prevents the reloaded mobile transcript from sliding underneath
-   a sticky footer while preserving the home page's sticky first-submit dock. */
+/* SQR-297 / SQR-366: once a surface contains a transcript, the whole
+   conversation column scrolls as one object. The ask widget remains in normal
+   flow after the transcript, so it appears after the current answer instead of
+   being pinned in a separate viewport lane. */
 .squire-column:has(> .squire-surface > .squire-transcript) {
-  height: 100vh;
-  height: 100dvh;
-  min-height: 100vh;
-  min-height: 100dvh;
-  overflow: hidden;
-}
-
-.squire-column:has(> .squire-surface > .squire-transcript) .squire-surface {
+  height: 100%;
   min-height: 0;
   overflow-y: auto;
 }
 
-.squire-column:has(> .squire-surface > .squire-transcript) .squire-input-dock {
-  position: static;
+.squire-column:has(> .squire-surface > .squire-transcript) .squire-surface {
+  flex: 0 0 auto;
+  overflow: visible;
+}
+
+.squire-column:has(> .squire-surface > .squire-transcript) .squire-composer {
+  flex: 0 0 auto;
 }
 
 .squire-column--wide {
@@ -489,8 +506,9 @@ html {
 
 /* 1. Header bar — thin, with bottom hairline rule. */
 .squire-header {
+  position: relative;
   display: grid;
-  grid-template-columns: auto auto 1fr auto;
+  grid-template-columns: auto auto auto 1fr auto;
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
@@ -512,12 +530,47 @@ html {
 }
 
 .squire-header__account {
+  grid-column: -2 / -1;
   justify-self: end;
 }
 
 .squire-header__brand:hover .squire-wordmark,
 .squire-header__brand:focus-visible .squire-wordmark {
   color: var(--wax);
+}
+
+.squire-app-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-md);
+  margin-left: var(--space-md);
+  padding: 0;
+  background: transparent;
+}
+
+.squire-app-nav__link {
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0 2px;
+  border-bottom: 2px solid transparent;
+  color: var(--sepia);
+  font-family: 'Geist', system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.squire-app-nav__link:hover,
+.squire-app-nav__link:focus-visible {
+  color: var(--parchment);
+}
+
+.squire-app-nav__link--active {
+  color: var(--parchment);
+  border-bottom-color: var(--wax);
 }
 
 .squire-account-menu {
@@ -637,8 +690,7 @@ html {
   height: 28px;
 }
 
-.squire-header .squire-wordmark,
-.squire-rail .squire-wordmark {
+.squire-header .squire-wordmark {
   font-family: 'Fraunces', 'Georgia', serif;
   font-size: 18px;
   font-weight: 500;
@@ -715,7 +767,7 @@ html {
 
 .squire-chat-context {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: var(--space-sm);
   align-items: center;
   margin: 0 0 var(--space-sm);
@@ -746,6 +798,7 @@ html {
 
 .squire-chat-context__name {
   min-width: 0;
+  display: block;
   overflow: hidden;
   color: var(--parchment);
   font-family: 'Fraunces', 'Georgia', serif;
@@ -756,7 +809,19 @@ html {
   white-space: nowrap;
 }
 
-.squire-chat-context__campaign-link,
+a.squire-chat-context__name {
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--sepia) 72%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+a.squire-chat-context__name:hover,
+a.squire-chat-context__name:focus-visible {
+  color: var(--wax);
+  text-decoration-color: var(--wax);
+}
+
 .squire-chat-context__setup,
 .squire-chat-context__switcher summary {
   min-height: 44px;
@@ -774,7 +839,6 @@ html {
   cursor: pointer;
 }
 
-.squire-chat-context__campaign-link:hover,
 .squire-chat-context__setup:hover,
 .squire-chat-context__switcher summary:hover {
   color: var(--parchment);
@@ -855,36 +919,57 @@ html {
   width: 100%;
 }
 
-/* 5. Input dock — sticky at the bottom of the viewport, never collapses,
-   respects iOS safe-area-inset-bottom so the home indicator doesn't sit on
-   top of the submit button. */
+.squire-composer {
+  width: 100%;
+  padding: 0 16px 16px;
+  flex-shrink: 0;
+}
+
+@media (min-width: 768px) {
+  .squire-composer {
+    padding: 0 var(--squire-content-inline-padding-desktop) 24px;
+  }
+}
+
+.squire-column:has(> .squire-composer):not(:has(> .squire-surface > .squire-transcript))
+  .squire-surface {
+  flex: 0 0 auto;
+}
+
+.squire-column:has(> .squire-composer):not(:has(> .squire-surface > .squire-transcript))
+  .squire-composer {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  transform: translateY(-50%);
+}
+
+/* 5. Input dock — the asking field. The submit control sits inside the
+   textarea edge so the first question reads as one focused action. */
 .squire-input-dock {
-  position: sticky;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
-  padding-bottom: max(12px, env(safe-area-inset-bottom));
-  background: var(--ink);
-  border-top: 1px solid var(--rule);
+  position: relative;
+  display: block;
+  padding: 0;
+  padding-bottom: max(0px, env(safe-area-inset-bottom));
+  background: transparent;
   flex-shrink: 0;
 }
 
 .squire-input-dock #squire-input {
-  flex: 1 1 auto;
+  display: block;
+  width: 100%;
+  min-height: 112px;
   background: var(--surface);
   color: var(--parchment);
   border: 1px solid var(--rule);
   border-radius: 8px;
-  padding: 12px 14px;
+  padding: 16px 68px 56px 16px;
   font-family: 'Geist', system-ui, sans-serif;
   font-size: 16px;
-  font-style: italic;
-
-  /* 44px tap target floor — input height = 16px text + 12px*2 padding +
-     1px*2 border = 43px; bump min-height for the WCAG floor. */
-  min-height: 44px;
+  font-style: normal;
+  line-height: 1.45;
+  resize: vertical;
 }
 
 .squire-input-dock #squire-input::placeholder {
@@ -895,6 +980,9 @@ html {
 /* The submit control IS the Squire seal (SQR-99): the same wax-seal mark as
    the header monogram, scaled to the 44px tap target. */
 .squire-input-dock__submit {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
   width: 44px;
   height: 44px;
   flex-shrink: 0;
@@ -1284,7 +1372,21 @@ template#squire-banner-fixtures {
    the desktop rail stays hidden — same regions, narrower main column. */
 @media (min-width: 768px) {
   .squire-surface {
-    padding: 32px 24px;
+    padding: 32px var(--squire-content-inline-padding-desktop);
+  }
+
+  .squire-app-nav {
+    position: absolute;
+    left: max(
+      var(--squire-header-nav-min-left),
+      calc(
+        (100vw - var(--squire-content-column-width)) / 2 +
+          var(--squire-content-inline-padding-desktop)
+      )
+    );
+    top: calc(50% + var(--squire-header-nav-baseline-offset));
+    transform: translateY(-50%);
+    margin-left: 0;
   }
 
   .squire-styleguide__summary,
@@ -1315,6 +1417,19 @@ template#squire-banner-fixtures {
     justify-content: end;
   }
 
+  .squire-app-nav {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    position: static;
+    transform: none;
+    justify-self: start;
+    margin-left: 0;
+  }
+
+  .squire-app-nav__link {
+    flex: 0 0 auto;
+  }
+
   .squire-history-toggle {
     grid-column: 2 / 3;
     grid-row: 1;
@@ -1323,6 +1438,17 @@ template#squire-banner-fixtures {
 
   .squire-header .squire-context {
     grid-column: 1 / -1;
+    grid-row: 2;
+    justify-self: start;
+  }
+
+  .squire-header:has(.squire-app-nav) .squire-context {
+    grid-row: 3;
+  }
+
+  .squire-campaign-strip {
+    grid-column: 1 / -1;
+    grid-row: 3;
     justify-self: start;
   }
 
@@ -1341,7 +1467,6 @@ template#squire-banner-fixtures {
     align-items: stretch;
   }
 
-  .squire-chat-context__campaign-link,
   .squire-chat-context__setup,
   .squire-chat-context__switcher summary {
     justify-content: flex-start;
@@ -1369,16 +1494,51 @@ template#squire-banner-fixtures {
   }
 
   .squire-frame {
-    /* Outer 12px border-radius lives on a wrapper container at this
-       breakpoint — DESIGN.md §Spacing border-radius scale. `overflow:
-       hidden` is required for the radius to actually clip the rail and
-       column corners — without it, child square corners poke through.
-       The frame keeps `min-height: 100vh`, so the input dock's
-       `position: sticky` still pins to the viewport bottom for short
-       content (the dock's nearest scroll ancestor becomes the frame
-       at this breakpoint, but the frame is at least viewport-tall). */
-    border-radius: 12px;
+    overflow: visible;
+  }
+
+  .squire-frame:has(.squire-rail) {
+    min-height: 0;
     overflow: hidden;
+  }
+
+  .squire-frame:has(.squire-rail) .squire-column {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .squire-frame:has(.squire-rail) .squire-column:not(.squire-column--wide) {
+    margin-left: max(
+      var(--space-xl),
+      calc((100vw - var(--squire-content-column-width)) / 2 - var(--squire-rail-width))
+    );
+    margin-right: auto;
+  }
+
+  .squire-body:has(.squire-rail) .squire-app-nav {
+    left: max(
+      var(--squire-header-nav-min-left),
+      calc(
+        var(--squire-rail-width) +
+          max(
+            var(--space-xl),
+            calc((100vw - var(--squire-content-column-width)) / 2 - var(--squire-rail-width))
+          ) +
+          var(--squire-content-inline-padding-desktop)
+      )
+    );
+  }
+
+  .squire-frame:has(.squire-rail)
+    .squire-column:not(:has(> .squire-surface > .squire-transcript))
+    .squire-surface {
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  .squire-frame:has(.squire-rail) .squire-rail {
+    height: 100%;
+    overflow-y: auto;
   }
 }
 
@@ -2353,6 +2513,14 @@ template#squire-banner-fixtures {
 
 .squire-campaign-strip--empty {
   color: var(--sepia-dim);
+}
+
+@media (max-width: 767px) {
+  .squire-campaign-strip {
+    grid-column: 1 / -1;
+    grid-row: 3;
+    justify-self: start;
+  }
 }
 
 .squire-campaigns,

--- a/test/campaign-pages.test.ts
+++ b/test/campaign-pages.test.ts
@@ -1,10 +1,10 @@
 /**
  * Campaign route shell + chat context tests (SQR-275, SQR-364).
  *
- * Campaign pages still use the header strip/wayfinding bridge. Chat renders
- * campaign context in the ask area so the next turn's binding is visible and
- * changeable immediately before asking. Non-member campaign pages are the
- * indistinguishable 404.
+ * Campaign pages share the same app header as chat. Chat renders campaign
+ * context in the ask area so the next turn's binding is visible and changeable
+ * immediately before asking. Non-member campaign pages are the indistinguishable
+ * 404.
  */
 import { generateSignedCookie } from 'hono/cookie';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
@@ -69,12 +69,14 @@ afterAll(async () => {
 });
 
 describe('chat context states', () => {
-  it('shows NO CAMPAIGN · SET UP for users without campaigns', async () => {
+  it('renders campaigns without campaign context in the app header for users without campaigns', async () => {
     const owner = await createTestUser(OWNER_EMAIL);
     const res = await pageRequest(owner, '/campaigns');
     expect(res.status).toBe(200);
     const body = await res.text();
-    expect(body).toContain('NO CAMPAIGN · SET UP');
+    const header = body.match(/<header class="squire-header">[\s\S]*?<\/header>/)?.[0] ?? '';
+    expect(header).not.toContain('NO CAMPAIGN');
+    expect(header).not.toContain('squire-campaign-strip');
     expect(body).toContain('No campaigns yet');
   });
 
@@ -89,7 +91,7 @@ describe('chat context states', () => {
     expect(res.status).toBe(200);
     const body = await res.text();
     const header = body.match(/<header class="squire-header">[\s\S]*?<\/header>/)?.[0] ?? '';
-    const context = body.match(/<section class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+    const context = body.match(/<section[^>]*class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
     expect(header).not.toContain('TRAVEL CAMPAIGN');
     expect(context).toContain('Current campaign');
     expect(context).toContain('Travel Campaign');
@@ -101,7 +103,7 @@ describe('chat context states', () => {
 });
 
 describe('campaign routes', () => {
-  it('renders the dashboard shell for members; prominent strip', async () => {
+  it('renders the dashboard shell for members without campaign context in the app header', async () => {
     const owner = await createTestUser(OWNER_EMAIL);
     const campaign = await CampaignService.createCampaign(identityFromSessionUser(owner.userId), {
       name: 'Travel Campaign',
@@ -111,10 +113,17 @@ describe('campaign routes', () => {
     const res = await pageRequest(owner, `/campaigns/${campaign.id}`);
     expect(res.status).toBe(200);
     const body = await res.text();
+    const header = body.match(/<header class="squire-header">[\s\S]*?<\/header>/)?.[0] ?? '';
     expect(body).toContain('Travel Campaign');
     expect(body).toContain('squire-column squire-column--wide');
     expect(body).toContain('squire-campaign-dashboard squire-campaign-dashboard--progress');
-    expect(body).toContain('squire-campaign-strip--prominent');
+    expect(header).toMatch(/<a[^>]*href="\/"[^>]*>\s*Chat\s*<\/a>/);
+    expect(header).toMatch(
+      /<a[^>]*href="\/campaigns"[^>]*aria-current="page"[^>]*>\s*Campaigns\s*<\/a>/,
+    );
+    expect(header).not.toContain('HAVEN · RULES');
+    expect(header).not.toContain('Travel Campaign');
+    expect(header).not.toContain('squire-campaign-strip');
     expect(body).toContain('Frosthaven · Prosperity 1');
     expect(body).toContain('<h2 class="squire-campaign-dashboard__section-title">Progress</h2>');
     expect(body).toContain(
@@ -204,7 +213,7 @@ describe('campaign picker (SQR-11)', () => {
       headers: { Cookie: `${owner.cookie}; ${cookie.split(';')[0]}` },
     });
     const body = await home.text();
-    const context = body.match(/<section class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+    const context = body.match(/<section[^>]*class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
     expect(context).toContain('Second Campaign');
     // E8: an active campaign hides the per-session game selector.
     expect(body).not.toContain('squire-game-picker');
@@ -235,7 +244,7 @@ describe('campaign picker (SQR-11)', () => {
       headers: { Cookie: `${owner.cookie}; ${cookie.split(';')[0]}` },
     });
     const body = await home.text();
-    const context = body.match(/<section class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+    const context = body.match(/<section[^>]*class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
     expect(context).toContain('Second Campaign');
     expect(body).toContain(`name="campaignId" value="${second.id}"`);
   });
@@ -260,7 +269,7 @@ describe('campaign picker (SQR-11)', () => {
     });
     const body = await home.text();
     const header = body.match(/<header class="squire-header">[\s\S]*?<\/header>/)?.[0] ?? '';
-    const context = body.match(/<section class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+    const context = body.match(/<section[^>]*class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
     const askForm = body.match(/<form[^>]*class="squire-input-dock"[\s\S]*?<\/form>/)?.[0];
     expect(header).not.toContain('Travel Campaign');
     expect(context).toContain('No campaign selected');

--- a/test/campaign-rename.test.ts
+++ b/test/campaign-rename.test.ts
@@ -4,7 +4,7 @@
  * A quiet rename disclosure in the Settings view. The campaign name is shared
  * state, so any active member may rename (matching updateSharedState's
  * authorization and the scenario-toggle control) — not owner-gated. Renaming
- * updates the title AND the header context strip; empty/over-long names and
+ * updates the workspace title while the global header remains generic; empty/over-long names and
  * stale version tokens surface inline; a non-member gets the 404.
  */
 import { generateSignedCookie } from 'hono/cookie';
@@ -140,7 +140,7 @@ describe('rename-campaign UI (SQR-320)', () => {
     expect(body).not.toContain('squire-campaign-rename__toggle">Rename</summary>');
   });
 
-  it('renames the campaign and updates the title + context strip', async () => {
+  it('renames the campaign and updates the workspace title without changing the global header', async () => {
     const { owner, campaign } = await setupFixture();
     const res = await rename(owner, campaign.id, 'Renamed Quest', campaign.version);
     expect(res.status).toBe(303);
@@ -149,10 +149,9 @@ describe('rename-campaign UI (SQR-320)', () => {
     const body = await (
       await app.request(`/campaigns/${campaign.id}`, { headers: { Cookie: owner.cookie } })
     ).text();
-    // Title (h1).
     expect(body).toContain('>Renamed Quest</h1>');
-    // Header context strip rebuilt from the new name.
-    expect(body.replace(/\s+/g, ' ')).toContain('RENAMED QUEST');
+    const globalHeader = body.match(/<header class="squire-header">[\s\S]*?<\/header>/)?.[0] ?? '';
+    expect(globalHeader).not.toContain('Renamed Quest');
     expect(body).not.toContain('>Original Name</h1>');
   });
 

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -91,6 +91,8 @@ import * as SessionRepository from '../src/db/repositories/session-repository.ts
 import { SESSION_LIFETIME_MS } from '../src/db/repositories/session-repository.ts';
 import {
   GENERIC_FAILURE_MESSAGE,
+  createPendingConversation,
+  createPendingFollowUp,
   loadConversation,
   loadConversationHistory,
 } from '../src/chat/conversation-service.ts';
@@ -338,6 +340,60 @@ async function assistantConsultedSources(): Promise<Array<string[] | null>> {
 }
 
 describe('conversation history summaries', () => {
+  it('pins a new conversation to the campaign selected for its first message', async () => {
+    const auth = await createAuthContext({ email: 'conversation-campaign@example.com' });
+    const campaignId = 'aaaaaaaa-0000-4000-8000-000000000000';
+
+    const pending = await createPendingConversation({
+      userId: auth.userId,
+      question: 'What is my party prosperity?',
+      idempotencyKey: 'conversation-campaign-start',
+      campaignId,
+    });
+
+    expect(pending.conversation.campaignId).toBe(campaignId);
+    expect(pending.currentUserMessage?.campaignId).toBe(campaignId);
+
+    const loaded = await loadConversation({
+      conversationId: pending.conversation.id,
+      userId: auth.userId,
+    });
+
+    expect(loaded?.conversation.campaignId).toBe(campaignId);
+    expect(loaded?.messages.map((message) => message.campaignId ?? null)).toEqual([campaignId]);
+  });
+
+  it('keeps follow-up messages in the conversation campaign even when another campaign is active', async () => {
+    const auth = await createAuthContext({ email: 'conversation-campaign-followup@example.com' });
+    const conversationCampaignId = 'aaaaaaaa-0000-4000-8000-000000000000';
+    const newlyActiveCampaignId = 'bbbbbbbb-0000-4000-8000-000000000000';
+    const pending = await createPendingConversation({
+      userId: auth.userId,
+      question: 'What is my active scenario?',
+      idempotencyKey: 'conversation-campaign-followup',
+      campaignId: conversationCampaignId,
+    });
+
+    const followUp = await createPendingFollowUp({
+      conversationId: pending.conversation.id,
+      userId: auth.userId,
+      question: 'What about now?',
+      campaignId: newlyActiveCampaignId,
+    });
+
+    expect(followUp?.conversation.campaignId).toBe(conversationCampaignId);
+    expect(followUp?.currentUserMessage?.campaignId).toBe(conversationCampaignId);
+
+    const loaded = await loadConversation({
+      conversationId: pending.conversation.id,
+      userId: auth.userId,
+    });
+    expect(loaded?.messages.map((message) => message.campaignId ?? null)).toEqual([
+      conversationCampaignId,
+      conversationCampaignId,
+    ]);
+  });
+
   it('lists only owned conversations newest first with derived row text', async () => {
     const alice = await createAuthContext({ email: 'alice-history@example.com' });
     const bob = await createAuthContext({

--- a/test/diagnostic-bundle.test.ts
+++ b/test/diagnostic-bundle.test.ts
@@ -15,6 +15,7 @@ const conversation: Conversation = {
   id: '11111111-1111-4111-8111-111111111111',
   userId: '22222222-2222-4222-8222-222222222222',
   creationIdempotencyKey: null,
+  campaignId: null,
   createdAt: new Date('2026-06-14T11:55:00.000Z'),
   lastMessageAt: new Date('2026-06-14T11:59:00.000Z'),
 };

--- a/test/e2e/sqr-11-campaign-picker.spec.ts
+++ b/test/e2e/sqr-11-campaign-picker.spec.ts
@@ -42,12 +42,11 @@ test.describe('campaign picker and chat context', () => {
     await page.getByLabel('GAME').selectOption('frosthaven');
     await page.getByRole('button', { name: 'CREATE' }).click();
 
-    // Create redirects to the new dashboard with the prominent strip.
+    // Create redirects to the new dashboard. The shared app header stays
+    // generic; campaign identity lives in page content.
     await expect(page).toHaveURL(/\/campaigns\/[0-9a-f-]{36}/);
     await expect(page.getByRole('heading', { name })).toBeVisible();
-    await expect(page.locator('.squire-campaign-strip--prominent')).toContainText(
-      name.toUpperCase(),
-    );
+    await expect(page.locator('.squire-header')).not.toContainText(name);
 
     // The picker lists it as ACTIVE; the chat context bridges to the dashboard.
     await page.goto('/campaigns');
@@ -59,7 +58,7 @@ test.describe('campaign picker and chat context', () => {
     await expect(page.locator('.squire-chat-context')).toContainText(name);
     // E8: an active campaign hides the per-session game selector.
     await expect(page.locator('.squire-game-picker')).toHaveCount(0);
-    await page.getByRole('link', { name: 'Open campaign' }).click();
+    await page.locator('.squire-chat-context').getByRole('link', { name }).click();
     await expect(page).toHaveURL(/\/campaigns\/[0-9a-f-]{36}/);
   });
 });

--- a/test/e2e/sqr-297-mobile-transcript-layout.spec.ts
+++ b/test/e2e/sqr-297-mobile-transcript-layout.spec.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 const appCss = readFileSync(new URL('../../src/web-ui/styles.css', import.meta.url), 'utf8');
 
 function renderReloadedConversationFixture(): string {
-  const longAnswerItems = Array.from({ length: 13 }, (_unused, index) => {
+  const longAnswerItems = Array.from({ length: 20 }, (_unused, index) => {
     const n = index + 1;
     return `<li>Drifter perk entry ${n} with enough text to wrap into the next line on a phone viewport.</li>`;
   }).join('');
@@ -17,13 +17,13 @@ function renderReloadedConversationFixture(): string {
         <style>${appCss}</style>
       </head>
       <body class="squire-body">
+        <header class="squire-header">
+          <span class="squire-monogram" aria-hidden="true"></span>
+          <span class="squire-wordmark">Squire</span>
+          <span class="squire-context">GH2 TABLETOP CAMPAIGN</span>
+        </header>
         <div class="squire-frame">
           <div class="squire-column">
-            <header class="squire-header">
-              <span class="squire-monogram" aria-hidden="true"></span>
-              <span class="squire-wordmark">Squire</span>
-              <span class="squire-context">GH2 TABLETOP CAMPAIGN</span>
-            </header>
             <main id="squire-surface" class="squire-surface" aria-live="off" aria-atomic="true">
               <section class="squire-transcript" data-testid="conversation-transcript" role="log" aria-live="polite">
                 <article class="squire-turn">
@@ -41,10 +41,18 @@ function renderReloadedConversationFixture(): string {
                 </article>
               </section>
             </main>
-            <form class="squire-input-dock" method="post" action="/chat/conversation-123/messages">
-              <input id="squire-input" name="question" type="text" autocomplete="off" placeholder="Ask a question..." />
-              <button type="submit" class="squire-input-dock__submit" aria-label="Ask"></button>
-            </form>
+            <div class="squire-composer">
+              <form class="squire-input-dock" method="post" action="/chat/conversation-123/messages">
+                <textarea
+                  id="squire-input"
+                  name="question"
+                  rows="3"
+                  autocomplete="off"
+                  placeholder="Ask about a rule, card, item, monster, or scenario"
+                ></textarea>
+                <button type="submit" class="squire-input-dock__submit" aria-label="Ask"></button>
+              </form>
+            </div>
           </div>
         </div>
       </body>
@@ -52,7 +60,7 @@ function renderReloadedConversationFixture(): string {
 }
 
 test.describe('SQR-297 mobile transcript layout', () => {
-  test('keeps a reloaded transcript scroll surface above the input dock at phone size', async ({
+  test('scrolls a reloaded transcript and ask widget as one column at phone size', async ({
     page,
   }, testInfo) => {
     test.skip(
@@ -64,27 +72,60 @@ test.describe('SQR-297 mobile transcript layout', () => {
     await page.setContent(renderReloadedConversationFixture());
 
     const geometry = await page.evaluate(() => {
+      const column = document.querySelector('.squire-column');
       const surface = document.querySelector('.squire-surface');
       const dock = document.querySelector('.squire-input-dock');
-      if (!(surface instanceof HTMLElement) || !(dock instanceof HTMLElement)) {
+      if (
+        !(column instanceof HTMLElement) ||
+        !(surface instanceof HTMLElement) ||
+        !(dock instanceof HTMLElement)
+      ) {
         throw new Error('missing Squire transcript fixture elements');
       }
 
+      const columnStyle = window.getComputedStyle(column);
       const surfaceRect = surface.getBoundingClientRect();
       const dockRect = dock.getBoundingClientRect();
       const surfaceStyle = window.getComputedStyle(surface);
 
       return {
-        dockTop: dockRect.top,
-        surfaceBottom: surfaceRect.bottom,
+        columnClientHeight: column.clientHeight,
+        columnOverflowY: columnStyle.overflowY,
+        columnScrollHeight: column.scrollHeight,
+        dockOffsetTop: dock.offsetTop,
+        dockTopBeforeScroll: dockRect.top,
+        surfaceHeight: surfaceRect.height,
         surfaceClientHeight: surface.clientHeight,
         surfaceOverflowY: surfaceStyle.overflowY,
         surfaceScrollHeight: surface.scrollHeight,
       };
     });
 
-    expect(geometry.surfaceBottom).toBeLessThanOrEqual(geometry.dockTop + 1);
-    expect(geometry.surfaceOverflowY).toBe('auto');
-    expect(geometry.surfaceScrollHeight).toBeGreaterThan(geometry.surfaceClientHeight);
+    expect(geometry.columnOverflowY).toBe('auto');
+    expect(geometry.columnScrollHeight).toBeGreaterThan(geometry.columnClientHeight);
+    expect(geometry.surfaceOverflowY).toBe('visible');
+    expect(geometry.surfaceScrollHeight).toBeLessThanOrEqual(geometry.surfaceClientHeight + 1);
+    expect(geometry.dockOffsetTop).toBeGreaterThanOrEqual(geometry.surfaceHeight - 1);
+    expect(geometry.dockTopBeforeScroll).toBeGreaterThan(geometry.columnClientHeight);
+
+    const afterScroll = await page.evaluate(() => {
+      const column = document.querySelector('.squire-column');
+      const dock = document.querySelector('.squire-input-dock');
+      if (column instanceof HTMLElement) {
+        column.scrollTop = column.scrollHeight - column.clientHeight;
+      }
+      if (!(dock instanceof HTMLElement)) {
+        throw new Error('missing Squire input dock after scroll');
+      }
+      const dockRect = dock.getBoundingClientRect();
+      return {
+        dockBottom: dockRect.bottom,
+        dockTop: dockRect.top,
+        viewportHeight: window.innerHeight,
+      };
+    });
+
+    expect(afterScroll.dockTop).toBeLessThan(afterScroll.viewportHeight);
+    expect(afterScroll.dockBottom).toBeLessThanOrEqual(afterScroll.viewportHeight + 1);
   });
 });

--- a/test/linear-bug-report-template.test.ts
+++ b/test/linear-bug-report-template.test.ts
@@ -10,6 +10,7 @@ const conversation: Conversation = {
   id: '11111111-1111-4111-8111-111111111111',
   userId: '22222222-2222-4222-8222-222222222222',
   creationIdempotencyKey: null,
+  campaignId: null,
   createdAt: new Date('2026-06-14T11:55:00.000Z'),
   lastMessageAt: new Date('2026-06-14T11:59:00.000Z'),
 };

--- a/test/web-ui-layout.test.ts
+++ b/test/web-ui-layout.test.ts
@@ -104,6 +104,28 @@ const noCampaignChatContext = {
   returnTo: '/',
 };
 
+const activeCampaignChatContext = {
+  activeCampaign: {
+    campaignId: 'campaign-123',
+    campaignName: 'Center Table Campaign',
+    game: 'frosthaven',
+  },
+  campaigns: [
+    {
+      campaignId: 'campaign-123',
+      campaignName: 'Center Table Campaign',
+      game: 'frosthaven',
+    },
+  ],
+  returnTo: '/',
+};
+
+const fixedCampaignChatContext = {
+  ...activeCampaignChatContext,
+  campaigns: [],
+  fixed: true,
+};
+
 function testConversationHistory() {
   return {
     rows: [
@@ -282,7 +304,7 @@ describe('GET / — companion-first layout shell (SQR-65)', () => {
       }),
     );
     const header = body.match(/<header class="squire-header">[\s\S]*?<\/header>/)?.[0] ?? '';
-    const context = body.match(/<section class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+    const context = body.match(/<section[^>]*class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
 
     expect(header).not.toContain('squire-game-picker');
     expect(context).toContain('No campaign selected');
@@ -356,14 +378,15 @@ describe('GET / — companion-first layout shell (SQR-65)', () => {
     expect(body).not.toContain('class="squire-run-progress"');
     expect(body).toContain('class="sr-only-focusable"');
     expect(body).toMatch(/<a href="#squire-input"[^>]*sr-only-focusable/);
-    expect(body).toMatch(/<input[^>]*id="squire-input"/);
+    expect(body).toMatch(/<textarea[^>]*id="squire-input"/);
+    expect(body).not.toMatch(/<input[^>]*id="squire-input"/);
     expect(body).not.toMatch(/<form[^>]*id="squire-input"/);
     expect(body).toMatch(/<form[^>]*class="squire-input-dock"[^>]*action="\/chat"/);
     expect(body).toMatch(/hx-post="\/chat"/);
     expect(body).toMatch(/hx-target="#squire-surface"/);
     expect(body).toMatch(/hx-swap="innerHTML"/);
     expect(body).toMatch(/<input[^>]*type="hidden"[^>]*name="idempotencyKey"[^>]*value=""/);
-    expect(body).toMatch(/placeholder="Ask a question\.\.\."/);
+    expect(body).toMatch(/placeholder="Ask about a rule, card, item, monster, or scenario"/);
     expect(body).toMatch(
       /<button[^>]*type="submit"[^>]*class="squire-input-dock__submit"[^>]*aria-label="Ask"[^>]*>\s*<\/button>/,
     );
@@ -394,6 +417,85 @@ describe('GET / — companion-first layout shell (SQR-65)', () => {
     expect(body).toContain('Frosthaven');
   });
 
+  it('renders chat as the primary header surface and keeps history subordinate (SQR-366)', async () => {
+    const body = String(
+      await actualLayout.renderHomePage(testSession, testCsrfToken, {
+        conversationHistory: testConversationHistory(),
+        chatCampaignContext: noCampaignChatContext,
+      }),
+    );
+    const header = body.match(/<header class="squire-header">[\s\S]*?<\/header>/)?.[0] ?? '';
+    const historyShell = body.match(/<div[^>]*id="squire-history-shell"[\s\S]*?<\/div>/)?.[0] ?? '';
+
+    expect(body.indexOf('<header class="squire-header">')).toBeLessThan(
+      body.indexOf('<div class="squire-frame">'),
+    );
+    expect(body.indexOf('id="squire-history-shell"')).toBeGreaterThan(
+      body.indexOf('<div class="squire-frame">'),
+    );
+    expect(header).toContain('class="squire-app-nav"');
+    expect(header).toMatch(/<a[^>]*href="\/"[^>]*aria-current="page"[^>]*>\s*Chat\s*<\/a>/);
+    expect(header).toMatch(/<a[^>]*href="\/campaigns"[^>]*>\s*Campaigns\s*<\/a>/);
+    expect(body).not.toContain('HAVEN · RULES');
+    expect(historyShell).toContain('class="squire-history-title"');
+    expect(historyShell).toContain('Conversations');
+    expect(historyShell).not.toContain('squire-history-brand');
+    expect(historyShell).not.toContain('squire-monogram--masthead');
+    expect(historyShell).not.toContain('squire-wordmark');
+  });
+
+  it('links the current campaign name from the chat context without a separate campaign action (SQR-366)', async () => {
+    const body = String(
+      await actualLayout.renderHomePage(testSession, testCsrfToken, {
+        chatCampaignContext: activeCampaignChatContext,
+      }),
+    );
+    const context = body.match(/<section[^>]*class="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+
+    expect(context).toMatch(
+      /<a[^>]*class="squire-chat-context__name"[^>]*href="\/campaigns\/campaign-123"[^>]*>\s*Center Table Campaign\s*<\/a>/,
+    );
+    expect(context).not.toContain('Open campaign');
+  });
+
+  it('renders an existing conversation with a fixed campaign context', async () => {
+    const body = String(
+      await actualLayout.renderConversationPage({
+        session: testSession,
+        csrfToken: testCsrfToken,
+        conversationId: 'conv-123',
+        messages: [],
+        chatCampaignContext: fixedCampaignChatContext,
+      }),
+    );
+    const context = body.match(/<section[^>]*id="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+    const form = body.match(/<form[^>]*class="squire-input-dock"[\s\S]*?<\/form>/)?.[0] ?? '';
+
+    expect(context).toContain('Conversation campaign');
+    expect(context).toContain('Center Table Campaign');
+    expect(context).toContain('Frosthaven context for this conversation');
+    expect(context).not.toContain('squire-chat-context__switcher');
+    expect(context).not.toContain('Change');
+    expect(context).not.toContain('Set up campaign');
+    expect(form).not.toMatch(/<input[^>]*name="campaignId"/);
+  });
+
+  it('keeps campaign context out of the shared app header (SQR-366)', async () => {
+    const body = String(
+      await actualLayout.renderHomePage(testSession, testCsrfToken, {
+        campaignStrip: activeCampaignChatContext.activeCampaign,
+        chatCampaignContext: activeCampaignChatContext,
+      }),
+    );
+    const header = body.match(/<header class="squire-header">[\s\S]*?<\/header>/)?.[0] ?? '';
+
+    expect(header).toContain('class="squire-app-nav"');
+    expect(header).not.toContain('squire-campaign-strip');
+    expect(header).not.toContain('Center Table Campaign');
+    expect(body).toContain('class="squire-chat-context"');
+    expect(body).toContain('Center Table Campaign');
+  });
+
   it('renders a history search affordance in the desktop rail and mobile drawer', async () => {
     const body = String(
       await actualLayout.renderHomePage(testSession, testCsrfToken, {
@@ -402,6 +504,7 @@ describe('GET / — companion-first layout shell (SQR-65)', () => {
     );
 
     expect(body).toContain('class="squire-history-search"');
+    expect(body).toContain('class="squire-history-search__field"');
     expect(body).toContain('name="historyQuery"');
     expect(body).toContain('placeholder="Search history"');
     expect(body).toContain('value="poison"');
@@ -1087,6 +1190,27 @@ describe('conversation transcript rendering helpers', () => {
     );
   });
 
+  it('can include an out-of-band fixed campaign context with the first transcript swap', () => {
+    const body = String(
+      actualLayout.renderConversationTranscriptWithHistoryOob({
+        conversationHistory: testConversationHistory(),
+        conversationId: 'conv-123',
+        messages: [messages[0]],
+        pendingStreamUrls: new Map([['m1', '/chat/conv-123/messages/m1/stream']]),
+        chatCampaignContext: fixedCampaignChatContext,
+        csrfToken: testCsrfToken,
+      }),
+    );
+    const context = body.match(/<section[^>]*id="squire-chat-context"[\s\S]*?<\/section>/)?.[0];
+
+    expect(context).toMatch(/hx-swap-oob="true"/);
+    expect(context).toContain('Conversation campaign');
+    expect(context).toContain('Frosthaven context for this conversation');
+    expect(context).not.toContain('Change');
+    expect(body).toContain('id="squire-history-shell"');
+    expect(body).toContain('class="squire-transcript"');
+  });
+
   it('renders multiple pending skeletons when concurrent turns exist (SQR-108 defense-in-depth)', async () => {
     // Codex flagged that an older still-running turn could disappear
     // from the in-flight UI on reload because computePendingStreamUrl
@@ -1226,6 +1350,66 @@ describe('GET / — signature components (SQR-66)', () => {
 
 describe('styles.css — SQR-66 signature component rules', () => {
   const css = readFileSync(new URL('../src/web-ui/styles.css', import.meta.url), 'utf8');
+  const compactCss = css.replace(/\s+/g, '');
+
+  it('uses one conversation-page scroll container so the transcript and ask widget move together (SQR-366)', () => {
+    expect(css).toMatch(
+      /\.squire-column:has\(> \.squire-surface > \.squire-transcript\)\s*\{[^}]*height:\s*100%[^}]*overflow-y:\s*auto/,
+    );
+    expect(css).toMatch(
+      /\.squire-column:has\(> \.squire-surface > \.squire-transcript\)\s+\.squire-surface\s*\{[^}]*flex:\s*0 0 auto[^}]*overflow:\s*visible/,
+    );
+    expect(compactCss).not.toContain(
+      '.squire-column:has(>.squire-surface>.squire-transcript).squire-surface{min-height:0;overflow-y:auto;',
+    );
+    expect(css).toMatch(
+      /@media\s*\(min-width:\s*1024px\)[\s\S]*\.squire-frame:has\(\.squire-rail\)\s*\{[^}]*min-height:\s*0[^}]*overflow:\s*hidden/,
+    );
+    expect(css).toMatch(
+      /@media\s*\(min-width:\s*1024px\)[\s\S]*\.squire-frame:has\(\.squire-rail\)\s+\.squire-rail\s*\{[^}]*height:\s*100%[^}]*overflow-y:\s*auto/,
+    );
+  });
+
+  it('keeps the SQR-366 chat nav lightweight and centers the home composer', () => {
+    const navRule = css.match(/\.squire-app-nav\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(navRule).toContain('background: transparent');
+    expect(navRule).not.toContain('border:');
+    expect(css).toContain('--squire-content-column-width: 640px');
+    expect(css).toContain('--squire-content-inline-padding-desktop: 24px');
+    expect(css).toContain('--squire-header-nav-baseline-offset: 5px');
+    expect(css).toMatch(/\.squire-header\s*\{[^}]*position:\s*relative/);
+    expect(compactCss).toContain(
+      '.squire-app-nav{position:absolute;left:max(var(--squire-header-nav-min-left),calc((100vw-var(--squire-content-column-width))/2+var(--squire-content-inline-padding-desktop)));top:calc(50%+var(--squire-header-nav-baseline-offset));',
+    );
+    expect(compactCss).toContain(
+      '.squire-body:has(.squire-rail).squire-app-nav{left:max(var(--squire-header-nav-min-left),calc(var(--squire-rail-width)+max(var(--space-xl),calc((100vw-var(--squire-content-column-width))/2-var(--squire-rail-width)))+var(--squire-content-inline-padding-desktop)));',
+    );
+    expect(css).toMatch(
+      /\.squire-app-nav__link--active\s*\{[^}]*border-bottom-color:\s*var\(--wax\)/,
+    );
+    expect(css).toMatch(
+      /\.squire-column:has\(> \.squire-composer\):not\(:has\(> \.squire-surface > \.squire-transcript\)\)\s+\.squire-composer\s*\{[^}]*position:\s*absolute[^}]*top:\s*50%[^}]*transform:\s*translateY\(-50%\)/,
+    );
+  });
+
+  it('aligns the desktop chat content column with non-rail pages when space allows (SQR-366)', () => {
+    expect(css).toContain('--squire-rail-width: 280px');
+    expect(compactCss).toContain(
+      '.squire-frame:has(.squire-rail).squire-column:not(.squire-column--wide){margin-left:max(var(--space-xl),calc((100vw-var(--squire-content-column-width))/2-var(--squire-rail-width)));margin-right:auto;',
+    );
+  });
+
+  it('places history search and ask actions inside their fields (SQR-366)', () => {
+    expect(css).toMatch(/\.squire-history-search__field\s*\{[^}]*position:\s*relative/);
+    expect(css).toMatch(
+      /\.squire-history-search__submit\s*\{[^}]*position:\s*absolute[^}]*right:\s*4px[^}]*bottom:\s*4px/,
+    );
+    expect(css).toMatch(/\.squire-input-dock\s*\{[^}]*position:\s*relative/);
+    expect(css).toMatch(/\.squire-input-dock #squire-input\s*\{[^}]*min-height:\s*112px/);
+    expect(css).toMatch(
+      /\.squire-input-dock__submit\s*\{[^}]*position:\s*absolute[^}]*right:\s*12px[^}]*bottom:\s*12px/,
+    );
+  });
 
   it('declares .squire-question with Fraunces clamp font-size and line-height 1.25', () => {
     expect(css).toMatch(/\.squire-question\s*\{[^}]*font-family:\s*["']?Fraunces["']?/);

--- a/test/web-ui-squire.regression-1.test.ts
+++ b/test/web-ui-squire.regression-1.test.ts
@@ -352,7 +352,7 @@ function bootPendingTranscript(
   };
 
   // SQR-108: setFormPendingState writes to form.dataset and reads back
-  // form.querySelector('input[name="question"]'/'button[type="submit"]'),
+  // form.querySelector('[name="question"]'/'button[type="submit"]'),
   // so the fake form needs both. We don't care about the input/button
   // pendingState transitions in these tests — just give them no-op
   // setAttribute/removeAttribute so the lock+unlock path doesn't blow up.
@@ -365,7 +365,7 @@ function bootPendingTranscript(
     setAttribute() {},
     dataset: {} as Record<string, string>,
     querySelector(selector: string) {
-      if (selector === 'input[name="question"]') return noopElement;
+      if (selector === '[name="question"]') return noopElement;
       if (selector === 'button[type="submit"]') return noopElement;
       return null;
     },
@@ -2342,7 +2342,7 @@ describe('squire.js chat form retargeting', () => {
           return sel === '.squire-input-dock';
         },
         querySelector(sel: string) {
-          if (sel === 'input[name="question"]') return noopElement;
+          if (sel === '[name="question"]') return noopElement;
           if (sel === 'button[type="submit"]') return noopElement;
           if (sel === 'input[name="idempotencyKey"]') return null;
           return null;
@@ -2480,7 +2480,7 @@ describe('squire.js chat form retargeting', () => {
         setAttribute() {},
         dataset: {} as Record<string, string>,
         querySelector(sel: string) {
-          if (sel === 'input[name="question"]') return noopElement;
+          if (sel === '[name="question"]') return noopElement;
           if (sel === 'button[type="submit"]') return noopElement;
           return null;
         },
@@ -2562,7 +2562,7 @@ describe('squire.js chat form retargeting', () => {
         setAttribute() {},
         dataset: {} as Record<string, string>,
         querySelector(sel: string) {
-          if (sel === 'input[name="question"]') return noopElement;
+          if (sel === '[name="question"]') return noopElement;
           if (sel === 'button[type="submit"]') return noopElement;
           return null;
         },
@@ -2662,7 +2662,7 @@ describe('squire.js chat form retargeting', () => {
           return sel === '.squire-input-dock';
         },
         querySelector(sel: string) {
-          if (sel === 'input[name="question"]') return noopElement;
+          if (sel === '[name="question"]') return noopElement;
           if (sel === 'button[type="submit"]') return noopElement;
           return null;
         },
@@ -2762,7 +2762,7 @@ describe('squire.js chat form retargeting', () => {
         setAttribute() {},
         dataset: {} as Record<string, string>,
         querySelector(selector: string) {
-          if (selector === 'input[name="question"]') return noopElement;
+          if (selector === '[name="question"]') return noopElement;
           if (selector === 'button[type="submit"]') return noopElement;
           return null;
         },


### PR DESCRIPTION
## Summary
- Reworks the shared Squire header so Chat and Campaigns use the same global shell, with campaign identity kept in page content or the chat composer instead of the header.
- Moves the chat composer into the main chat flow, keeps the empty-chat prompt centered, and lets existing conversations scroll with the composer as one surface.
- Pins each conversation to the campaign selected for its first message, backfills existing conversations from their first campaign-bound user message, and prevents follow-ups from drifting with the active campaign.

Fixes SQR-366

## Validation
- Manual QA on `http://localhost:5307/` for Chat, Campaigns, new chat, and existing conversation layouts.
- `npm test -- test/campaign-rename.test.ts`
- `npm run check` (157 test files, 1893 tests)

## Review
- Pre-landing diff review completed; no issues found.
- No VERSION or CHANGELOG update: ordinary feature branch PR per `docs/agent/shipping.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added route-specific campaign UI rules: chat uses a dedicated campaign context panel (with a fixed/changed behavior); campaign pages use breadcrumb + dominant page title instead of header controls.
  * Campaign-aware scoping is now consistently applied across conversation turns and follow-ups.

* **UI/UX Improvements**
  * Updated Phase 4 header/app-nav behavior, composer to a multi-line textarea, and refined history/search + mobile transcript scrolling layout.

* **Bug Fixes**
  * Prevented cross-campaign dedup/telemetry leakage; pending follow-ups and OOB transcript updates now respect the conversation’s bound campaign.

* **Tests**
  * Updated and expanded UI, E2E, and layout/CSS-drift assertions for the new header and chat/campaign context markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->