### PR TITLE
SQR-400 Preserve item usage flags: consumed, persistent, round, use slots

### DIFF
--- a/data/extracted/gh2/items.json
+++ b/data/extracted/gh2/items.json
@@ -9,6 +9,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/1"
   },
   {
@@ -21,6 +24,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/2"
   },
   {
@@ -30,9 +36,12 @@
     "cost": 10,
     "craftCost": null,
     "effect": "On the next two sources of Damage from attacks targeting you, gain Shield 1 for the attacks.",
-    "uses": null,
+    "uses": 2,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/3"
   },
   {
@@ -45,6 +54,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/4"
   },
   {
@@ -57,6 +69,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/5"
   },
   {
@@ -69,6 +84,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/6"
   },
   {
@@ -81,6 +99,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/7"
   },
   {
@@ -93,6 +114,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/8"
   },
   {
@@ -105,6 +129,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/9"
   },
   {
@@ -117,6 +144,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/10"
   },
   {
@@ -129,6 +159,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/11"
   },
   {
@@ -141,6 +174,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/12"
   },
   {
@@ -153,6 +189,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/13"
   },
   {
@@ -165,6 +204,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/14"
   },
   {
@@ -177,6 +219,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/15"
   },
   {
@@ -185,10 +230,13 @@
     "slot": "head",
     "cost": 20,
     "craftCost": null,
-    "effect": "During your turn, perform:; Element wild",
+    "effect": "During your turn, perform:; Consume Wild, Infuse Wild",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/16"
   },
   {
@@ -201,6 +249,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/17"
   },
   {
@@ -213,6 +264,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/18"
   },
   {
@@ -225,6 +279,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/19"
   },
   {
@@ -237,6 +294,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/20"
   },
   {
@@ -249,6 +309,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/21"
   },
   {
@@ -261,6 +324,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/22"
   },
   {
@@ -273,6 +339,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/23"
   },
   {
@@ -285,6 +354,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/24"
   },
   {
@@ -297,6 +369,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/25"
   },
   {
@@ -309,6 +384,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/26"
   },
   {
@@ -321,6 +399,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/27"
   },
   {
@@ -330,9 +411,12 @@
     "cost": 25,
     "craftCost": null,
     "effect": "On the next three sources of Damage from attacks targeting you, gain Shield 1 for the attacks.",
-    "uses": null,
+    "uses": 3,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/28"
   },
   {
@@ -345,6 +429,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/29"
   },
   {
@@ -357,6 +444,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/30"
   },
   {
@@ -369,6 +459,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/31"
   },
   {
@@ -381,6 +474,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": true,
     "sourceId": "gloomhavensecretariat:item/32"
   },
   {
@@ -393,6 +489,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/33"
   },
   {
@@ -405,6 +504,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/34"
   },
   {
@@ -417,6 +519,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/35"
   },
   {
@@ -429,6 +534,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/36"
   },
   {
@@ -441,6 +549,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/37"
   },
   {
@@ -453,6 +564,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/38"
   },
   {
@@ -465,6 +579,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/39"
   },
   {
@@ -477,6 +594,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/40"
   },
   {
@@ -489,6 +609,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/41"
   },
   {
@@ -501,6 +624,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/42"
   },
   {
@@ -513,6 +639,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/43"
   },
   {
@@ -525,6 +654,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/44"
   },
   {
@@ -537,6 +669,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/45"
   },
   {
@@ -549,6 +684,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/46"
   },
   {
@@ -561,6 +699,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/47"
   },
   {
@@ -573,6 +714,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/48"
   },
   {
@@ -585,6 +729,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/49"
   },
   {
@@ -597,6 +744,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/50"
   },
   {
@@ -609,6 +759,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/51"
   },
   {
@@ -621,6 +774,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/52"
   },
   {
@@ -633,6 +789,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/53"
   },
   {
@@ -642,9 +801,12 @@
     "cost": 45,
     "craftCost": null,
     "effect": "After the next three attacks targeting an ally within Range 2 flip this card over.",
-    "uses": null,
+    "uses": 3,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/54"
   },
   {
@@ -657,6 +819,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/55"
   },
   {
@@ -669,6 +834,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/56"
   },
   {
@@ -681,6 +849,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/57"
   },
   {
@@ -693,6 +864,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/58"
   },
   {
@@ -705,6 +879,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/59"
   },
   {
@@ -717,6 +894,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/60"
   },
   {
@@ -729,6 +909,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/61"
   },
   {
@@ -741,6 +924,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/62"
   },
   {
@@ -753,6 +939,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/63"
   },
   {
@@ -765,6 +954,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/64"
   },
   {
@@ -777,6 +969,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/65"
   },
   {
@@ -789,6 +984,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/66"
   },
   {
@@ -801,6 +999,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/67"
   },
   {
@@ -813,6 +1014,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/68"
   },
   {
@@ -822,9 +1026,12 @@
     "cost": 35,
     "craftCost": null,
     "effect": "On the next five sources of Damage from attacks targeting you, gain Shield 1 for the attacks.",
-    "uses": null,
+    "uses": 5,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/69"
   },
   {
@@ -837,6 +1044,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/70"
   },
   {
@@ -849,6 +1059,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/71"
   },
   {
@@ -858,9 +1071,12 @@
     "cost": 30,
     "craftCost": null,
     "effect": "Allies gain advantage on the next three attacks performed while adjacent to you. Then flip this card over.",
-    "uses": null,
+    "uses": 3,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/72"
   },
   {
@@ -873,6 +1089,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/73"
   },
   {
@@ -885,6 +1104,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/74"
   },
   {
@@ -897,6 +1119,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/75"
   },
   {
@@ -909,6 +1134,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/76"
   },
   {
@@ -921,6 +1149,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/77"
   },
   {
@@ -933,6 +1164,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/78"
   },
   {
@@ -945,6 +1179,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/79"
   },
   {
@@ -957,6 +1194,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/80"
   },
   {
@@ -969,6 +1209,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/81"
   },
   {
@@ -981,6 +1224,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/82"
   },
   {
@@ -993,6 +1239,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/83"
   },
   {
@@ -1005,6 +1254,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/84"
   },
   {
@@ -1017,6 +1269,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/85"
   },
   {
@@ -1029,6 +1284,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/86"
   },
   {
@@ -1041,6 +1299,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/87"
   },
   {
@@ -1053,6 +1314,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/88"
   },
   {
@@ -1062,9 +1326,12 @@
     "cost": 40,
     "craftCost": null,
     "effect": "On the next three sources of Damage from attacks targeting you, gain Shield 1, Retaliate 1 for the attacks",
-    "uses": null,
+    "uses": 3,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/89"
   },
   {
@@ -1077,6 +1344,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/90"
   },
   {
@@ -1089,6 +1359,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/91"
   },
   {
@@ -1101,6 +1374,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/92"
   },
   {
@@ -1113,6 +1389,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/93"
   },
   {
@@ -1125,6 +1404,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/94"
   },
   {
@@ -1137,6 +1419,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/95"
   },
   {
@@ -1149,6 +1434,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/96"
   },
   {
@@ -1161,6 +1449,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/97"
   },
   {
@@ -1173,6 +1464,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/98"
   },
   {
@@ -1185,6 +1479,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/99"
   },
   {
@@ -1194,9 +1491,12 @@
     "cost": 30,
     "craftCost": null,
     "effect": "After your next three turns during which you do not perform a move ability, flip this card over.",
-    "uses": null,
+    "uses": 3,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/100"
   },
   {
@@ -1209,6 +1509,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/101"
   },
   {
@@ -1221,6 +1524,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/102"
   },
   {
@@ -1233,6 +1539,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/103"
   },
   {
@@ -1245,6 +1554,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/104"
   },
   {
@@ -1257,6 +1569,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/105"
   },
   {
@@ -1266,9 +1581,12 @@
     "cost": 30,
     "craftCost": null,
     "effect": "On the next five sources of Damage from attacks targeting you, gain Shield 1 for the attacks.",
-    "uses": null,
+    "uses": 5,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/106"
   },
   {
@@ -1281,6 +1599,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/107"
   },
   {
@@ -1293,6 +1614,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/108"
   },
   {
@@ -1305,6 +1629,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/109"
   },
   {
@@ -1317,6 +1644,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/110"
   },
   {
@@ -1329,6 +1659,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/111"
   },
   {
@@ -1341,6 +1674,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/112"
   },
   {
@@ -1353,6 +1689,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/113"
   },
   {
@@ -1365,6 +1704,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/114"
   },
   {
@@ -1377,6 +1719,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/115"
   },
   {
@@ -1389,6 +1734,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/116"
   },
   {
@@ -1401,6 +1749,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/117"
   },
   {
@@ -1413,6 +1764,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/118"
   },
   {
@@ -1425,6 +1779,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/119"
   },
   {
@@ -1437,6 +1794,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/120"
   },
   {
@@ -1449,6 +1809,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/121"
   },
   {
@@ -1457,10 +1820,13 @@
     "slot": "one hand",
     "cost": 15,
     "craftCost": null,
-    "effect": "During your turn, perform:; Element wild",
+    "effect": "During your turn, perform:; Consume Wild, Infuse Ice",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/122"
   },
   {
@@ -1469,10 +1835,13 @@
     "slot": "one hand",
     "cost": 15,
     "craftCost": null,
-    "effect": "During your turn, perform:; Element wild",
+    "effect": "During your turn, perform:; Consume Wild, Infuse Air",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/123"
   },
   {
@@ -1481,10 +1850,13 @@
     "slot": "one hand",
     "cost": 15,
     "craftCost": null,
-    "effect": "During your turn, perform:; Element wild",
+    "effect": "During your turn, perform:; Consume Wild, Infuse Fire",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/124"
   },
   {
@@ -1493,10 +1865,13 @@
     "slot": "one hand",
     "cost": 15,
     "craftCost": null,
-    "effect": "During your turn, perform:; Element wild",
+    "effect": "During your turn, perform:; Consume Wild, Infuse Earth",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/125"
   },
   {
@@ -1505,10 +1880,13 @@
     "slot": "one hand",
     "cost": 15,
     "craftCost": null,
-    "effect": "During your turn, perform:; Element wild",
+    "effect": "During your turn, perform:; Consume Wild, Infuse Light",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/126"
   },
   {
@@ -1517,10 +1895,13 @@
     "slot": "one hand",
     "cost": 15,
     "craftCost": null,
-    "effect": "During your turn, perform:; Element wild",
+    "effect": "During your turn, perform:; Consume Wild, Infuse Dark",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/127"
   },
   {
@@ -1533,6 +1914,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/128"
   },
   {
@@ -1545,6 +1929,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/129"
   },
   {
@@ -1557,6 +1944,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/130"
   },
   {
@@ -1569,6 +1959,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/131"
   },
   {
@@ -1581,6 +1974,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/132"
   },
   {
@@ -1593,6 +1989,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/133"
   },
   {
@@ -1605,6 +2004,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/134"
   },
   {
@@ -1617,6 +2019,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/135"
   },
   {
@@ -1625,10 +2030,13 @@
     "slot": "small item",
     "cost": 40,
     "craftCost": null,
-    "effect": "During your turn, perform:; Element light; Element dark",
+    "effect": "During your turn, perform:; Consume Light, Heal 3, Self, Bless; Consume Dark, Attack 3, Curse",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/136"
   },
   {
@@ -1641,6 +2049,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/137"
   },
   {
@@ -1653,6 +2064,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/138"
   },
   {
@@ -1665,6 +2079,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/139"
   },
   {
@@ -1677,6 +2094,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/140"
   },
   {
@@ -1689,6 +2109,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/141"
   },
   {
@@ -1701,6 +2124,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/142"
   },
   {
@@ -1713,6 +2139,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/143"
   },
   {
@@ -1725,6 +2154,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/144"
   },
   {
@@ -1733,10 +2165,13 @@
     "slot": "one hand",
     "cost": 50,
     "craftCost": null,
-    "effect": "During your turn, perform:; Move 2; This movement must end adjacent to an obstacle or wall.",
+    "effect": "During your turn, perform:; Move 2, Jump; This movement must end adjacent to an obstacle or wall.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/145"
   },
   {
@@ -1749,6 +2184,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/146"
   },
   {
@@ -1761,6 +2199,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/147"
   },
   {
@@ -1773,6 +2214,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/148"
   },
   {
@@ -1785,6 +2229,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/149"
   },
   {
@@ -1797,6 +2244,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/150"
   },
   {
@@ -1809,6 +2259,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/151"
   },
   {
@@ -1821,6 +2274,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/152"
   },
   {
@@ -1829,10 +2285,13 @@
     "slot": "one hand",
     "cost": 50,
     "craftCost": null,
-    "effect": "After you push an enemy, perform:; Move 3; This movement may only enter hexes that the pushed enemy exited.",
+    "effect": "After you push an enemy, perform:; Move 3, Jump; This movement may only enter hexes that the pushed enemy exited.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/153"
   },
   {
@@ -1845,6 +2304,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/154"
   },
   {
@@ -1857,6 +2319,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/155"
   },
   {
@@ -1869,6 +2334,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/156"
   },
   {
@@ -1877,10 +2345,13 @@
     "slot": "one hand",
     "cost": 50,
     "craftCost": null,
-    "effect": "During your turn, perform your next attack or heal ability this turn as if you occupied the same hex as any obstacle.; Element earth",
+    "effect": "During your turn, perform your next attack or heal ability this turn as if you occupied the same hex as any obstacle.; Infuse Earth",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/157"
   },
   {
@@ -1893,6 +2364,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/158"
   },
   {
@@ -1901,10 +2375,13 @@
     "slot": "small item",
     "cost": 50,
     "craftCost": null,
-    "effect": "During your turn, grant self or one adjacent ally:; Move 4; Element light",
+    "effect": "During your turn, grant self or one adjacent ally:; Move 4, Jump; Infuse Light",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/159"
   },
   {
@@ -1917,6 +2394,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/160"
   },
   {
@@ -1929,6 +2409,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/161"
   },
   {
@@ -1941,6 +2424,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/162"
   },
   {
@@ -1953,6 +2439,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/163"
   },
   {
@@ -1965,6 +2454,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/164"
   },
   {
@@ -1977,6 +2469,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/165"
   },
   {
@@ -1989,6 +2484,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/166"
   },
   {
@@ -2001,6 +2499,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/167"
   },
   {
@@ -2013,6 +2514,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/168"
   },
   {
@@ -2025,6 +2529,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/169"
   },
   {
@@ -2037,6 +2544,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/170"
   }
 ]

--- a/data/extracted/items.json
+++ b/data/extracted/items.json
@@ -13,6 +13,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/1"
   },
   {
@@ -29,6 +32,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/2"
   },
   {
@@ -45,6 +51,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/3"
   },
   {
@@ -58,9 +67,12 @@
       }
     },
     "effect": "On the next two attacks targeting you, the attacker gains disadvantage.",
-    "uses": null,
+    "uses": 2,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/4"
   },
   {
@@ -73,10 +85,13 @@
         "hide": 2
       }
     },
-    "effect": "During your move ability, add +1 Move",
+    "effect": "During your move ability, add Move +1",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/5"
   },
   {
@@ -93,6 +108,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/6"
   },
   {
@@ -105,10 +123,13 @@
         "lumber": 1
       }
     },
-    "effect": "During your turn, add +1 Range to one of your ranged attacks.",
+    "effect": "During your turn, add Range +1 to one of your ranged attacks.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/7"
   },
   {
@@ -126,6 +147,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/8"
   },
   {
@@ -143,6 +167,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/9"
   },
   {
@@ -159,6 +186,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/10"
   },
   {
@@ -175,6 +205,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/11"
   },
   {
@@ -191,6 +224,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/12"
   },
   {
@@ -208,6 +244,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/13"
   },
   {
@@ -221,10 +260,13 @@
         "hide": 1
       }
     },
-    "effect": "During your melee attack ability, add +1 Attack to one attack.",
+    "effect": "During your melee attack ability, add Attack +1 to one attack.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/14"
   },
   {
@@ -241,6 +283,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/15"
   },
   {
@@ -258,6 +303,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/16"
   },
   {
@@ -267,9 +315,12 @@
     "cost": null,
     "craftCost": null,
     "effect": "On the next two attacks targeting you, the attacker gains disadvantage.",
-    "uses": null,
+    "uses": 2,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/17"
   },
   {
@@ -282,10 +333,13 @@
         "hide": 1
       }
     },
-    "effect": "During your turn add +1 Move to all your move abilities.",
+    "effect": "During your turn add Move +1 to all your move abilities.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/18"
   },
   {
@@ -304,6 +358,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/19"
   },
   {
@@ -316,10 +373,13 @@
         "arrowvine": 1
       }
     },
-    "effect": "During your turn, add +1 Range to all your ranged attacks.",
+    "effect": "During your turn, add Range +1 to all your ranged attacks.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/20"
   },
   {
@@ -337,6 +397,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/21"
   },
   {
@@ -353,6 +416,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/22"
   },
   {
@@ -366,10 +432,13 @@
         "hide": 2
       }
     },
-    "effect": "At the start of your turn, add -2 Move to all your move abilities to gain Shield 1 this round.",
+    "effect": "At the start of your turn, add Move -2 to all your move abilities to gain Shield 1 this round.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/23"
   },
   {
@@ -382,6 +451,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/24"
   },
   {
@@ -400,6 +472,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/25"
   },
   {
@@ -417,6 +492,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/26"
   },
   {
@@ -433,6 +511,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/27"
   },
   {
@@ -445,10 +526,13 @@
         "hide": 1
       }
     },
-    "effect": "During your turn add +1 Move to all your move abilities and ignore difficult terrain.",
+    "effect": "During your turn add Move +1 to all your move abilities and ignore difficult terrain.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/28"
   },
   {
@@ -466,6 +550,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/29"
   },
   {
@@ -483,6 +570,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/30"
   },
   {
@@ -495,6 +585,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/31"
   },
   {
@@ -513,6 +606,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/32"
   },
   {
@@ -525,10 +621,13 @@
         "metal": 1
       }
     },
-    "effect": "Up to once each turn during your move ability, add +1 Move, then flip this card over at the end of your turn.",
+    "effect": "Up to once each turn during your move ability, add Move +1, then flip this card over at the end of your turn.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/33"
   },
   {
@@ -545,6 +644,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/34"
   },
   {
@@ -562,6 +664,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/35"
   },
   {
@@ -579,6 +684,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/36"
   },
   {
@@ -595,6 +703,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/37"
   },
   {
@@ -607,6 +718,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/38"
   },
   {
@@ -615,10 +729,13 @@
     "slot": "two hands",
     "cost": null,
     "craftCost": null,
-    "effect": "During your attack ability, add +3 Attack and Pierce 1 to one attack targeting a Frozen Corpse, Ice Wraith, or Living Doom.",
+    "effect": "During your attack ability, add Attack +3 and Pierce 1 to one attack targeting a Frozen Corpse, Ice Wraith, or Living Doom.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/39"
   },
   {
@@ -631,10 +748,13 @@
         "lumber": 1
       }
     },
-    "effect": "During your turn, add +1 Attack and +2 Range to one of your ranged attacks.",
+    "effect": "During your turn, add Attack +1 and Range +2 to one of your ranged attacks.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/40"
   },
   {
@@ -651,6 +771,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/41"
   },
   {
@@ -664,9 +787,12 @@
       }
     },
     "effect": "On the next two sources of Damage from attacks targeting you gain Shield 2 for the attacks.",
-    "uses": null,
+    "uses": 2,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/42"
   },
   {
@@ -679,10 +805,13 @@
         "metal": 1
       }
     },
-    "effect": "During your melee attack ability, add Push2 to one attack.",
+    "effect": "During your melee attack ability, add Push 2 to one attack.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/43"
   },
   {
@@ -695,6 +824,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/44"
   },
   {
@@ -707,6 +839,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/45"
   },
   {
@@ -723,6 +858,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/46"
   },
   {
@@ -732,9 +870,12 @@
     "cost": null,
     "craftCost": null,
     "effect": "On the next two sources of Damage from attacks targeting you, suffer Damage 3 to give the attacker Brittle.",
-    "uses": null,
+    "uses": 2,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/47"
   },
   {
@@ -752,6 +893,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/48"
   },
   {
@@ -764,10 +908,13 @@
         "metal": 1
       }
     },
-    "effect": "During your melee attack ability, add +1 Attack and Wound one attack.",
+    "effect": "During your melee attack ability, add Attack +1 and Wound one attack.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/49"
   },
   {
@@ -784,6 +931,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/50"
   },
   {
@@ -800,6 +950,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/51"
   },
   {
@@ -808,10 +961,13 @@
     "slot": "head",
     "cost": null,
     "craftCost": null,
-    "effect": "During your turn, Fire to cause up to two enemies within Range 4 to suffer Damage 1.",
+    "effect": "During your turn, Consume to cause up to two enemies within Range 4 to suffer Damage 1.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/52"
   },
   {
@@ -828,6 +984,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/53"
   },
   {
@@ -844,6 +1003,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/54"
   },
   {
@@ -861,6 +1023,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/55"
   },
   {
@@ -874,10 +1039,13 @@
         "metal": 1
       }
     },
-    "effect": "During your turn, Earth to loot one adjacent loot token.",
+    "effect": "During your turn, Consume to loot one adjacent loot token.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/56"
   },
   {
@@ -895,6 +1063,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/57"
   },
   {
@@ -903,10 +1074,13 @@
     "slot": "one hand",
     "cost": null,
     "craftCost": null,
-    "effect": "During your melee attack ability, add +2 Attack to one attack. After the ability, gain Disarm.",
+    "effect": "During your melee attack ability, add Attack +2 to one attack. After the ability, gain Disarm.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/58"
   },
   {
@@ -919,6 +1093,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/59"
   },
   {
@@ -935,6 +1112,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/60"
   },
   {
@@ -951,6 +1131,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/61"
   },
   {
@@ -959,10 +1142,13 @@
     "slot": "legs",
     "cost": null,
     "craftCost": null,
-    "effect": "During your move ability, add +1 Move and gain Regenerate",
+    "effect": "During your move ability, add Move +1 and gain Regenerate",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/62"
   },
   {
@@ -971,10 +1157,13 @@
     "slot": "legs",
     "cost": null,
     "craftCost": null,
-    "effect": "During your move ability, Dark add +2 Move",
+    "effect": "During your move ability, Consume add Move +2",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/63"
   },
   {
@@ -991,6 +1180,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/64"
   },
   {
@@ -1003,10 +1195,13 @@
         "corpsecap": 1
       }
     },
-    "effect": "During your turn, place a character token on one normal or elite enemy within Range 3. That enemy gains -1 Shield for the scenario.",
+    "effect": "During your turn, place a character token on one normal or elite enemy within Range 3. That enemy gains Shield -1 for the scenario.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": true,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/65"
   },
   {
@@ -1019,6 +1214,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/66"
   },
   {
@@ -1031,10 +1229,13 @@
         "metal": 1
       }
     },
-    "effect": "When you are attacked, add +1 Attack to attack to instead of drawing an attack modifier card and flip this card over.",
+    "effect": "When you are attacked, add Attack +1 to attack to instead of drawing an attack modifier card and flip this card over.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/67"
   },
   {
@@ -1044,9 +1245,12 @@
     "cost": null,
     "craftCost": null,
     "effect": "On the next three sources of 2 or fewer Damage you would suffer, negate the Damage.",
-    "uses": null,
+    "uses": 3,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/68"
   },
   {
@@ -1055,10 +1259,13 @@
     "slot": "body",
     "cost": null,
     "craftCost": null,
-    "effect": "When you suffer Damage from an attack, Air to gain Shield 3 for the attack.",
+    "effect": "When you suffer Damage from an attack, Consume to gain Shield 3 for the attack.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/69"
   },
   {
@@ -1071,6 +1278,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/70"
   },
   {
@@ -1087,6 +1297,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/71"
   },
   {
@@ -1099,10 +1312,13 @@
         "lumber": 1
       }
     },
-    "effect": "During your turn, Light to perform:; Bless, Range 3",
+    "effect": "During your turn, Consume to perform:; Bless, Range 3",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/72"
   },
   {
@@ -1119,6 +1335,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/73"
   },
   {
@@ -1131,6 +1350,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/74"
   },
   {
@@ -1144,10 +1366,13 @@
         "snowthistle": 1
       }
     },
-    "effect": "After any ally within Range 2 suffers Damage from an attack, remove all negative conditions from the ally then perform:; Heal 3, Target the ally, Pull 2",
+    "effect": "After any ally within Range 2 suffers Damage from an attack, remove all negative conditions from the ally then perform:; Heal 3, the ally, Pull 2",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/75"
   },
   {
@@ -1166,6 +1391,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/76"
   },
   {
@@ -1182,6 +1410,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/77"
   },
   {
@@ -1199,6 +1430,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/78"
   },
   {
@@ -1213,10 +1447,13 @@
         "snowthistle": 1
       }
     },
-    "effect": "During your turn, add +1 Attack to all your attacks and perform:; Heal 2, Self",
+    "effect": "During your turn, add Attack +1 to all your attacks and perform:; Heal 2, Self",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/79"
   },
   {
@@ -1229,10 +1466,13 @@
         "rockroot": 1
       }
     },
-    "effect": "When you would suffer 4 or fewer Damage from attack, negate the Damage and perform Heal X self where x is the amount of damage you would have suffered.",
+    "effect": "When you would suffer 4 or fewer Damage from attack, negate the Damage and perform Heal self where x is the amount of damage you would have suffered.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/80"
   },
   {
@@ -1249,6 +1489,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/81"
   },
   {
@@ -1265,6 +1508,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/82"
   },
   {
@@ -1282,6 +1528,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/83"
   },
   {
@@ -1299,6 +1548,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/84"
   },
   {
@@ -1312,10 +1564,13 @@
         "axenut": 1
       }
     },
-    "effect": "During your turn, add +1 Attack to all your attacks.",
+    "effect": "During your turn, add Attack +1 to all your attacks.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/85"
   },
   {
@@ -1333,6 +1588,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/86"
   },
   {
@@ -1350,6 +1608,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/87"
   },
   {
@@ -1367,6 +1628,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/88"
   },
   {
@@ -1384,6 +1648,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/89"
   },
   {
@@ -1401,6 +1668,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/90"
   },
   {
@@ -1418,6 +1688,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/91"
   },
   {
@@ -1435,6 +1708,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/92"
   },
   {
@@ -1452,6 +1728,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/93"
   },
   {
@@ -1469,6 +1748,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/94"
   },
   {
@@ -1486,6 +1768,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/95"
   },
   {
@@ -1503,6 +1788,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/96"
   },
   {
@@ -1520,6 +1808,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/97"
   },
   {
@@ -1541,6 +1832,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/98"
   },
   {
@@ -1559,6 +1853,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/99"
   },
   {
@@ -1577,6 +1874,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/100"
   },
   {
@@ -1591,10 +1891,13 @@
         "corpsecap": 1
       }
     },
-    "effect": "During your turn, add +2 Attack to all your attacks.",
+    "effect": "During your turn, add Attack +2 to all your attacks.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/101"
   },
   {
@@ -1613,6 +1916,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/102"
   },
   {
@@ -1631,6 +1937,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/103"
   },
   {
@@ -1645,10 +1954,13 @@
         "flamefruit": 1
       }
     },
-    "effect": "During your move ability, add +3 Move and Jump.",
+    "effect": "During your move ability, add Move +3 and Jump.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/104"
   },
   {
@@ -1667,6 +1979,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/105"
   },
   {
@@ -1685,6 +2000,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/106"
   },
   {
@@ -1703,6 +2021,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/107"
   },
   {
@@ -1721,6 +2042,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/108"
   },
   {
@@ -1739,6 +2063,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/109"
   },
   {
@@ -1757,6 +2084,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/110"
   },
   {
@@ -1775,6 +2105,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/111"
   },
   {
@@ -1793,6 +2126,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/112"
   },
   {
@@ -1811,6 +2147,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/113"
   },
   {
@@ -1829,6 +2168,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/114"
   },
   {
@@ -1847,6 +2189,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/115"
   },
   {
@@ -1865,6 +2210,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/116"
   },
   {
@@ -1883,6 +2231,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/117"
   },
   {
@@ -1901,6 +2252,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/118"
   },
   {
@@ -1922,6 +2276,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/119"
   },
   {
@@ -1934,6 +2291,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/120"
   },
   {
@@ -1942,10 +2302,13 @@
     "slot": "head",
     "cost": 25,
     "craftCost": null,
-    "effect": "During your turn, perform:; Element wild",
+    "effect": "During your turn, perform:; Consume Wild, Infuse Wild",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/121"
   },
   {
@@ -1958,6 +2321,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/122"
   },
   {
@@ -1970,6 +2336,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/123"
   },
   {
@@ -1982,6 +2351,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/124"
   },
   {
@@ -1994,6 +2366,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/125"
   },
   {
@@ -2006,6 +2381,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/126"
   },
   {
@@ -2018,6 +2396,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/127"
   },
   {
@@ -2030,6 +2411,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/128"
   },
   {
@@ -2042,6 +2426,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/129"
   },
   {
@@ -2054,6 +2441,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/130"
   },
   {
@@ -2063,9 +2453,12 @@
     "cost": 25,
     "craftCost": null,
     "effect": "On the next three sources of Damage from attacks targeting you, you gain Shield 1 for the attacks.",
-    "uses": null,
+    "uses": 3,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/131"
   },
   {
@@ -2078,6 +2471,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/132"
   },
   {
@@ -2090,6 +2486,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/133"
   },
   {
@@ -2102,6 +2501,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/134"
   },
   {
@@ -2114,6 +2516,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/135"
   },
   {
@@ -2126,6 +2531,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/136"
   },
   {
@@ -2138,6 +2546,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/137"
   },
   {
@@ -2150,6 +2561,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/138"
   },
   {
@@ -2158,10 +2572,13 @@
     "slot": "head",
     "cost": 35,
     "craftCost": null,
-    "effect": "After your move 4 or more hexes on your turn, add +1 Attack to your next melee attack this turn.",
+    "effect": "After your move 4 or more hexes on your turn, add Attack +1 to your next melee attack this turn.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/139"
   },
   {
@@ -2174,6 +2591,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/140"
   },
   {
@@ -2186,6 +2606,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/141"
   },
   {
@@ -2198,6 +2621,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/142"
   },
   {
@@ -2210,6 +2636,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/143"
   },
   {
@@ -2218,10 +2647,13 @@
     "slot": "two hands",
     "cost": 50,
     "craftCost": null,
-    "effect": "During your turn, Wild to add +1 Attack to all your attacks.",
+    "effect": "During your turn, Consume to add Attack +1 to all your attacks.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/144"
   },
   {
@@ -2234,6 +2666,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/145"
   },
   {
@@ -2246,6 +2681,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/146"
   },
   {
@@ -2258,6 +2696,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/147"
   },
   {
@@ -2267,9 +2708,12 @@
     "cost": 45,
     "craftCost": null,
     "effect": "After the next three attacks targeting an ally within Range 2, flip this card over.",
-    "uses": null,
+    "uses": 3,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/148"
   },
   {
@@ -2279,9 +2723,12 @@
     "cost": 50,
     "craftCost": null,
     "effect": "On the next five sources of Damage from attacks targeting you, you gain Shield 1 for the attacks.",
-    "uses": null,
+    "uses": 5,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/149"
   },
   {
@@ -2294,6 +2741,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/150"
   },
   {
@@ -2306,6 +2756,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/151"
   },
   {
@@ -2318,6 +2771,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/152"
   },
   {
@@ -2330,6 +2786,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/153"
   },
   {
@@ -2342,6 +2801,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/154"
   },
   {
@@ -2354,6 +2816,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/155"
   },
   {
@@ -2366,6 +2831,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/156"
   },
   {
@@ -2378,6 +2846,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/157"
   },
   {
@@ -2386,10 +2857,13 @@
     "slot": "small item",
     "cost": 30,
     "craftCost": null,
-    "effect": "During your turn, perform:; ElementHalf earth:dark",
+    "effect": "During your turn, perform:; ElementHalf earth:dark, Heal 3, Self, Ward",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/158"
   },
   {
@@ -2402,6 +2876,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/159"
   },
   {
@@ -2414,6 +2891,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/160"
   },
   {
@@ -2426,6 +2906,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/161"
   },
   {
@@ -2434,10 +2917,13 @@
     "slot": "small item",
     "cost": 40,
     "craftCost": null,
-    "effect": "During your turn, perform:; ElementHalf ice:air",
+    "effect": "During your turn, perform:; ElementHalf ice:air, Attack 3, Range 3, Immobilize",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/162"
   },
   {
@@ -2450,6 +2936,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/163"
   },
   {
@@ -2462,6 +2951,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/164"
   },
   {
@@ -2474,6 +2966,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/165"
   },
   {
@@ -2482,10 +2977,13 @@
     "slot": "small item",
     "cost": 50,
     "craftCost": null,
-    "effect": "During your turn, perform:; ElementHalf fire:light",
+    "effect": "During your turn, perform:; ElementHalf fire:light, Attack 3, Disarm",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/166"
   },
   {
@@ -2494,10 +2992,13 @@
     "slot": "small item",
     "cost": 40,
     "craftCost": null,
-    "effect": "At the start of the enemy's turn, before it determines its focus, perform:; Pull 4, Target the enemy, Range 5, Muddle",
+    "effect": "At the start of the enemy's turn, before it determines its focus, perform:; Pull 4, the enemy, Range 5, Muddle",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/167"
   },
   {
@@ -2506,10 +3007,13 @@
     "slot": "head",
     "cost": 50,
     "craftCost": null,
-    "effect": "During your ranged attack ability, add +1 Target.",
+    "effect": "During your ranged attack ability, add Target +1.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/168"
   },
   {
@@ -2522,6 +3026,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/169"
   },
   {
@@ -2534,6 +3041,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/170"
   },
   {
@@ -2546,6 +3056,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/171"
   },
   {
@@ -2558,6 +3071,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/172"
   },
   {
@@ -2570,6 +3086,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/173"
   },
   {
@@ -2582,6 +3101,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/174"
   },
   {
@@ -2594,6 +3116,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/175"
   },
   {
@@ -2606,6 +3131,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/176"
   },
   {
@@ -2618,6 +3146,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/177"
   },
   {
@@ -2630,6 +3161,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/178"
   },
   {
@@ -2638,10 +3172,13 @@
     "slot": "legs",
     "cost": 25,
     "craftCost": null,
-    "effect": "During your move ability, add +4 Move. After the move ability gain Immobilize.",
+    "effect": "During your move ability, add Move +4. After the move ability gain Immobilize.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/179"
   },
   {
@@ -2654,6 +3191,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/180"
   },
   {
@@ -2666,6 +3206,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/181"
   },
   {
@@ -2678,6 +3221,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": true,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/182"
   },
   {
@@ -2686,10 +3232,13 @@
     "slot": "one hand",
     "cost": 35,
     "craftCost": null,
-    "effect": "During your turn, all figures gain disadvantage on and add -1 Range to all ranged attacks this round.",
+    "effect": "During your turn, all figures gain disadvantage on and add Range -1 to all ranged attacks this round.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/183"
   },
   {
@@ -2698,10 +3247,13 @@
     "slot": "one hand",
     "cost": 20,
     "craftCost": null,
-    "effect": "During your multi-target melee attack ability, add +1 Target.",
+    "effect": "During your multi-target melee attack ability, add Target +1.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/184"
   },
   {
@@ -2714,6 +3266,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/185"
   },
   {
@@ -2726,6 +3281,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/186"
   },
   {
@@ -2738,6 +3296,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/187"
   },
   {
@@ -2750,6 +3311,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/188"
   },
   {
@@ -2758,10 +3322,13 @@
     "slot": "small item",
     "cost": 50,
     "craftCost": null,
-    "effect": "During your, perform",
+    "effect": "During your, perform, Consume Dark or Wild: Invisible, Self",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/189"
   },
   {
@@ -2770,10 +3337,13 @@
     "slot": "small item",
     "cost": 20,
     "craftCost": null,
-    "effect": "During your turn, place a character token on one normal or elite enemy within Range 3. This enemy adds -1 Attack to all its attacks.",
+    "effect": "During your turn, place a character token on one normal or elite enemy within Range 3. This enemy adds Attack -1 to all its attacks.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": true,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/190"
   },
   {
@@ -2786,6 +3356,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/191"
   },
   {
@@ -2798,6 +3371,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/192"
   },
   {
@@ -2810,6 +3386,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/193"
   },
   {
@@ -2822,6 +3401,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/194"
   },
   {
@@ -2830,10 +3412,13 @@
     "slot": "head",
     "cost": 30,
     "craftCost": null,
-    "effect": "During your turn add +1 Range and Pierce 1 to one of your ranged attacks.",
+    "effect": "During your turn add Range +1 and Pierce 1 to one of your ranged attacks.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/195"
   },
   {
@@ -2846,6 +3431,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/196"
   },
   {
@@ -2858,6 +3446,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/197"
   },
   {
@@ -2870,6 +3461,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/198"
   },
   {
@@ -2882,6 +3476,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/199"
   },
   {
@@ -2890,10 +3487,13 @@
     "slot": "one hand",
     "cost": 50,
     "craftCost": null,
-    "effect": "During your heal ability targeting an ally, Light to add Regenerate one heal and flip this card over.",
+    "effect": "During your heal ability targeting an ally, Consume to add Regenerate one heal and flip this card over.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/200"
   },
   {
@@ -2902,10 +3502,13 @@
     "slot": "two hands",
     "cost": 50,
     "craftCost": null,
-    "effect": "During your melee attack ability performed while occupying or adjacent to a hex with a water tile, add Push1 and Immobilize to one attack.",
+    "effect": "During your melee attack ability performed while occupying or adjacent to a hex with a water tile, add Push 1 and Immobilize to one attack.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/201"
   },
   {
@@ -2918,6 +3521,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/202"
   },
   {
@@ -2930,6 +3536,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/203"
   },
   {
@@ -2942,6 +3551,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/204"
   },
   {
@@ -2954,6 +3566,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/205"
   },
   {
@@ -2962,10 +3577,13 @@
     "slot": "two hands",
     "cost": 40,
     "craftCost": null,
-    "effect": "During your melee attack ability, if you have not move this round, add +2 Attack to one attack, and you may perform no move abilities this turn.",
+    "effect": "During your melee attack ability, if you have not move this round, add Attack +2 to one attack, and you may perform no move abilities this turn.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/206"
   },
   {
@@ -2978,6 +3596,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/207"
   },
   {
@@ -2990,6 +3611,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/208"
   },
   {
@@ -2998,10 +3622,13 @@
     "slot": "two hands",
     "cost": 60,
     "craftCost": null,
-    "effect": "During your melee attack ability, give advantage on one attack. For each master you have completed also add one following to the attack: +1 Attack, Wound, or Poison.",
+    "effect": "During your melee attack ability, give advantage on one attack. For each master you have completed also add one following to the attack: Attack +1, Wound, or Poison.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/209"
   },
   {
@@ -3010,10 +3637,13 @@
     "slot": "two hands",
     "cost": 30,
     "craftCost": null,
-    "effect": "During your turn, add -3 Attack to all your attacks performed by Lurkers targeting you this round.",
+    "effect": "During your turn, add Attack -3 to all your attacks performed by Lurkers targeting you this round.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/210"
   },
   {
@@ -3026,6 +3656,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/211"
   },
   {
@@ -3038,6 +3671,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/212"
   },
   {
@@ -3046,10 +3682,13 @@
     "slot": "one hand",
     "cost": 70,
     "craftCost": null,
-    "effect": "During your attack ability Ice to add Immobilize one attack, then flip this card over at the end of your turn.",
+    "effect": "During your attack ability Consume to add Immobilize one attack, then flip this card over at the end of your turn.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/213"
   },
   {
@@ -3062,6 +3701,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/214"
   },
   {
@@ -3070,10 +3712,13 @@
     "slot": "one hand",
     "cost": 30,
     "craftCost": null,
-    "effect": "During your, add +1 Attack and Muddle to all your attacks. At the end of your turn, perform:; Muddle, Self",
+    "effect": "During your, add Attack +1 and Muddle to all your attacks. At the end of your turn, perform:; Muddle, Self",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/215"
   },
   {
@@ -3086,6 +3731,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/216"
   },
   {
@@ -3098,6 +3746,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/217"
   },
   {
@@ -3110,6 +3761,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/218"
   },
   {
@@ -3122,6 +3776,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": true,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/219"
   },
   {
@@ -3134,6 +3791,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/220"
   },
   {
@@ -3142,10 +3802,13 @@
     "slot": "one hand",
     "cost": 30,
     "craftCost": null,
-    "effect": "During your melee attack ability, Ice to add Pierce 3 to one attack.",
+    "effect": "During your melee attack ability, Consume to add Pierce 3 to one attack.",
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/221"
   },
   {
@@ -3158,6 +3821,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/222"
   },
   {
@@ -3170,6 +3836,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/223"
   },
   {
@@ -3179,9 +3848,12 @@
     "cost": 40,
     "craftCost": null,
     "effect": "After the next three attacks targeting you, flip this card over.",
-    "uses": null,
+    "uses": 3,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/224"
   },
   {
@@ -3190,10 +3862,13 @@
     "slot": "one hand",
     "cost": 60,
     "craftCost": null,
-    "effect": "During your melee attack ability, Earth to add +1 Attack to one attack and flip this card over.",
+    "effect": "During your melee attack ability, Consume to add Attack +1 to one attack and flip this card over.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/225"
   },
   {
@@ -3206,6 +3881,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/226"
   },
   {
@@ -3218,6 +3896,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/227"
   },
   {
@@ -3230,6 +3911,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/228"
   },
   {
@@ -3242,6 +3926,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/229"
   },
   {
@@ -3254,6 +3941,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/230"
   },
   {
@@ -3266,6 +3956,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/231"
   },
   {
@@ -3278,6 +3971,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/232"
   },
   {
@@ -3290,6 +3986,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/233"
   },
   {
@@ -3302,6 +4001,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/234"
   },
   {
@@ -3314,6 +4016,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/235"
   },
   {
@@ -3326,6 +4031,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/236"
   },
   {
@@ -3338,6 +4046,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/237"
   },
   {
@@ -3350,6 +4061,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/238"
   },
   {
@@ -3362,6 +4076,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/239"
   },
   {
@@ -3374,6 +4091,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/240"
   },
   {
@@ -3386,6 +4106,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/241"
   },
   {
@@ -3398,6 +4121,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/242"
   },
   {
@@ -3410,6 +4136,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/243"
   },
   {
@@ -3422,6 +4151,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/244"
   },
   {
@@ -3434,6 +4166,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/245"
   },
   {
@@ -3446,6 +4181,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/246"
   },
   {
@@ -3458,6 +4196,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/247"
   },
   {
@@ -3470,6 +4211,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/248"
   },
   {
@@ -3482,6 +4226,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/249"
   },
   {
@@ -3490,10 +4237,13 @@
     "slot": "one hand",
     "cost": 0,
     "craftCost": null,
-    "effect": "During your turn perform:, All your banners are treated as additionally occupying the hex of the attack target of their bonuses and that hex is treated as occupied by an ally this round.",
+    "effect": "During your turn perform: Attack 2, Range 3, All your banners are treated as additionally occupying the hex of the attack target of their bonuses and that hex is treated as occupied by an ally this round.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": true,
     "sourceId": "gloomhavensecretariat:item/250"
   },
   {
@@ -3506,6 +4256,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/251"
   },
   {
@@ -3514,10 +4267,13 @@
     "slot": "one hand",
     "cost": 0,
     "craftCost": null,
-    "effect": "On the next three deaths of any of your summons, Earth|dark and perform:",
-    "uses": null,
+    "effect": "On the next three deaths of any of your summons, Earth|dark and perform: Heal 2, Self",
+    "uses": 3,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/252"
   },
   {
@@ -3530,6 +4286,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/253"
   },
   {
@@ -3542,6 +4301,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/254"
   },
   {
@@ -3554,6 +4316,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/255"
   },
   {
@@ -3566,6 +4331,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/256"
   },
   {
@@ -3578,6 +4346,9 @@
     "uses": null,
     "spent": true,
     "lost": false,
+    "consumed": false,
+    "persistent": true,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/257"
   },
   {
@@ -3586,10 +4357,13 @@
     "slot": "small item",
     "cost": 0,
     "craftCost": null,
-    "effect": "When you suffer damage, if your hit point value is reduced to below half your maximum, perform:, This heal is not affect by and cannot remove negative conditions.",
+    "effect": "When you suffer damage, if your hit point value is reduced to below half your maximum, perform: Heal 7, Self, Curse, This heal is not affect by and cannot remove negative conditions.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/258"
   },
   {
@@ -3602,6 +4376,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/259"
   },
   {
@@ -3614,6 +4391,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/260"
   },
   {
@@ -3626,6 +4406,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/261"
   },
   {
@@ -3634,10 +4417,13 @@
     "slot": "legs",
     "cost": 0,
     "craftCost": null,
-    "effect": "During your move ability, when you have Drill 1 or Drill 2, add +1 Move, then flip this card over at the end of your turn.",
+    "effect": "During your move ability, when you have Drill 1 or Drill 2, add Move +1, then flip this card over at the end of your turn.",
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/262"
   },
   {
@@ -3650,6 +4436,9 @@
     "uses": null,
     "spent": false,
     "lost": false,
+    "consumed": false,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/263"
   },
   {
@@ -3662,6 +4451,9 @@
     "uses": null,
     "spent": false,
     "lost": true,
+    "consumed": true,
+    "persistent": false,
+    "round": false,
     "sourceId": "gloomhavensecretariat:item/264"
   }
 ]

--- a/eval/suites/gloomhaven-2e.json
+++ b/eval/suites/gloomhaven-2e.json
@@ -499,8 +499,8 @@
     "category": "items",
     "question": "What does Gloomhaven 2e item #011, Healing Potion, do?",
     "finalAnswer": {
-      "expected": "Healing Potion is item #011, a small item-slot item costing 10 gold. Its effect is: During your turn, perform: Heal 3, Self. It has no use count and is persistent or passive.",
-      "grading": "Must identify Healing Potion as item #011 and include the effect: During your turn, perform: Heal 3, Self. Must use Gloomhaven 2e item data, not Frosthaven or another game."
+      "expected": "Healing Potion is item #011, a small item-slot item costing 10 gold. Its effect is: During your turn, perform: Heal 3, Self. It is consumed on use (one-time item).",
+      "grading": "Must identify Healing Potion as item #011 and include the effect: During your turn, perform: Heal 3, Self. Should note the item is consumed on use; must not claim it is persistent or passive. Must use Gloomhaven 2e item data, not Frosthaven or another game. Documented factual case fix (SQR-400, 2026-07-09): the import previously dropped the GHS consumed flag, and the prior expected answer codified the wrong data."
     },
     "source": "data/extracted/gh2/items.json",
     "game": "gloomhaven-2e",
@@ -995,7 +995,7 @@
     "category": "character-abilities",
     "question": "For Gloomhaven 2e Doomstalker, what level, initiative, top action, and bottom action are on Rain of Arrows?",
     "finalAnswer": {
-      "expected": "Rain of Arrows is a level 1 Doomstalker card with initiative 9. Top: On the next four deaths of an enemy that has Doom while there is another enemy within Range 4 (of you), perform Attack 3, Range 4. Bottom: Doom — add Pierce 2 to all your attacks targeting this enemy.",
+      "expected": "Rain of Arrows is a level 1 Doomstalker card with initiative 9. Top: On the next four deaths of an enemy that has Doom while there is another enemy within Range 4 (of you), perform Attack 3, Range 4. Bottom: Doom \u2014 add Pierce 2 to all your attacks targeting this enemy.",
       "grading": "Must identify Rain of Arrows as level 1 for Doomstalker, state initiative 9, summarize the top Doom-triggered Attack 3 effect, and include the bottom Doom with its Pierce 2 rider from the Gloomhaven 2e character ability data."
     },
     "source": "data/extracted/gh2/character-abilities.json",
@@ -1059,7 +1059,7 @@
     "category": "character-abilities",
     "question": "For Gloomhaven 2e Mindthief, what level, initiative, top action, and bottom action are on Submissive Affliction?",
     "finalAnswer": {
-      "expected": "Submissive Affliction is a level 1 Mindthief card with initiative 48. Top: Attack 2, Add Attack +1 for each negative condition the target has. Bottom: Control one enemy within Range 4: Move 1 — with a Consume Ice rider, the controlled enemy suffers Damage 2 (XP 1).",
+      "expected": "Submissive Affliction is a level 1 Mindthief card with initiative 48. Top: Attack 2, Add Attack +1 for each negative condition the target has. Bottom: Control one enemy within Range 4: Move 1 \u2014 with a Consume Ice rider, the controlled enemy suffers Damage 2 (XP 1).",
       "grading": "Must identify Submissive Affliction as level 1 for Mindthief, state initiative 48, and summarize both actions. The bottom control action includes Move 1 and the Ice-consumption rider (controlled enemy suffers Damage 2); presenting those riders in any clear order is correct, not extraneous."
     },
     "source": "data/extracted/gh2/character-abilities.json",
@@ -1406,7 +1406,7 @@
         "card:gloomhaven-2e/monster-stats/gloomhavensecretariat:monster-stat/bandit-scout/0-3"
       ],
       "maxToolCalls": 8,
-      "notes": "LangGraph node coverage: retrieval planning and source verification should separate exact structured data from fuzzy search results. Expectation updated 2026-07-07 (SQR-409, documented case fix): resolve_entity is no longer required by name — lookup_entity performs resolution internally and is the sanctioned single-call path for a named record under ADR 0026/0027; the grounding guarantee stays with requiredRefs (the exact stat record must be opened) plus the search requirement and the 8-call cap. Requiring the literal resolve_entity call asserted implementation choreography, not behavior."
+      "notes": "LangGraph node coverage: retrieval planning and source verification should separate exact structured data from fuzzy search results. Expectation updated 2026-07-07 (SQR-409, documented case fix): resolve_entity is no longer required by name \u2014 lookup_entity performs resolution internally and is the sanctioned single-call path for a named record under ADR 0026/0027; the grounding guarantee stays with requiredRefs (the exact stat record must be opened) plus the search requirement and the 8-call cap. Requiring the literal resolve_entity call asserted implementation choreography, not behavior."
     },
     "source": "data/extracted/gh2/monster-stats.json",
     "game": "gloomhaven-2e",
@@ -1497,7 +1497,7 @@
     "category": "rulebook",
     "question": "In Gloomhaven 2e, when I lose a card to avoid all damage, do I lose Ward?",
     "finalAnswer": {
-      "expected": "Yes. Ward’s effects are considered before the damage negation step, so Ward is consumed even though the damage is negated.",
+      "expected": "Yes. Ward\u2019s effects are considered before the damage negation step, so Ward is consumed even though the damage is negated.",
       "grading": "Must answer yes: Ward applies before the damage-negation step."
     },
     "source": "gh2-faq.html",
@@ -1537,7 +1537,7 @@
     "category": "rulebook",
     "question": "In Gloomhaven 2e, what is the order of operations if I draw a x2 or Null with rolling modifiers?",
     "finalAnswer": {
-      "expected": "If a Null (x0) is anywhere in the final draws, the final damage is always 0. A x2 can be inserted at any point during attack modification, including at the very end, at the attacker’s choice.",
+      "expected": "If a Null (x0) is anywhere in the final draws, the final damage is always 0. A x2 can be inserted at any point during attack modification, including at the very end, at the attacker\u2019s choice.",
       "grading": "Must state that a Null always makes the final damage 0 regardless of position, and that a x2 can be applied at any chosen point in the order."
     },
     "source": "gh2-faq.html",
@@ -1575,7 +1575,7 @@
   {
     "id": "gh2-faq-target-immune-figure",
     "category": "rulebook",
-    "question": "In Gloomhaven 2e, can I target a figure with a condition they’re immune to?",
+    "question": "In Gloomhaven 2e, can I target a figure with a condition they\u2019re immune to?",
     "finalAnswer": {
       "expected": "Yes. The condition will not be applied, but targeting is still allowed, which can matter for other effects. This is a change from Gloomhaven 1st Edition.",
       "grading": "Must answer yes: targeting is allowed even though the condition is not applied."
@@ -1595,7 +1595,7 @@
   {
     "id": "gh2-faq-range-one-still-ranged",
     "category": "rulebook",
-    "question": "In Gloomhaven 2e, if an attack’s range is reduced to 1, does it become a melee attack?",
+    "question": "In Gloomhaven 2e, if an attack\u2019s range is reduced to 1, does it become a melee attack?",
     "finalAnswer": {
       "expected": "No. It remains a ranged attack with Range 1, so it usually has disadvantage against an adjacent target.",
       "grading": "Must answer no: it stays a ranged attack (with the usual adjacency disadvantage)."
@@ -1637,7 +1637,7 @@
     "category": "rulebook",
     "question": "In Gloomhaven 2e, if a monster must move through a choice of traps, does it consider the strength of those traps?",
     "finalAnswer": {
-      "expected": "No. Monsters count the number of negative hexes but ignore their strength or effects, and they always prefer a path with zero negative hexes regardless of length. Remaining ambiguity is resolved in the players’ favor.",
+      "expected": "No. Monsters count the number of negative hexes but ignore their strength or effects, and they always prefer a path with zero negative hexes regardless of length. Remaining ambiguity is resolved in the players\u2019 favor.",
       "grading": "Must answer no: monsters weigh the count of negative hexes, not their strength."
     },
     "source": "gh2-faq.html",
@@ -1675,7 +1675,7 @@
   {
     "id": "gh2-faq-rounding-direction",
     "category": "rulebook",
-    "question": "In Gloomhaven 2e, if a calculation doesn’t say which way to round, which way do you round?",
+    "question": "In Gloomhaven 2e, if a calculation doesn\u2019t say which way to round, which way do you round?",
     "finalAnswer": {
       "expected": "If a calculation does not indicate a rounding direction, assume it rounds up.",
       "grading": "Must state that unspecified rounding rounds up."
@@ -1697,7 +1697,7 @@
     "category": "rulebook",
     "question": "In Gloomhaven 2e, can I use an item in the middle of my move or attack ability?",
     "finalAnswer": {
-      "expected": "Only if the item is not itself an ability and says something like “during your move ability.” If the item performs another ability (healing, damaging, destroying an obstacle), you must finish your current ability first. This is a change from a Gloomhaven 1e FAQ ruling.",
+      "expected": "Only if the item is not itself an ability and says something like \u201cduring your move ability.\u201d If the item performs another ability (healing, damaging, destroying an obstacle), you must finish your current ability first. This is a change from a Gloomhaven 1e FAQ ruling.",
       "grading": "Must distinguish items usable mid-ability (non-ability items worded for it) from item abilities that require finishing the current ability first."
     },
     "source": "gh2-faq.html",

--- a/src/db/migrations/20260709120000_item_usage_flags/migration.sql
+++ b/src/db/migrations/20260709120000_item_usage_flags/migration.sql
@@ -1,0 +1,6 @@
+-- SQR-400: the items import dropped GHS usage flags — 192 consumables across
+-- both games read as passive items. consumed = one-time use (discarded);
+-- persistent/round = effect duration markers from the card.
+ALTER TABLE "card_items" ADD COLUMN "consumed" boolean NOT NULL DEFAULT false;
+ALTER TABLE "card_items" ADD COLUMN "persistent" boolean NOT NULL DEFAULT false;
+ALTER TABLE "card_items" ADD COLUMN "round" boolean NOT NULL DEFAULT false;

--- a/src/db/schema/cards.ts
+++ b/src/db/schema/cards.ts
@@ -200,6 +200,10 @@ export const cardItems = pgTable(
     uses: integer('uses'), // nullable
     spent: boolean('spent').notNull(),
     lost: boolean('lost').notNull(),
+    // SQR-400: usage-semantics flags from GHS. consumed = one-time use.
+    consumed: boolean('consumed').notNull().default(false),
+    persistent: boolean('persistent').notNull().default(false),
+    round: boolean('round').notNull().default(false),
     searchVector: tsvector('search_vector').generatedAlwaysAs(SV_MARKER),
   },
   (t) => [

--- a/src/extracted-data.ts
+++ b/src/extracted-data.ts
@@ -447,13 +447,14 @@ function recordToText(record: ExtractedRecord): string {
     const uses = r.uses ? ` (${r.uses} uses)` : '';
     const spent = r.spent ? ' [spent]' : '';
     const lost = r.lost ? ' [lost]' : '';
+    const consumed = r.consumed ? ' [consumed]' : '';
     const craftCostText = formatItemCraftCost(r.craftCost);
     const costParts = [
       typeof r.cost === 'number' ? `Cost: ${r.cost}g` : null,
       craftCostText,
     ].filter((part): part is string => part !== null);
     const costText = costParts.length > 0 ? costParts.join('. ') : 'Cost: not shown';
-    return `Item #${r.number}: ${r.name}. Slot: ${r.slot}. ${costText}. Effect: ${r.effect}${uses}${spent}${lost}`;
+    return `Item #${r.number}: ${r.name}. Slot: ${r.slot}. ${costText}. Effect: ${r.effect}${uses}${spent}${lost}${consumed}`;
   }
 
   if (t === 'events') {

--- a/src/import-items.ts
+++ b/src/import-items.ts
@@ -35,7 +35,9 @@ export interface GhsItem {
   slot?: string;
   cost?: number;
   spent?: boolean;
-  consumed?: boolean;
+  /** Boolean for one-time-use items; the string 'initial' marks items that
+   * enter play already flipped (FH Cursed Rock) — not one-time use. */
+  consumed?: boolean | 'initial';
   loss?: boolean;
   round?: boolean;
   persistent?: boolean;
@@ -70,6 +72,9 @@ interface ExtractedItem {
   uses: number | null;
   spent: boolean;
   lost: boolean;
+  consumed: boolean;
+  persistent: boolean;
+  round: boolean;
   sourceId: string;
 }
 
@@ -148,9 +153,18 @@ export function convertItem(ghs: GhsItem, labels: LabelData): ExtractedItem {
     cost: ghs.cost ?? null,
     craftCost,
     effect,
-    uses: null,
+    // GHS `slots` is the number of use circles printed on the card
+    // (e.g. Hide Armor has 2) — distinct from the equipment slot.
+    uses: ghs.slots ?? null,
     spent: ghs.spent ?? false,
     lost: ghs.loss ?? false,
+    // `consumed` = one-time use, discarded permanently (SQR-400: previously
+    // dropped, which made 192 potions/consumables read as passive items).
+    // Only literal true counts: GHS marks FH Cursed Rock 'initial' (enters
+    // play flipped), which is not one-time use.
+    consumed: ghs.consumed === true,
+    persistent: ghs.persistent ?? false,
+    round: ghs.round ?? false,
     sourceId: `gloomhavensecretariat:item/${ghs.id}`,
   };
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -139,6 +139,15 @@ export const ItemSchema = z.object({
   uses: nullableInt.describe('Number of use tokens, or null'),
   spent: z.boolean().describe('True if the card has a spent symbol (flip to use)'),
   lost: z.boolean().describe('True if the card has a lost symbol (remove from game)'),
+  consumed: z
+    .boolean()
+    .default(false)
+    .describe('True if the item is consumed on use (one-time; discarded permanently)'),
+  persistent: z
+    .boolean()
+    .default(false)
+    .describe('True if the effect persists until a stated condition ends it'),
+  round: z.boolean().default(false).describe('True if the effect lasts for the current round'),
 });
 
 export const EventSchema = z.object({

--- a/test/import-items.test.ts
+++ b/test/import-items.test.ts
@@ -52,8 +52,67 @@ describe('convertItem', () => {
       uses: null,
       spent: true,
       lost: false,
+      consumed: false,
+      persistent: false,
+      round: false,
       sourceId: 'gloomhavensecretariat:item/1',
     });
+  });
+
+  it('round-trips the consumed flag and use slots (SQR-400)', () => {
+    // GH2e Healing Potion is consumed on use; the import used to drop the
+    // flag, so 192 consumables across both games read as passive items.
+    const healingPotion = {
+      id: 11,
+      name: 'Healing Potion',
+      count: 4,
+      edition: 'gh2e',
+      slot: 'small',
+      cost: 10,
+      consumed: true,
+      actions: [],
+    };
+    const potion = convertItem(healingPotion, labels);
+    expect(potion.consumed).toBe(true);
+    expect(potion.spent).toBe(false);
+    expect(potion.lost).toBe(false);
+
+    // GHS `slots` is the printed use-circle count, distinct from equipment slot.
+    const hideArmor = {
+      id: 3,
+      name: 'Hide Armor',
+      count: 2,
+      edition: 'gh2e',
+      slot: 'body',
+      slots: 2,
+      spent: true,
+      actions: [],
+    };
+    expect(convertItem(hideArmor, labels).uses).toBe(2);
+
+    const robes = {
+      id: 47,
+      name: 'Robes of Doom',
+      count: 1,
+      edition: 'fh',
+      slot: 'body',
+      persistent: true,
+      actions: [],
+    };
+    expect(convertItem(robes, labels).persistent).toBe(true);
+
+    // GHS marks FH Cursed Rock consumed: 'initial' (enters play flipped) —
+    // that is not one-time use and must not read as consumed.
+    const cursedRock = {
+      id: 243,
+      name: 'Cursed Rock',
+      count: 1,
+      edition: 'fh',
+      slot: 'small',
+      consumed: 'initial' as const,
+      actions: [],
+    };
+    expect(convertItem(cursedRock, labels).consumed).toBe(false);
   });
 
   it('maps GHS slot names to schema slot names', () => {


### PR DESCRIPTION
## Summary

The items import silently dropped several usage flags from the upstream GHS data. The headline: **192 consumable items (61 GH2e + 131 FH) read as passive items** because `consumed` was dropped. The eval judge had correctly failed the agent for truthfully saying the GH2e Healing Potion is consumed — the recorded "expected answer" codified the wrong data.

Changes:
- `import-items` now maps `consumed`, `persistent`, `round`, and the use-slot count (`uses` was always null before; GHS `slots` is the printed use-circle count — Hide Armor has 2).
- GHS's `consumed: 'initial'` (FH Cursed Rock — enters play already flipped, not one-time use) maps to `false` with a regression test. Bonus: that item previously failed schema validation and was **skipped entirely**; all 264 FH items now import.
- `ItemSchema` + `card_items` columns (migration `20260709120000_item_usage_flags`), `[consumed]` marker in item search text.
- Re-extracted both games, reseeded dev + test databases.
- `gh2-item-011-healing-potion` expected answer corrected as a documented factual case fix (the grading note records the provenance).

## Verification
- `npm run check`: 2,039 tests green (includes new round-trip + Cursed Rock regression tests and DB load-parity)
- `gh2-item-011-healing-potion` passes at score 1 (was a chronic accepted failure); `item-crude-helmet` control row still passes
- DB probe: Healing Potion row carries `consumed: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added item usage details, including consumed, persistent, round-based, and available-use indicators.
  * Item descriptions now clearly identify one-time consumed items.

* **Bug Fixes**
  * Corrected item conversion to preserve usage counts and distinguish initial-use markers from consumed items.
  * Improved monster lookup expectations and clarified several rulebook and card responses.

* **Tests**
  * Expanded coverage for item usage semantics, conversion behavior, and related defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->