### PR TITLE
Print native LangSmith eval progress rows

### DIFF
--- a/docs/plans/sqr-375-table-turnaround-iteration-log.md
+++ b/docs/plans/sqr-375-table-turnaround-iteration-log.md
@@ -300,3 +300,38 @@ the two targeted LangSmith runs.
 Decision: keep. This removes the main SQR-380 Gloomhaven 2e groundedness
 measurement bug without prompt tuning and without weakening explicit wrong-game
 ref rejection.
+
+## 2026-07-04 — Native LangSmith eval progress output
+
+Problem: native LangSmith matrix runs printed the start banner, then stayed quiet
+until each dataset/model/runtime `evaluate(...)` call returned. During full-table
+runs this made it hard to tell whether the runner was progressing, waiting on
+LangSmith, or stuck on one case.
+
+Change:
+
+- Added a progress callback to the native LangSmith eval adapter and invoked it
+  after each completed matrix row.
+- Wired the CLI runner to print the existing incremental progress line for the
+  native path.
+- Expanded the progress line with game, suite, category, groundedness,
+  first-token latency, and retry count so long runs show useful state without
+  dumping per-token or per-tool logs.
+- Kept final table output, LangSmith experiment links, and local report formats
+  unchanged.
+
+Verification:
+
+- `npm test -- --run test/eval-runner.test.ts test/eval-langsmith-eval.test.ts`
+  passed: 2 files, 6 tests.
+- `npm run eval -- --matrix --id=gh2-battle-goal-accountant --run-label=sqr-382-progress-smoke --max-estimated-cost-usd=1 --local-report=/tmp/sqr-382-progress-smoke.json`
+  printed `[1/1] pass ...` before the final table and passed in LangSmith:
+  score 1, groundedness pass, trace
+  <https://smith.langchain.com/o/44be4d80-ba50-4833-ae22-6e176be2dbf2/projects/p/3aaf31c6-8a78-4f71-9bac-108fbdb44358/r/019f2f43-25e6-7000-8000-020c11c1e852?poll=true>.
+- `npm run check` passed: 158 files, 1942 tests.
+
+Eval spend: estimated $0.0026 provider cost plus $0.0500 guardrail cost for the
+one-case progress smoke.
+
+Decision: keep. This does not change scoring or answer behavior, but it makes
+long eval runs observable enough to manage during the Table Turnaround work.

--- a/eval/langsmith-eval.ts
+++ b/eval/langsmith-eval.ts
@@ -13,6 +13,7 @@ import {
   runMatrixInput,
   traceIdForMatrixRow,
   type EvalMatrixResult,
+  type EvalMatrixProgressEvent,
   type EvalMatrixRow,
   type EvalMatrixRunner,
   type EvalMatrixSelection,
@@ -30,6 +31,7 @@ interface LangSmithNativeEvalOptions {
   runner: EvalMatrixRunner;
   guardrails: EvalMatrixGuardrails;
   client: Client;
+  onProgress?: (event: EvalMatrixProgressEvent) => void;
 }
 
 interface LangSmithEvaluationResults {
@@ -136,6 +138,9 @@ export async function runLangSmithNativeEvalMatrix(
   const groupedCases = groupCasesByDataset(options.cases);
   const rows: EvalMatrixRow[] = [];
   const experimentUrls: string[] = [];
+  const totalRows =
+    options.cases.length * options.agentRuntimes.length * options.modelConfigs.length;
+  let completedRows = 0;
 
   for (const [datasetName, datasetCases] of groupedCases) {
     const examples = examplesForCases(
@@ -172,7 +177,7 @@ export async function runLangSmithNativeEvalMatrix(
             agentRuntime,
             providerConfig,
           );
-          return runMatrixInput(
+          const row = await runMatrixInput(
             {
               evalCase,
               agentRuntime,
@@ -187,6 +192,9 @@ export async function runLangSmithNativeEvalMatrix(
             options.runner,
             options.guardrails,
           );
+          completedRows += 1;
+          options.onProgress?.({ completed: completedRows, total: totalRows, row });
+          return row;
         };
 
         const result = await evaluate(target, {

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -45,15 +45,27 @@ function formatProgressNullable(value: string | number | boolean | null | undefi
 export function formatEvalMatrixProgress(event: EvalMatrixProgressEvent): string {
   const { completed, total, row } = event;
   const status = row.pass === null ? '-' : row.pass ? 'pass' : 'fail';
+  const groundedness =
+    row.groundednessPass === undefined || row.groundednessPass === null
+      ? '-'
+      : row.groundednessPass
+        ? 'pass'
+        : 'fail';
   const latency = row.latencyMs === null ? '-' : `${row.latencyMs}ms`;
+  const firstToken =
+    row.firstAnswerTokenLatencyMs === null ? '-' : `${row.firstAnswerTokenLatencyMs}ms`;
   return [
     `[${completed}/${total}]`,
     status,
+    `${row.game}/${row.suite}/${row.category}`,
     `${row.agentRuntime}:${row.provider}:${row.model}`,
     row.caseId,
     `failure=${row.failureClass}`,
     `score=${formatProgressNullable(row.score)}`,
+    `groundedness=${groundedness}`,
     `latency=${latency}`,
+    `firstToken=${firstToken}`,
+    `retries=${row.retryCount}`,
     `tokens=${formatProgressNullable(row.tokenTotal)}`,
     `tools=${formatProgressNullable(row.toolCallCount)}`,
     `loops=${formatProgressNullable(row.loopIterations)}`,
@@ -119,6 +131,7 @@ async function runLangSmithMatrix(
     runner: createEvalMatrixRunner(env, { langSmithTracing: false }),
     guardrails,
     client,
+    onProgress: (event) => console.log(formatEvalMatrixProgress(event)),
   });
 
   console.log(formatEvalMatrixTable(result.rows));

--- a/test/eval-langsmith-eval.test.ts
+++ b/test/eval-langsmith-eval.test.ts
@@ -66,6 +66,7 @@ describe('LangSmith native eval runner', () => {
     const client = {
       getProjectUrl: vi.fn(async () => 'https://smith.langchain.test/o/org/projects/p/native'),
     };
+    const onProgress = vi.fn();
     const runner: EvalMatrixRunner = vi.fn(async (input) => ({
       ok: true,
       answer: 'Poison adds +1 attack.',
@@ -114,6 +115,7 @@ describe('LangSmith native eval runner', () => {
         providerConcurrency: { anthropic: 2, openai: 1 },
       },
       client: client as never,
+      onProgress,
     });
 
     expect(mockEvaluate).toHaveBeenCalledWith(
@@ -175,5 +177,17 @@ describe('LangSmith native eval runner', () => {
       langsmithExperimentUrl: 'https://smith.langchain.test/o/org/projects/p/native',
       referenceExampleId: 'example-rule-poison',
     });
+    expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        completed: 1,
+        total: 1,
+        row: expect.objectContaining({
+          caseId: 'rule-poison',
+          pass: true,
+          latencyMs: 250,
+        }),
+      }),
+    );
   });
 });

--- a/test/eval-runner.test.ts
+++ b/test/eval-runner.test.ts
@@ -109,6 +109,7 @@ describe('eval runner', () => {
           answer: 'answer',
           score: 1,
           pass: true,
+          groundednessPass: true,
           latencyMs: 1234,
           firstAnswerTokenLatencyMs: 900,
           latencyBudgetFirstAnswerTokenMs: null,
@@ -142,7 +143,7 @@ describe('eval runner', () => {
         },
       }),
     ).toBe(
-      '[3/7] pass claude-sdk:openai:gpt-5.4-mini rule-poison failure=none score=1 latency=1234ms tokens=120 tools=2 loops=3',
+      '[3/7] pass frosthaven/table-qa/rulebook claude-sdk:openai:gpt-5.4-mini rule-poison failure=none score=1 groundedness=pass latency=1234ms firstToken=900ms retries=0 tokens=120 tools=2 loops=3',
     );
   });
 


### PR DESCRIPTION
## Summary

- emit native LangSmith matrix progress after each completed row inside the `evaluate(...)` target
- print the progress line from the CLI with game/suite/category, groundedness, first-token latency, and retry count
- keep final table output, LangSmith experiment links, and local report artifacts unchanged
- record SQR-382 evidence in the Table Turnaround iteration log

## Verification

- `npm test -- --run test/eval-runner.test.ts test/eval-langsmith-eval.test.ts` passed: 2 files, 6 tests
- `npm run eval -- --matrix --id=gh2-battle-goal-accountant --run-label=sqr-382-progress-smoke --max-estimated-cost-usd=1 --local-report=/tmp/sqr-382-progress-smoke.json` printed `[1/1] pass ...` before the final table and passed in LangSmith: score 1, groundedness pass
  - Trace: https://smith.langchain.com/o/44be4d80-ba50-4833-ae22-6e176be2dbf2/projects/p/3aaf31c6-8a78-4f71-9bac-108fbdb44358/r/019f2f43-25e6-7000-8000-020c11c1e852?poll=true
- `npx markdownlint-cli2 docs/plans/sqr-375-table-turnaround-iteration-log.md`
- `npx prettier --check eval/langsmith-eval.ts eval/runner.ts test/eval-runner.test.ts test/eval-langsmith-eval.test.ts docs/plans/sqr-375-table-turnaround-iteration-log.md`
- `npm run check` passed: 158 files, 1942 tests

Estimated eval spend: $0.0026 provider + $0.0500 guardrail.

Fixes SQR-382


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native LangSmith eval runs now show live progress updates during long matrix evaluations.
  * Progress lines include more useful run details, such as game, suite, category, groundedness, first-token latency, and retry count.

* **Bug Fixes**
  * Improved visibility for native eval runs without changing final results, experiment links, or report output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->