### PR TITLE
ci(eval): fix scheduled LangSmith regression matrix

### DIFF
--- a/.github/workflows/langsmith-regression.yml
+++ b/.github/workflows/langsmith-regression.yml
@@ -52,9 +52,11 @@ on:
           - pre-merge
           - debug
       max_estimated_cost_usd:
+        # $0.05/case estimate; the largest leg (gloomhaven-2e table-qa dev)
+        # crossed $3 at 61 cases, so the ceiling leaves growth headroom.
         description: Per-target matrix cost ceiling
         required: true
-        default: '3'
+        default: '4'
         type: string
       timeout_ms:
         description: Per-case timeout in milliseconds
@@ -95,8 +97,9 @@ jobs:
       fail-fast: false
       matrix:
         # split: dev keeps scheduled runs off the sealed holdout (SQR-405).
-        # The boundary suites carry no split field, so they pass no filter —
-        # a dev filter there would silently select zero safety cases.
+        # Only table-qa cases carry a split field. Trajectory and boundary
+        # suites have none, so those legs pass no filter — a dev filter there
+        # selects zero cases and fails the leg (2026-07-13 scheduled run).
         include:
           - label: frosthaven-table-qa
             game: frosthaven
@@ -105,7 +108,7 @@ jobs:
           - label: frosthaven-trajectory
             game: frosthaven
             suite: trajectory
-            split: dev
+            split: ''
           - label: gloomhaven-2e-table-qa
             game: gloomhaven-2e
             suite: table-qa
@@ -113,7 +116,7 @@ jobs:
           - label: gloomhaven-2e-trajectory
             game: gloomhaven-2e
             suite: trajectory
-            split: dev
+            split: ''
           - label: cross-game-boundary
             game: ''
             suite: cross-game-boundary
@@ -149,7 +152,7 @@ jobs:
       PROVIDER_INPUT: ${{ inputs.provider || 'anthropic' }}
       MODEL_INPUT: ${{ inputs.model || 'claude-sonnet-4-6' }}
       RUN_PURPOSE_INPUT: ${{ inputs.run_purpose || '' }}
-      MAX_ESTIMATED_COST_USD_INPUT: ${{ inputs.max_estimated_cost_usd || '3' }}
+      MAX_ESTIMATED_COST_USD_INPUT: ${{ inputs.max_estimated_cost_usd || '4' }}
       TIMEOUT_MS_INPUT: ${{ inputs.timeout_ms || '60000' }}
 
     steps:

--- a/test/deployment-config.test.ts
+++ b/test/deployment-config.test.ts
@@ -1,6 +1,9 @@
 import { readFile } from 'node:fs/promises';
 import { parse } from 'yaml';
 import { describe, expect, it } from 'vitest';
+import { filterEvalCases, loadEvalCases } from '../eval/dataset.ts';
+import { ESTIMATED_COST_PER_CASE_MODEL_USD } from '../eval/matrix.ts';
+import type { EvalSplit } from '../eval/schema.ts';
 
 async function readProjectFile(path: string): Promise<string> {
   return readFile(new URL(`../${path}`, import.meta.url), 'utf8');
@@ -134,6 +137,52 @@ describe('deployment configuration', () => {
     expect(workflow).toContain('missing+=("VOYAGE_API_KEY")');
     expect(workflow).toContain('cat "$REPORT_MD" >> "$GITHUB_STEP_SUMMARY"');
     expect(workflow).toContain('actions/upload-artifact');
+  });
+
+  it('keeps every LangSmith regression matrix leg non-empty and within the default cost ceiling', async () => {
+    const workflow = await readProjectFile('.github/workflows/langsmith-regression.yml');
+    const parsed = parse(workflow) as {
+      on?: {
+        workflow_dispatch?: { inputs?: Record<string, { default?: string }> };
+      };
+      jobs?: {
+        regression?: {
+          strategy?: {
+            matrix?: {
+              include?: Array<{ label: string; game: string; suite: string; split: string }>;
+            };
+          };
+        };
+      };
+    };
+
+    const legs = parsed.jobs?.regression?.strategy?.matrix?.include ?? [];
+    expect(legs.length).toBeGreaterThan(0);
+
+    const dispatchDefault = Number(
+      parsed.on?.workflow_dispatch?.inputs?.max_estimated_cost_usd?.default,
+    );
+    // Scheduled runs take the env fallback, not the dispatch default — the two
+    // must agree or the cron path runs with an untested ceiling.
+    const envFallback = Number(workflow.match(/max_estimated_cost_usd \|\| '([\d.]+)'/)?.[1]);
+    expect(dispatchDefault).toBeGreaterThan(0);
+    expect(envFallback).toBe(dispatchDefault);
+
+    const cases = loadEvalCases();
+    for (const leg of legs) {
+      const selected = filterEvalCases(cases, {
+        gameFilter: leg.game || undefined,
+        suiteFilter: leg.suite || undefined,
+        splitFilter: (leg.split || undefined) as EvalSplit | undefined,
+        categoryFilter: undefined,
+        idFilter: undefined,
+      });
+      expect(selected.length, `${leg.label} selects zero eval cases`).toBeGreaterThan(0);
+      expect(
+        selected.length * ESTIMATED_COST_PER_CASE_MODEL_USD,
+        `${leg.label} estimate exceeds the scheduled-run cost ceiling`,
+      ).toBeLessThanOrEqual(dispatchDefault);
+    }
   });
 
   it('defines the scheduled and manual authenticated API and agent smoke command', async () => {


### PR DESCRIPTION
## Summary

- Remove the `dev` split filter from trajectory legs, whose cases are unsplit and otherwise select zero cases.
- Raise the scheduled per-target estimate ceiling from $3 to $4, leaving headroom for the 61-case Gloomhaven 2e table-QA dev leg.
- Add a workflow contract test that asserts every matrix leg selects cases and stays within the scheduled ceiling.

Closes SQR-418

## Validation

- `npm run check`
- `npm test -- test/deployment-config.test.ts` (14 passed)
- `npm run lint:actions`
- `git diff --check origin/main...HEAD`

## Pre-Landing Review

No issues found.

## Documentation

No documentation changes required. This CI-only fix corrects matrix filtering and the scheduled cost ceiling; the contract test covers both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the default estimated-cost limit for scheduled regression runs from $3 to $4 per target.
  - Updated regression case selection so scheduled test legs use the appropriate evaluation cases consistently.

- **Tests**
  - Added validation to ensure every scheduled regression leg selects cases and remains within the configured cost limit.
  - Added checks to keep manually triggered and scheduled cost settings aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->