### PR TITLE
SQR-392 Freeze human-labeled judge calibration (90.6% agreement)

### DIFF
--- a/docs/plans/sqr-392-table-qa-judge-calibration.json
+++ b/docs/plans/sqr-392-table-qa-judge-calibration.json
@@ -1,0 +1,386 @@
+{
+  "generatedAt": "2026-07-05T21:56:47.152Z",
+  "fixturePath": "eval/judge-calibration/table-qa-reference.json",
+  "suite": "table-qa",
+  "split": "dev",
+  "judge": {
+    "model": "claude-haiku-4-5-20251001",
+    "promptVersion": "table-qa-answer-judge-v2",
+    "promptChanged": false
+  },
+  "estimatedCostUsd": 0.008,
+  "summary": {
+    "totalItems": 32,
+    "agreedItems": 29,
+    "disagreedItems": 3,
+    "agreementRate": 0.90625,
+    "agreementThreshold": 0.85,
+    "thresholdPass": true,
+    "byGame": {
+      "frosthaven": {
+        "totalItems": 23,
+        "agreedItems": 21,
+        "agreementRate": 0.9130434782608695
+      },
+      "gloomhaven-2e": {
+        "totalItems": 9,
+        "agreedItems": 8,
+        "agreementRate": 0.8888888888888888
+      }
+    }
+  },
+  "results": [
+    {
+      "id": "e2-fail-gh2-character-ability-cragheart-opposing-strike-1",
+      "caseId": "gh2-character-ability-cragheart-opposing-strike",
+      "game": "gloomhaven-2e",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "Required parts: (1) level 1, (2) initiative 46, (3) top action Attack 3, (4) bottom action effect Heal 2, Range 3. The actual answer correctly provides parts 1–3 but FAILS on part 4 by stating the bottom action effect is 'not available' in the data and referring the user to the physical card. Per grading criteria: 'An answer that omits the Heal 2, Range 3 effect or says it is unavailable does not pass.' This is an UNANSWERED hard failure — the required effect is explicitly marked as missing rather than provided. Score capped at 3.",
+      "rationale": "Expected AND answer both wrong: bottom action should be \"at the end of this and your next four turns, perform Heal 2, Range 3\" — checked-in data missing sub-actions (import bug)"
+    },
+    {
+      "id": "e2-fail-fh-scenario-4b-heart-of-ice-b-1",
+      "caseId": "fh-scenario-4b-heart-of-ice-b",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "HARD FAILURE - UNANSWERED. The actual answer states that the required data is unavailable and refers the user back to check other sources ('If you can share more context'). This violates the UNANSWERED hard failure rule: the answer does not provide the required parts (scenario name, unlocks, rewards, monsters) but instead claims they are missing from the data. The grading criteria explicitly requires identification of scenario 4B as 'Heart of Ice B' with its unlock, reward, and monster information. The expected answer demonstrates this data exists and is knowable. By refusing to answer and deflecting to the user, the actual answer fails to meet the threshold for passing, regardless of the reasoning offered about data structure or numbering conventions.",
+      "rationale": "Should recognize 4B means variant B of scenario 4"
+    },
+    {
+      "id": "e2-pass-rule-scenario-level-1",
+      "caseId": "rule-scenario-level",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "REQUIRED PARTS: (1) Divide average character level by 2, (2) Round up. ANALYSIS: The actual answer explicitly states 'the scenario level is equal to the average level of the characters divided by 2 (rounded up)' in the opening sentence, directly matching the expected answer. Both required parts are present and accurate. The answer includes a worked example, notes about scenario level flexibility, solo mode adjustments, and a table showing effects—all correct supplementary information that adds context without contradicting the core answer. No hard failures apply.",
+      "rationale": "Correct per Brian label."
+    },
+    {
+      "id": "e2-pass-gh2-character-ability-mindthief-submissive-affliction-1",
+      "caseId": "gh2-character-ability-mindthief-submissive-affliction",
+      "game": "gloomhaven-2e",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "Required parts: (1) Level 1 for Mindthief — present and correct; (2) Initiative 48 — present and correct; (3) Top action (Attack 2, +1 per negative condition) — present and correct; (4) Bottom action (Control within Range 4, consume Ice, Damage 2) — present and correct, including the Ice-consumption rider as required. All four required elements are accurately stated. The tabular format and source citation add helpful context without contradicting any required information.",
+      "rationale": "Correct per Brian label."
+    },
+    {
+      "id": "e2-fail-fh-character-mat-boneshaper-1",
+      "caseId": "fh-character-mat-boneshaper",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 1,
+      "agreement": true,
+      "reasoning": "WRONG SUBJECT: The actual answer addresses Scenario 1 (A Town in Flames) and its unlocks/rewards, which is completely unrelated to the question about the Frosthaven Boneshaper character mat. The question requires four specific parts: (1) hand size 12, (2) level 1 HP 6, (3) level 9 HP 14, and (4) traits (arcane, educated, intimidating). All four required parts are entirely absent from the answer, and the answer addresses a different game element entirely.",
+      "rationale": "Wrong category of answer (scenario data for a character-mat question)"
+    },
+    {
+      "id": "e2-pass-fh-monster-ability-algox-snowspeaker-trap-solo-blinding-vortex-1",
+      "caseId": "fh-monster-ability-algox-snowspeaker-trap-solo-blinding-vortex",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "REQUIRED PARTS: (1) Initiative value, (2) Move ability, (3) Attack ability with range, (4) Muddle effect, (5) Element air, (6) Correct game and monster. VERIFICATION: (1) Initiative 22 ✓ present and correct. (2) Move 0 ✓ present and correct. (3) Attack 1, Range 2 ✓ present and correct. (4) Muddle ✓ present and correct. (5) Element air ✓ present and correct. (6) Frosthaven, Algox Snowspeaker Trap Solo, Blinding Vortex ✓ correct game and monster. All required parts are present with accurate content. Formatting is clear and matches expected answer semantically.",
+      "rationale": "Brian asks what \"Algox Snowspeaker Trap Solo\" is — data-shaped phrasing, flag for rebalance review"
+    },
+    {
+      "id": "e2-pass-gh2-scenario-9-ruinous-rift-1",
+      "caseId": "gh2-scenario-9-ruinous-rift",
+      "game": "gloomhaven-2e",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "Required parts: (1) Scenario 9 name, (2) Unlocks, (3) Rewards, (4) Monsters (all seven demon types). All present and correct. Scenario correctly identified as Ruinous Rift. Unlocks correctly stated as none. Reward correctly stated as Prosperity 1. All seven demon types listed: Chaos Demon, Earth Demon, Flame Demon, Frost Demon, Night Demon, Sun Demon, Wind Demon. Extra detail (objectives, flow chart group, source) does not contradict or undermine the required information. Answer is accurate and actionable at a game table.",
+      "rationale": "Reconciled 2026-07-05: checked-in GHS 7-demon data confirmed right; consistent with #13 pass"
+    },
+    {
+      "id": "e2-fail-fh-scenario-4b-heart-of-ice-b-2",
+      "caseId": "fh-scenario-4b-heart-of-ice-b",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "HARD FAILURE - UNANSWERED/OMISSION. The question requires three specific parts: (1) the name of scenario 4B, (2) its unlock information, and (3) its reward and monster information. The actual answer claims scenario 4B does not exist in the data and declines to provide any of these required parts. This is an UNANSWERED response — the system refers the user to clarify rather than providing the structured data requested. The expected answer clearly identifies scenario 4B as 'Heart of Ice B' with specific unlocks (nothing), rewards (Prosperity 1, Morale 1), and monsters (Algox Archer, Algox Guard), indicating this scenario does exist in Frosthaven. The actual answer's claim that 'Frosthaven scenarios are numbered with plain integers' and 'does not use lettered sub-scenario identifiers' directly contradicts the expected answer's identification of '4B' as a valid scenario. This is both an UNANSWERED failure (no data provided) and a CONTRADICTION (denying the scenario exists when it does).",
+      "rationale": "Factually incorrect: claims FH has no lettered sub-scenario identifiers"
+    },
+    {
+      "id": "e2-pass-fh-battle-goal-accountant-1",
+      "caseId": "fh-battle-goal-accountant",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "Required parts: (1) Accountant battle goal condition, (2) checkmark value. Both are present and accurate. The actual answer states the condition as 'Have zero cards in your hand each time you rest' and the value as '1 checkmark', matching the expected answer exactly. The additional context about performing a rest during the scenario is helpful clarification that does not contradict anything.",
+      "rationale": "Correct per Brian label."
+    },
+    {
+      "id": "e2-fail-gh2-character-ability-cragheart-opposing-strike-2",
+      "caseId": "gh2-character-ability-cragheart-opposing-strike",
+      "game": "gloomhaven-2e",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "Required parts: (1) Level 1 — present and correct; (2) Initiative 46 — present and correct; (3) Top action Attack 3 — present and correct; (4) Bottom action with Heal 2, Range 3 effect — PARTIALLY PRESENT BUT INCOMPLETE. The answer correctly identifies the structure ('At the end of this and your next four turns, perform') but explicitly states the effect details are 'not available in the checked-in data' and directs the user to the physical card. This violates the hard failure rule UNANSWERED: the grading criteria explicitly requires the answer to 'summarize both actions including the bottom action effect Heal 2, Range 3' and states 'An answer that omits the Heal 2, Range 3 effect or says it is unavailable does not pass.' The actual answer says it is unavailable, which is a direct hard failure.",
+      "rationale": "Same as #1: missing Heal 2 Range 3 bottom-action detail"
+    },
+    {
+      "id": "e2-pass-drifter-ignore-negative-item-effects-correction-1",
+      "caseId": "drifter-ignore-negative-item-effects-correction",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "Required parts: (1) Confirm Drifter has a perk ignoring negative item effects, (2) Provide the perk text. Both are present and accurate. The answer directly states the perk exists, provides the exact supported text from the character mat, and acknowledges the prior error without deflection. No contradictions, no invented details, no redirection to other classes. Perfect compliance with grading criteria.",
+      "rationale": "Should not apologize: chat-session-relative apology has nothing to do with game data (behavior note for prompt work)"
+    },
+    {
+      "id": "e2-pass-gh2-scenario-9-ruinous-rift-2",
+      "caseId": "gh2-scenario-9-ruinous-rift",
+      "game": "gloomhaven-2e",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "REQUIRED PARTS: (1) Scenario 9 name, (2) Unlocks information, (3) Rewards information, (4) Monsters list with all seven demon types. ALL PRESENT AND CORRECT: (1) Correctly identified as 'Ruinous Rift' ✓ (2) Unlocks stated as 'None listed' ✓ (3) Rewards correctly lists 'Prosperity 1' ✓ (4) All seven demon types listed and named correctly: Chaos Demon, Earth Demon, Flame Demon, Frost Demon, Night Demon, Sun Demon, Wind Demon ✓. The answer is from the correct game (Gloomhaven 2e) and correct scenario. Extra details (Group, Objectives, Source note) do not contradict the expected answer and provide helpful context. No hard failures apply.",
+      "rationale": "Confirmed: checked-in GHS data (7 demons) is right"
+    },
+    {
+      "id": "e2-fail-fh-monster-ability-ancient-artillery-long-shot-1",
+      "caseId": "fh-monster-ability-ancient-artillery-long-shot",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "REQUIRED PARTS: (1) Initiative value 46, (2) Abilities including 'Focus on the enemy farthest away within Range 7' and 'Attack 1, Range 7' for the Long Shot card from Frosthaven Ancient Artillery.\n\nHARD FAILURE - UNANSWERED: The actual answer explicitly states that 'Long Shot' was not found in the tool results and declines to provide the required information, claiming the data is unavailable. This is an honest non-answer but still constitutes a failure to provide required parts. The answer lists other Ancient Artillery cards (Concussive Burst, Defensive Ordinance, etc.) but none of these are the Long Shot card requested. The grading criteria explicitly requires identifying the Long Shot card's initiative and abilities; the actual answer provides neither, instead explaining why it cannot be provided.",
+      "rationale": "Deck should have 8 cards and definitely has Long Shot; DB has Long Shot (agent retrieval miss) + GHS composition is 8 with Exploding Ammunition x2"
+    },
+    {
+      "id": "e2-fail-fh-character-ability-blinkblade-blurry-jab-1",
+      "caseId": "fh-character-ability-blinkblade-blurry-jab",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "Required parts: (1) level 1 identification, (2) two-speed initiative format (20 fast, 50 slow), (3) top action summary, (4) bottom action summary. Present: (1) Level 1 ✓. Missing/Failed: (2) CONTRADICTION — answer presents '2050' as a single initiative value, which the grading criteria explicitly forbids ('Must not present 2050 as a single initiative value'). (3) UNANSWERED — claims top action text is 'not available in the data,' violating the requirement that 'stating that the ability text is unavailable in the data does not satisfy this.' (4) UNANSWERED — same issue with bottom action. Hard failure rule CONTRADICTION + UNANSWERED applies.",
+      "rationale": "Expected and answer both wrong — case codifies data hole (SQR-396)"
+    },
+    {
+      "id": "e2-fail-fh-character-ability-blinkblade-blurry-jab-2",
+      "caseId": "fh-character-ability-blinkblade-blurry-jab",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "Required parts: (1) level 1 for Blinkblade, (2) two-speed initiative (20 fast, 50 slow), (3) top action text, (4) bottom action text. The actual answer correctly identifies level 1 and attempts to explain the initiative structure, but fails on two hard failure rules: (1) UNANSWERED — the answer states top and bottom actions are 'not available in the current data' and refers the user to the physical card, which violates the grading criterion that 'stating that the ability text is unavailable in the data does not satisfy this'; (2) CONTRADICTION — the answer describes the initiative as '20 (the raw value 2050 represents initiative 20, position 50 within that initiative)' which mischaracterizes the two-speed system. The grading criteria explicitly forbid presenting 2050 as a single value or describing the second number as a 'position' or tiebreaker. The correct framing is two distinct initiatives: 20 when fast, 50 when slow. The omission of actual action text and the misframing of initiative mechanics together constitute critical failures.",
+      "rationale": "2050 = initiative 20 when fast, 50 when slow (Blinkblade two-speed); top/bottom should be available"
+    },
+    {
+      "id": "e2-pass-fh-item-002-crude-helmet-1",
+      "caseId": "fh-item-002-crude-helmet",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "Required parts: (1) Identify as item #002 ✓, (2) Include the effect about treating Double attack modifier cards as +1 ✓, (3) Use Frosthaven data ✓. The actual answer correctly identifies Crude Helmet as item #002, states it is a head-slot item with craft cost 1 metal, and provides the exact effect: treating any Double attack modifier card the enemy draws as a +1 instead. The wording 'Plus1' vs '+1' is semantically equivalent. All required parts are present and accurate.",
+      "rationale": "Correct per Brian label."
+    },
+    {
+      "id": "e2-fail-fh-scenario-7-edge-of-the-world-1",
+      "caseId": "fh-scenario-7-edge-of-the-world",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": true,
+      "score": 4,
+      "agreement": false,
+      "reasoning": "Required parts: (1) scenario name, (2) unlocks, (3) rewards, (4) monsters. The actual answer correctly identifies scenario 7 as 'Edge of the World' (Frosthaven, not another game). It correctly states unlocks as scenarios 13 and 14. It correctly lists rewards as 10 XP and campaign sticker coral-shard. However, the monsters list is entirely absent—the answer does not mention Lurker Clawcrusher or Lurker Soldier. This is an omission of a required part. Per hard failure rules, this caps the score at 3 maximum. However, the omission is minor (one of four required elements), the three present elements are entirely correct, and the answer is otherwise well-structured and usable at a game table for most purposes. Score 4 reflects that all explicitly stated content is accurate, but the missing monsters list prevents a perfect score.",
+      "rationale": "Should mention monsters"
+    },
+    {
+      "id": "e2-fail-fh-scenario-3-algox-offensive-1",
+      "caseId": "fh-scenario-3-algox-offensive",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": true,
+      "score": 5,
+      "agreement": false,
+      "reasoning": "REQUIRED PARTS: (1) Scenario 3 name, (2) Unlock information, (3) Reward information, (4) Monster list, (5) Frosthaven game confirmation. All present and correct. The actual answer identifies the scenario as 'Algox Offensive' ✓, states it unlocks 'Scenario 4A' ✓, confirms no explicit rewards (null field) ✓, and lists all four monster types (Algox Archer, Algox Guard, Algox Priest, Hound) ✓. The answer is clearly from Frosthaven (references Scenario Book 2-21, Copperneck Mountains, Frosthaven-specific mechanics) ✓. Extra detail (complexity, location, loot deck breakdown, goal mechanics, section references) adds helpful context without contradicting the expected answer. Perfect execution.",
+      "rationale": "Should mention unlocks and rewards"
+    },
+    {
+      "id": "e2-fail-fh-scenario-8-crystal-trench-1",
+      "caseId": "fh-scenario-8-crystal-trench",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "Required parts: (1) scenario name, (2) unlocks, (3) rewards, (4) monsters. The actual answer provides parts 1–3 correctly: Crystal Trench is correct, unlocks 15 and 16 are correct, and rewards (1 lumber, 2 hide) are correct. However, part 4 (monsters) is entirely omitted. The grading criteria explicitly requires 'unlock, reward, and monster information,' making monsters a required part. This is an OMISSION hard failure.",
+      "rationale": "Should mention monsters"
+    },
+    {
+      "id": "e2-pass-fh-monster-abael-herder-elite-level-5-1",
+      "caseId": "fh-monster-abael-herder-elite-level-5",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "Required parts: (1) HP 20, (2) Move 4, (3) Attack 5 for elite level 5 Abael Herder in Frosthaven. All three are present and correct. The additional note about 'muddle' is extra context that does not contradict the expected answer. No Gloomhaven 2e data used.",
+      "rationale": "Contingent on data showing muddle — VERIFIED: notes contain \"elite L5: muddle\""
+    },
+    {
+      "id": "e2-fail-fh-scenario-1-a-town-in-flames-1",
+      "caseId": "fh-scenario-1-a-town-in-flames",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "Required parts: (1) scenario name, (2) unlocks, (3) rewards, (4) monsters. The actual answer correctly identifies the scenario as 'A Town in Flames' and accurately states the unlocks (scenarios 2 and 3) and rewards (2+X morale based on City Guards remaining). However, the answer OMITS the monsters entirely, which is an explicit required part of the grading criteria ('Must include its Frosthaven structured unlock, reward, and monster information'). This is a hard failure under the OMISSION rule.",
+      "rationale": "Should include monsters (template fast-path omission)"
+    },
+    {
+      "id": "e2-pass-building-alchemist-1",
+      "caseId": "building-alchemist",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "Required parts: (1) Level 1 initial build cost is zero/no cost, (2) if upgrade costs are mentioned, must distinguish them from initial cost, (3) effect text optional but if included must be accurate. The actual answer covers all required parts: clearly states the Alchemist starts built at Level 1 with no build cost (explicitly listing all zero resources), correctly distinguishes the upgrade cost to Level 2 (1 prosperity, 2 lumber, 2 metal, 1 hide), and includes the accurate effect text 'characters cannot use potions' without penalty. The answer is well-organized, sourced, and contains no contradictions with the expected answer or grading criteria.",
+      "rationale": "No-potions downside VERIFIED as the L1 effect field in checked-in data"
+    },
+    {
+      "id": "e2-fail-fh-scenario-5-frozen-crypt-1",
+      "caseId": "fh-scenario-5-frozen-crypt",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "Required parts: (1) scenario name, (2) unlocks, (3) rewards, (4) monsters. The actual answer correctly identifies Frozen Crypt and accurately states unlocks (9 and 10) and rewards (2 lumber). However, it OMITS the monsters entirely—a required part explicitly stated in both the question ('what does its structured scenario data say about unlocks, rewards, and monsters') and the expected answer (which lists Ice Wraith as an example). This is a hard failure under the OMISSION rule: a required part is entirely absent from the answer.",
+      "rationale": "Should include monsters"
+    },
+    {
+      "id": "e2-pass-tool-free-assistant-game-1",
+      "caseId": "tool-free-assistant-game",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "Required parts: (1) mention Frosthaven, (2) mention Gloomhaven 2e, (3) one short sentence. All three present and correct. The actual answer clearly states support for both games in a single sentence, matching the expected answer semantically. The addition of 'Squire' as the assistant name is extra detail that does not contradict anything.",
+      "rationale": "Correct per Brian label."
+    },
+    {
+      "id": "e2-pass-rule-looting-definition-1",
+      "caseId": "rule-looting-definition",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "REQUIRED PARTS: (1) Define looting as collecting loot tokens and treasure tiles; (2) Mention Loot X range or automatic end-of-turn looting; (3) Must not answer with step-budget exhaustion or inability to answer. ANALYSIS: (1) Present and correct — the answer explicitly states 'Loot X is an ability that allows a figure to loot all loot tokens and treasure tiles within range X' and covers treasure tile looting separately. (2) Present and correct — the answer covers Loot X range mechanics in detail ('within range X, including any in their current hex'). The expected answer also mentions 'automatically looting loot tokens in their own hex at the end of their turn,' which is not explicitly stated in the actual answer, but the Loot X ability description covers the core mechanic of collecting tokens within range including the character's own hex. (3) Satisfied — the answer provides a complete, detailed response. The extra detail about loot card types, treasure tiles, monsters not looting treasure tiles, and resource timing is all accurate and contextually relevant, enhancing rather than contradicting the expected answer. The answer correctly distinguishes between character and monster looting behavior.",
+      "rationale": "Correct per Brian label."
+    },
+    {
+      "id": "e2-fail-gh2-scenario-6-decaying-crypt-1",
+      "caseId": "gh2-scenario-6-decaying-crypt",
+      "game": "gloomhaven-2e",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "Required parts: (1) scenario name, (2) unlocks, (3) rewards, (4) monsters. The actual answer provides parts 1, 2, and 3 correctly: Decaying Crypt is correct, unlocks 11 is correct, and rewards (10 XP, 5 gold) are correct. However, part 4 (monsters) is entirely omitted. The grading criteria explicitly requires 'monsters' to be included in the structured scenario data. This is a hard failure under OMISSION: a required part is absent from the answer.",
+      "rationale": "Should include monsters"
+    },
+    {
+      "id": "e2-fail-gh2-scenario-3-frozen-hollow-1",
+      "caseId": "gh2-scenario-3-frozen-hollow",
+      "game": "gloomhaven-2e",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "Required parts: (1) scenario name, (2) unlocks, (3) rewards, (4) monsters. The actual answer correctly identifies Frozen Hollow and accurately states unlocks (4, 5) and rewards (Prosperity 1). However, it OMITS the monsters entirely—a required part explicitly stated in the grading criteria ('must include its Gloomhaven 2e structured unlock, reward, and monster information'). The expected answer specifies monsters include Hound and Living Spirit. This omission is a hard failure per the evaluation rules.",
+      "rationale": "Should include monsters"
+    },
+    {
+      "id": "e2-fail-gh2-scenario-1-bandit-camp-1",
+      "caseId": "gh2-scenario-1-bandit-camp",
+      "game": "gloomhaven-2e",
+      "expectedPass": false,
+      "actualPass": true,
+      "score": 4,
+      "agreement": false,
+      "reasoning": "Required parts: (1) scenario name, (2) unlocks information, (3) rewards information, (4) monsters information. The actual answer correctly identifies Bandit Camp as scenario 1 (✓), correctly states it unlocks scenario 2 (✓), and correctly states the reward as 10 gold (✓). However, the monsters information is entirely absent from the actual answer (✗ omission of required part). This is a hard failure rule violation (OMISSION), which caps the score at 3 maximum. However, the answer is otherwise accurate and complete for three of four required parts, making it functionally usable at a game table for most purposes. Score 4 is appropriate because the omission is a single element (monsters) rather than a fundamental misunderstanding, and the three present parts are entirely correct.",
+      "rationale": "Should include monsters"
+    },
+    {
+      "id": "e2-fail-fh-character-ability-coral-overwhelming-wave-1",
+      "caseId": "fh-character-ability-coral-overwhelming-wave",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "Required parts: (1) Level 1 for Coral, (2) Initiative 86, (3) Top action summary, (4) Bottom action summary. The actual answer correctly identifies level 1 and initiative 86, but fails on the hard failure rule UNANSWERED: it states the top and bottom actions are 'not available in the current data' and refers the user to physical components, rather than providing the action text. The grading criteria explicitly forbids this approach ('stating that the ability text is unavailable in the data does not satisfy this'). Two of four required parts are present and correct, but the answer violates a hard failure condition by refusing to provide required information.",
+      "rationale": "Reconciled with #15: both fail — the table needs real card text, honest data-gap disclosure is not a pass (fix data via SQR-396)"
+    },
+    {
+      "id": "e2-pass-gh2-character-ability-mindthief-submissive-affliction-2",
+      "caseId": "gh2-character-ability-mindthief-submissive-affliction",
+      "game": "gloomhaven-2e",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "Required parts: (1) Level 1 for Mindthief — present and correct; (2) Initiative 48 — present and correct; (3) Top action (Attack 2, +1 per negative condition) — present and correct; (4) Bottom action (Control within Range 4, consume Ice, Damage 2) — present and correct, including the Ice-consumption rider as specified in grading criteria. All required elements are accurate. The extra note about it not being a lost card is harmless context that does not contradict anything.",
+      "rationale": "Does not need the extraneous \"not a lost card\" bit"
+    },
+    {
+      "id": "e2-pass-fh-item-004-crude-hide-armor-1",
+      "caseId": "fh-item-004-crude-hide-armor",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualPass": true,
+      "score": 5,
+      "agreement": true,
+      "reasoning": "Required parts: (1) identify as item #004 ✓, (2) include effect about disadvantage on next two attacks ✓, (3) use Frosthaven data ✓. The actual answer correctly identifies Crude Hide Armor as Frosthaven item #004, states the exact effect (attacker gains disadvantage on next two attacks targeting you), and provides additional accurate context (body slot, craft cost 2 hide, spent but refreshable). All required elements are present and accurate. The extra detail about the card being spent but not lost is correct and helpful, not contradictory.",
+      "rationale": "Does not need to explain spent-not-lost"
+    },
+    {
+      "id": "e2-fail-fh-character-ability-blinkblade-blurry-jab-3",
+      "caseId": "fh-character-ability-blinkblade-blurry-jab",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualPass": false,
+      "score": 3,
+      "agreement": true,
+      "reasoning": "Required parts: (1) level 1 identification, (2) two-speed initiative format (20 fast, 50 slow), (3) top action text, (4) bottom action text. The actual answer correctly identifies level 1 and presents the initiative values, but CONTRADICTS the grading criteria by describing 50 as a 'tiebreaker' rather than the slow initiative. More critically, it FAILS the hard rule UNANSWERED by stating the top and bottom actions are 'not available in the data' and refusing to provide them. The grading criteria explicitly forbids this response: 'stating that the ability text is unavailable in the data does not satisfy this.' The answer provides only 2 of 4 required parts and violates the explicit instruction about how to handle missing action text.",
+      "rationale": "Blinkblade cards always have TWO initiatives — fast/slow choice each round governs which is used; the \"tiebreaker of 50\" claim is a hallucination; all Blinkblade card data needs fixing"
+    }
+  ]
+}

--- a/docs/plans/sqr-392-table-qa-judge-calibration.md
+++ b/docs/plans/sqr-392-table-qa-judge-calibration.md
@@ -1,0 +1,39 @@
+# SQR-379 Table-QA Judge Calibration
+
+Generated: 2026-07-05T21:56:47.152Z
+
+## Summary
+
+| Metric                | Value                                            |
+| --------------------- | ------------------------------------------------ |
+| Fixture               | `eval/judge-calibration/table-qa-reference.json` |
+| Suite                 | `table-qa`                                       |
+| Split                 | `dev`                                            |
+| Judge model           | `claude-haiku-4-5-20251001`                      |
+| Judge prompt version  | `table-qa-answer-judge-v2`                       |
+| Judge prompt changed  | no                                               |
+| Estimated judge spend | $0.0080                                          |
+| Agreement             | 29/32 (90.6%)                                    |
+| Required agreement    | 85.0%                                            |
+| Calibration gate      | pass                                             |
+
+## By Game
+
+| Game          | Agreement     |
+| ------------- | ------------- |
+| Frosthaven    | 21/23 (91.3%) |
+| Gloomhaven 2e | 8/9 (88.9%)   |
+
+## Disagreements
+
+| Case                              | Expected | Judge | Score | Reasoning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --------------------------------- | -------- | ----- | ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fh-scenario-7-edge-of-the-world` | fail     | pass  | 4/5   | Required parts: (1) scenario name, (2) unlocks, (3) rewards, (4) monsters. The actual answer correctly identifies scenario 7 as 'Edge of the World' (Frosthaven, not another game). It correctly states unlocks as scenarios 13 and 14. It correctly lists rewards as 10 XP and campaign sticker coral-shard. However, the monsters list is entirely absent—the answer does not mention Lurker Clawcrusher or Lurker Soldier. This is an omission of a required part. Per hard failure rules, this caps the score at 3 maximum. However, the omission is minor (one of four required elements), the three present elements are entirely correct, and the answer is otherwise well-structured and usable at a game table for most purposes. Score 4 reflects that all explicitly stated content is accurate, but the missing monsters list prevents a perfect score. |
+| `fh-scenario-3-algox-offensive`   | fail     | pass  | 5/5   | REQUIRED PARTS: (1) Scenario 3 name, (2) Unlock information, (3) Reward information, (4) Monster list, (5) Frosthaven game confirmation. All present and correct. The actual answer identifies the scenario as 'Algox Offensive' ✓, states it unlocks 'Scenario 4A' ✓, confirms no explicit rewards (null field) ✓, and lists all four monster types (Algox Archer, Algox Guard, Algox Priest, Hound) ✓. The answer is clearly from Frosthaven (references Scenario Book 2-21, Copperneck Mountains, Frosthaven-specific mechanics) ✓. Extra detail (complexity, location, loot deck breakdown, goal mechanics, section references) adds helpful context without contradicting the expected answer. Perfect execution.                                                                                                                                              |
+| `gh2-scenario-1-bandit-camp`      | fail     | pass  | 4/5   | Required parts: (1) scenario name, (2) unlocks information, (3) rewards information, (4) monsters information. The actual answer correctly identifies Bandit Camp as scenario 1 (✓), correctly states it unlocks scenario 2 (✓), and correctly states the reward as 10 gold (✓). However, the monsters information is entirely absent from the actual answer (✗ omission of required part). This is a hard failure rule violation (OMISSION), which caps the score at 3 maximum. However, the answer is otherwise accurate and complete for three of four required parts, making it functionally usable at a game table for most purposes. Score 4 is appropriate because the omission is a single element (monsters) rather than a fundamental misunderstanding, and the three present parts are entirely correct.                                                 |
+
+## Notes
+
+- This calibration uses only `table-qa` dev cases. Holdout cases were not used.
+- Safety, groundedness, and source-boundary scoring remain deterministic and separate from this semantic answer judge.
+- Judge prompt changes invalidate comparisons. This run did not change the judge prompt.

--- a/docs/plans/sqr-392-table-turnaround-2-iteration-log.md
+++ b/docs/plans/sqr-392-table-turnaround-2-iteration-log.md
@@ -12,6 +12,8 @@ Actual-spend ledger (provider-reported, counts toward the $150 project cap):
 | Date       | Slice                                       | Actual provider spend |
 | ---------- | ------------------------------------------- | --------------------- |
 | 2026-07-05 | SQR-393 stratification (deterministic only) | $0.00                 |
+| 2026-07-05 | SQR-394 rebalance authoring (deterministic) | $0.00                 |
+| 2026-07-05 | SQR-392 judge calibration (5 runs)          | ~$0.05                |
 
 ## 2026-07-05 — SQR-393: question-class stratification and per-class latency
 
@@ -114,3 +116,67 @@ upstream GHS files, and the local link graph).
 Decision: keep, pending `npm run check` and LangSmith reseed in this slice's
 PR. Epoch-2 baseline (SQR-395) remains blocked on calibration batch 4 and on
 the item #15 / item #30 label reconciliation.
+
+## 2026-07-05 — SQR-392: frozen human-labeled judge calibration
+
+Hypothesis: calibrating the semantic answer judge against Brian's frozen
+labels will produce a defensible judge before the epoch-2 baseline — and
+expose how misleading the epoch-1 self-authored calibration was.
+
+Fixture:
+
+- 32 human-labeled reference verdicts (14 pass / 18 fail), labeled by Brian
+  in four chat batches from real epoch-1 run answers; one candidate excluded
+  (no ground-truth access). Every item carries a `provenance` field; the
+  fixture is FROZEN — disagreements fix the judge or escalate, never the
+  reference. Fixture schema bumped to version 2; the duplicate rule now
+  permits multiple distinct answers per case (distinct failure modes) while
+  rejecting duplicated answer text.
+- Two label reconciliations recorded: item 7 flipped to pass (Brian confirmed
+  the 7-demon scenario-9 data); item 30 flipped to fail (consistent with item
+  15: the table needs real card text — honest data-gap disclosure is not a
+  pass).
+
+Calibration journey (each run ~$0.01 judge spend, temperature-stabilized):
+
+- v1 judge (epoch-1, self-calibrated at "100%"): **17/32 (53.1%)** against
+  human labels — barely better than a coin flip. Failure classes: passing
+  answers that omit explicitly-asked-for parts, passing "data doesn't have
+  it" non-answers, tolerating invented detail.
+- v2 draft (hard failure rules incl. a broad INVENTION rule): 19/32 (59.4%).
+  The invention rule was too blunt — it failed Brian-passed answers whose
+  extra detail is data-backed (Mindthief Ice rider, the seven demons).
+- v2 final (`table-qa-answer-judge-v2`): required-parts checklist procedure,
+  OMISSION/UNANSWERED/CONTRADICTION/WRONG-SUBJECT hard failure rules,
+  contradiction-only treatment of extra detail, `temperature: 0` and larger
+  reasoning budget on the judge call: **29/32 (90.6%)**, identical on a
+  repeat run. Gate (≥85%): **pass**.
+
+Documented factual case fixes applied alongside (all sanctioned by Brian's
+explicit rulings during labeling, separate from tuning):
+
+- `gh2-scenario-9-ruinous-rift`: expected now names all seven demon types
+  (Brian confirmed the checked-in GHS data is right).
+- `gh2-character-ability-mindthief-submissive-affliction`: bottom action
+  completed with the Ice-consumption rider Brian passed twice.
+- `gh2-character-ability-cragheart-opposing-strike`: bottom action completed
+  with "perform Heal 2, Range 3" per Brian's card reading (SQR-396 tracks the
+  underlying import fix).
+- `fh-character-ability-blinkblade-blurry-jab`: expected/grading now encode
+  two-speed initiative (20 fast / 50 slow, never "2050" or a "tiebreaker")
+  and reject data-gap non-answers. This case will fail baselines until
+  SQR-396 restores the ability text — that is a true defect signal.
+- `fh-character-ability-coral-overwhelming-wave`: grading likewise rejects
+  data-gap non-answers per Brian's item-30 reconciliation.
+
+Known residual judge weakness (documented, not tuned away): three reference
+fails still pass — the judge occasionally accepts multi-part scenario answers
+that omit monsters/unlocks under specific phrasings
+(`fh-scenario-7-edge-of-the-world`, `fh-scenario-3-algox-offensive`,
+`gh2-scenario-1-bandit-camp`). Watch these in baseline disagreement reviews;
+do not tighten the prompt against exactly these items.
+
+Eval spend: ~$0.05 actual judge spend across five calibration runs.
+
+Decision: keep. The judge is now human-calibrated at 90.6% with a frozen
+reference set. SQR-395 (epoch-2 double baseline + noise floor) is unblocked.

--- a/eval/evaluators.ts
+++ b/eval/evaluators.ts
@@ -17,23 +17,37 @@ interface EvalRunOutput {
 }
 
 export const ANSWER_JUDGE_MODEL = 'claude-haiku-4-5-20251001';
-export const ANSWER_JUDGE_PROMPT_VERSION = 'table-qa-answer-judge-v1';
+export const ANSWER_JUDGE_PROMPT_VERSION = 'table-qa-answer-judge-v2';
 
-export const ANSWER_JUDGE_PROMPT = `You are an evaluation judge for a Frosthaven and Gloomhaven (2nd Edition) board game rules assistant.
+// v2 (SQR-392): recalibrated against Brian's frozen human labels. v1 passed
+// answers that omitted asked-for parts, disclosed data gaps instead of
+// answering, or invented details — all hard fails at a real table.
+export const ANSWER_JUDGE_PROMPT = `You are an evaluation judge for a Frosthaven and Gloomhaven (2nd Edition) board game rules assistant. The bar is a real game table: an answer passes only if the players could act on it without re-checking the book.
 
 Given a question, expected answer, grading criteria, and the actual answer from the system, evaluate whether the actual answer is correct.
 Use the grading criteria as the source of truth. Accept semantically equivalent wording unless the grading criteria explicitly forbids it.
-Do not penalize extra correct context, examples, caveats, or optional variants unless they contradict the expected answer or grading criteria.
+Extra detail beyond the expected answer is fine and never penalized on its own — many correct answers add context from the game data. Only penalize extra detail when it CONTRADICTS the expected answer or grading criteria.
+
+Evaluation procedure — do this in order:
+1. REQUIRED PARTS: List every distinct part the question and grading criteria explicitly require (for example, a question asking about "unlocks, rewards, and monsters" requires three parts; grading saying "must include X and Y" requires both).
+2. For EACH required part, check: is it present in the actual answer with correct content?
+3. Apply the hard failure rules below.
+
+Hard failure rules — any of these caps the score at 3 (fail), regardless of what else is right:
+- OMISSION: any required part from step 1 is entirely absent from the answer. An answer that covers two of three asked-for parts fails, even if those two are perfect.
+- UNANSWERED: the answer says a required part is unavailable, missing from the data, or refers the user to the physical components. Honest non-answers are still non-answers.
+- CONTRADICTION: the answer states values, names, or mechanics that conflict with the expected answer or grading criteria.
+- WRONG SUBJECT: the answer addresses a different record, scenario, card, or game than the one asked about.
 
 Score on a 1-5 scale:
-5 = Perfect — all required information present and accurate
-4 = Good — minor omissions but core answer is correct
-3 = Partial — some correct information but missing key details
+5 = Perfect — all required parts present and accurate
+4 = Good — all required parts present; only trivial wording gaps
+3 = Partial — a hard failure rule applies, or key required details are missing
 2 = Poor — mostly incorrect or very incomplete
 1 = Wrong — incorrect answer or completely unrelated
 
 Respond with ONLY valid JSON in this exact format:
-{"score": <1-5>, "pass": <true if score >= 4>, "reasoning": "<brief explanation>"}`;
+{"score": <1-5>, "pass": <true if score >= 4>, "reasoning": "<first the required parts and which are missing, then brief explanation>"}`;
 
 export async function judgeAnswer(
   anthropic: Anthropic,
@@ -44,7 +58,10 @@ export async function judgeAnswer(
 ): Promise<{ score: number; pass: boolean; reasoning: string }> {
   const response = await anthropic.messages.create({
     model: ANSWER_JUDGE_MODEL,
-    max_tokens: 256,
+    max_tokens: 512,
+    // Deterministic judging: calibration exposed run-to-run verdict flips on
+    // borderline items at the default temperature (SQR-392).
+    temperature: 0,
     system: ANSWER_JUDGE_PROMPT,
     messages: [
       {

--- a/eval/judge-calibration.ts
+++ b/eval/judge-calibration.ts
@@ -135,7 +135,7 @@ export function resolveJudgeCalibrationItems(
     // failure modes (e.g. honest data-gap vs hallucinated detail). The real
     // invariant is that the SAME answer never appears twice for one case,
     // which would allow contradictory or padded verdicts.
-    const caseLabel = `${item.caseId}::${item.actualAnswer}`;
+    const caseLabel = JSON.stringify([item.caseId, item.actualAnswer]);
     if (seenCaseLabels.has(caseLabel)) {
       throw new Error(`Duplicate judge calibration answer for case ${item.caseId}`);
     }

--- a/eval/judge-calibration.ts
+++ b/eval/judge-calibration.ts
@@ -17,9 +17,9 @@ export const DEFAULT_JUDGE_CALIBRATION_FIXTURE_PATH = join(
   'table-qa-reference.json',
 );
 export const DEFAULT_JUDGE_CALIBRATION_REPORT_JSON_PATH =
-  'docs/plans/sqr-379-table-qa-judge-calibration.json';
+  'docs/plans/sqr-392-table-qa-judge-calibration.json';
 export const DEFAULT_JUDGE_CALIBRATION_REPORT_MARKDOWN_PATH =
-  'docs/plans/sqr-379-table-qa-judge-calibration.md';
+  'docs/plans/sqr-392-table-qa-judge-calibration.md';
 export const ESTIMATED_JUDGE_COST_USD_PER_ITEM = 0.00025;
 
 const CalibrationItemSchema = z.strictObject({
@@ -29,10 +29,16 @@ const CalibrationItemSchema = z.strictObject({
   expectedPass: z.boolean(),
   actualAnswer: z.string().min(1),
   rationale: z.string().min(1),
+  /**
+   * Human-labeling provenance (SQR-392). Epoch-2 references are FROZEN:
+   * a judge/reference disagreement is resolved by fixing the judge or
+   * escalating to Brian — never by editing a reference verdict.
+   */
+  provenance: z.string().min(1),
 });
 
 const CalibrationFixtureSchema = z.strictObject({
-  version: z.literal(1),
+  version: z.literal(2),
   suite: z.literal('table-qa'),
   split: z.literal('dev'),
   description: z.string().min(1),
@@ -125,9 +131,13 @@ export function resolveJudgeCalibrationItems(
     }
     seenIds.add(item.id);
 
-    const caseLabel = `${item.caseId}:${item.expectedPass ? 'pass' : 'fail'}`;
+    // Multiple items per case are allowed — distinct answers capture distinct
+    // failure modes (e.g. honest data-gap vs hallucinated detail). The real
+    // invariant is that the SAME answer never appears twice for one case,
+    // which would allow contradictory or padded verdicts.
+    const caseLabel = `${item.caseId}::${item.actualAnswer}`;
     if (seenCaseLabels.has(caseLabel)) {
-      throw new Error(`Duplicate judge calibration verdict for ${caseLabel}`);
+      throw new Error(`Duplicate judge calibration answer for case ${item.caseId}`);
     }
     seenCaseLabels.add(caseLabel);
 

--- a/eval/judge-calibration/table-qa-reference.json
+++ b/eval/judge-calibration/table-qa-reference.json
@@ -1,408 +1,296 @@
 {
-  "version": 1,
+  "version": 2,
   "suite": "table-qa",
   "split": "dev",
-  "description": "Reference answer verdicts for calibrating the table-qa semantic judge. Items intentionally use dev cases only so holdout remains untouched for baseline and release gates.",
+  "description": "FROZEN human-labeled reference verdicts for calibrating the table-qa semantic judge (epoch 2, SQR-392). Every verdict was labeled by Brian in chat on 2026-07-05 from real epoch-1 run answers; provenance records the labeling batch. Never edit a verdict to agree with the judge \u2014 fix the judge or escalate. Dev cases only; holdout untouched.",
   "items": [
     {
-      "id": "fh-pass-long-rest-init",
-      "caseId": "rule-long-rest-init",
-      "game": "frosthaven",
-      "expectedPass": true,
-      "actualAnswer": "In Frosthaven, a long rest has initiative 99.",
-      "rationale": "Correctly gives the exact Frosthaven long-rest initiative."
+      "id": "e2-fail-gh2-character-ability-cragheart-opposing-strike-1",
+      "caseId": "gh2-character-ability-cragheart-opposing-strike",
+      "game": "gloomhaven-2e",
+      "expectedPass": false,
+      "actualAnswer": "Here's what the verified tool data shows for the Cragheart's **Opposing Strike** (card #116):\n\n- **Level:** 1\n- **Initiative:** 46\n- **Top Action:** *Attack 3*\n- **Bottom Action:** \"At the end of this and your next four turns, perform:\" \u2014 the specific effect that follows this text is **not available** in the checked-in card data.\n\nThe bottom action's triggered effect is missing from the data. You'd need to reference the physical card for the full bottom action details.",
+      "rationale": "Expected AND answer both wrong: bottom action should be \"at the end of this and your next four turns, perform Heal 2, Range 3\" \u2014 checked-in data missing sub-actions (import bug)",
+      "provenance": "brian-2026-07-05-batch1"
     },
     {
-      "id": "fh-pass-poison",
-      "caseId": "rule-poison",
+      "id": "e2-fail-fh-scenario-4b-heart-of-ice-b-1",
+      "caseId": "fh-scenario-4b-heart-of-ice-b",
       "game": "frosthaven",
-      "expectedPass": true,
-      "actualAnswer": "Poison makes all attacks targeting the poisoned figure gain +1 Attack. It is removed when the figure is healed, but that heal does not restore hit points.",
-      "rationale": "Includes the required attack bonus and heal-prevention behavior."
+      "expectedPass": false,
+      "actualAnswer": "The data available does not include a scenario identified as **4B** in Frosthaven. The scenario book source covers 162 scenarios and the card data covers 159 scenario records, but none of the tool results returned a match \u2014 by lookup, resolution, or search \u2014 for \"scenario 4B.\"\n\n**What's missing:** A scenario with the identifier \"4B\" is not found in the checked data. Frosthaven scenarios are generally numbered (e.g., 1\u2013138 plus some unlockable extras), not labeled with letter suffixes. It's possible you may be thinking of a different identifier \u2014 for example, a **section** number like 4.B, or a scenario from a different product. If you can share more context about where you encountered \"scenario 4B,\" I can try a more targeted lookup.",
+      "rationale": "Should recognize 4B means variant B of scenario 4",
+      "provenance": "brian-2026-07-05-batch1"
     },
     {
-      "id": "fh-pass-small-items",
-      "caseId": "rule-small-items",
+      "id": "e2-pass-rule-scenario-level-1",
+      "caseId": "rule-scenario-level",
       "game": "frosthaven",
       "expectedPass": true,
-      "actualAnswer": "A Frosthaven character may bring small items equal to half their level, rounded up.",
-      "rationale": "Matches the required small-item limit."
+      "actualAnswer": "Here's how the recommended scenario level is calculated in Frosthaven:\n\n> At recommended difficulty, the scenario level is equal to the average level of the characters divided by 2 (rounded up).\n\n**Example from the rulebook:** If all characters are level 2, the average level (2) \u00f7 2 = 1, so the scenario is still level 1. Only once a character reaches level 3 would the scenario level potentially increase.\n\n---\n\n**A few important notes:**\n\n- The scenario level can always be set to any number from **0\u20137** at the start of a scenario, regardless of the recommendation. Lower if your party is struggling; higher if you want more challenge.\n- **Solo mode** (or the **Open Information** variant): Add 1 to the average character level *before* dividing by 2 and rounding up. For example, three level 4 characters normally gives scenario level 2, but in solo mode it becomes ((4+1)\u00f72, rounded up) = 3.\n\n**What the scenario level affects:**\n\n| Scenario Level | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |\n|---|---|---|---|---|---|---|---|---|\n| Monster Level | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |\n| Gold Conversion | 2 | 2 | 3 | 3 | 4 | 4 | 5 | 6 |\n| Trap Damage | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |\n| Hazardous Terrain | 1 | 2 | 2 | 2 | 3 | 3 | 3 | 4 |\n| Bonus Experience | 4 | 6 | 8 | 10 | 12 | 14 | 16 | 18 |\n\n*(Rulebook, p. 16)*",
+      "rationale": "Correct per Brian label.",
+      "provenance": "brian-2026-07-05-batch1"
     },
     {
-      "id": "fh-pass-spyglass",
-      "caseId": "item-spyglass",
-      "game": "frosthaven",
+      "id": "e2-pass-gh2-character-ability-mindthief-submissive-affliction-1",
+      "caseId": "gh2-character-ability-mindthief-submissive-affliction",
+      "game": "gloomhaven-2e",
       "expectedPass": true,
-      "actualAnswer": "Spyglass is Frosthaven item #001. It is a head item with craft cost 1 metal, and during your attack ability it lets you gain advantage on one attack.",
-      "rationale": "Gives the item number, slot/cost context, and effect."
+      "actualAnswer": "Here are the details for **Submissive Affliction** (Mindthief, Gloomhaven 2e):\n\n| Field | Details |\n|---|---|\n| **Level** | 1 |\n| **Initiative** | 48 |\n| **Top Action** | Attack 2, Add Attack +1 for each negative condition the target has. |\n| **Bottom Action** | Control one enemy within *Range 4*: consume Ice \u2014 the controlled enemy suffers *Damage 2* |\n\n*(Source: GHS Card Index \u2014 Gloomhaven 2e, Mindthief card #146)*",
+      "rationale": "Correct per Brian label.",
+      "provenance": "brian-2026-07-05-batch1"
     },
     {
-      "id": "fh-pass-building-alchemist",
-      "caseId": "building-alchemist",
-      "game": "frosthaven",
-      "expectedPass": true,
-      "actualAnswer": "The Alchemist starts built in Frosthaven, so its level 1 initial build cost is no cost: 0 prosperity, 0 gold, 0 lumber, 0 metal, and 0 hide.",
-      "rationale": "Correctly avoids confusing the start-built cost with upgrade cost."
-    },
-    {
-      "id": "fh-pass-scenario-61",
-      "caseId": "scenario-61-unlock",
-      "game": "frosthaven",
-      "expectedPass": true,
-      "actualAnswer": "Section 79.4 unlocks scenario 61, Life and Death. It is the Crain/star iron section, and the rewards include the new scenario unlock.",
-      "rationale": "Names the section and unlocked scenario."
-    },
-    {
-      "id": "fh-pass-crude-boots",
-      "caseId": "item-crude-boots",
-      "game": "frosthaven",
-      "expectedPass": true,
-      "actualAnswer": "Crude Boots are a Frosthaven legs item with craft cost 2 hide. During your move ability, they add +1 movement.",
-      "rationale": "Correct effect and item context."
-    },
-    {
-      "id": "fh-pass-abael-herder-elite",
-      "caseId": "fh-monster-abael-herder-elite-level-5",
-      "game": "frosthaven",
-      "expectedPass": true,
-      "actualAnswer": "An elite level 5 Abael Herder in Frosthaven has HP 20, Move 4, and Attack 5.",
-      "rationale": "All requested monster stats are correct."
-    },
-    {
-      "id": "fh-pass-edge-of-world",
-      "caseId": "fh-scenario-7-edge-of-the-world",
-      "game": "frosthaven",
-      "expectedPass": true,
-      "actualAnswer": "Scenario 7 is Edge of the World. It unlocks 13 and 14, rewards 10 XP and the coral-shard campaign sticker, and includes Lurker Clawcrusher and Lurker Soldier among its monsters.",
-      "rationale": "Covers title, unlocks, reward, and monster data."
-    },
-    {
-      "id": "fh-pass-boneshaper-mat",
+      "id": "e2-fail-fh-character-mat-boneshaper-1",
       "caseId": "fh-character-mat-boneshaper",
       "game": "frosthaven",
-      "expectedPass": true,
-      "actualAnswer": "Boneshaper has hand size 12, HP 6 at level 1, HP 14 at level 9, and the traits arcane, educated, and intimidating.",
-      "rationale": "Matches all requested character-mat fields."
+      "expectedPass": false,
+      "actualAnswer": "Scenario 1 is A Town in Flames. It unlocks scenarios 2 and 3. Its rewards are (Gain 2+X morale, where X is the number of City Guards still on the map.).",
+      "rationale": "Wrong category of answer (scenario data for a character-mat question)",
+      "provenance": "brian-2026-07-05-batch1"
     },
     {
-      "id": "fh-pass-fish-net",
-      "caseId": "fh-monster-ability-abael-herder-fish-net",
+      "id": "e2-pass-fh-monster-ability-algox-snowspeaker-trap-solo-blinding-vortex-1",
+      "caseId": "fh-monster-ability-algox-snowspeaker-trap-solo-blinding-vortex",
       "game": "frosthaven",
       "expectedPass": true,
-      "actualAnswer": "Fish Net has initiative 20. Its abilities are Move 0 and Attack 0 at Range 3 with Pull 2 and Immobilize.",
-      "rationale": "Correctly states initiative and ability text."
+      "actualAnswer": "Here is the **Algox Snowspeaker Trap Solo** \u2014 **Blinding Vortex** monster ability card:\n\n- **Initiative:** 22\n- **Abilities:**\n  - *Move 0*\n  - *Attack 1*, Range 2, *Muddle*\n  - Element: Air\n\n*(Source: Card Index \u2014 Frosthaven monster ability card, Algox Snowspeaker Trap Solo)*",
+      "rationale": "Brian asks what \"Algox Snowspeaker Trap Solo\" is \u2014 data-shaped phrasing, flag for rebalance review",
+      "provenance": "brian-2026-07-05-batch1"
     },
     {
-      "id": "fh-pass-accountant",
+      "id": "e2-pass-gh2-scenario-9-ruinous-rift-1",
+      "caseId": "gh2-scenario-9-ruinous-rift",
+      "game": "gloomhaven-2e",
+      "expectedPass": true,
+      "actualAnswer": "Here is what the structured data says about **Scenario 9** in Gloomhaven (2nd Edition):\n\n---\n\n**Scenario 9 \u2014 Ruinous Rift**\n*Source: Scenario Book | Flow Chart Group: Hail | Main Campaign*\n\n### Rewards\n- **Prosperity 1**\n\n### Unlocks\n- None listed in the structured data.\n\n### Monsters\nThe following monster types appear in this scenario:\n- Chaos Demon\n- Earth Demon\n- Flame Demon\n- Frost Demon\n- Night Demon\n- Sun Demon\n- Wind Demon\n\n### Objectives\n- **Hail** (escort objective)\n\n### Other Notes\n- This is **not** an initial/starting scenario.\n- No additional requirements or loot deck configuration are recorded in the structured data.",
+      "rationale": "Reconciled 2026-07-05: checked-in GHS 7-demon data confirmed right; consistent with #13 pass",
+      "provenance": "brian-2026-07-05-batch1-reconciled"
+    },
+    {
+      "id": "e2-fail-fh-scenario-4b-heart-of-ice-b-2",
+      "caseId": "fh-scenario-4b-heart-of-ice-b",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualAnswer": "Based on the tool results from this run, **\"scenario 4B\" does not exist** in the Frosthaven data. All three lookups \u2014 direct lookup, resolve, and search \u2014 returned no results for that identifier.\n\nFrosthaven scenarios are numbered with plain integers (e.g., scenario 4, scenario 5). The game does not use lettered sub-scenario identifiers like \"4B\" in its structured scenario data. It's possible you may be thinking of a **section number** (e.g., section 4.B or similar) rather than a scenario, or perhaps a scenario from a different product.\n\nIf you can clarify what you're looking for \u2014 such as the scenario's name, a nearby scenario number, or a section reference \u2014 I'm happy to look it up properly.",
+      "rationale": "Factually incorrect: claims FH has no lettered sub-scenario identifiers",
+      "provenance": "brian-2026-07-05-batch1"
+    },
+    {
+      "id": "e2-pass-fh-battle-goal-accountant-1",
       "caseId": "fh-battle-goal-accountant",
       "game": "frosthaven",
       "expectedPass": true,
-      "actualAnswer": "The Accountant battle goal requires you to have zero cards in your hand each time you rest. It is worth 1 checkmark.",
-      "rationale": "Correct battle-goal requirement and checkmark value."
+      "actualAnswer": "Here are the details for the **Accountant** battle goal in Frosthaven:\n\n- **Condition:** Have zero cards in your hand each time you rest.\n- **Checkmarks:** 1\n\nSo you must make sure your hand is completely empty every time you perform a rest during the scenario to earn the single checkmark reward.",
+      "rationale": "Correct per Brian label.",
+      "provenance": "brian-2026-07-05-batch1"
     },
     {
-      "id": "fh-pass-protective-scepter",
-      "caseId": "fh-item-009-protective-scepter",
-      "game": "frosthaven",
-      "expectedPass": true,
-      "actualAnswer": "Protective Scepter is item #009, a one-hand item crafted from 1 lumber and 1 hide. During your turn, it grants one ally within Range 2 Shield 1, and it is spent.",
-      "rationale": "Correct number, cost, and effect."
-    },
-    {
-      "id": "fh-fail-scenario-level-rounding",
-      "caseId": "rule-scenario-level",
-      "game": "frosthaven",
+      "id": "e2-fail-gh2-character-ability-cragheart-opposing-strike-2",
+      "caseId": "gh2-character-ability-cragheart-opposing-strike",
+      "game": "gloomhaven-2e",
       "expectedPass": false,
-      "actualAnswer": "Use the average character level exactly, rounded down, as the Frosthaven scenario level.",
-      "rationale": "Wrong formula and rounding direction."
+      "actualAnswer": "Here's what the verified data shows for the Cragheart's **Opposing Strike** (Gloomhaven 2e):\n\n| Field | Value |\n|---|---|\n| **Level** | 1 |\n| **Initiative** | 46 |\n| **Top Action** | *Attack 3* |\n| **Bottom Action** | At the end of this and your next four turns, perform: *(effect details not available in the checked-in data)* |\n| **Lost** | Yes |\n\nThe bottom action's repeated effect is not fully detailed in the tool data \u2014 you'll need to check the physical card for the specific ability performed over those five turns.",
+      "rationale": "Same as #1: missing Heal 2 Range 3 bottom-action detail",
+      "provenance": "brian-2026-07-05-batch1"
     },
     {
-      "id": "fh-fail-brittle-attack-only",
-      "caseId": "rule-brittle",
-      "game": "frosthaven",
-      "expectedPass": false,
-      "actualAnswer": "Brittle doubles the next attack against the figure, but it does not affect other damage sources.",
-      "rationale": "Incorrectly narrows Brittle to attacks instead of damage."
-    },
-    {
-      "id": "fh-fail-living-bones-immunity",
-      "caseId": "monster-living-bones-immunity",
-      "game": "frosthaven",
-      "expectedPass": false,
-      "actualAnswer": "Frosthaven Living Bones are immune to Poison and Wound.",
-      "rationale": "Contradicts the checked-in Frosthaven monster stat data."
-    },
-    {
-      "id": "fh-fail-crude-helmet-number-effect",
-      "caseId": "item-crude-helmet",
-      "game": "frosthaven",
-      "expectedPass": false,
-      "actualAnswer": "Crude Helmet is item #003 and gives Shield 1 for the next attack.",
-      "rationale": "Wrong item number and wrong effect."
-    },
-    {
-      "id": "fh-fail-drifter-perk",
+      "id": "e2-pass-drifter-ignore-negative-item-effects-correction-1",
       "caseId": "drifter-ignore-negative-item-effects-correction",
       "game": "frosthaven",
-      "expectedPass": false,
-      "actualAnswer": "The Frosthaven Drifter has no perk for ignoring negative item effects.",
-      "rationale": "Directly contradicts the required correction."
+      "expectedPass": true,
+      "actualAnswer": "The Drifter **does** have a perk that ignores negative item effects. The verified perk text reads:\n\n> \"You may ignore negative item effects and the appearance of a cursed item\"\n\nI was wrong to say otherwise. Apologies for the earlier error.",
+      "rationale": "Should not apologize: chat-session-relative apology has nothing to do with game data (behavior note for prompt work)",
+      "provenance": "brian-2026-07-05-batch2"
     },
     {
-      "id": "fh-fail-crude-boots-cost",
-      "caseId": "fh-item-005-crude-boots",
+      "id": "e2-pass-gh2-scenario-9-ruinous-rift-2",
+      "caseId": "gh2-scenario-9-ruinous-rift",
+      "game": "gloomhaven-2e",
+      "expectedPass": true,
+      "actualAnswer": "Here is what the structured data says about **Scenario 9** in Gloomhaven (2nd Edition):\n\n---\n\n## Scenario 9 \u2014 *Ruinous Rift*\n\n**Group:** Main campaign (flow chart group: Hail)\n\n---\n\n### Rewards\n- **Prosperity 1**\n\n---\n\n### Unlocks\n- None listed in the structured data.\n\n---\n\n### Monsters\nThe following monster types appear in this scenario:\n1. Chaos Demon\n2. Earth Demon\n3. Flame Demon\n4. Frost Demon\n5. Night Demon\n6. Sun Demon\n7. Wind Demon\n\n---\n\n### Objectives\n- **Hail** (escort objective)\n\n---\n\n**Source:** Gloomhaven (2nd Edition) Scenario Book, Scenario 9.\n\n> Note: The structured data does not include a complexity rating or specific page reference for this scenario.",
+      "rationale": "Confirmed: checked-in GHS data (7 demons) is right",
+      "provenance": "brian-2026-07-05-batch2"
+    },
+    {
+      "id": "e2-fail-fh-monster-ability-ancient-artillery-long-shot-1",
+      "caseId": "fh-monster-ability-ancient-artillery-long-shot",
       "game": "frosthaven",
       "expectedPass": false,
-      "actualAnswer": "Crude Boots cost 15 gold and add Jump to every move for the round.",
-      "rationale": "Uses Gloomhaven-like pricing and wrong effect."
+      "actualAnswer": "Based on the verified tool results from this conversation, the Ancient Artillery ability deck contains the following cards that were confirmed:\n\n- **Concussive Burst** (initiative 46)\n- **Defensive Ordinance** (initiative 17)\n- **Exploding Ammunition** (initiative 71)\n- **Grenade** (initiative 37)\n- **Massive Blast** (initiative 57)\n- **Heavy Shot** (initiative 95)\n\n**\"Long Shot\" was not found in any of the tool results.** The data returned does not include a card by that name for the Ancient Artillery monster ability deck. It's possible the card exists in the physical deck but is not present in the checked-in data, or the card may go by a different name in the dataset. I cannot confirm the initiative value or abilities for a \"Long Shot\" card without a verified tool result supporting it.",
+      "rationale": "Deck should have 8 cards and definitely has Long Shot; DB has Long Shot (agent retrieval miss) + GHS composition is 8 with Exploding Ammunition x2",
+      "provenance": "brian-2026-07-05-batch2"
     },
     {
-      "id": "fh-fail-abael-scout-stats",
-      "caseId": "fh-monster-abael-scout-normal-level-2",
+      "id": "e2-fail-fh-character-ability-blinkblade-blurry-jab-1",
+      "caseId": "fh-character-ability-blinkblade-blurry-jab",
       "game": "frosthaven",
       "expectedPass": false,
-      "actualAnswer": "A normal level 2 Abael Scout has HP 8, Move 2, and Attack 5.",
-      "rationale": "All requested stats are wrong."
+      "actualAnswer": "Here's what the verified tool data shows for **Blurry Jab** (Blinkblade):\n\n- **Level:** 1\n- **Initiative:** 2050\n- **Top action:** Not available in the checked-in data\n- **Bottom action:** Not available in the checked-in data\n\nThe card is confirmed as a Level 1 Blinkblade ability card with an initiative of 2050, but the detailed ability text for the top and bottom actions is not present in the current dataset.",
+      "rationale": "Expected and answer both wrong \u2014 case codifies data hole (SQR-396)",
+      "provenance": "brian-2026-07-05-batch2"
     },
     {
-      "id": "fh-fail-frozen-crypt-unlock",
-      "caseId": "fh-scenario-5-frozen-crypt",
+      "id": "e2-fail-fh-character-ability-blinkblade-blurry-jab-2",
+      "caseId": "fh-character-ability-blinkblade-blurry-jab",
       "game": "frosthaven",
       "expectedPass": false,
-      "actualAnswer": "Scenario 5 is Frozen Crypt, but it unlocks 13 and 14 and rewards 10 XP.",
-      "rationale": "Title is right but unlock and reward are wrong."
+      "actualAnswer": "Here is what the verified tool data confirms for **Blurry Jab** (Blinkblade):\n\n- **Level:** 1\n- **Initiative:** 20 (the raw value 2050 represents initiative 20, position 50 within that initiative)\n- **Top action:** Not available in the current data\n- **Bottom action:** Not available in the current data\n\nThe card index does not yet contain the ability text for either the top or bottom actions of Blurry Jab. You'd need to refer to your physical card for those details.",
+      "rationale": "2050 = initiative 20 when fast, 50 when slow (Blinkblade two-speed); top/bottom should be available",
+      "provenance": "brian-2026-07-05-batch2"
     },
     {
-      "id": "fh-fail-astral-mat",
-      "caseId": "fh-character-mat-astral",
+      "id": "e2-pass-fh-item-002-crude-helmet-1",
+      "caseId": "fh-item-002-crude-helmet",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualAnswer": "Crude Helmet is item #002. It is a head-slot item with craft cost 1 metal. Effect: When you are attacked, treat any Double attack modifier card the enemy draws as a +1 instead.",
+      "rationale": "Correct per Brian label.",
+      "provenance": "brian-2026-07-05-batch2"
+    },
+    {
+      "id": "e2-fail-fh-scenario-7-edge-of-the-world-1",
+      "caseId": "fh-scenario-7-edge-of-the-world",
       "game": "frosthaven",
       "expectedPass": false,
-      "actualAnswer": "Astral has hand size 9, HP 10 at level 1, HP 26 at level 9, and the traits outcast and nimble.",
-      "rationale": "Wrong hand size, HP, and traits."
+      "actualAnswer": "Scenario 7 is Edge of the World. It unlocks scenarios 13 and 14. Its rewards are 10 XP, campaign sticker coral-shard.",
+      "rationale": "Should mention monsters",
+      "provenance": "brian-2026-07-05-batch2"
     },
     {
-      "id": "fh-fail-blinding-vortex",
-      "caseId": "fh-monster-ability-algox-snowspeaker-trap-solo-blinding-vortex",
+      "id": "e2-fail-fh-scenario-3-algox-offensive-1",
+      "caseId": "fh-scenario-3-algox-offensive",
       "game": "frosthaven",
       "expectedPass": false,
-      "actualAnswer": "Blinding Vortex has initiative 50 and only performs Attack 4.",
-      "rationale": "Wrong initiative and omits the required move, range, muddle, and element details."
+      "actualAnswer": "Here is everything the structured data says about **Scenario 3** in Frosthaven:\n\n---\n\n## Scenario 3 \u2014 *Algox Offensive*\n**Location:** Copperneck Mountains\n**Complexity:** 2\n**Source:** Scenario Book 2-21, page 6\n\n---\n\n### Monsters\nThe following monster types appear in this scenario:\n- **Algox Archer** (\u00d74)\n- **Algox Guard** (\u00d74)\n- **Algox Priest** (\u00d72)\n- **Hound** (\u00d71 + \u00d71)\n\n> All Algox Priests and Hounds are allies to each other and enemies to all other figures. Likewise, all Algox Guards and Algox Archers are allies to each other and enemies to all other figures. Use the attack modifier deck for the Algox Priests and Hounds, though they are still considered enemies to you.\n\n---\n\n### Unlocks\nCompleting this scenario unlocks **Scenario 4A**.\n\n---\n\n### Rewards\nThe structured data records **no explicit rewards** for this scenario (the rewards field is null). The loot deck configuration is:\n\n| Loot Type | Count |\n|---|---|\n| Money | 4 |\n| Hide | 4 |\n| Metal | 4 |\n| Lumber | 4 |\n| Arrowvine | 2 |\n| Rockroot | 1 |\n| Random Item | 1 |\n\n---\n\n### Other Notes\n- **Goal:** All characters must *escape*; the scenario ends at the end of that round, then read **Section 8.3**.\n- **Section link:** When door 1 is opened, read **Section 30.2**.\n- If any character becomes *exhausted*, the scenario is **lost**.",
+      "rationale": "Should mention unlocks and rewards",
+      "provenance": "brian-2026-07-05-batch2"
     },
     {
-      "id": "fh-fail-town-in-flames",
+      "id": "e2-fail-fh-scenario-8-crystal-trench-1",
+      "caseId": "fh-scenario-8-crystal-trench",
+      "game": "frosthaven",
+      "expectedPass": false,
+      "actualAnswer": "Scenario 8 is Crystal Trench. It unlocks scenarios 15 and 16. Its rewards are 1 lumber, 2 hide.",
+      "rationale": "Should mention monsters",
+      "provenance": "brian-2026-07-05-batch2"
+    },
+    {
+      "id": "e2-pass-fh-monster-abael-herder-elite-level-5-1",
+      "caseId": "fh-monster-abael-herder-elite-level-5",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualAnswer": "An elite level 5 Abael Herder has HP 20, Move 4, and Attack 5. Notes: muddle.",
+      "rationale": "Contingent on data showing muddle \u2014 VERIFIED: notes contain \"elite L5: muddle\"",
+      "provenance": "brian-2026-07-05-batch3"
+    },
+    {
+      "id": "e2-fail-fh-scenario-1-a-town-in-flames-1",
       "caseId": "fh-scenario-1-a-town-in-flames",
       "game": "frosthaven",
       "expectedPass": false,
-      "actualAnswer": "Scenario 1 is A Town in Flames. It unlocks nothing, rewards Prosperity 2, and has only Algox Archer monsters.",
-      "rationale": "Wrong unlocks, reward, and monster list."
+      "actualAnswer": "Scenario 1 is A Town in Flames. It unlocks scenarios 2 and 3. Its rewards are (Gain 2+X morale, where X is the number of City Guards still on the map.).",
+      "rationale": "Should include monsters (template fast-path omission)",
+      "provenance": "brian-2026-07-05-batch3"
     },
     {
-      "id": "fh-fail-crude-shield-reusable",
-      "caseId": "fh-item-010-crude-shield",
+      "id": "e2-pass-building-alchemist-1",
+      "caseId": "building-alchemist",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualAnswer": "The **Alchemist** (Building #35) in Frosthaven starts the campaign **already built at Level 1** \u2014 it has no build cost (0 gold, 0 hide, 0 metal, 0 lumber, 0 prosperity required).\n\nHowever, note that at Level 1, the Alchemist has a downside: **characters cannot use potions**.\n\nTo **upgrade** it from Level 1 to Level 2, the cost is:\n- **1 hide**\n- **2 metal**\n- **2 lumber**\n- **Prosperity 1** (required)\n\n*Source: Frosthaven Building Card #35, Level 1*",
+      "rationale": "No-potions downside VERIFIED as the L1 effect field in checked-in data",
+      "provenance": "brian-2026-07-05-batch3"
+    },
+    {
+      "id": "e2-fail-fh-scenario-5-frozen-crypt-1",
+      "caseId": "fh-scenario-5-frozen-crypt",
       "game": "frosthaven",
       "expectedPass": false,
-      "actualAnswer": "Crude Shield is a reusable item that prevents all damage from the next attack.",
-      "rationale": "Wrong trigger and effect."
+      "actualAnswer": "Scenario 5 is Frozen Crypt. It unlocks scenarios 9 and 10. Its rewards are 2 lumber.",
+      "rationale": "Should include monsters",
+      "provenance": "brian-2026-07-05-batch3"
     },
     {
-      "id": "gh2-pass-scenario-level",
-      "caseId": "gh2-rule-scenario-level",
-      "game": "gloomhaven-2e",
+      "id": "e2-pass-tool-free-assistant-game-1",
+      "caseId": "tool-free-assistant-game",
+      "game": "frosthaven",
       "expectedPass": true,
-      "actualAnswer": "In Gloomhaven 2e, recommended scenario level is half the average character level, rounded up.",
-      "rationale": "Correct formula and rounding."
+      "actualAnswer": "Squire is a rules assistant for **Frosthaven** and **Gloomhaven (2nd Edition)**.",
+      "rationale": "Correct per Brian label.",
+      "provenance": "brian-2026-07-05-batch3"
     },
     {
-      "id": "gh2-pass-long-rest",
-      "caseId": "gh2-rule-long-rest-steps",
-      "game": "gloomhaven-2e",
+      "id": "e2-pass-rule-looting-definition-1",
+      "caseId": "rule-looting-definition",
+      "game": "frosthaven",
       "expectedPass": true,
-      "actualAnswer": "For a Gloomhaven 2e long rest, choose one discarded card to lose, return the rest to hand, optionally Heal 2 self, and recover spent items.",
-      "rationale": "Covers all required long-rest steps."
+      "actualAnswer": "Here's a full breakdown of **looting** in Frosthaven:\n\n---\n\n## The *Loot* Ability\n\n> \"*Loot X* is an ability that allows a figure to loot all loot tokens and treasure tiles within range X, including any in their current hex. This ability is unaffected by the presence of figures or overlay tiles. If there are no loot tokens or treasure tiles within the specified range, the ability cannot be performed.\"\n\n*(Rulebook, passage 111)*\n\n---\n\n## Looting Loot Tokens\n\nWhen a loot token is looted, it is removed from the map. What happens next depends on who looted it:\n\n- **Monsters:** Nothing else happens.\n- **Characters:** Draw one card from the **loot deck** (unless the deck is empty).\n\n### Loot Card Types\nEach scenario has a custom loot deck built from four types of cards:\n\n| Type | Details |\n|---|---|\n| **Money** | 20 cards showing 1\u20133 coins; converted to gold based on scenario level |\n| **Material Resources** | 8 cards per material type (lumber, metal, hide); amount varies by number of characters |\n| **Herb Resources** | 2 cards per herb type (arrowvine, axenut, corpsecap, flamefruit, rockroot, snowthistle); provides 1 herb each |\n| **Random Item** | 1 card; provides a random item drawn from the random item deck (can only be gained once per scenario) |\n\n- **Money and resources** are **not gained until the end of the scenario**.\n- **Random items** are gained **immediately** when looted and can be used for the rest of the scenario, even if it puts the character over the item limit.\n- If the random item deck is empty, the card counts as a money card worth **three coins**.\n\n---\n\n## Looting Treasure Tiles\n\nWhen a treasure tile is looted, it is removed from the map. **Monsters cannot loot treasure tiles.** If the tile is a **numbered treasure**, reference the Treasure Index and apply the effect \u2014 only the looting character gains the reward (unless it is a random item blueprint or random scenario).\n\n---\n\n## Key Notes\n\n- *Loot* range is unaffected by figures or overlay tiles.\n- Certain events can add a **+** sticker to a loot card, providing one additional resource of that type.\n- If a character gains an item they cannot keep for any reason, they must give it to another character or sell it immediately.\n\n*(Rulebook, passages 111\u2013112 and passage 67)*",
+      "rationale": "Correct per Brian label.",
+      "provenance": "brian-2026-07-05-batch3"
     },
     {
-      "id": "gh2-pass-advantage",
-      "caseId": "gh2-rule-advantage",
-      "game": "gloomhaven-2e",
-      "expectedPass": true,
-      "actualAnswer": "With advantage, draw two attack modifier cards and use one. Monsters use the better card, while characters may choose either card.",
-      "rationale": "Correct advantage behavior."
-    },
-    {
-      "id": "gh2-pass-red-hex",
-      "caseId": "gh2-faq-red-hex-aoe-targets",
-      "game": "gloomhaven-2e",
-      "expectedPass": true,
-      "actualAnswer": "Yes. In Gloomhaven 2e, a red hex AoE marks possible target hexes; targeting is still optional unless another rule makes it mandatory.",
-      "rationale": "Matches the FAQ answer."
-    },
-    {
-      "id": "gh2-pass-errata-section",
-      "caseId": "gh2-errata-campaign-sheet-section-29",
-      "game": "gloomhaven-2e",
-      "expectedPass": true,
-      "actualAnswer": "Use section 29.1. The Gloomhaven 2e errata says there is no section 29.5.",
-      "rationale": "Correct errata resolution."
-    },
-    {
-      "id": "gh2-pass-weathered-boots",
-      "caseId": "gh2-item-weathered-boots",
-      "game": "gloomhaven-2e",
-      "expectedPass": true,
-      "actualAnswer": "Weathered Boots are Gloomhaven 2e item #001, legs-slot boots costing 15 gold. During your move ability, they add Move +1.",
-      "rationale": "Correct item number, cost, slot, and effect."
-    },
-    {
-      "id": "gh2-pass-bandit-scout",
-      "caseId": "gh2-monster-bandit-scout",
-      "game": "gloomhaven-2e",
-      "expectedPass": true,
-      "actualAnswer": "A normal level 1 Bandit Scout in Gloomhaven 2e has HP 6, Move 3, and Attack 2.",
-      "rationale": "All requested stats are correct."
-    },
-    {
-      "id": "gh2-pass-scenario-11",
-      "caseId": "gh2-scenario-11-reward",
-      "game": "gloomhaven-2e",
-      "expectedPass": true,
-      "actualAnswer": "Gloomhaven 2e scenario 11 is Ritual Chamber. It unlocks scenario 15 and rewards 10 XP.",
-      "rationale": "Correct title, unlock, and reward."
-    },
-    {
-      "id": "gh2-pass-winged-shoes",
-      "caseId": "gh2-item-winged-shoes",
-      "game": "gloomhaven-2e",
-      "expectedPass": true,
-      "actualAnswer": "Winged Shoes are item #002 in Gloomhaven 2e. They are legs-slot shoes costing 15 gold, and during your turn they add Jump to all your move abilities.",
-      "rationale": "Correct item data."
-    },
-    {
-      "id": "gh2-pass-cave-bear-elite",
-      "caseId": "gh2-monster-cave-bear-elite-level-7",
-      "game": "gloomhaven-2e",
-      "expectedPass": true,
-      "actualAnswer": "An elite level 7 Cave Bear has HP 37, Move 5, and Attack 7.",
-      "rationale": "All requested monster stats are correct."
-    },
-    {
-      "id": "gh2-pass-cragheart-mat",
-      "caseId": "gh2-character-mat-cragheart",
-      "game": "gloomhaven-2e",
-      "expectedPass": true,
-      "actualAnswer": "Cragheart has hand size 11, HP 10 at level 1, HP 26 at level 9, and the traits arcane, outcast, and strong.",
-      "rationale": "Matches all requested character-mat fields."
-    },
-    {
-      "id": "gh2-pass-trample",
-      "caseId": "gh2-character-ability-bruiser-trample",
-      "game": "gloomhaven-2e",
-      "expectedPass": true,
-      "actualAnswer": "Trample is a level 1 Bruiser card with initiative 72. Top: Attack 3, Pierce 3. Bottom: Move 4.",
-      "rationale": "Correct level, initiative, and actions."
-    },
-    {
-      "id": "gh2-pass-personal-quest",
-      "caseId": "gh2-personal-quest-01-political-intrigue",
-      "game": "gloomhaven-2e",
-      "expectedPass": true,
-      "actualAnswer": "Political Intrigue requires Votes 30 and Solved Section 136.1 once. It unlocks class sun and personal quest 16.",
-      "rationale": "Correct personal quest requirements and unlocks."
-    },
-    {
-      "id": "gh2-fail-poison-healing",
-      "caseId": "gh2-rule-poison",
+      "id": "e2-fail-gh2-scenario-6-decaying-crypt-1",
+      "caseId": "gh2-scenario-6-decaying-crypt",
       "game": "gloomhaven-2e",
       "expectedPass": false,
-      "actualAnswer": "Poison in Gloomhaven 2e only gives disadvantage; healing works normally and does not remove it.",
-      "rationale": "Wrong poison effect and wrong healing interaction."
+      "actualAnswer": "Scenario 6 is Decaying Crypt. It unlocks scenario 11. Its rewards are 10 XP, 5 gold.",
+      "rationale": "Should include monsters",
+      "provenance": "brian-2026-07-05-batch3"
     },
     {
-      "id": "gh2-fail-wound-end-turn",
-      "caseId": "gh2-rule-wound",
+      "id": "e2-fail-gh2-scenario-3-frozen-hollow-1",
+      "caseId": "gh2-scenario-3-frozen-hollow",
       "game": "gloomhaven-2e",
       "expectedPass": false,
-      "actualAnswer": "Wound deals 2 damage at the end of each round and is removed by resting.",
-      "rationale": "Wrong timing, damage amount, and removal condition."
+      "actualAnswer": "Scenario 3 is Frozen Hollow. It unlocks scenarios 4 and 5. Its rewards are Prosperity 1.",
+      "rationale": "Should include monsters",
+      "provenance": "brian-2026-07-05-batch3"
     },
     {
-      "id": "gh2-fail-small-items-level",
-      "caseId": "gh2-rule-small-items",
-      "game": "gloomhaven-2e",
-      "expectedPass": false,
-      "actualAnswer": "A Gloomhaven 2e character can bring small items equal to their full level.",
-      "rationale": "Wrong small-item limit."
-    },
-    {
-      "id": "gh2-fail-scouting-lens",
-      "caseId": "gh2-item-scouting-lens",
-      "game": "gloomhaven-2e",
-      "expectedPass": false,
-      "actualAnswer": "Scouting Lens is item #010 and gives advantage on all attacks this turn.",
-      "rationale": "Wrong item number and wrong effect."
-    },
-    {
-      "id": "gh2-fail-living-spirit-hp",
-      "caseId": "gh2-monster-living-spirit-elite-level-7-hp",
-      "game": "gloomhaven-2e",
-      "expectedPass": false,
-      "actualAnswer": "An elite level 7 Living Spirit has 20 hit points.",
-      "rationale": "Wrong hit point value."
-    },
-    {
-      "id": "gh2-fail-section-67-parent",
-      "caseId": "gh2-section-67-1",
-      "game": "gloomhaven-2e",
-      "expectedPass": false,
-      "actualAnswer": "Section 67.1 is Black Barrow and belongs to scenario 7.",
-      "rationale": "Wrong section name and parent scenario."
-    },
-    {
-      "id": "gh2-fail-hide-armor",
-      "caseId": "gh2-item-003-hide-armor",
-      "game": "gloomhaven-2e",
-      "expectedPass": false,
-      "actualAnswer": "Hide Armor is item #003, costs 30 gold, and gives permanent Shield 2.",
-      "rationale": "Wrong cost and effect."
-    },
-    {
-      "id": "gh2-fail-ancient-artillery",
-      "caseId": "gh2-monster-ancient-artillery-elite-level-5",
-      "game": "gloomhaven-2e",
-      "expectedPass": false,
-      "actualAnswer": "An elite level 5 Ancient Artillery has HP 8, Move 3, and Attack 2.",
-      "rationale": "Wrong stats and movement."
-    },
-    {
-      "id": "gh2-fail-scenario-1",
+      "id": "e2-fail-gh2-scenario-1-bandit-camp-1",
       "caseId": "gh2-scenario-1-bandit-camp",
       "game": "gloomhaven-2e",
       "expectedPass": false,
-      "actualAnswer": "Scenario 1 is Black Barrow. It unlocks 8, has no reward, and includes Bandit Archers.",
-      "rationale": "Wrong title, unlock, reward, and monsters."
+      "actualAnswer": "Scenario 1 is Bandit Camp. It unlocks scenario 2. Its rewards are 10 gold.",
+      "rationale": "Should include monsters",
+      "provenance": "brian-2026-07-05-batch3"
     },
     {
-      "id": "gh2-fail-soultether-mat",
-      "caseId": "gh2-character-mat-soultether",
-      "game": "gloomhaven-2e",
+      "id": "e2-fail-fh-character-ability-coral-overwhelming-wave-1",
+      "caseId": "fh-character-ability-coral-overwhelming-wave",
+      "game": "frosthaven",
       "expectedPass": false,
-      "actualAnswer": "Soultether has hand size 9, HP 12 at level 1, HP 28 at level 9, and traits strong and intimidating.",
-      "rationale": "Wrong hand size, HP, and traits."
+      "actualAnswer": "Here's what the verified tool data shows for **Overwhelming Wave** (Coral, Frosthaven):\n\n- **Level:** 1\n- **Initiative:** 86\n- **Top action:** Not available in the current data\n- **Bottom action:** Not available in the current data\n\nThe card's ability text is not present in the checked-in data for either action. I'd recommend checking your physical card or the Frosthaven card viewer for the full action text.",
+      "rationale": "Reconciled with #15: both fail \u2014 the table needs real card text, honest data-gap disclosure is not a pass (fix data via SQR-396)",
+      "provenance": "brian-2026-07-05-batch3-reconciled"
     },
     {
-      "id": "gh2-fail-long-shot",
-      "caseId": "gh2-monster-ability-ancient-artillery-long-shot",
+      "id": "e2-pass-gh2-character-ability-mindthief-submissive-affliction-2",
+      "caseId": "gh2-character-ability-mindthief-submissive-affliction",
       "game": "gloomhaven-2e",
-      "expectedPass": false,
-      "actualAnswer": "Long Shot has initiative 10 and lets Ancient Artillery move 3 before attacking all adjacent enemies.",
-      "rationale": "Wrong initiative and ability text."
+      "expectedPass": true,
+      "actualAnswer": "Here are the details for **Submissive Affliction** (Mindthief, Gloomhaven 2e):\n\n| Field | Details |\n|---|---|\n| **Level** | 1 |\n| **Initiative** | 48 |\n| **Top Action** | *Attack 2*, add *Attack +1* for each negative condition the target has |\n| **Bottom Action** | *Control* one enemy within *Range 4*: consume Ice \u2014 the controlled enemy suffers *Damage 2* |\n\nThe card is not a *lost* card.",
+      "rationale": "Does not need the extraneous \"not a lost card\" bit",
+      "provenance": "brian-2026-07-05-batch4"
     },
     {
-      "id": "gh2-fail-accountant",
-      "caseId": "gh2-battle-goal-accountant",
-      "game": "gloomhaven-2e",
+      "id": "e2-pass-fh-item-004-crude-hide-armor-1",
+      "caseId": "fh-item-004-crude-hide-armor",
+      "game": "frosthaven",
+      "expectedPass": true,
+      "actualAnswer": "Here are the details for **Frosthaven Item #004 \u2013 Crude Hide Armor**:\n\n- **Slot:** Body\n- **Craft Cost:** 2 Hide resources\n- **Effect:** On the next two attacks targeting you, the attacker gains *Disadvantage*.\n- **Usage:** The card is **spent** (flipped face-down) when used, but **not lost** \u2014 so it can be refreshed and reused across scenarios.",
+      "rationale": "Does not need to explain spent-not-lost",
+      "provenance": "brian-2026-07-05-batch4"
+    },
+    {
+      "id": "e2-fail-fh-character-ability-blinkblade-blurry-jab-3",
+      "caseId": "fh-character-ability-blinkblade-blurry-jab",
+      "game": "frosthaven",
       "expectedPass": false,
-      "actualAnswer": "Accountant requires ending the scenario with at least 10 gold tokens and is worth 2 checkmarks.",
-      "rationale": "Wrong battle-goal requirement and checkmark value."
+      "actualAnswer": "Here's what the verified tool data shows for **Blurry Jab** (Blinkblade):\n\n- **Level:** 1\n- **Initiative:** 20 (stored as 2050, which represents initiative 20 with a tiebreaker of 50)\n- **Top action:** Not available in the checked-in data\n- **Bottom action:** Not available in the checked-in data\n\nThe card name, level, and initiative are confirmed, but the ability text for both the top and bottom actions is listed as \"(ability text not yet available)\" in the data source. I can't provide the action details without guessing.",
+      "rationale": "Blinkblade cards always have TWO initiatives \u2014 fast/slow choice each round governs which is used; the \"tiebreaker of 50\" claim is a hallucination; all Blinkblade card data needs fixing",
+      "provenance": "brian-2026-07-05-batch4"
     }
   ]
 }

--- a/eval/suites/frosthaven.json
+++ b/eval/suites/frosthaven.json
@@ -1228,8 +1228,8 @@
     "category": "character-abilities",
     "question": "For Frosthaven Blinkblade, what level, initiative, top action, and bottom action are on Blurry Jab?",
     "finalAnswer": {
-      "expected": "Blurry Jab is a level 1 Blinkblade card with initiative 2050. Top: (ability text not yet available) Bottom: (ability text not yet available)",
-      "grading": "Must identify Blurry Jab as level 1 for Blinkblade, state initiative 2050, and summarize both top and bottom actions from the Frosthaven character ability data."
+      "expected": "Blurry Jab is a level 1 Blinkblade card. Blinkblade cards always have two initiatives: Blurry Jab is initiative 20 when played fast and 50 when played slow. Top and bottom action text comes from the printed card.",
+      "grading": "Must identify Blurry Jab as level 1 for Blinkblade and present the two-speed initiative: 20 when fast, 50 when slow. Must not present 2050 as a single initiative value or describe the second number as a tiebreaker. Must summarize the top and bottom actions; stating that the ability text is unavailable in the data does not satisfy this."
     },
     "source": "data/extracted/character-abilities.json",
     "game": "frosthaven",
@@ -1260,8 +1260,8 @@
     "category": "character-abilities",
     "question": "For Frosthaven Coral, what level, initiative, top action, and bottom action are on Overwhelming Wave?",
     "finalAnswer": {
-      "expected": "Overwhelming Wave is a level 1 Coral card with initiative 86. Top: (ability text not yet available) Bottom: (ability text not yet available)",
-      "grading": "Must identify Overwhelming Wave as level 1 for Coral, state initiative 86, and summarize both top and bottom actions from the Frosthaven character ability data."
+      "expected": "Overwhelming Wave is a level 1 Coral card with initiative 86, and its top and bottom actions come from the printed card text.",
+      "grading": "Must identify Overwhelming Wave as level 1 for Coral with initiative 86 and summarize the top and bottom actions; stating that the ability text is unavailable in the data does not satisfy this."
     },
     "source": "data/extracted/character-abilities.json",
     "game": "frosthaven",
@@ -1568,7 +1568,7 @@
   {
     "id": "fh-multihop-scenario-2-read-now-chain",
     "category": "scenarios",
-    "question": "Frosthaven scenario 2 has a read-now link to section 27.1 — which section does that one link to next?",
+    "question": "Frosthaven scenario 2 has a read-now link to section 27.1 \u2014 which section does that one link to next?",
     "finalAnswer": {
       "expected": "Section 27.1 links onward to section 6.1.",
       "grading": "Must identify section 6.1 as the next read-now link from section 27.1. Must not substitute another section or game."
@@ -1640,7 +1640,7 @@
     "category": "rulebook",
     "question": "In Frosthaven, can a monster focus an invisible character?",
     "finalAnswer": {
-      "expected": "No. An invisible figure cannot be focused on or targeted by any enemy; enemies treat invisible figures as if they were not there and can move through them. Invisible is removed at the end of the figure’s next turn.",
+      "expected": "No. An invisible figure cannot be focused on or targeted by any enemy; enemies treat invisible figures as if they were not there and can move through them. Invisible is removed at the end of the figure\u2019s next turn.",
       "grading": "Must answer no: invisible figures cannot be focused or targeted by enemies. Removal timing and move-through detail are bonuses."
     },
     "source": "fh-rule-book.pdf",
@@ -1720,7 +1720,7 @@
     "category": "rulebook",
     "question": "In Frosthaven, what happens to the cards in my active area when I become exhausted?",
     "finalAnswer": {
-      "expected": "When a character becomes exhausted, all of their ability cards — including summons and other cards in their active area — are placed in their lost pile, and their figure is removed from the map. Exhausted characters can no longer participate in the scenario.",
+      "expected": "When a character becomes exhausted, all of their ability cards \u2014 including summons and other cards in their active area \u2014 are placed in their lost pile, and their figure is removed from the map. Exhausted characters can no longer participate in the scenario.",
       "grading": "Must state that active-area cards (including summons) go to the lost pile and the figure is removed from the map."
     },
     "source": "fh-rule-book.pdf",

--- a/eval/suites/gloomhaven-2e.json
+++ b/eval/suites/gloomhaven-2e.json
@@ -883,8 +883,8 @@
     "category": "scenarios",
     "question": "In Gloomhaven 2e, what is scenario 9 called, and what does its structured scenario data say about unlocks, rewards, and monsters?",
     "finalAnswer": {
-      "expected": "Scenario 9 is Ruinous Rift. It unlocks nothing, rewards Prosperity 1, and monsters include Chaos Demon, Earth Demon, Flame Demon, Frost Demon.",
-      "grading": "Must identify scenario 9 as Ruinous Rift. Must include its Gloomhaven 2e structured unlock, reward, and monster information. Must not substitute a scenario from another game."
+      "expected": "Scenario 9 is Ruinous Rift. It unlocks nothing, rewards Prosperity 1, and its monsters are the seven demon types: Chaos Demon, Earth Demon, Flame Demon, Frost Demon, Night Demon, Sun Demon, and Wind Demon.",
+      "grading": "Must identify scenario 9 as Ruinous Rift. Must include its Gloomhaven 2e structured unlock (none), reward (Prosperity 1), and monster information; the checked-in data lists seven demon types and naming all seven is correct, not extraneous. Must not substitute a scenario from another game."
     },
     "source": "data/extracted/gh2/scenarios.json",
     "game": "gloomhaven-2e",
@@ -1027,8 +1027,8 @@
     "category": "character-abilities",
     "question": "For Gloomhaven 2e Cragheart, what level, initiative, top action, and bottom action are on Opposing Strike?",
     "finalAnswer": {
-      "expected": "Opposing Strike is a level 1 Cragheart card with initiative 46. Top: Attack 3 Bottom: At the end of this and your next four turns, perform:",
-      "grading": "Must identify Opposing Strike as level 1 for Cragheart, state initiative 46, and summarize both top and bottom actions from the Gloomhaven 2e character ability data."
+      "expected": "Opposing Strike is a level 1 Cragheart card with initiative 46. Top: Attack 3. Bottom: At the end of this and your next four turns, perform Heal 2, Range 3.",
+      "grading": "Must identify Opposing Strike as level 1 for Cragheart, state initiative 46, and summarize both actions including the bottom action effect Heal 2, Range 3. An answer that omits the Heal 2, Range 3 effect or says it is unavailable does not pass."
     },
     "source": "data/extracted/gh2/character-abilities.json",
     "game": "gloomhaven-2e",
@@ -1059,8 +1059,8 @@
     "category": "character-abilities",
     "question": "For Gloomhaven 2e Mindthief, what level, initiative, top action, and bottom action are on Submissive Affliction?",
     "finalAnswer": {
-      "expected": "Submissive Affliction is a level 1 Mindthief card with initiative 48. Top: Attack 2, Add Attack +1 for each negative condition the target has. Bottom: Control one enemy within Range 4:",
-      "grading": "Must identify Submissive Affliction as level 1 for Mindthief, state initiative 48, and summarize both top and bottom actions from the Gloomhaven 2e character ability data."
+      "expected": "Submissive Affliction is a level 1 Mindthief card with initiative 48. Top: Attack 2, Add Attack +1 for each negative condition the target has. Bottom: Control one enemy within Range 4: consume Ice \u2014 the controlled enemy suffers Damage 2.",
+      "grading": "Must identify Submissive Affliction as level 1 for Mindthief, state initiative 48, and summarize both top and bottom actions. The bottom action includes the Ice-consumption rider (controlled enemy suffers Damage 2); including it is correct, not extraneous."
     },
     "source": "data/extracted/gh2/character-abilities.json",
     "game": "gloomhaven-2e",
@@ -1497,7 +1497,7 @@
     "category": "rulebook",
     "question": "In Gloomhaven 2e, when I lose a card to avoid all damage, do I lose Ward?",
     "finalAnswer": {
-      "expected": "Yes. Ward’s effects are considered before the damage negation step, so Ward is consumed even though the damage is negated.",
+      "expected": "Yes. Ward\u2019s effects are considered before the damage negation step, so Ward is consumed even though the damage is negated.",
       "grading": "Must answer yes: Ward applies before the damage-negation step."
     },
     "source": "gh2-faq.html",
@@ -1537,7 +1537,7 @@
     "category": "rulebook",
     "question": "In Gloomhaven 2e, what is the order of operations if I draw a x2 or Null with rolling modifiers?",
     "finalAnswer": {
-      "expected": "If a Null (x0) is anywhere in the final draws, the final damage is always 0. A x2 can be inserted at any point during attack modification, including at the very end, at the attacker’s choice.",
+      "expected": "If a Null (x0) is anywhere in the final draws, the final damage is always 0. A x2 can be inserted at any point during attack modification, including at the very end, at the attacker\u2019s choice.",
       "grading": "Must state that a Null always makes the final damage 0 regardless of position, and that a x2 can be applied at any chosen point in the order."
     },
     "source": "gh2-faq.html",
@@ -1575,7 +1575,7 @@
   {
     "id": "gh2-faq-target-immune-figure",
     "category": "rulebook",
-    "question": "In Gloomhaven 2e, can I target a figure with a condition they’re immune to?",
+    "question": "In Gloomhaven 2e, can I target a figure with a condition they\u2019re immune to?",
     "finalAnswer": {
       "expected": "Yes. The condition will not be applied, but targeting is still allowed, which can matter for other effects. This is a change from Gloomhaven 1st Edition.",
       "grading": "Must answer yes: targeting is allowed even though the condition is not applied."
@@ -1595,7 +1595,7 @@
   {
     "id": "gh2-faq-range-one-still-ranged",
     "category": "rulebook",
-    "question": "In Gloomhaven 2e, if an attack’s range is reduced to 1, does it become a melee attack?",
+    "question": "In Gloomhaven 2e, if an attack\u2019s range is reduced to 1, does it become a melee attack?",
     "finalAnswer": {
       "expected": "No. It remains a ranged attack with Range 1, so it usually has disadvantage against an adjacent target.",
       "grading": "Must answer no: it stays a ranged attack (with the usual adjacency disadvantage)."
@@ -1637,7 +1637,7 @@
     "category": "rulebook",
     "question": "In Gloomhaven 2e, if a monster must move through a choice of traps, does it consider the strength of those traps?",
     "finalAnswer": {
-      "expected": "No. Monsters count the number of negative hexes but ignore their strength or effects, and they always prefer a path with zero negative hexes regardless of length. Remaining ambiguity is resolved in the players’ favor.",
+      "expected": "No. Monsters count the number of negative hexes but ignore their strength or effects, and they always prefer a path with zero negative hexes regardless of length. Remaining ambiguity is resolved in the players\u2019 favor.",
       "grading": "Must answer no: monsters weigh the count of negative hexes, not their strength."
     },
     "source": "gh2-faq.html",
@@ -1675,7 +1675,7 @@
   {
     "id": "gh2-faq-rounding-direction",
     "category": "rulebook",
-    "question": "In Gloomhaven 2e, if a calculation doesn’t say which way to round, which way do you round?",
+    "question": "In Gloomhaven 2e, if a calculation doesn\u2019t say which way to round, which way do you round?",
     "finalAnswer": {
       "expected": "If a calculation does not indicate a rounding direction, assume it rounds up.",
       "grading": "Must state that unspecified rounding rounds up."
@@ -1697,7 +1697,7 @@
     "category": "rulebook",
     "question": "In Gloomhaven 2e, can I use an item in the middle of my move or attack ability?",
     "finalAnswer": {
-      "expected": "Only if the item is not itself an ability and says something like “during your move ability.” If the item performs another ability (healing, damaging, destroying an obstacle), you must finish your current ability first. This is a change from a Gloomhaven 1e FAQ ruling.",
+      "expected": "Only if the item is not itself an ability and says something like \u201cduring your move ability.\u201d If the item performs another ability (healing, damaging, destroying an obstacle), you must finish your current ability first. This is a change from a Gloomhaven 1e FAQ ruling.",
       "grading": "Must distinguish items usable mid-ability (non-ability items worded for it) from item abilities that require finishing the current ability first."
     },
     "source": "gh2-faq.html",

--- a/test/eval-judge-calibration.test.ts
+++ b/test/eval-judge-calibration.test.ts
@@ -22,19 +22,42 @@ describe('judge calibration', () => {
     }
   });
 
-  it('loads a 50-item dev-only table-qa reference fixture across both supported games', () => {
+  it('loads the frozen human-labeled dev-only reference fixture across both games', () => {
     const fixture = loadJudgeCalibrationFixture();
     const items = resolveJudgeCalibrationItems(fixture);
 
-    expect(fixture.items).toHaveLength(50);
+    expect(fixture.version).toBe(2);
+    expect(fixture.items).toHaveLength(32);
     expect(new Set(items.map((item) => item.game))).toEqual(
       new Set(['frosthaven', 'gloomhaven-2e']),
     );
     expect(items.every((item) => item.evalCase.suite === 'table-qa')).toBe(true);
     expect(items.every((item) => item.evalCase.split === 'dev')).toBe(true);
     expect(items.every((item) => item.evalCase.finalAnswer)).toBe(true);
-    expect(items.filter((item) => item.expectedPass)).toHaveLength(26);
-    expect(items.filter((item) => !item.expectedPass)).toHaveLength(24);
+    expect(items.filter((item) => item.expectedPass)).toHaveLength(14);
+    expect(items.filter((item) => !item.expectedPass)).toHaveLength(18);
+    // Epoch-2 frozen references: every verdict carries human-labeling provenance.
+    expect(items.every((item) => /^brian-\d{4}-\d{2}-\d{2}-batch/.test(item.provenance))).toBe(
+      true,
+    );
+  });
+
+  it('allows distinct answers per case but rejects a duplicated answer', () => {
+    const fixture = loadJudgeCalibrationFixture();
+    const blurryJab = fixture.items.filter(
+      (item) => item.caseId === 'fh-character-ability-blinkblade-blurry-jab',
+    );
+    // Distinct failure modes for one case (honest data-gap vs hallucinated
+    // tiebreaker) are legitimate separate references.
+    expect(blurryJab.length).toBeGreaterThanOrEqual(2);
+
+    const duplicated: JudgeCalibrationFixture = {
+      ...fixture,
+      items: [fixture.items[0]!, { ...fixture.items[0]!, id: 'duplicate-answer-different-id' }],
+    };
+    expect(() => resolveJudgeCalibrationItems(duplicated)).toThrow(
+      /Duplicate judge calibration answer/,
+    );
   });
 
   it('rejects calibration entries that point at holdout cases', () => {
@@ -48,6 +71,7 @@ describe('judge calibration', () => {
           expectedPass: true,
           actualAnswer: 'A monster should prefer the trap path.',
           rationale: 'Unit test fixture.',
+          provenance: 'unit-test',
         },
       ],
     };
@@ -66,6 +90,7 @@ describe('judge calibration', () => {
           expectedPass: true,
           actualAnswer: 'Spyglass gives advantage.',
           rationale: 'Unit test fixture.',
+          provenance: 'unit-test',
         },
       ],
     };
@@ -100,8 +125,8 @@ describe('judge calibration', () => {
       agreementRate: 1,
       thresholdPass: true,
     });
-    expect(report.summary.byGame.frosthaven.totalItems).toBe(25);
-    expect(report.summary.byGame['gloomhaven-2e'].totalItems).toBe(25);
+    expect(report.summary.byGame.frosthaven.totalItems).toBe(23);
+    expect(report.summary.byGame['gloomhaven-2e'].totalItems).toBe(9);
     expect(formatJudgeCalibrationMarkdown(report)).toContain('Calibration gate | pass');
     expect(JSON.parse(readFileSync(reportJsonPath, 'utf-8'))).toEqual(report);
     expect(readFileSync(reportMarkdownPath, 'utf-8')).toBe(formatJudgeCalibrationMarkdown(report));


### PR DESCRIPTION
## Summary
Phase 0 calibration slice for Table Turnaround II (SQR-392). Completes the human-labeling loop run with Brian over four chat batches.

- **Frozen fixture v2**: 32 human-labeled reference verdicts (14 pass / 18 fail) from real epoch-1 run answers, each with a `provenance` field. Duplicate rule now permits multiple distinct answers per case (distinct failure modes) while rejecting duplicated answer text.
- **The headline finding**: the epoch-1 judge — self-calibrated at "100%" — scores **53.1%** against human labels. The rewritten `table-qa-answer-judge-v2` (required-parts checklist; OMISSION / UNANSWERED / CONTRADICTION / WRONG-SUBJECT hard-failure rules; extra detail penalized only on contradiction) plus `temperature: 0` reaches **29/32 (90.6%)**, identical across repeat runs. Gate ≥85%: **pass**.
- **Five documented factual case fixes**, each sanctioned by an explicit Brian ruling during labeling (not tuning): Ruinous Rift's seven demon types, Mindthief/Cragheart bottom-action completions, Blinkblade two-speed initiative semantics (20 fast / 50 slow — never "2050" or a "tiebreaker"), Coral data-gap grading. The Blinkblade/Coral cases will now correctly FAIL baselines until SQR-396 restores the imported ability text — a true defect signal, not noise.
- **Known residual weakness recorded**: the judge still passes three multi-part scenario answers that omit asked-for parts under specific phrasings; documented in the iteration log rather than over-fitted away.
- Calibration report artifacts: `docs/plans/sqr-392-table-qa-judge-calibration.{json,md}`. Judge-version note: this invalidates comparisons with epoch-1 judged scores — by design, before any epoch-2 baseline exists (SQR-395 runs next).

## Test plan
- [x] `npx vitest run test/eval-judge-calibration.test.ts` — 7 tests (fixture v2, provenance, distinct-answers rule)
- [x] `npx vitest run test/eval-dataset.test.ts` — 31 tests
- [x] `npm run check` — 158 files, 1966 tests
- [x] `npm run eval:judge-calibration` — 29/32 (90.6%), gate pass, deterministic on repeat
- [x] `npm run eval -- --seed` — reseeded after case fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added and refreshed a frozen table-QA judge calibration report (JSON and Markdown) with run metadata and agreement metrics.
* **New Features**
  * Enhanced answer-judging strictness with updated required-part checks and improved handling of extra detail.
* **Bug Fixes**
  * Updated judge calibration fixture handling for provenance requirements and repeated answers per case.
  * Refined multiple Frosthaven and Gloomhaven-2e table-QA expectations to require complete, correctly formatted actions.
* **Tests**
  * Updated calibration tests for the new frozen reference format, provenance validation, and duplicate-answer error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->