### PR TITLE
SQR-397 Preserve monster deck composition: copy counts for duplicated cards

### DIFF
--- a/data/extracted/gh2/monster-abilities.json
+++ b/data/extracted/gh2/monster-abilities.json
@@ -7,6 +7,7 @@
       "Focus on the enemy farthest away within Range 7",
       "Attack 1, Range 7"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/600"
   },
   {
@@ -14,6 +15,7 @@
     "cardName": "Exploding Ammunition",
     "initiative": 71,
     "abilities": [],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/601"
   },
   {
@@ -21,9 +23,10 @@
     "cardName": "Grenade",
     "initiative": 37,
     "abilities": [
-      "Push 1, Target All, Range 1",
+      "Push 1, All, Range 1",
       "Attack 1, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/603"
   },
   {
@@ -31,9 +34,10 @@
     "cardName": "Massive Blast",
     "initiative": 57,
     "abilities": [
-      "Push 1, Target All, Range 1",
+      "Push 1, All, Range 1",
       "Attack 1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/604"
   },
   {
@@ -43,6 +47,7 @@
     "abilities": [
       "Attack 1, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/605"
   },
   {
@@ -50,10 +55,11 @@
     "cardName": "Defensive Ordinance",
     "initiative": 17,
     "abilities": [
-      "Push 2, Target All, Range 1",
+      "Push 2, All, Range 1",
       "Attack 2, Range 5",
       "Shield 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/606"
   },
   {
@@ -63,6 +69,7 @@
     "abilities": [
       "Attack 1, Range 5, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/607"
   },
   {
@@ -73,6 +80,7 @@
       "Move 0",
       "Attack 1, Range 5, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/648"
   },
   {
@@ -84,6 +92,7 @@
       "Attack 1, Range 5",
       "Create one Damage 3 trap in an adjacent empty hex closest to an enemy."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/649"
   },
   {
@@ -94,6 +103,7 @@
       "Move 0",
       "Attack 1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/650"
   },
   {
@@ -104,6 +114,7 @@
       "Move 1",
       "Attack 1, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/651"
   },
   {
@@ -113,6 +124,7 @@
     "abilities": [
       "Attack 1, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/652"
   },
   {
@@ -123,6 +135,7 @@
       "Move 0",
       "Attack 0, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/653"
   },
   {
@@ -133,6 +146,7 @@
       "Move 1",
       "Attack 1, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/654"
   },
   {
@@ -142,6 +156,7 @@
     "abilities": [
       "Attack 1, Target 2, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/655"
   },
   {
@@ -152,6 +167,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/bandit-archer-music-note2-solo/ordinal-1"
   },
   {
@@ -162,6 +178,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/bandit-scout-music-note2-solo/ordinal-1"
   },
   {
@@ -173,6 +190,7 @@
       "Muddle, Range 1",
       "If Bloated Victim dies this round, all figures adjacent to the hex it occupied suffer Damage 1 and gain Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/bloated-victim/752"
   },
   {
@@ -183,6 +201,7 @@
       "Move 0",
       "Attack 1, Target 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/bloated-victim/753"
   },
   {
@@ -193,6 +212,7 @@
       "Move 2",
       "Attack 1, Target 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/bloated-victim/754"
   },
   {
@@ -203,6 +223,7 @@
       "Move 1",
       "Attack 0, Target 2"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/bloated-victim/755"
   },
   {
@@ -211,9 +232,10 @@
     "initiative": 91,
     "abilities": [
       "Move 3",
-      "Element earth, Target 2",
+      "Consume Earth, Attack 0, Target 2",
       "If the move ability was performed, Bloated Victim suffers Damage 1."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/bloated-victim/757"
   },
   {
@@ -224,8 +246,9 @@
       "Move 1",
       "Attack 1, Target 2",
       "Poison, All, Range 1",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/bloated-victim/758"
   },
   {
@@ -236,6 +259,7 @@
       "Attack 2, Target 2, Push 1",
       "If the attack ability was performed, Bloated Victim suffers Damage 1."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/bloated-victim/759"
   },
   {
@@ -245,6 +269,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/744"
   },
   {
@@ -254,6 +279,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/745"
   },
   {
@@ -263,6 +289,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/746"
   },
   {
@@ -272,6 +299,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/747"
   },
   {
@@ -281,6 +309,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/748"
   },
   {
@@ -290,6 +319,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/749"
   },
   {
@@ -300,6 +330,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/750"
   },
   {
@@ -310,6 +341,7 @@
       "Move 1",
       "Attack 1, Target 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/751"
   },
   {
@@ -321,6 +353,7 @@
       "Attack 3, Wound, Advantage",
       "ElementHalf fire:light"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/candlekeeper-trice-scenario-56/0"
   },
   {
@@ -331,6 +364,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/cave-bear/704"
   },
   {
@@ -341,6 +375,7 @@
       "Move 1",
       "Attack 1, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/cave-bear/705"
   },
   {
@@ -350,6 +385,7 @@
     "abilities": [
       "Attack 1, Muddle"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/cave-bear/706"
   },
   {
@@ -360,6 +396,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/cave-bear/707"
   },
   {
@@ -370,6 +407,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/cave-bear/708"
   },
   {
@@ -381,6 +419,7 @@
       "Move 2",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/cave-bear/709"
   },
   {
@@ -391,6 +430,7 @@
       "Move 0",
       "Attack 1, Target 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/cave-bear/710"
   },
   {
@@ -401,6 +441,7 @@
       "Retaliate 2",
       "Heal 2, Self, Safeguard"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/cave-bear/711"
   },
   {
@@ -410,8 +451,9 @@
     "abilities": [
       "Move 1",
       "Attack 0",
-      "Element ice, Retaliate 2"
+      "Consume Ice, Retaliate 2, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/544"
   },
   {
@@ -420,8 +462,9 @@
     "initiative": 1,
     "abilities": [
       "Move 1",
-      "Attack 1, Range 2"
+      "Attack 1, Range 2, Consume Fire: Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/545"
   },
   {
@@ -430,8 +473,9 @@
     "initiative": 67,
     "abilities": [
       "Move 2",
-      "Attack 1, Push 2"
+      "Attack 1, Push 2, Consume Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/546"
   },
   {
@@ -441,8 +485,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 2",
-      "Element air, Shield 2"
+      "Consume Air, Shield 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/547"
   },
   {
@@ -452,8 +497,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, Advantage",
-      "Element light"
+      "Consume Light, Heal 4, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/548"
   },
   {
@@ -463,8 +509,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element dark, Invisible"
+      "Consume Dark, Invisible, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/549"
   },
   {
@@ -475,6 +522,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/550"
   },
   {
@@ -483,8 +531,9 @@
     "initiative": 98,
     "abilities": [
       "Move 1",
-      "Attack 1"
+      "Attack 1, Consume Wild: Disarm"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/551"
   },
   {
@@ -494,6 +543,7 @@
     "abilities": [
       "Remove City Guard from the map after being healed fully or given a medical pack."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/city-guard-saw2-solo/ordinal-1"
   },
   {
@@ -504,6 +554,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/city-guard-scenario-17/0"
   },
   {
@@ -515,6 +566,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/city-guard-sun2-solo/ordinal-1"
   },
   {
@@ -523,8 +575,9 @@
     "initiative": 28,
     "abilities": [
       "Attack 0, Range 4, Muddle",
-      "If the attack ability was performed, Crystal Rot performs:"
+      "If the attack ability was performed, Crystal Rot performs: Heal 2, Self, Strengthen"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/crystal-rot/784"
   },
   {
@@ -533,8 +586,9 @@
     "initiative": 40,
     "abilities": [
       "Move 1",
-      "Heal 1, Target 2, Range 3, Ward"
+      "Heal 1, Target 2, Range 3, Ward, Consume Dark: Target +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/crystal-rot/786"
   },
   {
@@ -544,8 +598,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 3",
-      "Heal 1, Range 3, Safeguard"
+      "Heal 1, Range 3, Safeguard, Consume Dark: Target +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/crystal-rot/787"
   },
   {
@@ -556,6 +611,7 @@
       "Muddle, All, Range 4",
       "Living Bones, Living Corpses, and Living Spirits within Range 4 add Attack +1 to all their attacks this round."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/crystal-rot/788"
   },
   {
@@ -565,8 +621,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, Range 3",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/crystal-rot/789"
   },
   {
@@ -578,6 +635,7 @@
       "Attack 1, Range 3",
       "Add Disarm if there are no Living Bones, Living Corpses or Living Spirits within Range 3."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/crystal-rot/790"
   },
   {
@@ -587,8 +645,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 3",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/crystal-rot/791"
   },
   {
@@ -598,8 +657,9 @@
     "abilities": [
       "Move 0",
       "Attack 1",
-      "If Cultist dies this round, first remove all negative conditions and perform:"
+      "If Cultist dies this round, first remove all negative conditions and perform: Attack 2"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist-scenario-54/760"
   },
   {
@@ -610,6 +670,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist-scenario-54/762"
   },
   {
@@ -619,6 +680,7 @@
     "abilities": [
       "The highest health enemy within Range 5 and within line-of-sight suffers X."
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist-scenario-54/764"
   },
   {
@@ -629,6 +691,7 @@
       "Move 1",
       "Heal 3, Range 3, Safeguard"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist-scenario-54/766"
   },
   {
@@ -638,8 +701,9 @@
     "abilities": [
       "Move 0",
       "Attack 1",
-      "If Cultist dies this round, first remove all negative conditions and perform:"
+      "If Cultist dies this round, first remove all negative conditions and perform: Attack 2"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist-scenario-82/760"
   },
   {
@@ -650,6 +714,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist-scenario-82/762"
   },
   {
@@ -661,6 +726,7 @@
       "SufferDamage 1",
       "Stun, Self"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist-scenario-82/764"
   },
   {
@@ -671,6 +737,7 @@
       "Move 1",
       "Heal 3, Range 3, Safeguard"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist-scenario-82/766"
   },
   {
@@ -680,8 +747,9 @@
     "abilities": [
       "Move 0",
       "Attack 1",
-      "If Cultist dies this round, first remove all negative conditions and perform:"
+      "If Cultist dies this round, first remove all negative conditions and perform: Attack 2"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist/760"
   },
   {
@@ -692,6 +760,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist/762"
   },
   {
@@ -703,6 +772,7 @@
       "SufferDamage 1",
       "Stun, Self"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist/764"
   },
   {
@@ -713,6 +783,7 @@
       "Move 1",
       "Heal 3, Range 3, Safeguard"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/cultist/766"
   },
   {
@@ -723,6 +794,7 @@
       "SufferDamage 1",
       "Stun, Self"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/dark-ritual-cultist-scenario-25A/764"
   },
   {
@@ -734,6 +806,7 @@
       "SufferDamage 1",
       "Stun, Self"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/dark-ritual-cultist/764"
   },
   {
@@ -743,6 +816,7 @@
     "abilities": [
       "Attack 0, Pierce 3"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror-scenario-51/633"
   },
   {
@@ -752,6 +826,7 @@
     "abilities": [
       "Attack 1, Range 3, Target 3, Curse"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/632"
   },
   {
@@ -761,6 +836,7 @@
     "abilities": [
       "Attack 0, Pierce 3"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/633"
   },
   {
@@ -771,6 +847,7 @@
       "Attack 1, EnemiesAdjacent",
       "Attack 0, Range 4, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/635"
   },
   {
@@ -781,6 +858,7 @@
       "Attack 1, Poison",
       "Attack 1, Range 5, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/636"
   },
   {
@@ -791,6 +869,7 @@
       "Attack 2, Disarm",
       "Attack 1, Target 2, Range 3, Muddle"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/637"
   },
   {
@@ -799,8 +878,9 @@
     "initiative": 96,
     "abilities": [
       "Attack 2, Range 6",
-      "If the attack ability was performed"
+      "If the attack ability was performed, Summon monsterStandee, in an empty hex adjacent to the target of the attack ability"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/638"
   },
   {
@@ -810,6 +890,7 @@
     "abilities": [
       "Attack 0, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/639"
   },
   {
@@ -819,6 +900,7 @@
     "abilities": [
       "Attack 1, Target all in row A"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/doomcannon/626"
   },
   {
@@ -828,6 +910,7 @@
     "abilities": [
       "Attack 1, Target all in row B"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/doomcannon/627"
   },
   {
@@ -837,6 +920,7 @@
     "abilities": [
       "Attack 1, Target all in row A"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/doomcannon/629"
   },
   {
@@ -846,6 +930,7 @@
     "abilities": [
       "Attack 1, Target all in row B"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/doomcannon/630"
   },
   {
@@ -855,6 +940,7 @@
     "abilities": [
       "Attack 1, Target all in row B"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/doomcannon/631"
   },
   {
@@ -864,6 +950,7 @@
     "abilities": [
       "Attack 1, Target all in row A"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/doomcannon/632"
   },
   {
@@ -873,6 +960,7 @@
     "abilities": [
       "Attack 1, Target all in row A"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/doomcannon/633"
   },
   {
@@ -881,8 +969,9 @@
     "initiative": 40,
     "abilities": [
       "Heal 4, Self",
-      "Element earth, Immobilize"
+      "Consume Earth, Immobilize, All, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/576"
   },
   {
@@ -893,6 +982,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/577"
   },
   {
@@ -902,8 +992,9 @@
     "abilities": [
       "Move 0",
       "Attack 0",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/578"
   },
   {
@@ -911,8 +1002,9 @@
     "cardName": "Boulder Throw",
     "initiative": 71,
     "abilities": [
-      "Attack 0, Range 4"
+      "Attack 0, Range 4, Consume Earth: Target +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/579"
   },
   {
@@ -922,8 +1014,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/580"
   },
   {
@@ -932,8 +1025,9 @@
     "initiative": 93,
     "abilities": [
       "Move 1",
-      "Attack 1, EnemiesAdjacent"
+      "Attack 1, EnemiesAdjacent, Consume Earth: Push 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/581"
   },
   {
@@ -942,8 +1036,9 @@
     "initiative": 79,
     "abilities": [
       "Move 1",
-      "Attack 0"
+      "Attack 0, Consume Air: Attack 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/582"
   },
   {
@@ -952,8 +1047,9 @@
     "initiative": 87,
     "abilities": [
       "Move 0",
-      "Element wild"
+      "Consume Wild, Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/583"
   },
   {
@@ -964,6 +1060,7 @@
       "Heal 1, Self",
       "If health increased beyond max: Destroy Egg and spawn one Normal Night Demon in same hex."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/egg-scenario-50/0"
   },
   {
@@ -971,9 +1068,10 @@
     "cardName": "To Fear is to Die",
     "initiative": 1,
     "abilities": [
-      "If odd round:, Grant all allies: Shield 1",
-      "If even round:, Grant all allies: Retaliate 1"
+      "If odd round: Grant all allies: Shield 1",
+      "If even round: Grant all allies: Retaliate 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/first-shield-harmon-scenario-56/0"
   },
   {
@@ -983,8 +1081,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Range 4",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/552"
   },
   {
@@ -994,8 +1093,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, Range 4",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/553"
   },
   {
@@ -1003,8 +1103,9 @@
     "cardName": "Explosive Blast",
     "initiative": 46,
     "abilities": [
-      "Attack 0, Range 4"
+      "Attack 0, Range 4, Consume Fire: Range 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/554"
   },
   {
@@ -1014,8 +1115,9 @@
     "abilities": [
       "Move 1",
       "Create one Damage 4 trap in an adjacent empty hex closest to an enemy",
-      "Element wild"
+      "Consume Wild, Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/555"
   },
   {
@@ -1023,8 +1125,9 @@
     "cardName": "Intense Torch",
     "initiative": 49,
     "abilities": [
-      "Attack 0"
+      "Attack 0, Consume Fire: Attack +1, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/556"
   },
   {
@@ -1034,8 +1137,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Range 3",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/557"
   },
   {
@@ -1044,8 +1148,9 @@
     "initiative": 77,
     "abilities": [
       "Attack 0, EnemiesAdjacent",
-      "Element ice"
+      "Consume Ice, Damage 1, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/558"
   },
   {
@@ -1053,10 +1158,11 @@
     "cardName": "Raging Blaze",
     "initiative": 30,
     "abilities": [
-      "Element fire, All adjacent enemies suffer Damage 2",
+      "Consume Fire, All adjacent enemies suffer Damage 2",
       "Move 0",
       "Attack 2, Target 2, Range 4, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/559"
   },
   {
@@ -1064,9 +1170,10 @@
     "cardName": "Gather the Frost",
     "initiative": 18,
     "abilities": [
-      "Immobilize, Target All, Range 2",
-      "Element ice"
+      "Immobilize, All, Range 2",
+      "Consume Ice, Heal 3, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/560"
   },
   {
@@ -1077,6 +1184,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/561"
   },
   {
@@ -1085,8 +1193,9 @@
     "initiative": 58,
     "abilities": [
       "Move 1",
-      "Attack 0, Range 2"
+      "Attack 0, Range 2, Consume Ice: Attack +2, Range +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/562"
   },
   {
@@ -1097,6 +1206,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/563"
   },
   {
@@ -1106,8 +1216,9 @@
     "abilities": [
       "Move 1",
       "Attack 0",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/564"
   },
   {
@@ -1117,8 +1228,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Pierce 3",
-      "Element wild"
+      "Consume Wild, Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/566"
   },
   {
@@ -1128,8 +1240,9 @@
     "abilities": [
       "Move 1",
       "Shield 2",
-      "Element fire"
+      "Consume Fire, Damage 1, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/667"
   },
   {
@@ -1140,6 +1253,7 @@
       "Move 0",
       "Attack 0, Add Attack +2 if the target is adjacent to any of the Giant Viper's allies"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-viper/768"
   },
   {
@@ -1150,6 +1264,7 @@
       "Shield 1",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-viper/770"
   },
   {
@@ -1160,6 +1275,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-viper/771"
   },
   {
@@ -1167,9 +1283,10 @@
     "cardName": "Swift Fangs",
     "initiative": 33,
     "abilities": [
-      "Move 1",
+      "Move 1, Jump",
       "Attack 0, Target 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-viper/772"
   },
   {
@@ -1177,9 +1294,10 @@
     "cardName": "Find Cover",
     "initiative": 18,
     "abilities": [
-      "Move 1",
+      "Move 1, Jump",
       "Attack 1, All attacks targeting Giant Viper this round gain disadvantage."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-viper/773"
   },
   {
@@ -1187,9 +1305,10 @@
     "cardName": "Toxic Frenzy",
     "initiative": 43,
     "abilities": [
-      "Move 1",
+      "Move 1, Jump",
       "Attack 1, EnemiesAdjacent"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-viper/774"
   },
   {
@@ -1201,6 +1320,7 @@
       "Attack 1, Immobilize",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-viper/775"
   },
   {
@@ -1211,6 +1331,7 @@
       "Shield 1",
       "Retaliate 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/640"
   },
   {
@@ -1221,6 +1342,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/641"
   },
   {
@@ -1231,6 +1353,7 @@
       "Move 1",
       "Attack 0, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/642"
   },
   {
@@ -1241,6 +1364,7 @@
       "Attack 0, Poison",
       "Shield 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/643"
   },
   {
@@ -1251,6 +1375,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/644"
   },
   {
@@ -1261,6 +1386,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/645"
   },
   {
@@ -1272,6 +1398,7 @@
       "Attack 0",
       "Strengthen, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/647"
   },
   {
@@ -1282,6 +1409,7 @@
       "Move 1",
       "Attack 1, Target 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/688"
   },
   {
@@ -1291,8 +1419,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Poison",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/689"
   },
   {
@@ -1304,6 +1433,7 @@
       "Attack 1",
       "Heal 5, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/690"
   },
   {
@@ -1314,6 +1444,7 @@
       "Attack 1, Range 3, Muddle",
       "Heal 4, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/691"
   },
   {
@@ -1324,6 +1455,7 @@
       "Attack 2, Immobilize",
       "Retaliate 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/692"
   },
   {
@@ -1334,6 +1466,7 @@
       "Shield 2",
       "Retaliate 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/693"
   },
   {
@@ -1343,8 +1476,9 @@
     "abilities": [
       "Move 1",
       "Attack 0",
-      "Element dark, Perform \" Heal, self\" where X is twice the number of enemies targeted by the attack ability."
+      "Consume Dark, Perform \" Heal, self\" where X is twice the number of enemies targeted by the attack ability."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/694"
   },
   {
@@ -1353,8 +1487,9 @@
     "initiative": 38,
     "abilities": [
       "Move 0",
-      "Attack 1, Target 2, Wound"
+      "Attack 1, Target 2, Wound, Consume Dark: Attack +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/695"
   },
   {
@@ -1365,6 +1500,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/hawthorne/ordinal-1"
   },
   {
@@ -1375,6 +1511,7 @@
       "Move 1",
       "Attack 0, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/712"
   },
   {
@@ -1383,8 +1520,9 @@
     "initiative": 7,
     "abilities": [
       "Move 0",
-      "Muddle, Target All, Range 1"
+      "Muddle, All, Range 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/713"
   },
   {
@@ -1394,6 +1532,7 @@
     "abilities": [
       "Move 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/714"
   },
   {
@@ -1404,6 +1543,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/716"
   },
   {
@@ -1414,6 +1554,7 @@
       "Move 2",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/718"
   },
   {
@@ -1425,6 +1566,7 @@
       "Move 2",
       "Attack 1, Pierce 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/719"
   },
   {
@@ -1434,8 +1576,9 @@
     "abilities": [
       "Shield 5",
       "Heal 1, Self",
-      "Element wild"
+      "Infuse Wild"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/696"
   },
   {
@@ -1446,6 +1589,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/697"
   },
   {
@@ -1456,6 +1600,7 @@
       "Move 1",
       "Heal 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/699"
   },
   {
@@ -1464,8 +1609,9 @@
     "initiative": 43,
     "abilities": [
       "Move 0",
-      "Attack 1, Range 3, Poison"
+      "Attack 1, Range 3, Poison, Consume Wild: Target +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/700"
   },
   {
@@ -1476,6 +1622,7 @@
       "Move 1",
       "Attack 1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/701"
   },
   {
@@ -1484,8 +1631,9 @@
     "initiative": 43,
     "abilities": [
       "Move 0",
-      "Attack 1, Range 3, Curse"
+      "Attack 1, Range 3, Curse, Consume Wild: Target +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/702"
   },
   {
@@ -1493,9 +1641,10 @@
     "cardName": "Tip the Scales",
     "initiative": 24,
     "abilities": [
-      "Strengthen, Target All, Range 2",
-      "Muddle, Target All, Range 2"
+      "Strengthen, All, Range 2",
+      "Muddle, All, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/703"
   },
   {
@@ -1506,6 +1655,7 @@
       "Spawn one Living Bones. It is Normal for 2 characters, Elite every second spawn for 3 and Elite for 4 characters.",
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/jekserah-scenario-23/874"
   },
   {
@@ -1516,6 +1666,7 @@
       "Spawn one Living Bones. It is Normal for 2 characters, Elite every second spawn for 3 and Elite for 4 characters.",
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/jekserah-scenario-23/875"
   },
   {
@@ -1526,6 +1677,7 @@
       "Spawn one Living Bones. It is Normal for 2 characters, Elite every second spawn for 3 and Elite for 4 characters.",
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/jekserah-scenario-23/876"
   },
   {
@@ -1536,6 +1688,7 @@
       "Spawn one Living Corpse. It is Normal for 2 characters, Elite every second spawn for 3 and Elite for 4 characters.",
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/jekserah-scenario-23/877"
   },
   {
@@ -1546,6 +1699,7 @@
       "Spawn one Living Corpse. It is Normal for 2 characters, Elite every second spawn for 3 and Elite for 4 characters.",
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/jekserah-scenario-23/878"
   },
   {
@@ -1556,6 +1710,7 @@
       "Spawn one Living Corpse. It is Normal for 2 characters, Elite every second spawn for 3 and Elite for 4 characters.",
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/jekserah-scenario-23/879"
   },
   {
@@ -1567,6 +1722,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/jekserah-scenario-23/880"
   },
   {
@@ -1578,6 +1734,7 @@
       "Move 1",
       "Attack 1, Target 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/jekserah-scenario-23/881"
   },
   {
@@ -1585,9 +1742,10 @@
     "cardName": "Purple Glow",
     "initiative": 1,
     "abilities": [
-      "If odd round:",
-      "If even round:"
+      "If odd round: Summon monsterStandee",
+      "If even round: Heal 2, Target 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/jekserah-scenario-56/0"
   },
   {
@@ -1597,6 +1755,7 @@
     "abilities": [
       "Move 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bomb/0"
   },
   {
@@ -1607,6 +1766,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/616"
   },
   {
@@ -1618,6 +1778,7 @@
       "Attack 0",
       "Heal 2, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/617"
   },
   {
@@ -1628,6 +1789,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/618"
   },
   {
@@ -1638,6 +1800,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/619"
   },
   {
@@ -1647,6 +1810,7 @@
     "abilities": [
       "Attack 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/621"
   },
   {
@@ -1657,6 +1821,7 @@
       "Move 0",
       "Attack 0, EnemyOneAll"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/622"
   },
   {
@@ -1667,6 +1832,7 @@
       "Shield 1",
       "Heal 2, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/623"
   },
   {
@@ -1677,6 +1843,7 @@
       "Move 1",
       "If Living Corpse dies this round, all figures adjacent to the hex it occupied suffer Damage 1 and gain Poison."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-corpse/752"
   },
   {
@@ -1687,6 +1854,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-corpse/753"
   },
   {
@@ -1697,6 +1865,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-corpse/754"
   },
   {
@@ -1707,6 +1876,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/living-corpse/755"
   },
   {
@@ -1715,9 +1885,10 @@
     "initiative": 91,
     "abilities": [
       "Move 2",
-      "Element earth",
+      "Consume Earth, Attack 0",
       "If the move ability was performed, Living Corpse suffers Damage 1."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-corpse/757"
   },
   {
@@ -1728,8 +1899,9 @@
       "Move 0",
       "Attack 1",
       "Poison, All, Range 1",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-corpse/758"
   },
   {
@@ -1740,6 +1912,7 @@
       "Attack 2, Push 1",
       "If the attack ability was performed, Living Corpse suffers Damage 1."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-corpse/759"
   },
   {
@@ -1749,6 +1922,7 @@
     "abilities": [
       "Living Spirits without Poison do not act."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit-squidface-solo/ordinal-1"
   },
   {
@@ -1759,6 +1933,7 @@
       "Move 1",
       "Attack 1, Range 3, Muddle"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/608"
   },
   {
@@ -1769,6 +1944,7 @@
       "Move 1",
       "Attack 1, Target 3, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/609"
   },
   {
@@ -1779,6 +1955,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/610"
   },
   {
@@ -1788,6 +1965,7 @@
     "abilities": [
       "Attack 0, Target 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/612"
   },
   {
@@ -1798,8 +1976,9 @@
       "Move 1",
       "Attack 1, Range 2",
       "Heal 1, Self",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/613"
   },
   {
@@ -1809,8 +1988,9 @@
     "abilities": [
       "Move 0",
       "Curse, Target 3, Range 2",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/614"
   },
   {
@@ -1819,8 +1999,9 @@
     "initiative": 67,
     "abilities": [
       "Move 1",
-      "Attack 0, Range 4"
+      "Attack 0, Range 4, Consume Ice: Stun"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/615"
   },
   {
@@ -1829,8 +2010,9 @@
     "initiative": 11,
     "abilities": [
       "Wound, All, Range 1",
-      "Shield 1"
+      "Shield 1, Consume Ice: Shield 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/624"
   },
   {
@@ -1841,6 +2023,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/625"
   },
   {
@@ -1851,6 +2034,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/626"
   },
   {
@@ -1861,6 +2045,7 @@
       "Move 0",
       "Attack 0, EnemyOneAll"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/627"
   },
   {
@@ -1871,6 +2056,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/628"
   },
   {
@@ -1878,8 +2064,9 @@
     "cardName": "Berserk Rage",
     "initiative": 64,
     "abilities": [
-      "Attack 1, Target 2 enemies within 2 hexes, Muddle"
+      "Attack 1, 2 enemies within 2 hexes, Muddle"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/629"
   },
   {
@@ -1887,10 +2074,11 @@
     "cardName": "Strength of the Deep",
     "initiative": 41,
     "abilities": [
-      "Element ice, Strengthen",
+      "Consume Ice, Strengthen, Self",
       "Move 0",
       "Attack 1, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/630"
   },
   {
@@ -1901,8 +2089,9 @@
       "Move 0",
       "Attack 1",
       "Shield 1",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/631"
   },
   {
@@ -1912,8 +2101,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/584"
   },
   {
@@ -1923,8 +2113,9 @@
     "abilities": [
       "Move 1",
       "Attack 2",
-      "Element dark, Invisible"
+      "Consume Dark, Invisible, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/585"
   },
   {
@@ -1934,8 +2125,9 @@
     "abilities": [
       "Move 0",
       "Attack 0",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/586"
   },
   {
@@ -1943,8 +2135,9 @@
     "cardName": "Black Thorns",
     "initiative": 26,
     "abilities": [
-      "Attack 2, Target 3, Range 3"
+      "Attack 2, Target 3, Range 3, Consume Dark: Muddle"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/587"
   },
   {
@@ -1953,8 +2146,9 @@
     "initiative": 46,
     "abilities": [
       "Move 1",
-      "Attack 1"
+      "Attack 1, Consume Dark: Attack +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/588"
   },
   {
@@ -1964,8 +2158,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/589"
   },
   {
@@ -1975,8 +2170,9 @@
     "abilities": [
       "Attack 1",
       "Attack 1, Pierce 2",
-      "Element light, Curse"
+      "Consume Light, Curse, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/590"
   },
   {
@@ -1987,8 +2183,9 @@
       "Move 0",
       "Attack 1",
       "All adjacent allies and enemies suffer Damage 1.",
-      "Element wild"
+      "Consume Wild, Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/591"
   },
   {
@@ -1998,8 +2195,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Range 3",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/736"
   },
   {
@@ -2010,6 +2208,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/737"
   },
   {
@@ -2017,8 +2216,9 @@
     "cardName": "Toxic Explosion",
     "initiative": 59,
     "abilities": [
-      "Attack 0, Target 2, Range 3, Poison"
+      "Attack 0, Target 2, Range 3, Poison, Consume Earth: Target +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/738"
   },
   {
@@ -2026,9 +2226,10 @@
     "cardName": "Plasma Ward",
     "initiative": 85,
     "abilities": [
-      "Push 1, Target All, Range 1, Poison",
+      "Push 1, All, Range 1, Poison",
       "Attack 1, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/739"
   },
   {
@@ -2038,8 +2239,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Range 4",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/740"
   },
   {
@@ -2050,6 +2252,7 @@
       "SufferDamage 2",
       "Summon, with H equal to the summoning Ooze's current hit point value (limited by a normal Ooze's maximum hit point values)."
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/741"
   },
   {
@@ -2059,8 +2262,9 @@
     "abilities": [
       "Move 1",
       "Loot 1",
-      "Heal 2, Self"
+      "Heal 2, Self, Consume Dark: Heal +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/743"
   },
   {
@@ -2071,6 +2275,7 @@
       "Move 1",
       "Attack 0, Range 3, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/656"
   },
   {
@@ -2081,6 +2286,7 @@
       "Move 0",
       "Attack 1, Range 3, Disarm"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/657"
   },
   {
@@ -2091,6 +2297,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/658"
   },
   {
@@ -2101,6 +2308,7 @@
       "Move 0",
       "Heal 3, Range 3"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/659"
   },
   {
@@ -2111,6 +2319,7 @@
       "Move 1",
       "Attack 1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/661"
   },
   {
@@ -2122,6 +2331,7 @@
       "Heal 1, Allies, Range 1",
       "Bless, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/662"
   },
   {
@@ -2132,6 +2342,7 @@
       "Move 1",
       "Attack 1, Target 2, Range 3, Curse"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/663"
   },
   {
@@ -2142,6 +2353,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/720"
   },
   {
@@ -2153,6 +2365,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/721"
   },
   {
@@ -2163,6 +2376,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/722"
   },
   {
@@ -2173,6 +2387,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/723"
   },
   {
@@ -2183,6 +2398,7 @@
       "Move 2",
       "Attack 1, Target 2, Range 3, Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/724"
   },
   {
@@ -2193,6 +2409,7 @@
       "Move 2",
       "Attack 1, Target 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/725"
   },
   {
@@ -2204,6 +2421,7 @@
       "Attack 1",
       "Attack 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/726"
   },
   {
@@ -2214,6 +2432,7 @@
       "Shield 2",
       "Heal 2, Self, Strengthen"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/727"
   },
   {
@@ -2223,9 +2442,10 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 3",
-      "Grant all allies within Range 2 and self:, Shield 1",
-      "Element ice"
+      "Grant all allies within Range 2 and self: Shield 1",
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm-scenario-40/797"
   },
   {
@@ -2233,10 +2453,11 @@
     "cardName": "Freezing Winds",
     "initiative": 14,
     "abilities": [
-      "Attack 0, Range 4",
+      "Attack 0, Range 4, Consume Ice: Attack 2, Immobilize",
       "Retaliate 2",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm-scenario-40/798"
   },
   {
@@ -2245,9 +2466,10 @@
     "initiative": 14,
     "abilities": [
       "Shield 4",
-      "Heal 2, Range 3",
-      "Element air"
+      "Heal 2, Range 3, Consume Ice: Heal +3",
+      "Consume Air, Attack -1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm-scenario-40/799"
   },
   {
@@ -2255,11 +2477,12 @@
     "cardName": "Forceful Gust",
     "initiative": 47,
     "abilities": [
-      "Disarm, Target All, Range 1",
+      "Disarm, All, Range 1",
       "Move 0",
       "Attack 1, Range 4",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm-scenario-40/800"
   },
   {
@@ -2269,8 +2492,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm-scenario-40/801"
   },
   {
@@ -2278,9 +2502,10 @@
     "cardName": "Repulsive Torrent",
     "initiative": 70,
     "abilities": [
-      "Push 2, Target All, Range 1",
+      "Push 2, All, Range 1, Consume Air: Push +2",
       "Attack 1, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/680"
   },
   {
@@ -2289,8 +2514,9 @@
     "initiative": 98,
     "abilities": [
       "Summon",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/681"
   },
   {
@@ -2299,8 +2525,9 @@
     "initiative": 98,
     "abilities": [
       "Summon",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/682"
   },
   {
@@ -2310,9 +2537,10 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 3",
-      "Grant all allies within Range 2 and self:, Shield 1",
-      "Element ice"
+      "Grant all allies within Range 2 and self: Shield 1",
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/683"
   },
   {
@@ -2320,10 +2548,11 @@
     "cardName": "Freezing Winds",
     "initiative": 14,
     "abilities": [
-      "Attack 0, Range 4",
+      "Attack 0, Range 4, Consume Ice: Attack 2, Immobilize",
       "Retaliate 2",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/684"
   },
   {
@@ -2332,9 +2561,10 @@
     "initiative": 14,
     "abilities": [
       "Shield 4",
-      "Heal 2, Range 3",
-      "Element air"
+      "Heal 2, Range 3, Consume Ice: Heal +3",
+      "Consume Air, Attack -1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/685"
   },
   {
@@ -2342,11 +2572,12 @@
     "cardName": "Forceful Gust",
     "initiative": 47,
     "abilities": [
-      "Disarm, Target All, Range 1",
+      "Disarm, All, Range 1",
       "Move 0",
       "Attack 1, Range 4",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/686"
   },
   {
@@ -2356,8 +2587,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/687"
   },
   {
@@ -2367,8 +2599,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, EnemiesAdjacent",
-      "Element fire, Retaliate 3"
+      "Consume Fire, Retaliate 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow-scenario-40/788"
   },
   {
@@ -2377,8 +2610,9 @@
     "initiative": 68,
     "abilities": [
       "Move 1",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow-scenario-40/789"
   },
   {
@@ -2387,8 +2621,9 @@
     "initiative": 41,
     "abilities": [
       "Move 0",
-      "Attack 1"
+      "Attack 1, Consume Earth: Attack +2, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow-scenario-40/790"
   },
   {
@@ -2396,8 +2631,9 @@
     "cardName": "Strength of the Mountain",
     "initiative": 31,
     "abilities": [
-      "Heal 4, Range 3"
+      "Heal 4, Range 3, Consume Earth: Target +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow-scenario-40/792"
   },
   {
@@ -2407,8 +2643,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Target 2, Range 3",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow-scenario-40/793"
   },
   {
@@ -2417,8 +2654,9 @@
     "initiative": 97,
     "abilities": [
       "Summon",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/672"
   },
   {
@@ -2427,8 +2665,9 @@
     "initiative": 97,
     "abilities": [
       "Summon",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/673"
   },
   {
@@ -2438,8 +2677,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, EnemiesAdjacent",
-      "Element fire, Retaliate 3"
+      "Consume Fire, Retaliate 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/674"
   },
   {
@@ -2448,8 +2688,9 @@
     "initiative": 68,
     "abilities": [
       "Move 1",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/675"
   },
   {
@@ -2458,8 +2699,9 @@
     "initiative": 41,
     "abilities": [
       "Move 0",
-      "Attack 1"
+      "Attack 1, Consume Earth: Attack +2, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/676"
   },
   {
@@ -2468,9 +2710,10 @@
     "initiative": 51,
     "abilities": [
       "All enemies within Range 4 suffer Damage 2.",
-      "Element fire, Wound",
-      "Element earth, Disarm"
+      "Consume Fire, Wound, All, Range 4",
+      "Consume Earth, Disarm, All, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/677"
   },
   {
@@ -2478,8 +2721,9 @@
     "cardName": "Strength of the Mountain",
     "initiative": 31,
     "abilities": [
-      "Heal 4, Range 3"
+      "Heal 4, Range 3, Consume Earth: Target +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/678"
   },
   {
@@ -2489,8 +2733,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Target 2, Range 3",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/679"
   },
   {
@@ -2501,6 +2746,7 @@
       "Move 1",
       "Attack 1, Range 3, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/664"
   },
   {
@@ -2511,6 +2757,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/665"
   },
   {
@@ -2521,6 +2768,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/666"
   },
   {
@@ -2531,6 +2779,7 @@
       "Move 2",
       "Attack 0, Range 3, Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/667"
   },
   {
@@ -2541,6 +2790,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/668"
   },
   {
@@ -2550,6 +2800,7 @@
     "abilities": [
       "Attack 2, Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/669"
   },
   {
@@ -2559,6 +2810,7 @@
     "abilities": [
       "Attack 1, Target 2, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/670"
   },
   {
@@ -2566,9 +2818,10 @@
     "cardName": "Greed",
     "initiative": 35,
     "abilities": [
-      "Move 1",
+      "Move 1, Jump",
       "Loot 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/671"
   },
   {
@@ -2579,6 +2832,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/shyreth/ordinal-1"
   },
   {
@@ -2589,6 +2843,7 @@
       "Move 1",
       "Attack 1, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/728"
   },
   {
@@ -2599,6 +2854,7 @@
       "Move 0",
       "Attack 0, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/729"
   },
   {
@@ -2609,6 +2865,7 @@
       "Move 0",
       "Attack 1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/730"
   },
   {
@@ -2618,6 +2875,7 @@
     "abilities": [
       "Attack 0, Target 2, Range 4, Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/731"
   },
   {
@@ -2628,6 +2886,7 @@
       "Move 1",
       "Attack 1, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/732"
   },
   {
@@ -2637,6 +2896,7 @@
     "abilities": [
       "Attack 2, Range 4, Stun"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/733"
   },
   {
@@ -2647,6 +2907,7 @@
       "Shield 2",
       "Heal 2, Self, Strengthen"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/734"
   },
   {
@@ -2657,6 +2918,7 @@
       "Move 1",
       "Attack 2, Range 3, Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/735"
   },
   {
@@ -2667,6 +2929,7 @@
       "Move 3",
       "Attack 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spymaster-argeise/0"
   },
   {
@@ -2676,6 +2939,7 @@
     "abilities": [
       "Retaliate 3, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/stone-construct/776"
   },
   {
@@ -2687,6 +2951,7 @@
       "Attack 0",
       "If the move ability was performed, Stone Construct suffers Damage 1."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/stone-construct/777"
   },
   {
@@ -2697,6 +2962,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/stone-construct/778"
   },
   {
@@ -2707,6 +2973,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/stone-construct/779"
   },
   {
@@ -2717,6 +2984,7 @@
       "Attack 1, Range 3",
       "If the attack ability was performed, Stone Construct suffers Damage 1."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/stone-construct/780"
   },
   {
@@ -2727,6 +2995,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/stone-construct/781"
   },
   {
@@ -2737,6 +3006,7 @@
       "Move 0",
       "Attack 0, EnemiesAdjacent"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/stone-construct/782"
   },
   {
@@ -2747,6 +3017,7 @@
       "Move 1",
       "Attack 2, Range 3, Pull 2, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/stone-construct/783"
   },
   {
@@ -2754,8 +3025,9 @@
     "cardName": "Ray of Warmth",
     "initiative": 17,
     "abilities": [
-      "Heal 3, Range 3"
+      "Heal 3, Range 3, Consume Light: All"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/592"
   },
   {
@@ -2765,8 +3037,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, EnemiesAdjacent",
-      "Element light"
+      "Infuse Light"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/593"
   },
   {
@@ -2776,8 +3049,9 @@
     "abilities": [
       "Move 0",
       "Attack 1",
-      "Element light"
+      "Infuse Light"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/595"
   },
   {
@@ -2787,8 +3061,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element light"
+      "Consume Light, Heal 3, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/596"
   },
   {
@@ -2797,8 +3072,9 @@
     "initiative": 95,
     "abilities": [
       "Move 1",
-      "Attack 0, Range 3"
+      "Attack 0, Range 3, Consume Light: All"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/597"
   },
   {
@@ -2808,8 +3084,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, EnemiesAdjacent",
-      "Element dark, Muddle"
+      "Consume Dark, Muddle, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/598"
   },
   {
@@ -2819,8 +3096,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, Range 3",
-      "Element wild"
+      "Consume Wild, Infuse Light"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/599"
   },
   {
@@ -2830,6 +3108,7 @@
     "abilities": [
       "Refer to special rules"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/the-prime-demon-scenario-25/0"
   },
   {
@@ -2840,6 +3119,7 @@
       "Move 4",
       "Attack 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/the-prime-demon-scenario-56/0"
   },
   {
@@ -2849,6 +3129,7 @@
     "abilities": [
       "Does Not Act"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/training-dummy/0"
   },
   {
@@ -2859,6 +3140,7 @@
       "Move 2",
       "Attack 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/training-partner/0"
   },
   {
@@ -2866,9 +3148,10 @@
     "cardName": "Repulsive Torrent",
     "initiative": 70,
     "abilities": [
-      "Push 2, Target All, Range 1",
+      "Push 2, All, Range 1, Consume Air: Push +2",
       "Attack 1, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/tyrant-of-the-tides/794"
   },
   {
@@ -2877,8 +3160,9 @@
     "initiative": 98,
     "abilities": [
       "Summon",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/tyrant-of-the-tides/795"
   },
   {
@@ -2887,8 +3171,9 @@
     "initiative": 98,
     "abilities": [
       "Spawn one Lurker Soldier at B. It is Normal for 2 characters and Elite for 3-4.",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/tyrant-of-the-tides/796"
   },
   {
@@ -2898,9 +3183,10 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 3",
-      "Grant all allies within Range 2 and self:, Shield 1",
-      "Element ice"
+      "Grant all allies within Range 2 and self: Shield 1",
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/tyrant-of-the-tides/797"
   },
   {
@@ -2908,10 +3194,11 @@
     "cardName": "Freezing Winds",
     "initiative": 14,
     "abilities": [
-      "Attack 0, Range 4",
+      "Attack 0, Range 4, Consume Ice: Attack 2, Immobilize",
       "Retaliate 2",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/tyrant-of-the-tides/798"
   },
   {
@@ -2920,9 +3207,10 @@
     "initiative": 14,
     "abilities": [
       "Shield 4",
-      "Heal 2, Range 3",
-      "Element air"
+      "Heal 2, Range 3, Consume Ice: Heal +3",
+      "Consume Air, Attack -1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/tyrant-of-the-tides/799"
   },
   {
@@ -2930,11 +3218,12 @@
     "cardName": "Forceful Gust",
     "initiative": 47,
     "abilities": [
-      "Disarm, Target All, Range 1",
+      "Disarm, All, Range 1",
       "Move 0",
       "Attack 1, Range 4",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/tyrant-of-the-tides/800"
   },
   {
@@ -2944,8 +3233,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/tyrant-of-the-tides/801"
   },
   {
@@ -2956,6 +3246,7 @@
       "Move 1",
       "Attack 1, Range 3, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/vermling-scout-mindthief2-solo/ordinal-1"
   },
   {
@@ -2965,8 +3256,9 @@
     "abilities": [
       "Attack 1, Range 2",
       "Heal 1, Self",
-      "Element air, Invisible"
+      "Consume Air, Invisible, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/568"
   },
   {
@@ -2976,8 +3268,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, Range 3, Pull 1",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/569"
   },
   {
@@ -2986,8 +3279,9 @@
     "initiative": 29,
     "abilities": [
       "Move 0",
-      "Attack 1, Target 2, Range 3"
+      "Attack 1, Target 2, Range 3, Consume Air: Push 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/571"
   },
   {
@@ -2997,6 +3291,7 @@
     "abilities": [
       "Move 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/572"
   },
   {
@@ -3005,8 +3300,9 @@
     "initiative": 43,
     "abilities": [
       "Move 1",
-      "Attack 1, Range 3"
+      "Attack 1, Range 3, Consume Air: Disarm"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/573"
   },
   {
@@ -3014,9 +3310,10 @@
     "cardName": "Blast of Air",
     "initiative": 43,
     "abilities": [
-      "Push 1, Target All, Range 1",
-      "Attack 0, Range 4, Disarm"
+      "Push 1, All, Range 1",
+      "Attack 0, Range 4, Disarm, Consume Earth: Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/574"
   },
   {
@@ -3027,8 +3324,9 @@
       "Move 1",
       "Attack 1, Range 3",
       "Shield 1",
-      "Element wild"
+      "Consume Wild, Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/575"
   }
 ]

--- a/data/extracted/monster-abilities.json
+++ b/data/extracted/monster-abilities.json
@@ -5,8 +5,9 @@
     "initiative": 18,
     "abilities": [
       "Move 1",
-      "Grant the closest Piranha Pig within Range 4:"
+      "Grant the closest Piranha Pig within Range 4: Move 0, Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/abael-herder/778"
   },
   {
@@ -15,8 +16,9 @@
     "initiative": 72,
     "abilities": [
       "Move 1",
-      "Grant all Piranha Pigs within Range 3:, Piranha Pig suffers Damage 1."
+      "Grant all Piranha Pigs within Range 3: Move -1, Attack -2, Piranha Pig suffers Damage 1."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/abael-herder/779"
   },
   {
@@ -26,6 +28,7 @@
     "abilities": [
       "Summon"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/abael-herder/780"
   },
   {
@@ -36,6 +39,7 @@
       "Move 0",
       "Attack 0, Range 3, Pull 2, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/abael-herder/781"
   },
   {
@@ -43,9 +47,10 @@
     "cardName": "Advancing Horde",
     "initiative": 88,
     "abilities": [
-      "Grant the closest Piranha Pig within Range 4:",
-      "If no Piranha Pig was targeted by the grant ability:"
+      "Grant the closest Piranha Pig within Range 4: Move 0, Attack 0, Muddle",
+      "If no Piranha Pig was targeted by the grant ability: Summon monsterStandee"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/abael-herder/782"
   },
   {
@@ -54,8 +59,9 @@
     "initiative": 12,
     "abilities": [
       "Attack 0, Range 3",
-      "Strengthen, Target all Piranha Pigs, Range 3"
+      "Strengthen, all Piranha Pigs, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/abael-herder/783"
   },
   {
@@ -65,6 +71,7 @@
     "abilities": [
       "Move 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/abael-herder/784"
   },
   {
@@ -75,6 +82,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/abael-herder/785"
   },
   {
@@ -85,8 +93,9 @@
       "Move 1",
       "Attack 1",
       "Shield 1",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-icespeaker/730"
   },
   {
@@ -96,8 +105,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Stun",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-icespeaker/731"
   },
   {
@@ -106,9 +116,10 @@
     "initiative": 41,
     "abilities": [
       "Move 1",
-      "Attack 1",
-      "Attack 1"
+      "Attack 1, Consume Ice: Attack +2",
+      "Attack 1, Consume Earth: Attack +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-icespeaker/732"
   },
   {
@@ -117,8 +128,9 @@
     "initiative": 39,
     "abilities": [
       "Move 1",
-      "Attack 0, Range 3"
+      "Attack 0, Range 3, Consume Ice: Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-icespeaker/733"
   },
   {
@@ -128,8 +140,9 @@
     "abilities": [
       "Create one 1-hex obstacle tile in an adjacent empty hex closest to an enemy.",
       "All enemies adjacent to the created obstacle suffer hazardous terrain damage.",
-      "Element ice:earth"
+      "Infuse Ice:earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-icespeaker/734"
   },
   {
@@ -139,8 +152,9 @@
     "abilities": [
       "Move 0",
       "Attack 0",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-icespeaker/735"
   },
   {
@@ -149,8 +163,9 @@
     "initiative": 80,
     "abilities": [
       "Attack 0",
-      "Disarm, Target All, Range 2"
+      "Disarm, All, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-icespeaker/736"
   },
   {
@@ -159,9 +174,10 @@
     "initiative": 12,
     "abilities": [
       "Shield 3",
-      "Element earth",
+      "Consume Earth, Heal 1, Self",
       "Heal 3, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-icespeaker/737"
   },
   {
@@ -171,8 +187,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 2, Muddle",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker-trap-solo/738"
   },
   {
@@ -180,8 +197,9 @@
     "cardName": "Cold Winds",
     "initiative": 18,
     "abilities": [
-      "Attack 0, Target 2, Range 4"
+      "Attack 0, Target 2, Range 4, Consume Ice: Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker-trap-solo/739"
   },
   {
@@ -191,8 +209,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 3",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker-trap-solo/740"
   },
   {
@@ -201,8 +220,9 @@
     "initiative": 30,
     "abilities": [
       "Move 1",
-      "Attack 1, Range 3, Push 1"
+      "Attack 1, Range 3, Push 1, Consume Air: Push +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker-trap-solo/741"
   },
   {
@@ -211,9 +231,10 @@
     "initiative": 6,
     "abilities": [
       "(ability text not yet available)",
-      "Push 2, Target All, Range 2",
-      "Element ice:air"
+      "Push 2, All, Range 2",
+      "Infuse Ice:air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker-trap-solo/742"
   },
   {
@@ -222,8 +243,9 @@
     "initiative": 59,
     "abilities": [
       "Move 1",
-      "Attack 1, Range 3"
+      "Attack 1, Range 3, Consume Ice: Attack +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker-trap-solo/743"
   },
   {
@@ -233,8 +255,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, Range 4",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker-trap-solo/744"
   },
   {
@@ -242,9 +265,10 @@
     "cardName": "Snow Drifts",
     "initiative": 66,
     "abilities": [
-      "Immobilize, Target All, Range 5",
-      "Element air, Muddle"
+      "Immobilize, All, Range 5",
+      "Consume Air, Muddle, All, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker-trap-solo/745"
   },
   {
@@ -254,8 +278,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 3, Muddle",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker/738"
   },
   {
@@ -263,8 +288,9 @@
     "cardName": "Cold Winds",
     "initiative": 18,
     "abilities": [
-      "Attack 0, Target 2, Range 5"
+      "Attack 0, Target 2, Range 5, Consume Ice: Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker/739"
   },
   {
@@ -274,8 +300,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 4",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker/740"
   },
   {
@@ -284,8 +311,9 @@
     "initiative": 30,
     "abilities": [
       "Move 1",
-      "Attack 1, Range 4, Push 1"
+      "Attack 1, Range 4, Push 1, Consume Air: Push +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker/741"
   },
   {
@@ -294,9 +322,10 @@
     "initiative": 6,
     "abilities": [
       "All enemies within Range 3 suffer Damage 2",
-      "Push 2, Target All, Range 3",
-      "Element ice:air"
+      "Push 2, All, Range 3",
+      "Infuse Ice:air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker/742"
   },
   {
@@ -305,8 +334,9 @@
     "initiative": 59,
     "abilities": [
       "Move 1",
-      "Attack 1, Range 4"
+      "Attack 1, Range 4, Consume Ice: Attack +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker/743"
   },
   {
@@ -316,8 +346,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, Range 5",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker/744"
   },
   {
@@ -325,9 +356,10 @@
     "cardName": "Snow Drifts",
     "initiative": 66,
     "abilities": [
-      "Immobilize, Target All, Range 6",
-      "Element air, Muddle"
+      "Immobilize, All, Range 6",
+      "Consume Air, Muddle, All, Range 6"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/algox-snowspeaker/745"
   },
   {
@@ -338,6 +370,7 @@
       "Focus on the enemy farthest away within Range 7",
       "Attack 1, Range 7"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/626"
   },
   {
@@ -345,6 +378,7 @@
     "cardName": "Exploding Ammunition",
     "initiative": 71,
     "abilities": [],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/627"
   },
   {
@@ -352,9 +386,10 @@
     "cardName": "Grenade",
     "initiative": 37,
     "abilities": [
-      "Push 1, Target All, Range 1",
+      "Push 1, All, Range 1",
       "Attack 1, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/629"
   },
   {
@@ -362,9 +397,10 @@
     "cardName": "Massive Blast",
     "initiative": 57,
     "abilities": [
-      "Push 1, Target All, Range 1",
+      "Push 1, All, Range 1",
       "Attack 1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/630"
   },
   {
@@ -374,6 +410,7 @@
     "abilities": [
       "Attack 1, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/631"
   },
   {
@@ -381,10 +418,11 @@
     "cardName": "Defensive Ordinance",
     "initiative": 17,
     "abilities": [
-      "Push 2, Target All, Range 1",
+      "Push 2, All, Range 1",
       "Attack 2, Range 5",
       "Shield 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/632"
   },
   {
@@ -394,6 +432,7 @@
     "abilities": [
       "Attack 1, Range 5, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ancient-artillery/633"
   },
   {
@@ -404,6 +443,7 @@
       "Move 0",
       "Attack 1, Range 5, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/754"
   },
   {
@@ -415,6 +455,7 @@
       "Attack 1, Range 5",
       "Create one Damage 3 trap in an adjacent empty hex closest to an enemy."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/755"
   },
   {
@@ -425,6 +466,7 @@
       "Move 0",
       "Attack 1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/756"
   },
   {
@@ -435,6 +477,7 @@
       "Move 1",
       "Attack 1, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/757"
   },
   {
@@ -444,6 +487,7 @@
     "abilities": [
       "Attack 1, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/758"
   },
   {
@@ -454,6 +498,7 @@
       "Move 0",
       "Attack 0, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/759"
   },
   {
@@ -464,6 +509,7 @@
       "Move 1",
       "Attack 1, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/760"
   },
   {
@@ -473,6 +519,7 @@
     "abilities": [
       "Attack 1, Target 2, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/archer/761"
   },
   {
@@ -481,8 +528,9 @@
     "initiative": 97,
     "abilities": [
       "Summon",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/belara/786"
   },
   {
@@ -491,8 +539,9 @@
     "initiative": 97,
     "abilities": [
       "Summon",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/belara/787"
   },
   {
@@ -502,8 +551,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, EnemiesAdjacent",
-      "Element fire, Retaliate 3"
+      "Consume Fire, Retaliate 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/belara/788"
   },
   {
@@ -512,8 +562,9 @@
     "initiative": 68,
     "abilities": [
       "Move 1",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/belara/789"
   },
   {
@@ -522,8 +573,9 @@
     "initiative": 41,
     "abilities": [
       "Move 0",
-      "Attack 1"
+      "Attack 1, Consume Earth: Attack +2, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/belara/790"
   },
   {
@@ -532,9 +584,10 @@
     "initiative": 51,
     "abilities": [
       "All enemies within Range 4 suffer Damage 2.",
-      "Element fire, Wound",
-      "Element earth, Disarm"
+      "Consume Fire, Wound, All, Range 4",
+      "Consume Earth, Disarm, All, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/belara/791"
   },
   {
@@ -542,8 +595,9 @@
     "cardName": "Strength of the Mountain",
     "initiative": 31,
     "abilities": [
-      "Heal 4, Range 3"
+      "Heal 4, Range 3, Consume Earth: Target +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/belara/792"
   },
   {
@@ -553,8 +607,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Target 2, Range 3",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/belara/793"
   },
   {
@@ -564,6 +619,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/874"
   },
   {
@@ -573,6 +629,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/875"
   },
   {
@@ -582,6 +639,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/876"
   },
   {
@@ -591,6 +649,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/877"
   },
   {
@@ -600,6 +659,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/878"
   },
   {
@@ -609,6 +669,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/879"
   },
   {
@@ -619,6 +680,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/880"
   },
   {
@@ -629,6 +691,7 @@
       "Move 1",
       "Attack 1, Target 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/boss/881"
   },
   {
@@ -636,9 +699,10 @@
     "cardName": "Tunneling Slices",
     "initiative": 68,
     "abilities": [
-      "SpecialTarget focusEnemyFarthest",
+      "SpecialTarget focusEnemyFarthest, Move 1, Jump",
       "Attack 2, EnemiesMovedThroughAdjacent"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/burrowing-blade/818"
   },
   {
@@ -648,8 +712,9 @@
     "abilities": [
       "All adjacent enemies suffer Damage 2.",
       "Invisible, Self",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/burrowing-blade/820"
   },
   {
@@ -657,10 +722,11 @@
     "cardName": "Soaring Strikes",
     "initiative": 53,
     "abilities": [
-      "Move 0",
+      "Move 0, Jump",
       "Attack 1, Target 2",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/burrowing-blade/821"
   },
   {
@@ -668,10 +734,11 @@
     "cardName": "Explosive Ascent",
     "initiative": 63,
     "abilities": [
-      "Move 0",
+      "Move 0, Jump",
       "All enemies within Range 2 suffer Damage 2.",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/burrowing-blade/822"
   },
   {
@@ -679,8 +746,9 @@
     "cardName": "Aura of Fear",
     "initiative": 37,
     "abilities": [
-      "SpecialTarget focusEnemyFarthest"
+      "SpecialTarget focusEnemyFarthest, Move 2, Jump"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/burrowing-blade/823"
   },
   {
@@ -689,8 +757,9 @@
     "initiative": 65,
     "abilities": [
       "Move 1",
-      "Attack 1"
+      "Attack 1, Consume Earth: Attack +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/burrowing-blade/824"
   },
   {
@@ -698,8 +767,9 @@
     "cardName": "Crashing Blow",
     "initiative": 85,
     "abilities": [
-      "Attack 2"
+      "Attack 2, Consume Earth: Attack +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/burrowing-blade/825"
   },
   {
@@ -709,8 +779,9 @@
     "abilities": [
       "Move 1",
       "Attack 0",
-      "Element ice, Retaliate 2"
+      "Consume Ice, Retaliate 2, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/538"
   },
   {
@@ -719,8 +790,9 @@
     "initiative": 1,
     "abilities": [
       "Move 1",
-      "Attack 1, Range 2"
+      "Attack 1, Range 2, Consume Fire: Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/539"
   },
   {
@@ -729,8 +801,9 @@
     "initiative": 67,
     "abilities": [
       "Move 2",
-      "Attack 1, Push 2"
+      "Attack 1, Push 2, Consume Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/540"
   },
   {
@@ -740,8 +813,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 2",
-      "Element air, Shield 2"
+      "Consume Air, Shield 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/541"
   },
   {
@@ -751,8 +825,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, Advantage",
-      "Element light"
+      "Consume Light, Heal 4, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/542"
   },
   {
@@ -762,8 +837,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element dark, Invisible"
+      "Consume Dark, Invisible, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/543"
   },
   {
@@ -774,6 +850,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/544"
   },
   {
@@ -782,8 +859,9 @@
     "initiative": 98,
     "abilities": [
       "Move 1",
-      "Attack 1"
+      "Attack 1, Consume Wild: Bane"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-demon/545"
   },
   {
@@ -795,6 +873,7 @@
       "Attack (C-2), +(2xT)",
       "where T is the number of damage tokens on the target's character mat"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/chaos-spark/ordinal-1"
   },
   {
@@ -802,8 +881,9 @@
     "cardName": "Nothing Special",
     "initiative": 50,
     "abilities": [
-      "Attack [(L/2){$math.ceil}]"
+      "Attack [Math.ceil(L/2)]"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/city-guard-banner-spear-solo/752"
   },
   {
@@ -813,6 +893,7 @@
     "abilities": [
       "Does not perform a turn."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/city-guard-scenario-1/752"
   },
   {
@@ -822,6 +903,7 @@
     "abilities": [
       "Attack 1, Range 3, Target 3, Curse"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/722"
   },
   {
@@ -831,6 +913,7 @@
     "abilities": [
       "Attack 0, Pierce 3"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/723"
   },
   {
@@ -841,6 +924,7 @@
       "Attack 1, EnemiesAdjacent",
       "Attack 0, Range 4, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/725"
   },
   {
@@ -851,6 +935,7 @@
       "Attack 1, Poison",
       "Attack 1, Range 5, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/726"
   },
   {
@@ -861,6 +946,7 @@
       "Attack 2, Disarm",
       "Attack 1, Target 2, Range 3, Impair"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/727"
   },
   {
@@ -869,8 +955,9 @@
     "initiative": 96,
     "abilities": [
       "Attack 2, Range 6",
-      "If the attack ability was performed"
+      "If the attack ability was performed, Summon monsterStandee, in an empty hex adjacent to the target of the attack ability"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/728"
   },
   {
@@ -880,6 +967,7 @@
     "abilities": [
       "Attack 0, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/deep-terror/739"
   },
   {
@@ -888,8 +976,9 @@
     "initiative": 40,
     "abilities": [
       "Heal 4, Self",
-      "Element earth, Immobilize"
+      "Consume Earth, Immobilize, All, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/570"
   },
   {
@@ -900,6 +989,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/571"
   },
   {
@@ -909,8 +999,9 @@
     "abilities": [
       "Move 0",
       "Attack 0",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/572"
   },
   {
@@ -918,8 +1009,9 @@
     "cardName": "Boulder Throw",
     "initiative": 71,
     "abilities": [
-      "Attack 0, Range 4"
+      "Attack 0, Range 4, Consume Earth: Target +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/573"
   },
   {
@@ -929,8 +1021,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/574"
   },
   {
@@ -939,8 +1032,9 @@
     "initiative": 93,
     "abilities": [
       "Move 1",
-      "Attack 1, EnemiesAdjacent"
+      "Attack 1, EnemiesAdjacent, Consume Earth: Push 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/575"
   },
   {
@@ -949,8 +1043,9 @@
     "initiative": 79,
     "abilities": [
       "Move 1",
-      "Attack 0"
+      "Attack 0, Consume Air: Attack 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/576"
   },
   {
@@ -959,8 +1054,9 @@
     "initiative": 87,
     "abilities": [
       "Move 0",
-      "Element wild"
+      "Consume Wild, Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/earth-demon/577"
   },
   {
@@ -970,6 +1066,7 @@
     "abilities": [
       "The Fish King does not act."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/fish-king-scenario-76/752"
   },
   {
@@ -979,8 +1076,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Range 4",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/546"
   },
   {
@@ -990,8 +1088,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, Range 4",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/547"
   },
   {
@@ -999,8 +1098,9 @@
     "cardName": "Explosive Blast",
     "initiative": 46,
     "abilities": [
-      "Attack 0, Range 4"
+      "Attack 0, Range 4, Consume Fire: Range 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/548"
   },
   {
@@ -1010,8 +1110,9 @@
     "abilities": [
       "Move 1",
       "Create one Damage 4 trap in an adjacent empty hex closest to an enemy",
-      "Element wild"
+      "Consume Wild, Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/549"
   },
   {
@@ -1019,8 +1120,9 @@
     "cardName": "Intense Torch",
     "initiative": 49,
     "abilities": [
-      "Attack 0"
+      "Attack 0, Consume Fire: Attack +1, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/550"
   },
   {
@@ -1030,8 +1132,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Range 3",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/551"
   },
   {
@@ -1040,8 +1143,9 @@
     "initiative": 77,
     "abilities": [
       "Attack 0, EnemiesAdjacent",
-      "Element ice, Damage 1"
+      "Consume Ice, Damage 1, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/552"
   },
   {
@@ -1049,10 +1153,11 @@
     "cardName": "Raging Blaze",
     "initiative": 30,
     "abilities": [
-      "Element fire, All adjacent enemies suffer Damage 2",
+      "Consume Fire, All adjacent enemies suffer Damage 2",
       "Move 0",
       "Attack 2, Target 2, Range 4, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flame-demon/553"
   },
   {
@@ -1062,8 +1167,9 @@
     "abilities": [
       "Move 2",
       "Attack 1",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flaming-bladespinner/610"
   },
   {
@@ -1073,8 +1179,9 @@
     "abilities": [
       "Move 2",
       "Attack 1",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flaming-bladespinner/611"
   },
   {
@@ -1085,8 +1192,9 @@
       "Move 0",
       "Attack 1",
       "Strengthen, Self",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flaming-bladespinner/612"
   },
   {
@@ -1095,8 +1203,9 @@
     "initiative": 12,
     "abilities": [
       "Shield 2",
-      "Element fire, All enemies within Range 2 suffer Damage 2."
+      "Consume Fire, All enemies within Range 2 suffer Damage 2."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flaming-bladespinner/613"
   },
   {
@@ -1105,8 +1214,9 @@
     "initiative": 58,
     "abilities": [
       "Move 0",
-      "Attack 0"
+      "Attack 0, Consume Fire: Attack +1, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flaming-bladespinner/614"
   },
   {
@@ -1116,8 +1226,9 @@
     "abilities": [
       "Move 2",
       "All enemies within Range 2 suffer Damage 1.",
-      "Element fire, Wound"
+      "Consume Fire, Wound, All, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flaming-bladespinner/615"
   },
   {
@@ -1128,6 +1239,7 @@
       "Shield 1",
       "Retaliate 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flaming-bladespinner/616"
   },
   {
@@ -1135,9 +1247,10 @@
     "cardName": "Spinning Charge",
     "initiative": 68,
     "abilities": [
-      "SpecialTarget focusEnemyFarthest",
-      "Attack 1, EnemiesMovedThroughAdjacent"
+      "SpecialTarget focusEnemyFarthest, Move 1, Jump",
+      "Attack 1, EnemiesMovedThroughAdjacent, Consume Fire: Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/flaming-bladespinner/617"
   },
   {
@@ -1145,9 +1258,10 @@
     "cardName": "Gather the Frost",
     "initiative": 18,
     "abilities": [
-      "Immobilize, Target All, Range 2",
-      "Element ice"
+      "Immobilize, All, Range 2",
+      "Consume Ice, Heal 3, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/554"
   },
   {
@@ -1158,6 +1272,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/555"
   },
   {
@@ -1166,8 +1281,9 @@
     "initiative": 58,
     "abilities": [
       "Move 1",
-      "Attack 0, Range 2"
+      "Attack 0, Range 2, Consume Ice: Attack +2, Range +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/556"
   },
   {
@@ -1178,6 +1294,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/557"
   },
   {
@@ -1187,8 +1304,9 @@
     "abilities": [
       "Move 1",
       "Attack 0",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/558"
   },
   {
@@ -1198,8 +1316,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Pierce 3",
-      "Element wild"
+      "Consume Wild, Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/560"
   },
   {
@@ -1209,8 +1328,9 @@
     "abilities": [
       "Move 1",
       "Shield 2",
-      "Element fire, Damage 1"
+      "Consume Fire, Damage 1, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frost-demon/627"
   },
   {
@@ -1220,6 +1340,7 @@
     "abilities": [
       "Move 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frozen-corpse/634"
   },
   {
@@ -1229,8 +1350,9 @@
     "abilities": [
       "Move 0",
       "Attack 0",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frozen-corpse/635"
   },
   {
@@ -1239,8 +1361,9 @@
     "initiative": 42,
     "abilities": [
       "Move 1",
-      "Attack 1"
+      "Attack 1, Consume Ice: Brittle"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/frozen-corpse/636"
   },
   {
@@ -1248,10 +1371,11 @@
     "cardName": "Thawed Strike",
     "initiative": 68,
     "abilities": [
-      "Move 1",
+      "Move 1, Consume Fire: Move +2",
       "If the element is consumed by the Frozen Corpse during the move ability, it suffers Damage 2.",
       "Attack 1"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/frozen-corpse/638"
   },
   {
@@ -1261,8 +1385,9 @@
     "abilities": [
       "Move 0",
       "Attack 1",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frozen-corpse/640"
   },
   {
@@ -1272,8 +1397,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/frozen-corpse/641"
   },
   {
@@ -1283,6 +1409,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-piranha-pig-boss/874"
   },
   {
@@ -1292,6 +1419,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-piranha-pig-boss/875"
   },
   {
@@ -1301,6 +1429,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-piranha-pig-boss/876"
   },
   {
@@ -1310,6 +1439,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-piranha-pig-boss/877"
   },
   {
@@ -1319,6 +1449,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-piranha-pig-boss/878"
   },
   {
@@ -1328,6 +1459,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-piranha-pig-boss/879"
   },
   {
@@ -1337,6 +1469,7 @@
     "abilities": [
       "Nothing"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-piranha-pig-boss/880"
   },
   {
@@ -1346,6 +1479,7 @@
     "abilities": [
       "Nothing"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/giant-piranha-pig-boss/881"
   },
   {
@@ -1356,6 +1490,7 @@
       "Shield 1",
       "Retaliate 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/746"
   },
   {
@@ -1366,6 +1501,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/747"
   },
   {
@@ -1376,6 +1512,7 @@
       "Move 1",
       "Attack 0, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/748"
   },
   {
@@ -1386,6 +1523,7 @@
       "Attack 0, Poison",
       "Shield 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/749"
   },
   {
@@ -1396,6 +1534,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/750"
   },
   {
@@ -1406,6 +1545,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/751"
   },
   {
@@ -1417,6 +1557,7 @@
       "Attack 0",
       "Strengthen, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/guard/753"
   },
   {
@@ -1427,6 +1568,7 @@
       "Move 1",
       "Attack 1, Target 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/802"
   },
   {
@@ -1436,8 +1578,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Poison",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/803"
   },
   {
@@ -1449,6 +1592,7 @@
       "Attack 1",
       "Heal 5, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/804"
   },
   {
@@ -1459,6 +1603,7 @@
       "Attack 1, Range 3, Muddle",
       "Heal 4, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/805"
   },
   {
@@ -1469,6 +1614,7 @@
       "Attack 2, Immobilize",
       "Retaliate 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/806"
   },
   {
@@ -1479,6 +1625,7 @@
       "Shield 2",
       "Retaliate 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/807"
   },
   {
@@ -1488,8 +1635,9 @@
     "abilities": [
       "Move 1",
       "Attack 0",
-      "Element dark, Perform \" Heal X, self\" where X is twice the number of enemies targeted by the attack ability."
+      "Consume Dark, Perform \" Heal, self\" where X is twice the number of enemies targeted by the attack ability."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/808"
   },
   {
@@ -1498,8 +1646,9 @@
     "initiative": 38,
     "abilities": [
       "Move 0",
-      "Attack 1, Target 2, Impair"
+      "Attack 1, Target 2, Impair, Consume Dark: Attack +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/harrower-infester/809"
   },
   {
@@ -1510,6 +1659,7 @@
       "Move 2",
       "Attack 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/hound-scenario-0/846"
   },
   {
@@ -1520,6 +1670,7 @@
       "Move 1",
       "Attack 0, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/842"
   },
   {
@@ -1528,8 +1679,9 @@
     "initiative": 7,
     "abilities": [
       "Move 0",
-      "Muddle, Target All, Range 1"
+      "Muddle, All, Range 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/843"
   },
   {
@@ -1539,6 +1691,7 @@
     "abilities": [
       "Move 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/844"
   },
   {
@@ -1549,6 +1702,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/846"
   },
   {
@@ -1559,6 +1713,7 @@
       "Move 2",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/848"
   },
   {
@@ -1570,6 +1725,7 @@
       "Move 2",
       "Attack 1, Pierce 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/hound/849"
   },
   {
@@ -1580,8 +1736,9 @@
       "All elite Ice Wraiths become normal, and all normal Ice Wraiths become elite.",
       "Heal 1, Self",
       "Move 0",
-      "Attack 1"
+      "Attack 1, MonsterType normal, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ice-wraith/642"
   },
   {
@@ -1591,9 +1748,10 @@
     "abilities": [
       "Heal 1, Self",
       "Move 0",
-      "Attack 0",
-      "Element ice"
+      "Attack 0, MonsterType normal, Range 4",
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ice-wraith/643"
   },
   {
@@ -1601,9 +1759,10 @@
     "cardName": "Unholy Strength",
     "initiative": 59,
     "abilities": [
-      "Element ice",
+      "Consume Ice, Strengthen, Self, Bless, Self, Self",
       "Attack 0, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ice-wraith/644"
   },
   {
@@ -1612,9 +1771,10 @@
     "initiative": 59,
     "abilities": [
       "Invisible, Self",
-      "Element ice",
-      "Element ice"
+      "Consume Ice, Bless, Self, Strengthen, Self, Self",
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ice-wraith/645"
   },
   {
@@ -1623,9 +1783,10 @@
     "initiative": 41,
     "abilities": [
       "Move 1",
-      "Attack 1",
-      "Element ice"
+      "Attack 1, MonsterType normal, Range 4",
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ice-wraith/646"
   },
   {
@@ -1634,9 +1795,10 @@
     "initiative": 71,
     "abilities": [
       "Move 1",
-      "Attack 1",
-      "Element ice"
+      "Attack 1, MonsterType normal, Range 4",
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ice-wraith/647"
   },
   {
@@ -1645,8 +1807,9 @@
     "initiative": 13,
     "abilities": [
       "Heal 3, Self",
-      "Element ice, Shield 2"
+      "Consume Ice, Shield 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ice-wraith/648"
   },
   {
@@ -1654,9 +1817,10 @@
     "cardName": "Shard Strike",
     "initiative": 16,
     "abilities": [
-      "Attack 0",
-      "Element ice, Retaliate 2"
+      "Attack 0, MonsterType normal, Range 4",
+      "Consume Ice, Retaliate 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ice-wraith/649"
   },
   {
@@ -1666,8 +1830,9 @@
     "abilities": [
       "Shield 5",
       "Heal 1, Self",
-      "Element wild"
+      "Infuse Wild"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/826"
   },
   {
@@ -1678,6 +1843,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/827"
   },
   {
@@ -1688,6 +1854,7 @@
       "Move 1",
       "Heal 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/829"
   },
   {
@@ -1696,8 +1863,9 @@
     "initiative": 43,
     "abilities": [
       "Move 0",
-      "Attack 1, Range 3, Poison"
+      "Attack 1, Range 3, Poison, Consume Wild: Target +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/830"
   },
   {
@@ -1708,6 +1876,7 @@
       "Move 1",
       "Attack 1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/831"
   },
   {
@@ -1716,8 +1885,9 @@
     "initiative": 43,
     "abilities": [
       "Move 0",
-      "Attack 1, Range 3, Curse"
+      "Attack 1, Range 3, Curse, Consume Wild: Target +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/832"
   },
   {
@@ -1725,9 +1895,10 @@
     "cardName": "Tip the Scales",
     "initiative": 24,
     "abilities": [
-      "Strengthen, Target All, Range 2",
-      "Muddle, Target All, Range 2"
+      "Strengthen, All, Range 2",
+      "Muddle, All, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/imp/833"
   },
   {
@@ -1737,6 +1908,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/laser-spires/874"
   },
   {
@@ -1746,6 +1918,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/laser-spires/875"
   },
   {
@@ -1755,6 +1928,7 @@
     "abilities": [
       "Special 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/laser-spires/876"
   },
   {
@@ -1764,6 +1938,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/laser-spires/877"
   },
   {
@@ -1773,6 +1948,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/laser-spires/878"
   },
   {
@@ -1782,6 +1958,7 @@
     "abilities": [
       "Special 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/laser-spires/879"
   },
   {
@@ -1791,6 +1968,7 @@
     "abilities": [
       "Rotate each laser spire clockwise (if able)"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/laser-spires/880"
   },
   {
@@ -1800,6 +1978,7 @@
     "abilities": [
       "Rotate each laser spire counterclockwise (if able)"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/laser-spires/881"
   },
   {
@@ -1809,8 +1988,9 @@
     "abilities": [
       "Move 0",
       "Attack 0",
-      "Element light"
+      "Infuse Light"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lightning-eel/706"
   },
   {
@@ -1819,8 +1999,9 @@
     "initiative": 82,
     "abilities": [
       "Move 1",
-      "Attack 1, EnemiesAdjacent"
+      "Attack 1, EnemiesAdjacent, Consume Light: Stun"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lightning-eel/707"
   },
   {
@@ -1831,6 +2012,7 @@
       "Move 1",
       "Attack 1, EnemiesAdjacent"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lightning-eel/708"
   },
   {
@@ -1840,8 +2022,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element light"
+      "Infuse Light"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lightning-eel/709"
   },
   {
@@ -1850,8 +2033,9 @@
     "initiative": 67,
     "abilities": [
       "Move 1",
-      "Attack 0"
+      "Attack 0, Consume Light: Attack +1, Stun"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lightning-eel/710"
   },
   {
@@ -1859,10 +2043,11 @@
     "cardName": "Leaping Dive",
     "initiative": 12,
     "abilities": [
-      "Move 2",
+      "Move 2, Jump",
       "Attack 1",
-      "Element light"
+      "Infuse Light"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lightning-eel/711"
   },
   {
@@ -1872,8 +2057,9 @@
     "abilities": [
       "Move 1",
       "Attack 0, Range 2",
-      "Element light"
+      "Infuse Light"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lightning-eel/712"
   },
   {
@@ -1884,6 +2070,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lightning-eel/713"
   },
   {
@@ -1894,6 +2081,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/666"
   },
   {
@@ -1905,6 +2093,7 @@
       "Attack 0",
       "Heal 2, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/667"
   },
   {
@@ -1915,6 +2104,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/668"
   },
   {
@@ -1925,6 +2115,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/669"
   },
   {
@@ -1934,6 +2125,7 @@
     "abilities": [
       "Attack 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/671"
   },
   {
@@ -1944,6 +2136,7 @@
       "Move 0",
       "Attack 0, EnemyOneAll"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/672"
   },
   {
@@ -1954,6 +2147,7 @@
       "Shield 1",
       "Heal 2, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-bones/673"
   },
   {
@@ -1963,8 +2157,9 @@
     "abilities": [
       "Move 0",
       "Attack 1",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-doom/650"
   },
   {
@@ -1973,8 +2168,9 @@
     "initiative": 82,
     "abilities": [
       "Move 1",
-      "Attack 1"
+      "Attack 1, Consume Dark: Disarm"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-doom/651"
   },
   {
@@ -1983,8 +2179,9 @@
     "initiative": 32,
     "abilities": [
       "Move 1",
-      "Attack 1"
+      "Attack 1, Consume Ice: Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-doom/652"
   },
   {
@@ -1994,8 +2191,9 @@
     "abilities": [
       "Move 0",
       "Attack 0",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-doom/653"
   },
   {
@@ -2006,8 +2204,9 @@
       "Curse, Range 2",
       "Shield 1",
       "Retaliate 2, Range 2",
-      "Element ice:dark"
+      "Infuse Ice:dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-doom/654"
   },
   {
@@ -2017,8 +2216,9 @@
     "abilities": [
       "Attack 1",
       "Retaliate 2",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-doom/655"
   },
   {
@@ -2029,6 +2229,7 @@
       "Move 1",
       "Attack 3, Bane"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-doom/656"
   },
   {
@@ -2036,8 +2237,9 @@
     "cardName": "Call For Souls",
     "initiative": 78,
     "abilities": [
-      "Summon"
+      "Summon, Summon X normal Living Spirits, where X is the Living Doom's current hit point value divided by 5 (rounded down), up to a maximum of three."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-doom/657"
   },
   {
@@ -2048,6 +2250,7 @@
       "Move 1",
       "Attack 1, Range 3, Muddle"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/658"
   },
   {
@@ -2058,6 +2261,7 @@
       "Move 1",
       "Attack 1, Target 3, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/659"
   },
   {
@@ -2068,6 +2272,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/660"
   },
   {
@@ -2077,6 +2282,7 @@
     "abilities": [
       "Attack 0, Target 2, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/662"
   },
   {
@@ -2087,8 +2293,9 @@
       "Move 1",
       "Attack 1, Range 2",
       "Heal 1, Self",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/663"
   },
   {
@@ -2098,8 +2305,9 @@
     "abilities": [
       "Move 0",
       "Curse, Target 3, Range 2",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/664"
   },
   {
@@ -2108,8 +2316,9 @@
     "initiative": 67,
     "abilities": [
       "Move 1",
-      "Attack 0, Range 4"
+      "Attack 0, Range 4, Consume Ice: Stun"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/living-spirit/665"
   },
   {
@@ -2121,6 +2330,7 @@
       "Attack 2",
       "Summon"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lost-in-seaweed/698"
   },
   {
@@ -2132,6 +2342,7 @@
       "Attack 1, Range 6",
       "Summon"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lost-in-seaweed/699"
   },
   {
@@ -2143,6 +2354,7 @@
       "Attack 1, Range 2",
       "Summon"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lost-in-seaweed/700"
   },
   {
@@ -2153,6 +2365,7 @@
       "(ability text not yet available)",
       "Summon"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/lost-in-seaweed/701"
   },
   {
@@ -2164,6 +2377,7 @@
       "Attack 1",
       "Summon"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lost-in-seaweed/703"
   },
   {
@@ -2175,6 +2389,7 @@
       "Attack 0",
       "Summon"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lost-in-seaweed/704"
   },
   {
@@ -2186,6 +2401,7 @@
       "Attack 0, Range 3",
       "Summon"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lost-in-seaweed/705"
   },
   {
@@ -2195,8 +2411,9 @@
     "abilities": [
       "Move 0",
       "Attack 0",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-clawcrusher/690"
   },
   {
@@ -2206,6 +2423,7 @@
     "abilities": [
       "Move 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-clawcrusher/691"
   },
   {
@@ -2216,6 +2434,7 @@
       "Move 0",
       "Attack 1, Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-clawcrusher/692"
   },
   {
@@ -2225,8 +2444,9 @@
     "abilities": [
       "Attack 1, Immobilize",
       "Shield 2",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-clawcrusher/693"
   },
   {
@@ -2235,8 +2455,9 @@
     "initiative": 60,
     "abilities": [
       "Move 1",
-      "Attack 1"
+      "Attack 1, Consume Earth: Poison, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-clawcrusher/694"
   },
   {
@@ -2246,6 +2467,7 @@
     "abilities": [
       "Move 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-clawcrusher/695"
   },
   {
@@ -2255,8 +2477,9 @@
     "abilities": [
       "Shield 2",
       "Retaliate 2",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-clawcrusher/696"
   },
   {
@@ -2266,8 +2489,9 @@
     "abilities": [
       "Move 1",
       "Attack 2, EnemiesAdjacent, Poison",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-clawcrusher/697"
   },
   {
@@ -2275,9 +2499,10 @@
     "cardName": "Psychic Shock",
     "initiative": 6,
     "abilities": [
-      "Retaliate 3, Range 3",
-      "Muddle, Target All, Range 3"
+      "Retaliate 3, Range 3, Consume Dark: Retaliate +2",
+      "Muddle, All, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-mindsnipper/682"
   },
   {
@@ -2287,8 +2512,9 @@
     "abilities": [
       "Move 2",
       "Attack 1, Range 3",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-mindsnipper/683"
   },
   {
@@ -2298,8 +2524,9 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 3, Curse",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-mindsnipper/684"
   },
   {
@@ -2309,8 +2536,9 @@
     "abilities": [
       "Move 2",
       "Attack 1, Range 3",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-mindsnipper/685"
   },
   {
@@ -2318,8 +2546,9 @@
     "cardName": "Instill Fear",
     "initiative": 37,
     "abilities": [
-      "Attack 1, Target 2, Range 3, Push 2"
+      "Attack 1, Target +2, Range 3, Push 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-mindsnipper/686"
   },
   {
@@ -2330,6 +2559,7 @@
       "Move 0",
       "Attack 2, Range 2, Disarm"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-mindsnipper/687"
   },
   {
@@ -2339,8 +2569,9 @@
     "abilities": [
       "Move 0",
       "Attack 2, Range 3",
-      "Control all targets of the attack ability in initiative order:"
+      "Control all targets of the attack ability in initiative order: Attack 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-mindsnipper/688"
   },
   {
@@ -2348,8 +2579,9 @@
     "cardName": "Paralyze",
     "initiative": 46,
     "abilities": [
-      "Attack 1, Range 4"
+      "Attack 1, Range 4, Consume Dark: Stun"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-mindsnipper/689"
   },
   {
@@ -2357,9 +2589,10 @@
     "cardName": "Defensive Claws",
     "initiative": 11,
     "abilities": [
-      "Wound, Target All, Range 1",
-      "Shield 1"
+      "Wound, All, Range 1",
+      "Shield 1, Consume Ice: Shield +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/674"
   },
   {
@@ -2370,6 +2603,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/675"
   },
   {
@@ -2380,6 +2614,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/676"
   },
   {
@@ -2390,6 +2625,7 @@
       "Move 0",
       "Attack 0, EnemyOneAll"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/677"
   },
   {
@@ -2400,6 +2636,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/678"
   },
   {
@@ -2409,6 +2646,7 @@
     "abilities": [
       "Attack 1, Target enemies within 2 hexes, Impair"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/679"
   },
   {
@@ -2416,10 +2654,11 @@
     "cardName": "Strength of the Deep",
     "initiative": 41,
     "abilities": [
-      "Element ice, Strengthen",
+      "Consume Ice, Strengthen, Self",
       "Move 0",
       "Attack 1, Wound"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/680"
   },
   {
@@ -2430,8 +2669,9 @@
       "Move 0",
       "Attack 1",
       "Shield 1",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-soldier/681"
   },
   {
@@ -2442,6 +2682,7 @@
       "Move 1",
       "Attack 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-128/698"
   },
   {
@@ -2452,6 +2693,7 @@
       "Focus on the enemy farthest away within Range 6",
       "Attack 1, Range 6"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-128/699"
   },
   {
@@ -2462,6 +2704,7 @@
       "Move 1",
       "Attack 1, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-128/700"
   },
   {
@@ -2471,6 +2714,7 @@
     "abilities": [
       "Create one 1-hex water tile in an adjacent empty hex."
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-128/701"
   },
   {
@@ -2481,6 +2725,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-128/703"
   },
   {
@@ -2491,6 +2736,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-128/704"
   },
   {
@@ -2501,6 +2747,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-128/705"
   },
   {
@@ -2511,6 +2758,7 @@
       "Move 1",
       "Attack 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-131/698"
   },
   {
@@ -2521,6 +2769,7 @@
       "Focus on the enemy farthest away within Range 6",
       "Attack 1, Range 6"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-131/699"
   },
   {
@@ -2531,6 +2780,7 @@
       "Move 1",
       "Attack 1, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-131/700"
   },
   {
@@ -2540,8 +2790,9 @@
     "abilities": [
       "Create one 1-hex water tile in an adjacent empty hex.",
       "Attack 1, Range 4",
-      "Teleport , to the leftmost empty hex if it is an odd round or rightmost if it is even"
+      "Teleport, to the leftmost empty hex if it is an odd round or rightmost if it is even"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-131/701"
   },
   {
@@ -2552,6 +2803,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-131/703"
   },
   {
@@ -2562,6 +2814,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-131/704"
   },
   {
@@ -2572,6 +2825,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower-scenario-131/705"
   },
   {
@@ -2582,6 +2836,7 @@
       "Move 1",
       "Attack 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower/698"
   },
   {
@@ -2592,6 +2847,7 @@
       "Focus on the enemy farthest away within Range 6",
       "Attack 1, Range 6"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower/699"
   },
   {
@@ -2602,6 +2858,7 @@
       "Move 1",
       "Attack 1, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower/700"
   },
   {
@@ -2611,6 +2868,7 @@
     "abilities": [
       "Create one 1-hex water tile in an adjacent empty hex."
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower/701"
   },
   {
@@ -2621,6 +2879,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower/703"
   },
   {
@@ -2631,6 +2890,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower/704"
   },
   {
@@ -2641,6 +2901,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/lurker-wavethrower/705"
   },
   {
@@ -2650,8 +2911,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/578"
   },
   {
@@ -2661,8 +2923,9 @@
     "abilities": [
       "Move 1",
       "Attack 2",
-      "Element dark, Invisible"
+      "Consume Dark, Invisible, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/579"
   },
   {
@@ -2672,8 +2935,9 @@
     "abilities": [
       "Move 0",
       "Attack 0",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/580"
   },
   {
@@ -2681,8 +2945,9 @@
     "cardName": "Black Thorns",
     "initiative": 26,
     "abilities": [
-      "Attack 2, Target 3, Range 3"
+      "Attack 2, Target 3, Range 3, Consume Dark: Muddle"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/581"
   },
   {
@@ -2691,8 +2956,9 @@
     "initiative": 46,
     "abilities": [
       "Move 1",
-      "Attack 1"
+      "Attack 1, Consume Dark: Attack +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/582"
   },
   {
@@ -2702,8 +2968,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/583"
   },
   {
@@ -2713,8 +2980,9 @@
     "abilities": [
       "Attack 1",
       "Attack 1, Pierce 2",
-      "Element light, Curse"
+      "Consume Light, Curse, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/584"
   },
   {
@@ -2725,8 +2993,9 @@
       "Move 0",
       "Attack 1",
       "All adjacent allies and enemies suffer Damage 1.",
-      "Element wild"
+      "Consume Wild, Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/night-demon/585"
   },
   {
@@ -2736,8 +3005,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Range 3",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/866"
   },
   {
@@ -2748,6 +3018,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/867"
   },
   {
@@ -2755,8 +3026,9 @@
     "cardName": "Toxic Explosion",
     "initiative": 59,
     "abilities": [
-      "Attack 0, Target 2, Range 3, Poison"
+      "Attack 0, Target 2, Range 3, Poison, Consume Earth: Target +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/868"
   },
   {
@@ -2764,9 +3036,10 @@
     "cardName": "Plasma Ward",
     "initiative": 85,
     "abilities": [
-      "Push 1, Target All, Range 1, Poison",
+      "Push 1, All, Range 1, Poison",
       "Attack 1, Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/869"
   },
   {
@@ -2776,8 +3049,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Range 4",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/870"
   },
   {
@@ -2788,6 +3062,7 @@
       "SufferDamage 2",
       "Summon, with H equal to the summoning Ooze's current hit point value (limited by a normal Ooze's maximum hit point values)."
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/871"
   },
   {
@@ -2797,8 +3072,9 @@
     "abilities": [
       "Move 1",
       "Loot 1",
-      "Heal 2, Self"
+      "Heal 2, Self, Consume Dark: Heal +1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ooze/873"
   },
   {
@@ -2808,6 +3084,7 @@
     "abilities": [
       "Move 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/piranha-pig/714"
   },
   {
@@ -2817,6 +3094,7 @@
     "abilities": [
       "Move 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/piranha-pig/715"
   },
   {
@@ -2826,6 +3104,7 @@
     "abilities": [
       "Move 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/piranha-pig/716"
   },
   {
@@ -2835,6 +3114,7 @@
     "abilities": [
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/piranha-pig/717"
   },
   {
@@ -2842,9 +3122,10 @@
     "cardName": "Hasty Assault",
     "initiative": 18,
     "abilities": [
-      "Move 1",
+      "Move 1, Jump",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/piranha-pig/718"
   },
   {
@@ -2854,6 +3135,7 @@
     "abilities": [
       "Attack 1, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/piranha-pig/719"
   },
   {
@@ -2861,10 +3143,11 @@
     "cardName": "Bared Teeth",
     "initiative": 13,
     "abilities": [
-      "Move 1",
-      "Wound, Target All, Range 1",
+      "Move 1, Jump",
+      "Wound, All, Range 1",
       "Retaliate 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/piranha-pig/720"
   },
   {
@@ -2875,6 +3158,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/piranha-pig/721"
   },
   {
@@ -2885,6 +3169,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/polar-bear/834"
   },
   {
@@ -2895,6 +3180,7 @@
       "Move 1",
       "Attack 1, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/polar-bear/835"
   },
   {
@@ -2904,6 +3190,7 @@
     "abilities": [
       "Attack 1, Impair"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/polar-bear/836"
   },
   {
@@ -2914,6 +3201,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/polar-bear/837"
   },
   {
@@ -2924,6 +3212,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/polar-bear/838"
   },
   {
@@ -2935,6 +3224,7 @@
       "Move 2",
       "Attack 1, Impair"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/polar-bear/839"
   },
   {
@@ -2945,6 +3235,7 @@
       "Move 0",
       "Attack 1, Target 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/polar-bear/840"
   },
   {
@@ -2956,6 +3247,7 @@
       "Retaliate 2",
       "Heal 2, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/polar-bear/841"
   },
   {
@@ -2966,6 +3258,7 @@
       "Move 1",
       "Attack 0, Range 3, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/762"
   },
   {
@@ -2976,6 +3269,7 @@
       "Move 0",
       "Attack 1, Range 3, Disarm"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/763"
   },
   {
@@ -2986,6 +3280,7 @@
       "Move 0",
       "Attack 0, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/764"
   },
   {
@@ -2996,6 +3291,7 @@
       "Move 0",
       "Heal 3, Range 3"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/765"
   },
   {
@@ -3006,6 +3302,7 @@
       "Move 1",
       "Attack 1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/767"
   },
   {
@@ -3017,6 +3314,7 @@
       "Heal 1, Allies, Range 1",
       "Bless, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/768"
   },
   {
@@ -3027,6 +3325,7 @@
       "Move 1",
       "Attack 1, Target 2, Range 3, Curse"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/priest/769"
   },
   {
@@ -3037,6 +3336,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/850"
   },
   {
@@ -3048,6 +3348,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/851"
   },
   {
@@ -3058,6 +3359,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/852"
   },
   {
@@ -3068,6 +3370,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/853"
   },
   {
@@ -3078,6 +3381,7 @@
       "Move 2",
       "Attack 1, Target 2, Range 3, Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/854"
   },
   {
@@ -3088,6 +3392,7 @@
       "Move 2",
       "Attack 1, Target 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/855"
   },
   {
@@ -3099,6 +3404,7 @@
       "Attack 1",
       "Attack 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/856"
   },
   {
@@ -3109,6 +3415,7 @@
       "Shield 2",
       "Heal 2, Self, Strengthen"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/rending-drake/857"
   },
   {
@@ -3119,6 +3426,7 @@
       "Move 1",
       "Attack 1, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/robotic-boltshooter/602"
   },
   {
@@ -3130,6 +3438,7 @@
       "Attack 1, Range 4",
       "Shield 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/robotic-boltshooter/603"
   },
   {
@@ -3140,6 +3449,7 @@
       "Move 1",
       "Attack 1, Range 5, Pierce 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/robotic-boltshooter/604"
   },
   {
@@ -3151,6 +3461,7 @@
       "Attack 0, Range 4",
       "Shield 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/robotic-boltshooter/605"
   },
   {
@@ -3161,6 +3472,7 @@
       "Move 0",
       "Attack 0, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/robotic-boltshooter/606"
   },
   {
@@ -3170,6 +3482,7 @@
     "abilities": [
       "Attack 2, Target 1, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/robotic-boltshooter/607"
   },
   {
@@ -3180,6 +3493,7 @@
       "Move 0",
       "Attack 1, EnemyOneAll, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/robotic-boltshooter/608"
   },
   {
@@ -3190,6 +3504,7 @@
       "Shield 1",
       "Heal 3, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/robotic-boltshooter/609"
   },
   {
@@ -3199,6 +3514,7 @@
     "abilities": [
       "Move 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ruined-machine/594"
   },
   {
@@ -3209,6 +3525,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ruined-machine/595"
   },
   {
@@ -3219,6 +3536,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ruined-machine/596"
   },
   {
@@ -3229,6 +3547,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ruined-machine/597"
   },
   {
@@ -3237,9 +3556,10 @@
     "initiative": 29,
     "abilities": [
       "Move 1",
-      "If the move ability was performed,",
+      "If the move ability was performed,, SufferDamage 1",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ruined-machine/598"
   },
   {
@@ -3248,8 +3568,9 @@
     "initiative": 42,
     "abilities": [
       "Attack 2, Immobilize",
-      "If the attack ability was performed,"
+      "If the attack ability was performed,, SufferDamage 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ruined-machine/599"
   },
   {
@@ -3258,9 +3579,10 @@
     "initiative": 56,
     "abilities": [
       "Move 0",
-      "Muddle, Target All, Range 2",
+      "Muddle, All, Range 2",
       "SufferDamage 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ruined-machine/600"
   },
   {
@@ -3272,6 +3594,7 @@
       "Attack 0",
       "If the attack ability was performed, all adjacent enemies suffer trap damage and the Ruined Machine dies."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/ruined-machine/601"
   },
   {
@@ -3279,9 +3602,10 @@
     "cardName": "Repulsive Torrent",
     "initiative": 70,
     "abilities": [
-      "Push 2, Target All, Range 1",
+      "Push 2, All, Range 1, Consume Air: Push +2",
       "Attack 1, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/794"
   },
   {
@@ -3290,8 +3614,9 @@
     "initiative": 98,
     "abilities": [
       "Summon",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/795"
   },
   {
@@ -3300,8 +3625,9 @@
     "initiative": 98,
     "abilities": [
       "Summon",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/796"
   },
   {
@@ -3311,9 +3637,10 @@
     "abilities": [
       "Move 0",
       "Attack 1, Range 3",
-      "Grant all allies within Range 2 and self:, Shield 1",
-      "Element ice"
+      "Grant all allies within Range 2 and self: Shield 1",
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/797"
   },
   {
@@ -3321,10 +3648,11 @@
     "cardName": "Freezing Winds",
     "initiative": 14,
     "abilities": [
-      "Attack 0, Range 4",
+      "Attack 0, Range 4, Consume Ice: Attack 2, Immobilize",
       "Retaliate 2",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/798"
   },
   {
@@ -3333,9 +3661,10 @@
     "initiative": 14,
     "abilities": [
       "Shield 4",
-      "Heal 2, Range 3",
-      "Element air"
+      "Heal 2, Range 3, Consume Ice: Heal +3",
+      "Consume Air, Attack -1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/799"
   },
   {
@@ -3343,11 +3672,12 @@
     "cardName": "Forceful Gust",
     "initiative": 47,
     "abilities": [
-      "Disarm, Target All, Range 1",
+      "Disarm, All, Range 1",
       "Move 0",
       "Attack 1, Range 4",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/800"
   },
   {
@@ -3357,8 +3687,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element ice"
+      "Infuse Ice"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-icestorm/801"
   },
   {
@@ -3367,8 +3698,9 @@
     "initiative": 97,
     "abilities": [
       "Summon",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/786"
   },
   {
@@ -3377,8 +3709,9 @@
     "initiative": 97,
     "abilities": [
       "Summon",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/787"
   },
   {
@@ -3388,8 +3721,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, EnemiesAdjacent",
-      "Element fire, Retaliate 3"
+      "Consume Fire, Retaliate 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/788"
   },
   {
@@ -3398,8 +3732,9 @@
     "initiative": 68,
     "abilities": [
       "Move 1",
-      "Element earth"
+      "Infuse Earth"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/789"
   },
   {
@@ -3408,8 +3743,9 @@
     "initiative": 41,
     "abilities": [
       "Move 0",
-      "Attack 1"
+      "Attack 1, Consume Earth: Attack +2, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/790"
   },
   {
@@ -3418,9 +3754,10 @@
     "initiative": 51,
     "abilities": [
       "All enemies within Range 4 suffer Damage 2.",
-      "Element fire, Wound",
-      "Element earth, Disarm"
+      "Consume Fire, Wound, All, Range 4",
+      "Consume Earth, Disarm, All, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/791"
   },
   {
@@ -3428,8 +3765,9 @@
     "cardName": "Strength of the Mountain",
     "initiative": 31,
     "abilities": [
-      "Heal 4, Range 3"
+      "Heal 4, Range 3, Consume Earth: Target +2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/792"
   },
   {
@@ -3439,8 +3777,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, Target 2, Range 3",
-      "Element fire"
+      "Infuse Fire"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/savvas-lavaflow/793"
   },
   {
@@ -3451,6 +3790,7 @@
       "Move 1",
       "Attack 1, Range 3, Impair"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/770"
   },
   {
@@ -3461,6 +3801,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/771"
   },
   {
@@ -3471,6 +3812,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/772"
   },
   {
@@ -3481,6 +3823,7 @@
       "Move 2",
       "Attack 0, Range 3, Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/773"
   },
   {
@@ -3491,6 +3834,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/774"
   },
   {
@@ -3500,6 +3844,7 @@
     "abilities": [
       "Attack 2, Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/775"
   },
   {
@@ -3509,6 +3854,7 @@
     "abilities": [
       "Attack 1, Target 2, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/776"
   },
   {
@@ -3516,9 +3862,10 @@
     "cardName": "Greed",
     "initiative": 35,
     "abilities": [
-      "Move 1",
+      "Move 1, Jump",
       "Loot 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/scout/777"
   },
   {
@@ -3529,6 +3876,7 @@
       "Move 0",
       "Attack 1, Target 3, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/shrike-fiend/810"
   },
   {
@@ -3539,6 +3887,7 @@
       "Move 1",
       "Attack 0, Target 2, Range 5"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/shrike-fiend/811"
   },
   {
@@ -3549,6 +3898,7 @@
       "Move 2",
       "Attack 0, Push 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/shrike-fiend/812"
   },
   {
@@ -3558,8 +3908,9 @@
     "abilities": [
       "All enemies within Range 3 suffer Damage 2.",
       "Retaliate 2, Range 3",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/shrike-fiend/813"
   },
   {
@@ -3567,9 +3918,10 @@
     "cardName": "Gather the Flock",
     "initiative": 72,
     "abilities": [
-      "Pull 2, Target All, Range 5",
+      "Pull 2, All, Range 5",
       "All enemies within Range 3 suffer Damage 2."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/shrike-fiend/814"
   },
   {
@@ -3579,6 +3931,7 @@
     "abilities": [
       "Attack 0, Target 2, Range 3, Immobilize"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/shrike-fiend/815"
   },
   {
@@ -3588,8 +3941,9 @@
     "abilities": [
       "Move 0",
       "Attack 0",
-      "Element dark"
+      "Infuse Dark"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/shrike-fiend/816"
   },
   {
@@ -3598,8 +3952,9 @@
     "initiative": 23,
     "abilities": [
       "Attack 2, Target 3, Range 6, Pull 2",
-      "Element dark, Shield 2"
+      "Consume Dark, Shield 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/shrike-fiend/817"
   },
   {
@@ -3610,6 +3965,7 @@
       "Move 1",
       "Attack 1, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/858"
   },
   {
@@ -3620,6 +3976,7 @@
       "Move 0",
       "Attack 0, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/859"
   },
   {
@@ -3630,6 +3987,7 @@
       "Move 0",
       "Attack 1, Range 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/860"
   },
   {
@@ -3639,6 +3997,7 @@
     "abilities": [
       "Attack 0, Target 2, Range 4, Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/861"
   },
   {
@@ -3649,6 +4008,7 @@
       "Move 1",
       "Attack 1, Range 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/862"
   },
   {
@@ -3658,6 +4018,7 @@
     "abilities": [
       "Attack 2, Range 4, Stun"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/863"
   },
   {
@@ -3668,6 +4029,7 @@
       "Shield 2",
       "Heal 2, Self, Strengthen"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/864"
   },
   {
@@ -3678,6 +4040,7 @@
       "Move 1",
       "Attack 2, Range 3, Poison"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/spitting-drake/865"
   },
   {
@@ -3688,6 +4051,7 @@
       "Move 1",
       "Attack 1"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/steel-automaton/618"
   },
   {
@@ -3699,6 +4063,7 @@
       "Move 2",
       "All adjacent enemies suffer hazardous terrain damage."
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/steel-automaton/619"
   },
   {
@@ -3708,6 +4073,7 @@
     "abilities": [
       "Attack 1, Stun"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/steel-automaton/620"
   },
   {
@@ -3719,6 +4085,7 @@
       "Shield 1",
       "Retaliate 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/steel-automaton/621"
   },
   {
@@ -3729,6 +4096,7 @@
       "Move 0",
       "Attack 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/steel-automaton/622"
   },
   {
@@ -3738,6 +4106,7 @@
     "abilities": [
       "Attack 1, Range 3, Pierce 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/steel-automaton/623"
   },
   {
@@ -3748,6 +4117,7 @@
       "Move 1",
       "Attack 1, Push 3"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/steel-automaton/624"
   },
   {
@@ -3757,6 +4127,7 @@
     "abilities": [
       "Shield 4"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/steel-automaton/625"
   },
   {
@@ -3764,8 +4135,9 @@
     "cardName": "Ray of Warmth",
     "initiative": 17,
     "abilities": [
-      "Heal 3, Range 3"
+      "Heal 3, Range 3, Consume Light: All"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/586"
   },
   {
@@ -3775,8 +4147,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, EnemiesAdjacent",
-      "Element light"
+      "Infuse Light"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/587"
   },
   {
@@ -3786,8 +4159,9 @@
     "abilities": [
       "Move 0",
       "Attack 1",
-      "Element light"
+      "Infuse Light"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/589"
   },
   {
@@ -3797,8 +4171,9 @@
     "abilities": [
       "Move 1",
       "Attack 1",
-      "Element light"
+      "Consume Light, Heal 3, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/590"
   },
   {
@@ -3807,8 +4182,9 @@
     "initiative": 95,
     "abilities": [
       "Move 1",
-      "Attack 0, Range 3"
+      "Attack 0, Range 3, Consume Light: All"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/591"
   },
   {
@@ -3818,8 +4194,9 @@
     "abilities": [
       "Move 1",
       "Attack 1, EnemiesAdjacent",
-      "Element dark, Muddle"
+      "Consume Dark, Muddle, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/592"
   },
   {
@@ -3829,8 +4206,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, Range 3",
-      "Element wild"
+      "Consume Wild, Infuse Light"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/sun-demon/593"
   },
   {
@@ -3840,6 +4218,7 @@
     "abilities": [
       "Move 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/vermling-scout-scenario-94/752"
   },
   {
@@ -3849,8 +4228,9 @@
     "abilities": [
       "Attack 1, Range 2",
       "Heal 1, Self",
-      "Element air, Invisible"
+      "Consume Air, Invisible, Self"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/562"
   },
   {
@@ -3860,8 +4240,9 @@
     "abilities": [
       "Move 0",
       "Attack 0, Range 3, Pull 1",
-      "Element air"
+      "Infuse Air"
     ],
+    "count": 2,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/563"
   },
   {
@@ -3870,8 +4251,9 @@
     "initiative": 29,
     "abilities": [
       "Move 0",
-      "Attack 1, Target 2, Range 3"
+      "Attack 1, Target 2, Range 3, Consume Air: Push 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/565"
   },
   {
@@ -3881,6 +4263,7 @@
     "abilities": [
       "Move 0"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/566"
   },
   {
@@ -3889,8 +4272,9 @@
     "initiative": 43,
     "abilities": [
       "Move 1",
-      "Attack 1, Range 3"
+      "Attack 1, Range 3, Consume Air: Disarm"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/567"
   },
   {
@@ -3898,9 +4282,10 @@
     "cardName": "Blast of Air",
     "initiative": 43,
     "abilities": [
-      "Push 1, Target All, Range 1",
-      "Attack 0, Range 4, Disarm"
+      "Push 1, All, Range 1",
+      "Attack 0, Range 4, Disarm, Consume Earth: Range 2"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/568"
   },
   {
@@ -3911,8 +4296,9 @@
       "Move 1",
       "Attack 1, Range 3",
       "Shield 1",
-      "Element wild"
+      "Consume Wild, Infuse Air"
     ],
+    "count": 1,
     "sourceId": "gloomhavensecretariat:monster-ability/wind-demon/651"
   }
 ]

--- a/src/db/migrations/20260709130000_monster_ability_card_count/migration.sql
+++ b/src/db/migrations/20260709130000_monster_ability_card_count/migration.sql
@@ -1,0 +1,4 @@
+-- SQR-397: monster decks contain physically duplicated cards (FH Ancient
+-- Artillery ships Exploding Ammunition x2); the import collapsed them,
+-- losing deck composition. One row per distinct card, with a copy count.
+ALTER TABLE "card_monster_abilities" ADD COLUMN "count" integer NOT NULL DEFAULT 1;

--- a/src/db/schema/cards.ts
+++ b/src/db/schema/cards.ts
@@ -113,6 +113,8 @@ export const cardMonsterAbilities = pgTable(
     cardName: text('card_name').notNull(),
     initiative: integer('initiative').notNull(),
     abilities: text('abilities').array().notNull(),
+    // SQR-397: physical copies of this card in the deck (decks contain dupes).
+    count: integer('count').notNull().default(1),
     searchVector: tsvector('search_vector').generatedAlwaysAs(SV_MARKER),
   },
   (t) => [

--- a/src/extracted-data.ts
+++ b/src/extracted-data.ts
@@ -401,7 +401,8 @@ function recordToText(record: ExtractedRecord): string {
   if (t === 'monster-abilities') {
     const r = record as ExtractedRecord;
     const abilities = ((r.abilities as string[]) || []).join('; ');
-    return `Monster Ability Card — ${r.monsterType}: "${r.cardName}" (initiative ${r.initiative}). Abilities: ${abilities}`;
+    const copies = typeof r.count === 'number' && r.count > 1 ? ` [x${r.count} in deck]` : '';
+    return `Monster Ability Card — ${r.monsterType}: "${r.cardName}" (initiative ${r.initiative})${copies}. Abilities: ${abilities}`;
   }
 
   if (t === 'character-abilities') {

--- a/src/import-monster-abilities.ts
+++ b/src/import-monster-abilities.ts
@@ -31,6 +31,9 @@ interface ExtractedMonsterAbility {
   cardName: string;
   initiative: number;
   abilities: string[];
+  /** Physical copies of this card in the deck (SQR-397): upstream lists one
+   * entry per physical card, and real decks contain duplicates. */
+  count: number;
   sourceId: string;
 }
 
@@ -66,6 +69,7 @@ export function convertMonsterAbility(
     cardName,
     initiative: ghs.initiative,
     abilities,
+    count: 1,
     sourceId: `gloomhavensecretariat:monster-ability/${deckName}/${cardIdSuffix}`,
   };
 }
@@ -102,13 +106,12 @@ export function importMonsterAbilities(
         ((b as { cardId?: number }).cardId ?? -Infinity),
     );
 
-    // Dedupe within a deck by content equivalence. Upstream GHS data contains
-    // genuine duplicates (e.g. ancient-artillery cards 627 and 628 both
-    // "Exploding Ammunition" with byte-identical actions). Keep the first
-    // occurrence and drop subsequent rows whose (name, initiative, abilities)
-    // tuple matches a row already kept. Log dropped sourceIds to stderr so
-    // reviewers can spot the upstream dupes.
-    const seen = new Set<string>();
+    // Collapse physically identical cards into one row with a copy count
+    // (SQR-397). Upstream lists one entry per PHYSICAL card, and real decks
+    // contain duplicates (ancient-artillery ships Exploding Ammunition x2);
+    // the previous behavior dropped the copies, losing deck composition —
+    // draw-probability and "how many cards" answers were wrong.
+    const seen = new Map<string, ExtractedMonsterAbility>();
 
     for (const [index, ability] of sortedAbilities.entries()) {
       const converted = convertMonsterAbility(ability, deckName, labels, index + 1);
@@ -128,13 +131,12 @@ export function importMonsterAbilities(
       }
 
       const dedupeKey = `${converted.cardName}|${converted.initiative}|${JSON.stringify(converted.abilities)}`;
-      if (seen.has(dedupeKey)) {
-        console.warn(
-          `[import-monster-abilities] dropping upstream duplicate: ${converted.sourceId} (matches an earlier row in ${deckName})`,
-        );
+      const existing = seen.get(dedupeKey);
+      if (existing) {
+        existing.count += 1;
         continue;
       }
-      seen.add(dedupeKey);
+      seen.set(dedupeKey, converted);
 
       allResults.push(converted);
     }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -62,6 +62,12 @@ export const MonsterAbilitySchema = z.object({
   abilities: z
     .array(z.string())
     .describe('Each ability line verbatim, describing icons as words (e.g. "Attack +1", "Muddle")'),
+  count: z
+    .number()
+    .int()
+    .min(1)
+    .default(1)
+    .describe('Physical copies of this card in the deck (real decks contain duplicates)'),
 });
 
 export const CharacterAbilitySchema = z.object({

--- a/test/import-monster-abilities.test.ts
+++ b/test/import-monster-abilities.test.ts
@@ -33,6 +33,7 @@ describe('convertMonsterAbility', () => {
       cardName: 'Forceful Strike',
       initiative: 45,
       abilities: ['Move 1', 'Attack 2'],
+      count: 1,
       sourceId: 'gloomhavensecretariat:monster-ability/algox-archer/100',
     });
   });
@@ -142,6 +143,7 @@ describe('convertMonsterAbility', () => {
       cardName: 'Chaos Spark',
       initiative: 90,
       abilities: ['Move 2'],
+      count: 1,
       sourceId: 'gloomhavensecretariat:monster-ability/chaos-spark/ordinal-1',
     });
   });
@@ -166,5 +168,52 @@ describe('convertMonsterAbility', () => {
 
     const result = convertMonsterAbility(ghsAbility, 'archer', labels);
     expect(result.abilities).toEqual(['Attack 3, Range 4, Pierce 2']);
+  });
+});
+
+// ─── deck composition (SQR-397) ─────────────────────────────────────────────
+
+describe('deck composition (SQR-397)', () => {
+  it('collapses physically duplicated cards into one row with a copy count', async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { importMonsterAbilities } = await import('../src/import-monster-abilities.ts');
+
+    const root = mkdtempSync(join(tmpdir(), 'sqr397-'));
+    const dir = join(root, 'data', 'fh');
+    try {
+      const deckDir = join(dir, 'monster', 'deck');
+      mkdirSync(deckDir, { recursive: true });
+      mkdirSync(join(dir, 'label', 'spoiler'), { recursive: true });
+      writeFileSync(join(dir, 'label', 'en.json'), JSON.stringify({}));
+      writeFileSync(join(dir, 'label', 'spoiler', 'en.json'), JSON.stringify({}));
+      // FH Ancient Artillery ships 8 physical cards; Exploding Ammunition x2
+      // are byte-identical entries with distinct cardIds.
+      writeFileSync(
+        join(deckDir, 'ancient-artillery.json'),
+        JSON.stringify({
+          name: 'ancient-artillery',
+          abilities: [
+            { name: 'Long Shot', cardId: 626, initiative: 46, actions: [] },
+            { name: 'Exploding Ammunition', cardId: 627, initiative: 71, actions: [] },
+            { name: 'Exploding Ammunition', cardId: 628, initiative: 71, actions: [] },
+            { name: 'Grenade', cardId: 629, initiative: 37, actions: [] },
+          ],
+        }),
+      );
+
+      const rows = importMonsterAbilities({ sourceDir: root, game: 'frosthaven' });
+
+      // One row per DISTINCT card; the duplicate keeps the lowest cardId and
+      // carries the physical copy count. Total copies = physical deck size.
+      expect(rows).toHaveLength(3);
+      const exploding = rows.find((r) => r.cardName === 'Exploding Ammunition');
+      expect(exploding?.count).toBe(2);
+      expect(exploding?.sourceId).toContain('/627');
+      expect(rows.reduce((sum, r) => sum + r.count, 0)).toBe(4);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/test/import-monster-abilities.test.ts
+++ b/test/import-monster-abilities.test.ts
@@ -188,7 +188,8 @@ describe('deck composition (SQR-397)', () => {
       mkdirSync(join(dir, 'label', 'spoiler'), { recursive: true });
       writeFileSync(join(dir, 'label', 'en.json'), JSON.stringify({}));
       writeFileSync(join(dir, 'label', 'spoiler', 'en.json'), JSON.stringify({}));
-      // FH Ancient Artillery ships 8 physical cards; Exploding Ammunition x2
+      // Reduced four-card fixture modeled on FH Ancient Artillery (whose real
+      // 8-card deck ships Exploding Ammunition x2): the duplicate pair below
       // are byte-identical entries with distinct cardIds.
       writeFileSync(
         join(deckDir, 'ancient-artillery.json'),
@@ -206,7 +207,8 @@ describe('deck composition (SQR-397)', () => {
       const rows = importMonsterAbilities({ sourceDir: root, game: 'frosthaven' });
 
       // One row per DISTINCT card; the duplicate keeps the lowest cardId and
-      // carries the physical copy count. Total copies = physical deck size.
+      // carries the physical copy count. Counts sum to the fixture's four
+      // physical cards.
       expect(rows).toHaveLength(3);
       const exploding = rows.find((r) => r.cardName === 'Exploding Ammunition');
       expect(exploding?.count).toBe(2);


### PR DESCRIPTION
## Summary

Monster decks contain physically duplicated cards — the FH Ancient Artillery deck has 8 physical cards including Exploding Ammunition ×2. The import treated the second copy as a data error and dropped it, so deck composition was silently wrong for **53 cards across both games** (20 FH + 33 GH2e — far beyond the one deck named in the issue). Composition matters at the table: draw probabilities and "how many cards does this deck have" both depend on it.

Changes:
- Import aggregates byte-identical entries (same name, initiative, abilities) into one row with a `count` of physical copies, keeping the lowest cardId as the stable identifier.
- `MonsterAbilitySchema` and `card_monster_abilities` gain `count` (migration `20260709130000_monster_ability_card_count`, default 1).
- Search/render text shows `[x2 in deck]` so answers can see composition.
- Regression test: a 4-physical-card deck with one duplicate imports as 3 distinct rows whose counts sum to 4, duplicate keeps `/627`.

Re-extracted both games and reseeded dev + test databases. Grep-verified that no eval expected answers assumed the old collapsed composition.

## Verification
- `npm run check`: 2,039 tests green
- `gh2-monster-ability-ancient-artillery-long-shot` and `gh2-monster-ability-bloated-victim-rotting-embrace` still pass at score 1
- Extract diff: FH 379→386 rows... rows stayed one-per-distinct-card; counts now carry the extra copies (FH 20, GH2e 33 cards with count 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserves duplicate monster ability cards by recording their physical copy count.
  * Displays copy counts in extracted card text when multiple copies are present.
  * Validates copy counts as positive integers, defaulting to one.

* **Bug Fixes**
  * Prevents duplicate cards from being discarded during deck imports, preserving accurate deck composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->