### PR TITLE
fix(ci): serialize production data workflows

### DIFF
--- a/.github/workflows/production-reindex-pdfs.yml
+++ b/.github/workflows/production-reindex-pdfs.yml
@@ -31,7 +31,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-reindex-pdfs
+  # Shared across production data workflows because each runs db:migrate against prod.
+  group: production-data-db
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/production-seed-cards.yml
+++ b/.github/workflows/production-seed-cards.yml
@@ -22,7 +22,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-seed-cards
+  # Shared across production data workflows because each runs db:migrate against prod.
+  group: production-data-db
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/production-seed-scenario-section-books.yml
+++ b/.github/workflows/production-seed-scenario-section-books.yml
@@ -29,7 +29,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-seed-scenario-section-books
+  # Shared across production data workflows because each runs db:migrate against prod.
+  group: production-data-db
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/production-seed-unlock-graphs.yml
+++ b/.github/workflows/production-seed-unlock-graphs.yml
@@ -13,7 +13,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-seed-unlock-graphs
+  # Shared across production data workflows because each runs db:migrate against prod.
+  group: production-data-db
   cancel-in-progress: false
 
 jobs:

--- a/test/production-data-workflows.test.ts
+++ b/test/production-data-workflows.test.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 
+import { parse } from 'yaml';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -22,6 +23,20 @@ function postgresFixtureUrl(options: { host: string; database?: string; port?: n
   if (options.database !== undefined) url.pathname = `/${options.database}`;
   return url.toString();
 }
+
+const productionDataMigrationWorkflowPaths = [
+  '.github/workflows/production-seed-cards.yml',
+  '.github/workflows/production-seed-scenario-section-books.yml',
+  '.github/workflows/production-seed-unlock-graphs.yml',
+  '.github/workflows/production-reindex-pdfs.yml',
+];
+
+type WorkflowConfig = {
+  concurrency?: {
+    group?: string;
+    'cancel-in-progress'?: boolean;
+  };
+};
 
 describe('production data lifecycle workflows', () => {
   it('defines package scripts for production data URL verification and sanity checks', async () => {
@@ -156,6 +171,17 @@ describe('production data lifecycle workflows', () => {
     expect(() => parseProductionDataOptions(['bogus'])).toThrow(
       /cards, scenario-section-books, unlock-graphs, embeddings, all, smoke, verify-url, or truncate-embeddings/,
     );
+  });
+
+  it('serializes production data workflows before they run production migrations', async () => {
+    for (const workflowPath of productionDataMigrationWorkflowPaths) {
+      const workflow = parse(await readProjectFile(workflowPath)) as WorkflowConfig;
+
+      expect(workflow.concurrency, workflowPath).toEqual({
+        group: 'production-data-db',
+        'cancel-in-progress': false,
+      });
+    }
   });
 
   it('seeds production card data only through the protected production environment', async () => {


### PR DESCRIPTION
## Summary

- Put every production-data workflow that runs production migrations into one shared GitHub Actions concurrency group.
- Keep cancel-in-progress disabled so overlapping card, section-book, unlock-graph, and reindex runs queue instead of canceling each other.
- Add a regression test that fails if these workflows drift back to separate groups.

## Validation

- Confirmed the new test failed before the workflow fix.
- npm test -- test/production-data-workflows.test.ts
- npm run lint:actions
- npm run format:check
- npm run typecheck
- npm run check

Fixes SQR-315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated concurrency settings for production database migration workflows—including PDF reindexing, card seeding, and scenario data operations—to enable coordinated execution
  * Added automated test suite to validate production database migration workflows maintain consistent concurrency configuration standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->