### PR TITLE
Qualify Gloomhaven 2e source refs for groundedness

### DIFF
--- a/docs/plans/sqr-375-table-turnaround-iteration-log.md
+++ b/docs/plans/sqr-375-table-turnaround-iteration-log.md
@@ -265,3 +265,38 @@ combined estimate of $11.0153. This is under the project cap of $100.
 Decision: keep as the Phase 2 baseline. The next distinct issue should fix
 Gloomhaven 2e canonical-ref game mapping before prompt or retrieval tuning, so
 the groundedness scorer stops hiding otherwise-correct Gloomhaven 2e answers.
+
+## 2026-07-04 — Gloomhaven 2e canonical-ref groundedness fix
+
+Hypothesis: Gloomhaven 2e table-qa groundedness is failing because legacy
+`gloomhavensecretariat:*` refs are collected without the active game, then the
+scorer normalizes them as Frosthaven refs.
+
+Change:
+
+- Qualified legacy `gloomhavensecretariat:*` refs during tool-output trajectory
+  collection when an active game is known.
+- Applied the active-game qualification in both Anthropic agent loops, including
+  the production LangGraph path.
+- Left already game-qualified refs unchanged so explicit wrong-game refs still
+  fail deterministic groundedness.
+- Added focused tests for ref qualification, Gloomhaven 2e groundedness pass,
+  wrong-game groundedness rejection, and LangGraph trajectory metadata.
+
+Verification:
+
+- `npm test -- --run test/agent.test.ts test/agent-langgraph.test.ts test/eval-scoring.test.ts`
+  passed: 3 files, 93 tests.
+- `npm run eval -- --matrix --id=gh2-battle-goal-accountant --run-label=sqr-381-gh2-groundedness-dev --max-estimated-cost-usd=1 --local-report=/tmp/sqr-381-gh2-groundedness-dev.json`
+  passed in LangSmith: score 1, groundedness pass, trace
+  <https://smith.langchain.com/o/44be4d80-ba50-4833-ae22-6e176be2dbf2/projects/p/7fe48da1-129f-4a2b-ba99-4cd94700f6bd/r/019f2f2f-959b-7000-8000-03dd0f946b12?poll=true>.
+- `npm run eval -- --matrix --id=gh2-item-006-amulet-of-life --run-label=sqr-381-gh2-groundedness-holdout --max-estimated-cost-usd=1 --local-report=/tmp/sqr-381-gh2-groundedness-holdout.json`
+  passed in LangSmith: score 1, groundedness pass, trace
+  <https://smith.langchain.com/o/44be4d80-ba50-4833-ae22-6e176be2dbf2/projects/p/35cec418-4963-4bc6-8c55-cff73946cdb0/r/019f2f30-4134-7000-8000-01da361d0e9b?poll=true>.
+
+Eval spend: estimated $0.0061 provider cost plus $0.1000 guardrail cost across
+the two targeted LangSmith runs.
+
+Decision: keep. This removes the main SQR-380 Gloomhaven 2e groundedness
+measurement bug without prompt tuning and without weakening explicit wrong-game
+ref rejection.

--- a/src/agent-langgraph.ts
+++ b/src/agent-langgraph.ts
@@ -860,7 +860,9 @@ async function runLangGraphAgentLoop(
         }
 
         const toolEndedAtMs = Date.now();
-        const { summary, canonicalRefs } = summarizeToolOutput(toolResult.content);
+        const { summary, canonicalRefs } = summarizeToolOutput(toolResult.content, {
+          game: activeGame,
+        });
         const toolOk = !isError && isToolResultOk(toolResult);
         nextToolCalls.push({
           iteration: state.iterations,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -34,7 +34,7 @@ import {
   type BookRecordKind,
 } from './scenario-section-schemas.ts';
 import { resolveSquireEnv } from './squire-env.ts';
-import { requireGameId } from './game.ts';
+import { requireGameId, type GameId } from './game.ts';
 import * as WriteTools from './campaign/write-tools.ts';
 import { langSmithRunReferenceFromSpan, type LangSmithRunReference } from './langsmith-links.ts';
 
@@ -1058,10 +1058,41 @@ export function emptyTokenUsage(): TokenUsage {
   };
 }
 
-function collectCanonicalRefs(value: unknown, refs = new Set<string>()): Set<string> {
+const CARD_TYPE_BY_SOURCE_PREFIX: ReadonlyMap<string, CardType> = new Map([
+  ['scenario', 'scenarios'],
+  ['item', 'items'],
+  ['monster-stat', 'monster-stats'],
+  ['monster-ability', 'monster-abilities'],
+  ['character-ability', 'character-abilities'],
+  ['character-mat', 'character-mats'],
+  ['building', 'buildings'],
+  ['event', 'events'],
+  ['battle-goal', 'battle-goals'],
+  ['personal-quest', 'personal-quests'],
+]);
+
+function qualifyLegacyGhsRef(ref: string, game?: GameId): string {
+  if (!game) return ref;
+
+  const scenarioMatch = ref.match(/^gloomhavensecretariat:scenario\/(\d+)$/);
+  if (scenarioMatch) return `scenario:${game}/${scenarioMatch[1].padStart(3, '0')}`;
+
+  const cardMatch = ref.match(/^gloomhavensecretariat:([^/]+)\/(.+)$/);
+  if (!cardMatch) return ref;
+
+  const type = CARD_TYPE_BY_SOURCE_PREFIX.get(cardMatch[1]);
+  if (!type) return ref;
+  return `card:${game}/${type}/${ref}`;
+}
+
+function collectCanonicalRefs(
+  value: unknown,
+  refs = new Set<string>(),
+  game?: GameId,
+): Set<string> {
   if (!value || typeof value !== 'object') return refs;
   if (Array.isArray(value)) {
-    for (const item of value) collectCanonicalRefs(item, refs);
+    for (const item of value) collectCanonicalRefs(item, refs, game);
     return refs;
   }
 
@@ -1070,18 +1101,21 @@ function collectCanonicalRefs(value: unknown, refs = new Set<string>()): Set<str
       (key === 'ref' || key === 'sourceId' || key === 'sourceRef') &&
       typeof nested === 'string'
     ) {
-      refs.add(nested);
+      refs.add(qualifyLegacyGhsRef(nested, game));
     } else {
-      collectCanonicalRefs(nested, refs);
+      collectCanonicalRefs(nested, refs, game);
     }
   }
   return refs;
 }
 
-export function summarizeToolOutput(content: string): { summary: string; canonicalRefs: string[] } {
+export function summarizeToolOutput(
+  content: string,
+  options: { game?: GameId } = {},
+): { summary: string; canonicalRefs: string[] } {
   try {
     const parsed = JSON.parse(content) as unknown;
-    const canonicalRefs = [...collectCanonicalRefs(parsed)];
+    const canonicalRefs = [...collectCanonicalRefs(parsed, new Set<string>(), options.game)];
     if (Array.isArray(parsed)) {
       return {
         summary: `json array (${parsed.length} item${parsed.length === 1 ? '' : 's'})`,
@@ -1834,7 +1868,9 @@ async function runAgentLoopInternal(
                   block.input as Record<string, unknown>,
                   { game: activeGame, userId: options?.userId },
                 );
-                const { summary, canonicalRefs } = summarizeToolOutput(result.content);
+                const { summary, canonicalRefs } = summarizeToolOutput(result.content, {
+                  game: activeGame,
+                });
                 const toolOk = isToolResultOk(result);
                 span.setAttributes({
                   ...createObservationAttributes('tool', {
@@ -1880,7 +1916,9 @@ async function runAgentLoopInternal(
             isError = true;
           }
           const toolEndedAtMs = Date.now();
-          const { summary, canonicalRefs } = summarizeToolOutput(toolResult.content);
+          const { summary, canonicalRefs } = summarizeToolOutput(toolResult.content, {
+            game: activeGame,
+          });
           const toolOk = !isError && isToolResultOk(toolResult);
           toolCalls.push({
             iteration: i + 1,

--- a/test/agent-langgraph.test.ts
+++ b/test/agent-langgraph.test.ts
@@ -321,11 +321,18 @@ describe.sequential('runLangGraphAgentLoopWithTrajectory', () => {
       {
         toolSurface: 'redesigned',
         userMessageId: 'message-living-spirit',
+        game: 'gloomhaven-2e',
       },
     );
 
     expect(result.answer).toBe('An elite level 7 Living Spirit has 10 hit points.');
     expect(mockMessagesCreate).toHaveBeenCalledTimes(3);
+    expect(result.trajectory.toolCalls[0]?.canonicalRefs).toEqual(
+      expect.arrayContaining([
+        'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/living-spirit/0-3',
+        'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/living-spirit/4-7',
+      ]),
+    );
   });
 
   it('emits card lookup intent before the card work row can render', async () => {

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -126,6 +126,7 @@ import {
   LEGACY_AGENT_SYSTEM_PROMPT,
   MAX_AGENT_ITERATIONS,
   NEIGHBORS_TARGET_PROMPT,
+  summarizeToolOutput,
 } from '../src/agent.ts';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -1642,6 +1643,27 @@ describe('isToolResultOk', () => {
   it('treats successful structured payloads and plain text as usable tool results', () => {
     expect(isToolResultOk({ content: JSON.stringify({ ok: true, results: [] }) })).toBe(true);
     expect(isToolResultOk({ content: 'plain legacy tool output' })).toBe(true);
+  });
+});
+
+describe('summarizeToolOutput', () => {
+  it('qualifies legacy GHS refs with the active game for source scoring', () => {
+    expect(
+      summarizeToolOutput(
+        JSON.stringify({
+          ref: 'gloomhavensecretariat:item/6',
+          sourceId: 'gloomhavensecretariat:monster-stat/city-archer/0-3',
+          nested: {
+            sourceRef: 'source:gloomhaven-2e/cards/items',
+          },
+        }),
+        { game: 'gloomhaven-2e' },
+      ).canonicalRefs,
+    ).toEqual([
+      'card:gloomhaven-2e/items/gloomhavensecretariat:item/6',
+      'card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/city-archer/0-3',
+      'source:gloomhaven-2e/cards/items',
+    ]);
   });
 });
 

--- a/test/eval-scoring.test.ts
+++ b/test/eval-scoring.test.ts
@@ -144,6 +144,48 @@ describe('eval scoring summaries', () => {
     });
   });
 
+  it('accepts Gloomhaven 2e refs and still rejects explicit wrong-game refs', () => {
+    const evalCase = {
+      id: 'gh2-item-006-amulet-of-life',
+      game: 'gloomhaven-2e',
+      suite: 'table-qa',
+      runtime: 'langgraph',
+      split: 'holdout',
+      caseCategory: 'items',
+      category: 'items',
+      source: 'data/extracted/items.json',
+      question: 'What does Amulet of Life do?',
+      finalAnswer: {
+        expected: 'Amulet of Life heals.',
+        grading: 'Must mention healing.',
+      },
+    } as const;
+
+    expect(
+      scoreAnswerGroundedness(evalCase, 'Amulet of Life heals.', [
+        toolCall({
+          canonicalRefs: ['card:gloomhaven-2e/items/gloomhavensecretariat:item/6'],
+        }),
+      ]),
+    ).toMatchObject({
+      pass: true,
+      failures: [],
+    });
+
+    expect(
+      scoreAnswerGroundedness(evalCase, 'Amulet of Life heals.', [
+        toolCall({
+          canonicalRefs: ['card:frosthaven/items/gloomhavensecretariat:item/6'],
+        }),
+      ]),
+    ).toMatchObject({
+      pass: false,
+      failures: [
+        'canonical refs point at the wrong game: card:frosthaven/items/gloomhavensecretariat:item/6',
+      ],
+    });
+  });
+
   it('does not require tool evidence for app-source table answers', () => {
     const score = scoreAnswerGroundedness(
       {


### PR DESCRIPTION
## Summary

- qualify legacy `gloomhavensecretariat:*` refs with the active game during Anthropic tool-output trajectory collection
- pass active game context through the production LangGraph agent loop and legacy Anthropic loop when summarizing tool output
- keep explicit game-qualified refs unchanged so wrong-game groundedness failures still work
- update the Table Turnaround iteration log with SQR-381 evidence

## Verification

- `npm test -- --run test/agent.test.ts test/agent-langgraph.test.ts test/eval-scoring.test.ts` passed: 3 files, 93 tests
- `npm run eval -- --matrix --id=gh2-battle-goal-accountant --run-label=sqr-381-gh2-groundedness-dev --max-estimated-cost-usd=1 --local-report=/tmp/sqr-381-gh2-groundedness-dev.json` passed: score 1, groundedness pass
  - Trace: https://smith.langchain.com/o/44be4d80-ba50-4833-ae22-6e176be2dbf2/projects/p/7fe48da1-129f-4a2b-ba99-4cd94700f6bd/r/019f2f2f-959b-7000-8000-03dd0f946b12?poll=true
- `npm run eval -- --matrix --id=gh2-item-006-amulet-of-life --run-label=sqr-381-gh2-groundedness-holdout --max-estimated-cost-usd=1 --local-report=/tmp/sqr-381-gh2-groundedness-holdout.json` passed: score 1, groundedness pass
  - Trace: https://smith.langchain.com/o/44be4d80-ba50-4833-ae22-6e176be2dbf2/projects/p/35cec418-4963-4bc6-8c55-cff73946cdb0/r/019f2f30-4134-7000-8000-01da361d0e9b?poll=true
- `npx markdownlint-cli2 docs/plans/sqr-375-table-turnaround-iteration-log.md`
- `npx prettier --check src/agent.ts src/agent-langgraph.ts test/agent.test.ts test/agent-langgraph.test.ts test/eval-scoring.test.ts docs/plans/sqr-375-table-turnaround-iteration-log.md`
- `npm run check` passed: 158 files, 1942 tests

Estimated eval spend: $0.0061 provider + $0.1000 guardrail.

Fixes SQR-381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how tool results are tracked so references are tied to the active game, reducing incorrect cross-game reference handling.
  * Fixed groundedness scoring so correct-game references pass while wrong-game references are still rejected.

* **Tests**
  * Added coverage for legacy reference rewriting, game-aware tool output handling, and groundedness scoring behavior.

* **Documentation**
  * Added a dated log entry summarizing the fix and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->