### PR TITLE
SQR-406 Fix stream-reconnect race: serialize event sequences, unwrap driver errors, replay fallback

### DIFF
--- a/src/db/repositories/message-stream-event-repository.ts
+++ b/src/db/repositories/message-stream-event-repository.ts
@@ -35,9 +35,15 @@ const PUBLIC_WORK_EVENTS: ConversationMessagePublicWorkEventName[] = [
 ];
 
 function isUniqueViolation(error: unknown): boolean {
-  return (
-    typeof error === 'object' && error !== null && (error as { code?: string }).code === '23505'
-  );
+  // Drizzle wraps driver errors (DrizzleQueryError with the pg error as
+  // `cause`), so walk the cause chain — checking only the top-level error
+  // meant the append retry/dedupe path never engaged (SQR-406).
+  for (let current: unknown = error; current; current = (current as { cause?: unknown }).cause) {
+    if (typeof current === 'object' && (current as { code?: string }).code === '23505') {
+      return true;
+    }
+  }
+  return false;
 }
 
 function toDomain(row: typeof messageStreamEvents.$inferSelect): MessageStreamEvent {
@@ -153,7 +159,21 @@ async function insertNext(input: {
   payload: Record<string, unknown>;
 }): Promise<MessageStreamEvent> {
   const { db } = getDb('server');
-  const result = await db.execute(sql`
+  // Sequence allocation is serialized per user message (SQR-406): the
+  // max(sequence)+1 CTE races when a reconnecting client and the finishing
+  // generator append concurrently, colliding on the (user_message_id,
+  // sequence) unique index. The advisory key deliberately differs from the
+  // turn-generation lock (conversationId, userMessageId) — the generation
+  // transaction holds that one for the whole turn on another connection, so
+  // reusing it here would deadlock the generator against its own appends.
+  const result = await db.transaction(async (tx) => {
+    await tx.execute(sql`
+      select pg_advisory_xact_lock(
+        hashtext(${input.userMessageId}),
+        hashtext('stream-event-sequence')
+      )
+    `);
+    return tx.execute(sql`
     with next_sequence as (
       select coalesce(max(sequence), 0) + 1 as sequence
       from message_stream_events
@@ -175,6 +195,7 @@ async function insertNext(input: {
     from next_sequence
     returning sequence, event, payload, created_at as "createdAt"
   `);
+  });
   const row = result.rows[0] as
     | { sequence: number; event: string; payload: Record<string, unknown>; createdAt: Date }
     | undefined;
@@ -202,7 +223,18 @@ export async function append(input: {
       if (terminal && TERMINAL_EVENTS.has(input.event)) return terminal;
     }
   }
-  return insertNext(input);
+  // Last attempt: a terminal event must never die on a sequence race — if a
+  // concurrent writer landed the real terminal, surface that instead
+  // (SQR-406: the propagated violation killed the reconnect SSE).
+  try {
+    return await insertNext(input);
+  } catch (error) {
+    if (isUniqueViolation(error) && TERMINAL_EVENTS.has(input.event)) {
+      const terminal = await findTerminal(input.userMessageId);
+      if (terminal) return terminal;
+    }
+    throw error;
+  }
 }
 
 export async function isTurnGenerationLocked(input: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4044,6 +4044,22 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
           );
         };
 
+        // SQR-406: between the lock probe and the failure write, the real
+        // generator can land its own terminal; a sequence collision here must
+        // fall back to replaying the stored terminal, not kill the SSE.
+        const persistFailureOrReplayTerminal = async () => {
+          try {
+            const assistantMessage = await persistAssistantFailureTurn({
+              conversationId: loaded.conversation.id,
+              userMessageId: loaded.message.id,
+            });
+            await appendTerminalForAssistantMessage(assistantMessage);
+          } catch (error) {
+            const replay = await replayStoredEvents();
+            if (!replay.reachedTerminal) throw error;
+          }
+        };
+
         const existingTerminal = await MessageStreamEventRepository.findTerminal(loaded.message.id);
         if (existingTerminal && existingTerminal.sequence <= replayCursor) {
           recordChatLifecycleEvent('stream.completed', {
@@ -4090,11 +4106,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
                 return;
               }
 
-              const assistantMessage = await persistAssistantFailureTurn({
-                conversationId: loaded.conversation.id,
-                userMessageId: loaded.message.id,
-              });
-              await appendTerminalForAssistantMessage(assistantMessage);
+              await persistFailureOrReplayTerminal();
               return;
             }
 
@@ -4110,11 +4122,7 @@ app.get('/chat/:conversationId/messages/:messageId/stream', async (c) => {
             return;
           }
 
-          const assistantMessage = await persistAssistantFailureTurn({
-            conversationId: loaded.conversation.id,
-            userMessageId: loaded.message.id,
-          });
-          await appendTerminalForAssistantMessage(assistantMessage);
+          await persistFailureOrReplayTerminal();
           return;
         }
 

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -2299,6 +2299,47 @@ describe('conversation web backend', () => {
     );
   });
 
+  it('allocates unique sequences under concurrent appends (SQR-406)', async () => {
+    // The max(sequence)+1 CTE raced when a reconnecting client and the
+    // finishing generator appended at once, colliding on the unique index
+    // and killing the reconnect SSE. Allocation is now serialized per user
+    // message with an advisory lock — concurrent appends must all land.
+    const MessageStreamEventRepository =
+      await import('../src/db/repositories/message-stream-event-repository.ts');
+    const auth = await createAuthContext();
+    const seeded = await seedConversationWithTurns(auth, [{ question: 'race me' }]);
+    const userMessageId = seeded.userMessages[0]!.id;
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        MessageStreamEventRepository.append({
+          conversationId: seeded.conversationId,
+          userMessageId,
+          event: 'text-delta',
+          payload: { delta: `chunk ${i}` },
+        }),
+      ),
+    );
+
+    const sequences = results.map((event) => event.sequence).sort((a, b) => a - b);
+    expect(sequences).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+    // Concurrent terminal appends dedupe to a single stored terminal.
+    const terminals = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        MessageStreamEventRepository.append({
+          conversationId: seeded.conversationId,
+          userMessageId,
+          event: 'done',
+          payload: {},
+        }),
+      ),
+    );
+    expect(new Set(terminals.map((event) => event.sequence)).size).toBeLessThanOrEqual(4);
+    const stored = await MessageStreamEventRepository.listAfter({ userMessageId });
+    expect(stored).toHaveLength(new Set(stored.map((event) => event.sequence)).size);
+  });
+
   it('waits for an active stream and replays the terminal event on reconnect', async () => {
     let finishAnswer!: () => void;
     const answerGate = new Promise<void>((resolve) => {

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -2335,8 +2335,14 @@ describe('conversation web backend', () => {
         }),
       ),
     );
-    expect(new Set(terminals.map((event) => event.sequence)).size).toBeLessThanOrEqual(4);
+    // All four callers must resolve to the SAME stored terminal: exactly one
+    // 'done' row exists, and every append returned its sequence.
     const stored = await MessageStreamEventRepository.listAfter({ userMessageId });
+    const storedTerminals = stored.filter((event) => event.event === 'done');
+    expect(storedTerminals).toHaveLength(1);
+    expect(new Set(terminals.map((event) => event.sequence))).toEqual(
+      new Set([storedTerminals[0]!.sequence]),
+    );
     expect(stored).toHaveLength(new Set(stored.map((event) => event.sequence)).size);
   });
 


### PR DESCRIPTION
## Summary

The flaky CI failure in `conversation.test.ts` ("replays the terminal event on reconnect" returning zero events) was a real production race, and fixing it surfaced two more defects stacked underneath:

1. **Sequence race**: stream-event inserts computed `max(sequence)+1` in a CTE — a reconnecting client and the finishing generator could both read the same max and collide on the `(user_message_id, sequence)` unique index. Sequence allocation is now serialized per user message with its own advisory transaction lock. The key is deliberately distinct from the turn-generation lock: the generator holds that one for its entire turn on another connection, so sharing it would deadlock the generator against its own event appends.

2. **Dead retry path**: `isUniqueViolation` checked `error.code` on the top-level error, but Drizzle wraps driver errors (`DrizzleQueryError` with the pg error as `cause`). The existing retry/dedupe logic in `append()` therefore **never engaged** — violations sailed through and killed the SSE. It now walks the cause chain. This also matters for the one-terminal-per-message partial unique index: concurrent terminal writes now dedupe to the stored terminal instead of erroring.

3. **No recovery in the reconnect handler**: if the real generator landed its terminal between the reconnect handler's lock probe and its failure-terminal write, the connection died. `persistFailureOrReplayTerminal` now falls back to replaying stored events and only rethrows when no terminal actually exists.

## Verification
- New regression test: 10 concurrent appends allocate sequences 1–10 exactly; 4 concurrent terminal appends dedupe cleanly (this test fails on the old code with the exact CI error signature, including the wrapped-error form)
- The previously flaky reconnect test stress-run 5× green
- `npm run check`: 2,039 tests green

Diagnosis trail is in the Linear issue (filed from the original CI failure on PR #671).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency handling for streaming message events to keep sequence numbers unique and contiguous under simultaneous appends.
  * Hardened terminal event persistence in the SSE flow to prevent stream failures when multiple generators write terminal states at once.
  * Enhanced duplicate detection and retry behavior for Postgres unique-violation races, including safe recovery by replaying an already-stored terminal event when needed.
* **Tests**
  * Added a regression test covering concurrent `text-delta` appends, terminal de-duplication, and verification of no duplicate persisted sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->