### PR TITLE
SQR-394 Rebalance table-qa toward rules-synthesis and multi-hop

### DIFF
--- a/docs/plans/sqr-392-table-turnaround-2-iteration-log.md
+++ b/docs/plans/sqr-392-table-turnaround-2-iteration-log.md
@@ -52,3 +52,65 @@ Verification:
 Eval spend: $0. Deterministic changes only.
 
 Decision: keep. Measurement-shape change only; no runtime behavior touched.
+
+## 2026-07-05 — SQR-393 merged; calibration batches 1–3; import bugs found
+
+SQR-393 merged as PR #659 after CodeRabbit approval. The one review nitpick
+was valid and fixed in-series: `EvalLatencyPercentiles` now reports
+`firstAnswerTokenMeasuredCount` separately from the complete-latency
+`measuredCount` so both percentile pairs carry their own sample size.
+
+Judge-calibration labeling (SQR-392) is 30/33 complete via Brian's chat
+batches. Findings routed out of the label stream:
+
+- **SQR-396**: the character-ability import drops GHS `subActions` (verified
+  against upstream `data/gh2e/character/deck/cragheart.json` — Opposing
+  Strike's bottom action carries heal 2 → range 3 upstream, empty in our
+  extract). Also FH ability text absent entirely (Blinkblade/Coral) and raw
+  two-speed initiative encoding (2050 = 20 fast / 50 slow, per Brian).
+- **SQR-397**: monster-ability import collapses duplicate physical cards
+  (GHS FH Ancient Artillery: 8 cards with Exploding Ammunition ×2; our table:
+  7 rows), losing deck composition.
+- The repeated "missing monsters" scenario-answer failures in Brian's labels
+  (batch-2 #18/#20, batch-3 #22/#24/#27/#28/#29) trace to the epoch-1
+  template fast path: its scenario formatter had no monsters field even when
+  the question asked for monsters. Direct evidence for the Phase 1 plan of
+  record (replace templates with the fast model lane).
+- Label reconciliations: #7 flipped to pass after Brian confirmed the
+  checked-in 7-demon scenario-9 data is correct; #15-vs-#30 consistency
+  question pending with Brian; #11 excluded (no ground-truth access).
+- Two label contingencies verified against data before recording: Abael
+  Herder "elite L5: muddle" note (present) and the Alchemist L1
+  "characters cannot use potions" effect (present — the answer was grounded).
+
+## 2026-07-05 — SQR-394: dataset rebalance toward synthesis and multi-hop
+
+Hypothesis: adding Brian-approved rules-synthesis and multi-hop cases with
+sourced ground truth will make per-class latency and correctness reporting
+meaningful before any runtime tuning.
+
+Change:
+
+- Added 30 table-qa cases (all 30 candidates approved by Brian with no
+  vetoes): 14 GH2e rules-synthesis from the official checked-in FAQ
+  (`gh2-faq.html`), 6 FH rules-synthesis verified against rulebook chunk text,
+  8 FH multi-hop conclusion/read-now chains and 2 GH2e section-parent
+  traversals verified against `book_references`.
+- Two FH candidates rephrased to stay corpus-answerable (flagged to Brian):
+  retaliate timing (was "does retaliate trigger if the attacker kills me") and
+  spent-item recovery (was "can I use items while long resting").
+- Multi-hop cases carry trajectory expectations (traversal tool kind +
+  required target ref) alongside judged answers.
+- New totals: 180 table-qa (119 dev / 61 holdout); classes: 128 exact-lookup,
+  40 rules-synthesis, 12 multi-hop. Distribution-floor tests added:
+  ≥35 rules-synthesis and ≥10 multi-hop overall; ≥7 and ≥3 in holdout.
+- All new cases carry epoch-2 latency budgets: 2500ms first-token,
+  10000ms complete (the P95 bar as a per-case ceiling for synthesis and
+  multi-hop).
+
+Eval spend: $0 (deterministic authoring; ground truth from checked-in data,
+upstream GHS files, and the local link graph).
+
+Decision: keep, pending `npm run check` and LangSmith reseed in this slice's
+PR. Epoch-2 baseline (SQR-395) remains blocked on calibration batch 4 and on
+the item #15 / item #30 label reconciliation.

--- a/eval/suites/frosthaven.json
+++ b/eval/suites/frosthaven.json
@@ -1414,5 +1414,325 @@
     "split": "holdout",
     "questionClass": "exact-lookup",
     "caseCategory": "personal-quests"
+  },
+  {
+    "id": "fh-multihop-scenario-10-conclusion-unlock",
+    "category": "scenarios",
+    "question": "Which scenario does the conclusion of Frosthaven scenario 10 unlock?",
+    "finalAnswer": {
+      "expected": "The conclusion of scenario 10 (Crystal Enclosure) is section 42.4, which unlocks scenario 18, Crystal Fields.",
+      "grading": "Must identify scenario 18 (Crystal Fields) as the unlock. Reaching it requires following scenario 10's conclusion link to section 42.4 and its unlock link. Must not substitute another scenario or game."
+    },
+    "trajectory": {
+      "requiredToolKinds": ["traversal"],
+      "requiredRefs": ["scenario:frosthaven/018"],
+      "maxToolCalls": 8
+    },
+    "source": "data/extracted/scenario-section-books.json",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "scenarios",
+    "split": "dev",
+    "questionClass": "multi-hop",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-multihop-scenario-14-conclusion-unlock",
+    "category": "scenarios",
+    "question": "Which scenario does the conclusion of Frosthaven scenario 14 unlock?",
+    "finalAnswer": {
+      "expected": "The conclusion of scenario 14 (Jagged Shoals) is section 4.1, which unlocks scenario 22, Ice Floes.",
+      "grading": "Must identify scenario 22 (Ice Floes) as the unlock via conclusion section 4.1. Must not substitute another scenario or game."
+    },
+    "trajectory": {
+      "requiredToolKinds": ["traversal"],
+      "requiredRefs": ["scenario:frosthaven/022"],
+      "maxToolCalls": 8
+    },
+    "source": "data/extracted/scenario-section-books.json",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "scenarios",
+    "split": "dev",
+    "questionClass": "multi-hop",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-multihop-scenario-17-conclusion-unlock",
+    "category": "scenarios",
+    "question": "What does the conclusion section of Frosthaven scenario 17 unlock?",
+    "finalAnswer": {
+      "expected": "Scenario 17 (Haunted Vault) concludes at section 82.1, which unlocks scenario 27, Depths of Delirium.",
+      "grading": "Must identify scenario 27 (Depths of Delirium) as the unlock via conclusion section 82.1. Must not substitute another scenario or game."
+    },
+    "trajectory": {
+      "requiredToolKinds": ["traversal"],
+      "requiredRefs": ["scenario:frosthaven/027"],
+      "maxToolCalls": 8
+    },
+    "source": "data/extracted/scenario-section-books.json",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "scenarios",
+    "split": "holdout",
+    "questionClass": "multi-hop",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-multihop-scenario-23-conclusion-unlock",
+    "category": "scenarios",
+    "question": "Which scenario is unlocked by the conclusion of Frosthaven scenario 23?",
+    "finalAnswer": {
+      "expected": "Scenario 23 (Spire Basement) concludes at section 105.2, which unlocks scenario 34, Top of the Spire.",
+      "grading": "Must identify scenario 34 (Top of the Spire) as the unlock via conclusion section 105.2. Must not substitute another scenario or game."
+    },
+    "trajectory": {
+      "requiredToolKinds": ["traversal"],
+      "requiredRefs": ["scenario:frosthaven/034"],
+      "maxToolCalls": 8
+    },
+    "source": "data/extracted/scenario-section-books.json",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "scenarios",
+    "split": "holdout",
+    "questionClass": "multi-hop",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-multihop-scenario-31-conclusion-unlock",
+    "category": "scenarios",
+    "question": "Which scenario does the conclusion of Frosthaven scenario 31 unlock?",
+    "finalAnswer": {
+      "expected": "Scenario 31 (Crackling Tunnel) concludes at section 81.3, which unlocks scenario 41, Unfettered Shard.",
+      "grading": "Must identify scenario 41 (Unfettered Shard) as the unlock via conclusion section 81.3. Must not substitute another scenario or game."
+    },
+    "trajectory": {
+      "requiredToolKinds": ["traversal"],
+      "requiredRefs": ["scenario:frosthaven/041"],
+      "maxToolCalls": 8
+    },
+    "source": "data/extracted/scenario-section-books.json",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "scenarios",
+    "split": "dev",
+    "questionClass": "multi-hop",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-multihop-scenario-36-conclusion-unlock",
+    "category": "scenarios",
+    "question": "What scenario does completing Frosthaven scenario 36 unlock through its conclusion section?",
+    "finalAnswer": {
+      "expected": "Scenario 36 (Buried Ducts) concludes at section 118.1, which unlocks scenario 44, Nerve Center.",
+      "grading": "Must identify scenario 44 (Nerve Center) as the unlock via conclusion section 118.1. Must not substitute another scenario or game."
+    },
+    "trajectory": {
+      "requiredToolKinds": ["traversal"],
+      "requiredRefs": ["scenario:frosthaven/044"],
+      "maxToolCalls": 8
+    },
+    "source": "data/extracted/scenario-section-books.json",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "scenarios",
+    "split": "dev",
+    "questionClass": "multi-hop",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-multihop-scenario-2-read-now-chain",
+    "category": "scenarios",
+    "question": "Frosthaven scenario 2 has a read-now link to section 27.1 — which section does that one link to next?",
+    "finalAnswer": {
+      "expected": "Section 27.1 links onward to section 6.1.",
+      "grading": "Must identify section 6.1 as the next read-now link from section 27.1. Must not substitute another section or game."
+    },
+    "trajectory": {
+      "requiredToolKinds": ["traversal"],
+      "requiredRefs": ["section:frosthaven/6.1"],
+      "maxToolCalls": 8
+    },
+    "source": "data/extracted/scenario-section-books.json",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "scenarios",
+    "split": "dev",
+    "questionClass": "multi-hop",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-multihop-scenario-8-read-now-chain",
+    "category": "scenarios",
+    "question": "Following the read-now chain from Frosthaven scenario 8: section 21.1 links onward to which section?",
+    "finalAnswer": {
+      "expected": "Section 21.1 links onward to section 12.1.",
+      "grading": "Must identify section 12.1 as the next link from section 21.1. Must not substitute another section or game."
+    },
+    "trajectory": {
+      "requiredToolKinds": ["traversal"],
+      "requiredRefs": ["section:frosthaven/12.1"],
+      "maxToolCalls": 8
+    },
+    "source": "data/extracted/scenario-section-books.json",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "scenarios",
+    "split": "holdout",
+    "questionClass": "multi-hop",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-rule-retaliate-timing",
+    "category": "rulebook",
+    "question": "In Frosthaven, when does Retaliate trigger, and does it count as an attack?",
+    "finalAnswer": {
+      "expected": "Retaliate X deals X damage to any figure who attacks the retaliating figure, if the attacker is within the specified range (adjacent if no range is given) after all attack effects including push and pull are resolved. It triggers after each attack is resolved, and a retaliate bonus is not an attack.",
+      "grading": "Must state that retaliate triggers after the attack is resolved (per attack) and that retaliate is not itself an attack. Range/adjacency detail is a bonus."
+    },
+    "source": "fh-rule-book.pdf",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-rule-invisible-focus",
+    "category": "rulebook",
+    "question": "In Frosthaven, can a monster focus an invisible character?",
+    "finalAnswer": {
+      "expected": "No. An invisible figure cannot be focused on or targeted by any enemy; enemies treat invisible figures as if they were not there and can move through them. Invisible is removed at the end of the figure’s next turn.",
+      "grading": "Must answer no: invisible figures cannot be focused or targeted by enemies. Removal timing and move-through detail are bonuses."
+    },
+    "source": "fh-rule-book.pdf",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "holdout",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-rule-elements-wane",
+    "category": "rulebook",
+    "question": "When do infused elements wane in Frosthaven?",
+    "finalAnswer": {
+      "expected": "At the end of every round, all infused elements wane, moving one column to the left on the element board (strong to waning, waning to inert).",
+      "grading": "Must state that infused elements wane at the end of every round, moving one column (strong to waning to inert)."
+    },
+    "source": "fh-rule-book.pdf",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-rule-monster-ability-shuffle",
+    "category": "rulebook",
+    "question": "In Frosthaven, what happens when a drawn monster ability card has a shuffle icon?",
+    "finalAnswer": {
+      "expected": "During the End of Round step, if any drawn monster ability card (or attack modifier card) has a shuffle icon, the corresponding discard pile is shuffled back into its deck.",
+      "grading": "Must state that the discard pile is shuffled back into the deck, at the end of the round."
+    },
+    "source": "fh-rule-book.pdf",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "holdout",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-rule-spent-item-recovery",
+    "category": "rulebook",
+    "question": "In Frosthaven, when are spent items recovered?",
+    "finalAnswer": {
+      "expected": "Spent items (rotated sideways) are recovered the next time the character performs a long rest.",
+      "grading": "Must state that spent items are recovered on a long rest. Must not confuse spent with lost items."
+    },
+    "source": "fh-rule-book.pdf",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "fh-rule-exhaustion-active-cards",
+    "category": "rulebook",
+    "question": "In Frosthaven, what happens to the cards in my active area when I become exhausted?",
+    "finalAnswer": {
+      "expected": "When a character becomes exhausted, all of their ability cards — including summons and other cards in their active area — are placed in their lost pile, and their figure is removed from the map. Exhausted characters can no longer participate in the scenario.",
+      "grading": "Must state that active-area cards (including summons) go to the lost pile and the figure is removed from the map."
+    },
+    "source": "fh-rule-book.pdf",
+    "game": "frosthaven",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
   }
 ]

--- a/eval/suites/gloomhaven-2e.json
+++ b/eval/suites/gloomhaven-2e.json
@@ -1431,5 +1431,335 @@
     "suite": "trajectory",
     "runtime": "langgraph",
     "caseCategory": "trajectory"
+  },
+  {
+    "id": "gh2-faq-push-pull-same-attack",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, can I Push and Pull with the same attack?",
+    "finalAnswer": {
+      "expected": "Yes. All Pushes are combined together and all Pulls are combined together, and you must fully complete one before performing the other. This can make an enemy take damage from the same hazardous terrain hex twice.",
+      "grading": "Must answer yes, and mention that pushes and pulls are each combined and one must be fully completed before the other."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-push-line-of-sight",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, do I need line of sight to every hex I push an enemy into?",
+    "finalAnswer": {
+      "expected": "No. The push target must be within line of sight to start the push, but the push can move the target out of line of sight and even around doors.",
+      "grading": "Must answer no, with line of sight required only to start the push."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "holdout",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-push-pull-allies",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, can I Push or Pull allies?",
+    "finalAnswer": {
+      "expected": "Forced movement is a negative ability, so you can only push or pull allies if the specific ability says you can.",
+      "grading": "Must state that forced movement on allies is only allowed when the ability specifically permits it."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-ward-damage-negation",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, when I lose a card to avoid all damage, do I lose Ward?",
+    "finalAnswer": {
+      "expected": "Yes. Ward’s effects are considered before the damage negation step, so Ward is consumed even though the damage is negated.",
+      "grading": "Must answer yes: Ward applies before the damage-negation step."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-shield-ward-order",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, how does Shield interact with Ward?",
+    "finalAnswer": {
+      "expected": "Shield reduces the damage first, then Ward halves what remains. With Shield 2 and Ward against 6 damage: Shield reduces it to 4, then Ward halves it to 2.",
+      "grading": "Must state that Shield applies before Ward. The worked example is a bonus."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "holdout",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-null-x2-rolling-order",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, what is the order of operations if I draw a x2 or Null with rolling modifiers?",
+    "finalAnswer": {
+      "expected": "If a Null (x0) is anywhere in the final draws, the final damage is always 0. A x2 can be inserted at any point during attack modification, including at the very end, at the attacker’s choice.",
+      "grading": "Must state that a Null always makes the final damage 0 regardless of position, and that a x2 can be applied at any chosen point in the order."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-disadvantage-identical-effects",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e with Disadvantage, if I draw a +1 Stun and a +0 Stun, is that ambiguous?",
+    "finalAnswer": {
+      "expected": "No. Two identical non-numeric effects can be compared, so the +1 Stun is simply better; the draw is not ambiguous.",
+      "grading": "Must answer no and identify the +1 Stun as the better card because identical effects are comparable."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "holdout",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-target-immune-figure",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, can I target a figure with a condition they’re immune to?",
+    "finalAnswer": {
+      "expected": "Yes. The condition will not be applied, but targeting is still allowed, which can matter for other effects. This is a change from Gloomhaven 1st Edition.",
+      "grading": "Must answer yes: targeting is allowed even though the condition is not applied."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-range-one-still-ranged",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, if an attack’s range is reduced to 1, does it become a melee attack?",
+    "finalAnswer": {
+      "expected": "No. It remains a ranged attack with Range 1, so it usually has disadvantage against an adjacent target.",
+      "grading": "Must answer no: it stays a ranged attack (with the usual adjacency disadvantage)."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-long-rest-initiative-99",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, is my Long Rest at initiative 99, or always last in order?",
+    "finalAnswer": {
+      "expected": "A long rest takes place at initiative 99, not necessarily last: an effect can push a figure above 99 to act after your rest. Your long rest happens before monster turns at initiative 99 and is ambiguously timed with other players at 99.",
+      "grading": "Must state the long rest is at initiative 99 rather than automatically last, and that it resolves before monsters acting at 99."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-monster-trap-strength",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, if a monster must move through a choice of traps, does it consider the strength of those traps?",
+    "finalAnswer": {
+      "expected": "No. Monsters count the number of negative hexes but ignore their strength or effects, and they always prefer a path with zero negative hexes regardless of length. Remaining ambiguity is resolved in the players’ favor.",
+      "grading": "Must answer no: monsters weigh the count of negative hexes, not their strength."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "holdout",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-multi-target-attack-order",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, when a monster attacks more than one target, what order are the attacks made in?",
+    "finalAnswer": {
+      "expected": "The order is ambiguous, and players decide it once all targets are determined; the primary focus does not need to be attacked first. With Retaliate this can kill the monster before all its attacks resolve. This applies to Target X and red-hex AoE attacks.",
+      "grading": "Must state that players choose the attack order after targets are determined and the focus need not be first."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-rounding-direction",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, if a calculation doesn’t say which way to round, which way do you round?",
+    "finalAnswer": {
+      "expected": "If a calculation does not indicate a rounding direction, assume it rounds up.",
+      "grading": "Must state that unspecified rounding rounds up."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "holdout",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-faq-item-mid-ability",
+    "category": "rulebook",
+    "question": "In Gloomhaven 2e, can I use an item in the middle of my move or attack ability?",
+    "finalAnswer": {
+      "expected": "Only if the item is not itself an ability and says something like “during your move ability.” If the item performs another ability (healing, damaging, destroying an obstacle), you must finish your current ability first. This is a change from a Gloomhaven 1e FAQ ruling.",
+      "grading": "Must distinguish items usable mid-ability (non-ability items worded for it) from item abilities that require finishing the current ability first."
+    },
+    "source": "gh2-faq.html",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "rulebook",
+    "split": "dev",
+    "questionClass": "rules-synthesis",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-multihop-section-10-3-parent",
+    "category": "scenarios",
+    "question": "In Gloomhaven 2e, which scenario is section 10.3 attached to?",
+    "finalAnswer": {
+      "expected": "Section 10.3 belongs to scenario 15, Plane of Elemental Power.",
+      "grading": "Must identify scenario 15 (Plane of Elemental Power) as the parent scenario of section 10.3. Must not substitute another scenario or game."
+    },
+    "trajectory": {
+      "requiredToolKinds": ["traversal"],
+      "requiredRefs": ["scenario:gloomhaven-2e/015"],
+      "maxToolCalls": 8
+    },
+    "source": "data/extracted/gh2/scenario-section-books.json",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "scenarios",
+    "split": "dev",
+    "questionClass": "multi-hop",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
+  },
+  {
+    "id": "gh2-multihop-section-101-2-parent",
+    "category": "scenarios",
+    "question": "In Gloomhaven 2e, section 101.2 belongs to which scenario?",
+    "finalAnswer": {
+      "expected": "Section 101.2 belongs to scenario 47, Slave Pens.",
+      "grading": "Must identify scenario 47 (Slave Pens) as the parent scenario of section 101.2. Must not substitute another scenario or game."
+    },
+    "trajectory": {
+      "requiredToolKinds": ["traversal"],
+      "requiredRefs": ["scenario:gloomhaven-2e/047"],
+      "maxToolCalls": 8
+    },
+    "source": "data/extracted/gh2/scenario-section-books.json",
+    "game": "gloomhaven-2e",
+    "suite": "table-qa",
+    "runtime": "langgraph",
+    "caseCategory": "scenarios",
+    "split": "holdout",
+    "questionClass": "multi-hop",
+    "latencyBudget": {
+      "firstAnswerTokenMs": 2500,
+      "completeAnswerMs": 10000
+    }
   }
 ]

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -154,6 +154,11 @@ describe('eval dataset', () => {
     const total = byClass();
     expect(total['rules-synthesis']).toBeGreaterThanOrEqual(35);
     expect(total['multi-hop']).toBeGreaterThanOrEqual(10);
+    // No case hides in an unlisted class: the three tracked classes account
+    // for every table-qa case until a campaign-class case exists.
+    expect(total['exact-lookup'] + total['rules-synthesis'] + total['multi-hop']).toBe(
+      tableQaCases.length,
+    );
     const holdoutByClass = byClass('holdout');
     expect(holdoutByClass['rules-synthesis']).toBeGreaterThanOrEqual(7);
     expect(holdoutByClass['multi-hop']).toBeGreaterThanOrEqual(3);

--- a/test/eval-dataset.test.ts
+++ b/test/eval-dataset.test.ts
@@ -73,8 +73,8 @@ describe('eval dataset', () => {
   });
 
   it('keeps the existing final-answer cases and adds enough trajectory coverage', () => {
-    expect(cases).toHaveLength(195);
-    expect(cases.filter(evalCaseHasFinalAnswer)).toHaveLength(171);
+    expect(cases).toHaveLength(225);
+    expect(cases.filter(evalCaseHasFinalAnswer)).toHaveLength(201);
     expect(countTrajectoryCases(cases)).toBeGreaterThanOrEqual(25);
     expect(cases.filter(evalCaseHasSafety)).toHaveLength(14);
   });
@@ -93,7 +93,7 @@ describe('eval dataset', () => {
 
   it('requires table-qa cases to declare dev or holdout split metadata', () => {
     const tableQaCases = cases.filter((evalCase) => evalCase.suite === 'table-qa');
-    expect(tableQaCases).toHaveLength(150);
+    expect(tableQaCases).toHaveLength(180);
     expect(
       tableQaCases.every((evalCase) => evalCase.split === 'dev' || evalCase.split === 'holdout'),
     ).toBe(true);
@@ -104,7 +104,7 @@ describe('eval dataset', () => {
     const holdoutCaseIds = tableQaCases
       .filter((evalCase) => evalCase.split === 'holdout')
       .map((evalCase) => evalCase.id);
-    expect(holdoutCaseIds).toHaveLength(50);
+    expect(holdoutCaseIds).toHaveLength(61);
     expect(holdoutCaseIds).toEqual(
       expect.arrayContaining([
         'building-mining-camp-level-1',
@@ -136,6 +136,27 @@ describe('eval dataset', () => {
     expect(multiHop.map((evalCase) => evalCase.id)).toEqual(
       expect.arrayContaining(['scenario-61-unlock', 'gh2-section-67-1']),
     );
+
+    // Epoch-2 distribution floors (SQR-394): the dataset must keep meaningful
+    // synthesis and multi-hop coverage in both splits so lookup-heavy sampling
+    // cannot mask the classes that dominate real table use.
+    const byClass = (split?: string) =>
+      Object.fromEntries(
+        ['exact-lookup', 'rules-synthesis', 'multi-hop'].map((questionClass) => [
+          questionClass,
+          tableQaCases.filter(
+            (evalCase) =>
+              evalCase.questionClass === questionClass &&
+              (split === undefined || evalCase.split === split),
+          ).length,
+        ]),
+      );
+    const total = byClass();
+    expect(total['rules-synthesis']).toBeGreaterThanOrEqual(35);
+    expect(total['multi-hop']).toBeGreaterThanOrEqual(10);
+    const holdoutByClass = byClass('holdout');
+    expect(holdoutByClass['rules-synthesis']).toBeGreaterThanOrEqual(7);
+    expect(holdoutByClass['multi-hop']).toBeGreaterThanOrEqual(3);
 
     const untagged: Record<string, unknown> = { ...tableQaCases[0] };
     delete untagged.questionClass;
@@ -243,14 +264,14 @@ describe('eval dataset', () => {
   it('derives parity baseline counts from fixture metadata', () => {
     expect(baselineCountsFor(cases, 'frosthaven')).toEqual({
       game: 'frosthaven',
-      finalAnswerCases: 74,
-      trajectoryCases: 12,
+      finalAnswerCases: 88,
+      trajectoryCases: 20,
       boundaryCases: 1,
     });
     expect(baselineCountsFor(cases, 'gloomhaven-2e')).toEqual({
       game: 'gloomhaven-2e',
-      finalAnswerCases: 76,
-      trajectoryCases: 11,
+      finalAnswerCases: 92,
+      trajectoryCases: 13,
       boundaryCases: 2,
     });
   });


### PR DESCRIPTION
## Summary
Phase 0 dataset-rebalance slice for Table Turnaround II (SQR-394). All 30 candidates were reviewed and approved by Brian with no vetoes.

- 14 GH2e rules-synthesis cases grounded in the official checked-in FAQ (`data/rule-sources/gh2-faq.html`) — forced movement, Ward/Shield ordering, modifier order-of-operations, monster AI, items.
- 6 FH rules-synthesis cases verified against `fh-rule-book.pdf` chunk text (two candidates rephrased to stay corpus-answerable; flagged to Brian).
- 8 FH multi-hop cases over verified `book_references` chains (scenario → conclusion/read-now section → unlock/next), with trajectory expectations (traversal kind + required target ref).
- 2 GH2e section→parent-scenario traversal cases (the only edge type in GH2e's link graph).
- New distribution: **180 table-qa (119 dev / 61 holdout); 128 exact-lookup / 40 rules-synthesis / 12 multi-hop**, enforced by distribution-floor tests (≥35/≥10 overall, ≥7/≥3 in holdout).
- Every new case carries epoch-2 latency budgets: 2500ms first-token / 10000ms complete.
- Epoch-2 iteration log updated: SQR-393 closeout, calibration batch 1–3 findings, SQR-396/397 import-bug discoveries, template-fast-path missing-monsters pattern.
- LangSmith datasets reseeded with `questionClass` metadata (74→88 FH, 76→92 GH2e table-qa items).

## Test plan
- [x] `npx vitest run test/eval-dataset.test.ts` — 31 tests, incl. new distribution floors
- [x] `npm run check` — 158 files, 1965 tests
- [x] `npm run eval -- --seed` — all datasets reseeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated table-turnaround iteration log with new evaluation status, dataset rebalance details, and remaining blocking items.
* **New Features**
  * Expanded the evaluation dataset with additional Frosthaven and Gloomhaven 2e table-qa cases, including multi-hop and rules-clarification scenarios.
* **Tests**
  * Strengthened evaluation dataset assertions to reflect expanded coverage, including stricter distribution-floor checks for key question types and updated baseline expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->