### PR TITLE
SQR-405 Eval cost accounting: judge instrumentation, CI gating, ledger restated

### DIFF
--- a/.github/workflows/langsmith-regression.yml
+++ b/.github/workflows/langsmith-regression.yml
@@ -2,7 +2,9 @@ name: LangSmith Regression
 
 on:
   schedule:
-    - cron: '42 9 * * *'
+    # Weekly (Mondays), not daily: each scheduled run is a 6-leg live eval
+    # matrix billed to the project API key (SQR-405 cost reconciliation).
+    - cron: '42 9 * * 1'
   pull_request:
     paths:
       - '.github/workflows/langsmith-regression.yml'
@@ -92,25 +94,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # split: dev keeps scheduled runs off the sealed holdout (SQR-405).
+        # The boundary suites carry no split field, so they pass no filter —
+        # a dev filter there would silently select zero safety cases.
         include:
           - label: frosthaven-table-qa
             game: frosthaven
             suite: table-qa
+            split: dev
           - label: frosthaven-trajectory
             game: frosthaven
             suite: trajectory
+            split: dev
           - label: gloomhaven-2e-table-qa
             game: gloomhaven-2e
             suite: table-qa
+            split: dev
           - label: gloomhaven-2e-trajectory
             game: gloomhaven-2e
             suite: trajectory
+            split: dev
           - label: cross-game-boundary
             game: ''
             suite: cross-game-boundary
+            split: ''
           - label: adversarial-boundary
             game: ''
             suite: adversarial-boundary
+            split: ''
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -224,6 +235,9 @@ jobs:
           )
           if [[ -n "${{ matrix.game }}" ]]; then
             cmd+=("--game=${{ matrix.game }}")
+          fi
+          if [[ -n "${{ matrix.split }}" ]]; then
+            cmd+=("--split=${{ matrix.split }}")
           fi
           printf 'Running %s\n' "${cmd[*]}"
           "${cmd[@]}"

--- a/docs/plans/sqr-392-table-turnaround-2-iteration-log.md
+++ b/docs/plans/sqr-392-table-turnaround-2-iteration-log.md
@@ -7,7 +7,15 @@ Epoch-1 history lives in
 epoch-1 reports are historical context only once the epoch-2 dataset and judge
 calibration land.
 
-Actual-spend ledger (provider-reported, counts toward the $150 project cap):
+Spend accounting (RESTATED 2026-07-06, SQR-405): **Brian's Anthropic console
+is the ledger of record.** Console-reported usage through 2026-07-06 is
+**$102.88** across both epochs, leaving **~$47.12** against the $150 cap.
+The per-slice rows below are harness estimates of the _agent under test
+only_ — they exclude answer-judge tokens (uninstrumented before SQR-405),
+scheduled CI regression runs, and estimate-vs-billed drift, which is how
+the original ledger under-reported by ~15x. Rows are kept for relative
+slice cost, not cap accounting; console deltas are recorded at each phase
+checkpoint going forward.
 
 | Date       | Slice                                       | Actual provider spend |
 | ---------- | ------------------------------------------- | --------------------- |
@@ -523,3 +531,43 @@ Eval spend: ~$1.45 actual (full dev run $1.30 + targeted runs/rechecks).
 
 Decision: keep. Phase 2 complete pending checkpoint; holdout remains
 sealed for the Phase 4 gate.
+
+## 2026-07-06 — SQR-405: cost accounting reconciliation
+
+Brian's console showed $102.88 of key usage over three days against a
+ledger claiming ~$7. Root causes, verified in code:
+
+- **Judge calls were never costed.** Every judged row spawns a
+  `claude-haiku-4-5` answer-judge call whose tokens flowed into no report
+  field; the `guardrail_cost_usd` column is a flat $0.05/case pre-run
+  budget constant, not a measurement.
+- **Scheduled CI evals billed the key invisibly.** The langsmith-regression
+  cron ran a 6-leg live eval matrix daily over the FULL suites — including
+  the sealed holdout split. (Initial diagnosis wrongly implicated the 98
+  pull_request-triggered runs; those were the $0 preflight job only — the
+  `regression` job already carried `if: github.event_name !=
+'pull_request'`.)
+- **Estimates are not bills**: the price sheet has no cache-write tier
+  (billed 1.25x) and retried attempts' tokens are not accumulated.
+
+Fixes shipped:
+
+- Ledger restated above: console is the ledger of record; $102.88 burned,
+  ~$47.12 headroom.
+- `judgeAnswer` now returns its token usage; the matrix path carries a
+  per-row `judgeEstimatedCostUsd` (Haiku pricing, matching the model price
+  table), the TSV gains a `judge_cost_usd` column, and row
+  `estimatedCostUsd` is agent + judge.
+- langsmith-regression: cron drops daily → weekly (Mondays); the four
+  game-suite legs pass `--split=dev` so scheduled runs never touch the
+  sealed holdout. The boundary/safety legs stay unfiltered — their cases
+  carry no split field, and a dev filter would have silently selected zero
+  safety cases.
+
+Eval spend: $0 (code and workflow changes only; verified with mocked
+tests).
+
+Budget posture for the remaining phases: ~$47 covers Phase 3 (judged
+verification is now cost-visible per row), a bounded Phase 4 loop, and two
+holdout gate runs (~$2.5–3 each including judges) — tight but sufficient
+if targeted-first discipline holds.

--- a/eval/evaluators.ts
+++ b/eval/evaluators.ts
@@ -19,6 +19,32 @@ interface EvalRunOutput {
 export const ANSWER_JUDGE_MODEL = 'claude-haiku-4-5-20251001';
 export const ANSWER_JUDGE_PROMPT_VERSION = 'table-qa-answer-judge-v2';
 
+// Judge pricing matches EVAL_MODEL_PRICE_TABLE's anthropic:claude-haiku-4-5
+// entry. Judge calls bill the same API key as the agent under test but were
+// invisible to cost reporting until SQR-405 — every judged row now carries
+// its judge cost.
+const JUDGE_INPUT_USD_PER_MILLION_TOKENS = 1;
+const JUDGE_OUTPUT_USD_PER_MILLION_TOKENS = 5;
+
+export interface JudgeTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface JudgeVerdict {
+  score: number;
+  pass: boolean;
+  reasoning: string;
+  tokenUsage: JudgeTokenUsage;
+}
+
+export function judgeCostEstimateUsd(usage: JudgeTokenUsage): number {
+  return (
+    (usage.inputTokens / 1_000_000) * JUDGE_INPUT_USD_PER_MILLION_TOKENS +
+    (usage.outputTokens / 1_000_000) * JUDGE_OUTPUT_USD_PER_MILLION_TOKENS
+  );
+}
+
 // v2 (SQR-392): recalibrated against Brian's frozen human labels. v1 passed
 // answers that omitted asked-for parts, disclosed data gaps instead of
 // answering, or invented details — all hard fails at a real table.
@@ -55,7 +81,7 @@ export async function judgeAnswer(
   expected: string,
   grading: string,
   actual: string,
-): Promise<{ score: number; pass: boolean; reasoning: string }> {
+): Promise<JudgeVerdict> {
   const response = await anthropic.messages.create({
     model: ANSWER_JUDGE_MODEL,
     max_tokens: 512,
@@ -71,6 +97,10 @@ export async function judgeAnswer(
     ],
   });
 
+  const tokenUsage: JudgeTokenUsage = {
+    inputTokens: response.usage.input_tokens,
+    outputTokens: response.usage.output_tokens,
+  };
   const block = response.content[0];
   let text = block?.type === 'text' ? block.text : '';
   text = text
@@ -78,9 +108,15 @@ export async function judgeAnswer(
     .replace(/\s*```\s*$/m, '')
     .trim();
   try {
-    return JSON.parse(text) as { score: number; pass: boolean; reasoning: string };
+    const parsed = JSON.parse(text) as { score: number; pass: boolean; reasoning: string };
+    return { ...parsed, tokenUsage };
   } catch {
-    return { score: 0, pass: false, reasoning: `Judge returned unparseable response: ${text}` };
+    return {
+      score: 0,
+      pass: false,
+      reasoning: `Judge returned unparseable response: ${text}`,
+      tokenUsage,
+    };
   }
 }
 

--- a/eval/matrix-runtime.ts
+++ b/eval/matrix-runtime.ts
@@ -105,6 +105,7 @@ function outputFromTrace(
         ? ('deep' as const)
         : undefined,
     tokenUsage: tokenUsage(trace),
+    judgeEstimatedCostUsd: scoreNamed(trace, 'judge_cost_usd'),
     estimatedCostUsd:
       nonZeroCost(trace.costEstimate.totalUsd) ??
       nonZeroCost(scoreNamed(trace, 'model_cost_usd')) ??

--- a/eval/matrix.ts
+++ b/eval/matrix.ts
@@ -55,6 +55,8 @@ export interface EvalMatrixRunnerOutput {
     output: number;
     total: number;
   };
+  /** Answer-judge token cost for this row (SQR-405); null when not judged. */
+  judgeEstimatedCostUsd?: number | null;
   estimatedCostUsd: number;
   toolCallCount: number;
   loopIterations: number;
@@ -95,6 +97,8 @@ export interface EvalMatrixRow {
   tokenTotal: number | null;
   guardrailEstimatedCostUsd: number;
   providerEstimatedCostUsd: number | null;
+  /** Answer-judge token cost (SQR-405); null when the row was not judged. */
+  judgeEstimatedCostUsd: number | null;
   estimatedCostUsd: number | null;
   toolCallCount: number | null;
   retryCount: number;
@@ -518,6 +522,13 @@ export function rowFromOutput(
   const compatibility = evalRunCompatibilityFor(input.providerConfig, input.toolSurface);
   const providerEstimatedCostUsd =
     providerCostEstimateUsd(input.providerConfig, output.tokenUsage) ?? output.estimatedCostUsd;
+  const judgeEstimatedCostUsd = output.judgeEstimatedCostUsd ?? null;
+  // The row's billed total is agent + judge: both hit the same API key
+  // (SQR-405 — judge spend was previously invisible to every ledger).
+  const estimatedCostUsd =
+    providerEstimatedCostUsd === null && judgeEstimatedCostUsd === null
+      ? null
+      : (providerEstimatedCostUsd ?? 0) + (judgeEstimatedCostUsd ?? 0);
   const latencyBudget = evaluateLatencyBudget(input.evalCase, output);
   const failedLatencyBudget = latencyBudget.latencyBudgetPass === false;
   const failedGroundedness = output.groundednessPass === false;
@@ -549,7 +560,8 @@ export function rowFromOutput(
     tokenTotal: output.tokenUsage.total,
     guardrailEstimatedCostUsd: ESTIMATED_COST_PER_CASE_MODEL_USD,
     providerEstimatedCostUsd,
-    estimatedCostUsd: providerEstimatedCostUsd,
+    judgeEstimatedCostUsd,
+    estimatedCostUsd,
     toolCallCount: output.toolCallCount,
     retryCount,
     loopIterations: output.loopIterations,
@@ -613,6 +625,7 @@ export function rowFromError(
     tokenTotal: null,
     guardrailEstimatedCostUsd: ESTIMATED_COST_PER_CASE_MODEL_USD,
     providerEstimatedCostUsd: null,
+    judgeEstimatedCostUsd: null,
     estimatedCostUsd: null,
     toolCallCount: null,
     retryCount,
@@ -752,7 +765,7 @@ function formatNullable(value: string | number | boolean | null | undefined): st
 
 export function formatEvalMatrixTable(rows: EvalMatrixRow[]): string {
   const lines = [
-    'case\tgame\tsuite\tcategory\tquestion_class\tlane\tsource_authority\tgame_pair\truntime_model\tpass\tfailure_class\tscore\tgroundedness\tgroundedness_failures\tlatency_ms\tfirst_answer_token_ms\tlatency_budget\ttokens\tcached_input_tokens\tguardrail_cost_usd\tprovider_cost_usd\ttools\tretries\tloops\ttrace\tlangsmith_trace\terror',
+    'case\tgame\tsuite\tcategory\tquestion_class\tlane\tsource_authority\tgame_pair\truntime_model\tpass\tfailure_class\tscore\tgroundedness\tgroundedness_failures\tlatency_ms\tfirst_answer_token_ms\tlatency_budget\ttokens\tcached_input_tokens\tguardrail_cost_usd\tprovider_cost_usd\tjudge_cost_usd\ttools\tretries\tloops\ttrace\tlangsmith_trace\terror',
   ];
   for (const row of rows) {
     lines.push(
@@ -782,6 +795,7 @@ export function formatEvalMatrixTable(rows: EvalMatrixRow[]): string {
         formatNullable(row.tokenCachedInput),
         row.guardrailEstimatedCostUsd.toFixed(4),
         row.providerEstimatedCostUsd === null ? '-' : row.providerEstimatedCostUsd.toFixed(4),
+        row.judgeEstimatedCostUsd === null ? '-' : row.judgeEstimatedCostUsd.toFixed(4),
         formatNullable(row.toolCallCount),
         row.retryCount,
         formatNullable(row.loopIterations),

--- a/eval/scoring.ts
+++ b/eval/scoring.ts
@@ -5,7 +5,7 @@ import { sourceAuthorityForCase } from './dataset.ts';
 import type { EvalCase } from './schema.ts';
 import { normalizeTrajectoryRef, scoreAnswerSafety, scoreTrajectory } from './schema.ts';
 import type { EvalTraceScore } from './trace.ts';
-import { judgeAnswer } from './evaluators.ts';
+import { judgeAnswer, judgeCostEstimateUsd } from './evaluators.ts';
 
 export interface EvalScoringInput {
   evalCase: EvalCase;
@@ -179,6 +179,12 @@ export async function traceScoresForEvalResult(
           name: 'pass',
           value: verdict.pass ? 'pass' : 'fail',
           comment: verdict.reasoning,
+        },
+        // Judge spend bills the same key as the agent under test; carrying
+        // it per row keeps the ledger honest (SQR-405).
+        {
+          name: 'judge_cost_usd',
+          value: judgeCostEstimateUsd(verdict.tokenUsage),
         },
       );
     }

--- a/test/eval-cost-harness.test.ts
+++ b/test/eval-cost-harness.test.ts
@@ -64,6 +64,7 @@ function row(overrides: Partial<EvalMatrixRow>): EvalMatrixRow {
     tokenTotal: 150,
     guardrailEstimatedCostUsd: 0.05,
     providerEstimatedCostUsd: 0.02,
+    judgeEstimatedCostUsd: null,
     estimatedCostUsd: 0.02,
     toolCallCount: 4,
     retryCount: 1,

--- a/test/eval-matrix.test.ts
+++ b/test/eval-matrix.test.ts
@@ -722,6 +722,55 @@ describe('eval matrix runner', () => {
     );
   });
 
+  it('adds judge cost into the row total when the runner reports it (SQR-405)', async () => {
+    const config: EvalProviderConfig = {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      reasoningEffort: undefined,
+      maxOutputTokens: undefined,
+      timeoutMs: undefined,
+      toolLoopLimit: undefined,
+    };
+    const runner: EvalMatrixRunner = vi.fn(async ({ traceId }) => ({
+      ok: true,
+      answer: 'judged',
+      traceId,
+      traceUrl: `https://smith.langchain.test/project/default/traces/${traceId}`,
+      score: 1,
+      pass: true,
+      latencyMs: 500,
+      tokenUsage: { input: 1_000_000, output: 100_000, total: 1_100_000 },
+      judgeEstimatedCostUsd: 0.0125,
+      estimatedCostUsd: 0.05,
+      toolCallCount: 0,
+      loopIterations: 1,
+      failureClass: 'none',
+    }));
+
+    const result = await runEvalMatrix({
+      cases: [selectedCase],
+      runLabel: 'matrix-judge-pricing',
+      toolSurface: 'redesigned',
+      selection: 'id',
+      modelConfigs: [config],
+      runner,
+      guardrails: {
+        allowFullDataset: false,
+        allowEstimatedCostOverride: false,
+        maxEstimatedCostUsd: 10,
+        retryCount: 0,
+        continueOnModelFailure: true,
+        providerConcurrency: { anthropic: 1, openai: 1 },
+      },
+    });
+
+    expect(result.rows[0]).toMatchObject({
+      providerEstimatedCostUsd: 4.5,
+      judgeEstimatedCostUsd: 0.0125,
+      estimatedCostUsd: 4.5125,
+    });
+  });
+
   it('does not bill cached input tokens beyond total input tokens', async () => {
     const config: EvalProviderConfig = {
       provider: 'openai',
@@ -917,7 +966,7 @@ describe('eval matrix runner', () => {
     });
 
     expect(formatEvalMatrixTable(result.rows)).toContain(
-      'case\tgame\tsuite\tcategory\tquestion_class\tlane\tsource_authority\tgame_pair\truntime_model\tpass\tfailure_class\tscore\tgroundedness\tgroundedness_failures\tlatency_ms\tfirst_answer_token_ms\tlatency_budget\ttokens\tcached_input_tokens\tguardrail_cost_usd\tprovider_cost_usd\ttools\tretries\tloops\ttrace\tlangsmith_trace\terror',
+      'case\tgame\tsuite\tcategory\tquestion_class\tlane\tsource_authority\tgame_pair\truntime_model\tpass\tfailure_class\tscore\tgroundedness\tgroundedness_failures\tlatency_ms\tfirst_answer_token_ms\tlatency_budget\ttokens\tcached_input_tokens\tguardrail_cost_usd\tprovider_cost_usd\tjudge_cost_usd\ttools\tretries\tloops\ttrace\tlangsmith_trace\terror',
     );
     expect(formatEvalMatrixTable(result.rows)).toContain('item-spyglass');
     expect(formatEvalMatrixTable(result.rows)).toContain('exact-lookup');

--- a/test/eval-runner.test.ts
+++ b/test/eval-runner.test.ts
@@ -124,6 +124,7 @@ describe('eval runner', () => {
           tokenTotal: 120,
           guardrailEstimatedCostUsd: 0.05,
           providerEstimatedCostUsd: 0.01,
+          judgeEstimatedCostUsd: null,
           estimatedCostUsd: 0.01,
           toolCallCount: 2,
           retryCount: 0,


### PR DESCRIPTION
## Summary

Cost reconciliation after the Anthropic console showed **$102.88 actual vs ~$7 ledgered** over three days. Root causes verified in code; three fixes:

**1. Judge calls are now costed.** Every judged row spawns a `claude-haiku-4-5` answer-judge call whose tokens previously flowed into no report field (the `guardrail_cost_usd` column is a flat $0.05/case pre-run constant, not a measurement). `judgeAnswer` now returns its token usage; the score channel carries a `judge_cost_usd` metric; matrix rows gain `judgeEstimatedCostUsd` (priced to match `EVAL_MODEL_PRICE_TABLE`'s Haiku entry); row `estimatedCostUsd` is now agent + judge; the TSV gains a `judge_cost_usd` column.

**2. Scheduled CI evals are gated.** The langsmith-regression cron ran a 6-leg live eval matrix **daily** over the **full suites — including the sealed holdout split**. Cron drops to weekly (Mondays), and the four game-suite legs pass `--split=dev`. The boundary/safety legs deliberately stay unfiltered: their cases carry no `split` field, so a dev filter would have silently selected **zero** safety cases. One correction from the initial diagnosis: the 98 pull_request-triggered runs were the $0 preflight job only — the `regression` job already skipped PR events.

**3. Ledger restated.** The iteration-log ledger now states that the Anthropic console is the ledger of record ($102.88 burned through 2026-07-06, ~$47.12 headroom against the $150 cap); per-slice harness estimates are kept for relative cost only, and console deltas get recorded at phase checkpoints.

## Verification

- `npm run check` fully green (163 files / 2009 tests), including a new matrix test asserting judge cost folds into the row total, plus updated fixtures and TSV-header expectations.
- `actionlint` clean on the workflow.
- No live API calls in this PR ($0).

SQR-405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluation results now include estimated judge cost alongside existing cost data.
  * Matrix summaries and TSV output now show a separate `judge_cost_usd` column.

* **Bug Fixes**
  * Total estimated cost now reflects both agent and judge spend instead of agent spend alone.
  * Regression scheduling was reduced to run weekly and limited to dev-only splits for selected suites.

* **Documentation**
  * Updated cost-tracking notes to reflect the revised spend totals and reporting approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->