### PR TITLE
fix(campaigns): finish workspace visual QA

### DIFF
--- a/src/web-ui/campaign-pages.ts
+++ b/src/web-ui/campaign-pages.ts
@@ -213,7 +213,7 @@ function renderCharacterCreateForm(
     class="squire-party-section__add squire-character-create-reveal"
     ${data.errorMessage ? raw('open') : raw('')}
   >
-    <summary class="squire-party-section__add-summary">Add character</summary>
+    <summary class="squire-party-section__add-summary" role="button">Add character</summary>
     <div class="squire-party-section__add-body">
       ${data.errorMessage
         ? html`<div class="squire-banner squire-banner--error" role="alert">
@@ -366,7 +366,9 @@ function renderPlayerConfirmAction(input: {
     class="squire-player-row__action squire-player-row__action--${input.action}"
     ${open ? raw('open') : raw('')}
   >
-    <summary aria-label="${input.label} ${playerDisplayName(input.member)}">${input.label}</summary>
+    <summary aria-label="${input.label} ${playerDisplayName(input.member)}" role="button">
+      ${input.label}
+    </summary>
     <div class="squire-player-row__confirm">
       <p>${input.prompt}</p>
       ${open ? renderPlayerActionError(input.member, input.actionError) : html``}
@@ -482,7 +484,9 @@ function renderPlayersSection(input: {
       <div class="squire-player-section__action">
         ${input.inviteForm?.canInvite
           ? html`<details class="squire-player-section__invite">
-              <summary class="squire-player-section__invite-summary">Invite player</summary>
+              <summary class="squire-player-section__invite-summary" role="button">
+                Invite player
+              </summary>
               <div class="squire-player-section__invite-body">
                 ${renderInviteMemberForm(campaign.id, input.inviteForm)}
               </div>
@@ -552,7 +556,7 @@ function renderCharacterLevelAction(
     class="squire-party-row__action squire-party-row__action--level"
     ${open ? raw('open') : raw('')}
   >
-    <summary aria-label="Level ${character.name}">Level</summary>
+    <summary aria-label="Level ${character.name}" role="button">Level</summary>
     <form method="post" action="/campaigns/${campaignId}/characters/${character.id}/level">
       <input type="hidden" name="_csrf" value="${csrfToken}" />
       <input type="hidden" name="expectedVersion" value="${character.version}" />
@@ -582,7 +586,9 @@ function renderCharacterConfirmAction(input: {
     class="squire-party-row__action squire-party-row__action--${input.action}"
     ${open ? raw('open') : raw('')}
   >
-    <summary aria-label="${input.label} ${input.character.name}">${input.label}</summary>
+    <summary aria-label="${input.label} ${input.character.name}" role="button">
+      ${input.label}
+    </summary>
     <div class="squire-party-row__confirm">
       <p>${input.label} ${input.character.name}?</p>
       ${open ? renderCharacterActionError(input.character, input.actionError) : html``}

--- a/src/web-ui/styles.css
+++ b/src/web-ui/styles.css
@@ -525,6 +525,7 @@ html {
 }
 
 .squire-header__brand {
+  min-height: 44px;
   color: inherit;
   text-decoration: none;
 }
@@ -549,7 +550,8 @@ html {
 }
 
 .squire-app-nav__link {
-  min-height: 32px;
+  min-width: 44px;
+  min-height: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -581,6 +583,8 @@ html {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
   padding: 0;
   background: transparent;
   border: 0;
@@ -2582,6 +2586,9 @@ template#squire-banner-fixtures {
 }
 
 .squire-campaign-workspace__breadcrumb-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
   color: var(--sepia);
   text-decoration: underline;
   text-decoration-color: var(--sepia-dim);
@@ -3132,6 +3139,7 @@ template#squire-banner-fixtures {
 
 .squire-campaign-settings__field--with-action input {
   width: 100%;
+  min-height: 52px;
   padding-right: 5.5rem;
 }
 
@@ -3171,7 +3179,7 @@ template#squire-banner-fixtures {
   position: absolute;
   right: 4px;
   bottom: 4px;
-  min-height: 36px;
+  min-height: 44px;
   padding: 0 var(--space-sm);
 }
 
@@ -3581,9 +3589,14 @@ template#squire-banner-fixtures {
     justify-content: flex-start;
   }
 
+  .squire-player-row__action[open] {
+    flex-basis: 100%;
+  }
+
   .squire-player-row__confirm {
-    right: auto;
-    left: 0;
+    position: static;
+    width: 100%;
+    margin-top: var(--space-xs);
   }
 }
 
@@ -3900,10 +3913,15 @@ template#squire-banner-fixtures {
     justify-content: flex-start;
   }
 
+  .squire-party-row__action[open] {
+    flex-basis: 100%;
+  }
+
   .squire-party-row__action--level form,
   .squire-party-row__confirm {
-    right: auto;
-    left: 0;
+    position: static;
+    width: 100%;
+    margin-top: var(--space-xs);
   }
 }
 

--- a/test/campaign-character-create.test.ts
+++ b/test/campaign-character-create.test.ts
@@ -157,7 +157,9 @@ describe('create-character UI (SQR-318)', () => {
     )?.[0];
     expect(revealTag).toBeDefined();
     expect(revealTag).not.toContain('open');
-    expect(body).toContain('squire-party-section__add-summary">Add character</summary>');
+    expect(body).toContain(
+      'squire-party-section__add-summary" role="button">Add character</summary>',
+    );
     expect(body).toContain('squire-character-create');
     expect(body).toContain('action="/campaigns/' + campaign.id + '/characters"');
     // Class select offers the seeded real class names.
@@ -216,9 +218,10 @@ describe('create-character UI (SQR-318)', () => {
     expect(body).toContain('Level');
     expect(body).toContain('Retire');
     expect(body).toContain('Remove');
-    expect(body).toContain('aria-label="Retire Manual Bruiser"');
-    expect(body).toContain('aria-label="Remove Manual Bruiser"');
-    expect(body).toContain('aria-label="Remove Old Bones"');
+    expect(body).toContain('aria-label="Level Manual Bruiser" role="button"');
+    expect(body).toContain('aria-label="Retire Manual Bruiser" role="button"');
+    expect(body).toContain('aria-label="Remove Manual Bruiser" role="button"');
+    expect(body).toContain('aria-label="Remove Old Bones" role="button"');
     expect(body).toContain(`href="/campaigns/${campaign.id}/party"`);
     expect(body).toContain('Cancel');
     expect(body).not.toContain('Invite by email');
@@ -236,7 +239,9 @@ describe('create-character UI (SQR-318)', () => {
     const body = await res.text();
 
     expect(body).toContain('squire-party-section__action');
-    expect(body).toContain('squire-party-section__add-summary">Add character</summary>');
+    expect(body).toContain(
+      'squire-party-section__add-summary" role="button">Add character</summary>',
+    );
     const revealTag = body.match(
       /<details[^>]*class="squire-party-section__add squire-character-create-reveal"[^>]*>/,
     )?.[0];
@@ -359,7 +364,7 @@ describe('create-character UI (SQR-318)', () => {
       headers: { Cookie: owner.cookie },
     });
     let body = await page.text();
-    expect(body).toContain('aria-label="Remove Remove Retired"');
+    expect(body).toContain('aria-label="Remove Remove Retired" role="button"');
 
     const remove = new FormData();
     remove.set('_csrf', createCsrfToken(owner.sessionId));

--- a/test/campaign-dashboard.test.ts
+++ b/test/campaign-dashboard.test.ts
@@ -221,7 +221,9 @@ describe('dashboard rendering', () => {
     expect(body).toContain('class="squire-campaign-dashboard__party"');
     expect(body).toContain('aria-label="Party"');
     expect(body).toContain('squire-party-section__action');
-    expect(body).toContain('squire-party-section__add-summary">Add character</summary>');
+    expect(body).toContain(
+      'squire-party-section__add-summary" role="button">Add character</summary>',
+    );
     expect(body).toContain('Active characters');
     expect(body).toContain('Retired characters');
     expect(body).not.toContain('aria-label="Scenario progression"');

--- a/test/campaign-invite-member.test.ts
+++ b/test/campaign-invite-member.test.ts
@@ -135,6 +135,7 @@ describe('invite-member UI (SQR-319)', () => {
     ).text();
     expect(ownerView).toContain('squire-invite-member');
     expect(ownerView).toContain('INVITE BY EMAIL');
+    expect(ownerView).toContain('squire-player-section__invite-summary" role="button"');
 
     const memberView = await (
       await app.request(`/campaigns/${campaign.id}/players`, {
@@ -178,9 +179,11 @@ describe('invite-member UI (SQR-319)', () => {
     expect(ownerView).toContain('action="/campaigns/' + campaign.id + '/members/');
     expect(ownerView).toContain('/remove"');
     expect(ownerView).toContain('Remove member@example.com?');
+    expect(ownerView).toContain('aria-label="Remove member" role="button"');
     expect(ownerView).toContain('action="/campaigns/' + campaign.id + '/invites/');
     expect(ownerView).toContain('/cancel"');
     expect(ownerView).toContain('Cancel invite for invitee@example.com?');
+    expect(ownerView).toContain('aria-label="Cancel invitee@example.com" role="button"');
     expect(ownerView).not.toContain('No pending invites.');
 
     const memberView = await (


### PR DESCRIPTION
## Summary
- Makes the Party and Players disclosure actions expose button semantics after the mobile styling changes.
- Keeps mobile level/remove/retire/player confirmation panels inside the row instead of clipping off-screen.
- Normalizes small header, breadcrumb, account, and Settings save targets to at least 44px.

## Review
- Pre-landing review: no issues found.
- Design review: no issues found against DESIGN.md for this focused frontend diff.

## Test plan
- [x] Browser QA on the campaign workspace pages at mobile and desktop widths
- [x] DOM audit: no horizontal overflow and no visible interactive targets below 44px on tested campaign workspace pages
- [x] `npm test -- test/campaign-dashboard.test.ts test/campaign-character-create.test.ts test/campaign-invite-member.test.ts`
- [x] `npm test -- test/tools.test.ts -t 'includes incoming section links when listing scenario neighbors'`
- [x] `npm test -- test/tools.test.ts`
- [x] `npm run check`

Fixes SQR-363


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced accessibility for expandable controls with improved keyboard navigation and screen reader support across the campaign interface
  * Increased touch target sizing to meet accessibility standards, providing a better experience on mobile and touch devices
  * Optimized mobile layout for action panels and forms with full-width display and improved action labeling for greater clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->